### PR TITLE
Issue #73 Add circle ci for building on macOS and publish artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,44 @@
+## Circleci version
+version: 2
+
+## Machine specific variable
+jobs:
+  build:
+    macos:
+      xcode: "10.0.0"
+    environment:
+      GOVERSION: "1.11.6"
+
+## Build crc
+    steps:
+    - checkout
+    - run:
+        name: Configure GOPATH
+        command: echo 'export GOPATH=$HOME/go' >> $BASH_ENV
+    - run:
+        name: Configure Path
+        command: echo 'export PATH=$GOPATH/bin:/usr/local/go/bin/:$PATH' >> $BASH_ENV
+    - run:
+        name: Cleanup GOROOT
+        command: sudo rm -rf /usr/local/go
+    - run:
+        name: Install go
+        command: curl https://dl.google.com/go/go${GOVERSION}.darwin-amd64.tar.gz | sudo tar -C /usr/local -xz
+    - run:
+        name: List go version
+        command: go version
+    - run:
+        name: List go environment
+        command: go env
+    - run:
+        name: Make
+        command: make
+    - run:
+        name: Make cross
+        command: make cross
+    - run:
+        name: Run unit tests
+        command: make test
+    - store_artifacts:
+        path: ~/project/out
+        destination: crc

--- a/pkg/crc/logging/logging.go
+++ b/pkg/crc/logging/logging.go
@@ -93,41 +93,41 @@ func InitLogrus(logLevel string) {
 }
 
 func Info(args ...interface{}) {
-	logrus.Info(args)
+	logrus.Info(args...)
 }
 
 func InfoF(s string, args ...interface{}) {
-	logrus.Infof(s, args)
+	logrus.Infof(s, args...)
 }
 
 func Warn(args ...interface{}) {
-	logrus.Warn(args)
+	logrus.Warn(args...)
 }
 
 func WarnF(s string, args ...interface{}) {
-	logrus.Warnf(s, args)
+	logrus.Warnf(s, args...)
 }
 
 func Fatal(args ...interface{}) {
-	logrus.Fatal(args)
+	logrus.Fatal(args...)
 }
 
 func FatalF(s string, args ...interface{}) {
-	logrus.Fatalf(s, args)
+	logrus.Fatalf(s, args...)
 }
 
 func Error(args ...interface{}) {
-	logrus.Error(args)
+	logrus.Error(args...)
 }
 
 func ErrorF(s string, args ...interface{}) {
-	logrus.Errorf(s, args)
+	logrus.Errorf(s, args...)
 }
 
 func Debug(args ...interface{}) {
-	logrus.Debug(args)
+	logrus.Debug(args...)
 }
 
 func DebugF(s string, args ...interface{}) {
-	logrus.Debugf(s, args)
+	logrus.Debugf(s, args...)
 }

--- a/pkg/crc/preflight/preflight_common.go
+++ b/pkg/crc/preflight/preflight_common.go
@@ -9,7 +9,7 @@ type PreflightCheckFixFuncType func() (bool, error)
 func preflightCheckSucceedsOrFails(configuredToSkip bool, check PreflightCheckFixFuncType, message string, configuredToWarn bool) {
 	log.InfoF(" %s", message)
 	if configuredToSkip {
-		log.Info("Skipping above check ...")
+		log.Info(" Skipping above check ...")
 		return
 	}
 


### PR DESCRIPTION
- Also fixed errors reported by `make test`
```
[anjan@localhost]~/github.com/code-ready/crc% make test
go test -v -ldflags="-X github.com/code-ready/crc/pkg/crc.crcVersion=0.0.1-alpha.1 -X github.com/code-ready/crc/pkg/crc.commitSha=68b80cd" github.com/code-ready/crc/cmd/crc github.com/code-ready/crc/cmd/crc/cmd github.com/code-ready/crc/cmd/crc/cmd/config github.com/code-ready/crc/pkg/crc github.com/code-ready/crc/pkg/crc/config github.com/code-ready/crc/pkg/crc/constants github.com/code-ready/crc/pkg/crc/logging github.com/code-ready/crc/pkg/crc/preflight github.com/code-ready/crc/pkg/os
# github.com/code-ready/crc/pkg/crc/logging
pkg/crc/logging/logging.go:96: missing ... in args forwarded to print-like function
pkg/crc/logging/logging.go:100: missing ... in args forwarded to printf-like function
pkg/crc/logging/logging.go:104: missing ... in args forwarded to print-like function
pkg/crc/logging/logging.go:108: missing ... in args forwarded to printf-like function
pkg/crc/logging/logging.go:112: missing ... in args forwarded to print-like function
pkg/crc/logging/logging.go:116: missing ... in args forwarded to printf-like function
pkg/crc/logging/logging.go:120: missing ... in args forwarded to print-like function
pkg/crc/logging/logging.go:124: missing ... in args forwarded to printf-like function
pkg/crc/logging/logging.go:128: missing ... in args forwarded to print-like function
pkg/crc/logging/logging.go:132: missing ... in args forwarded to printf-like function

```

Fixes #73 #76 