### PR TITLE
Issue #102 Add cluster Kubeconfig details to output

### DIFF
--- a/cmd/crc/cmd/constants.go
+++ b/cmd/crc/cmd/constants.go
@@ -2,6 +2,6 @@ package cmd
 
 const (
 	commandName      = "crc"
-	descriptionShort = "Local OpenShift 4.0 clusters"
+	descriptionShort = "Local OpenShift 4.0 cluster"
 	descriptionLong  = "Deploy local instance of an OpenShift 4.0 cluster for development purpose"
 )

--- a/cmd/crc/cmd/start.go
+++ b/cmd/crc/cmd/start.go
@@ -5,10 +5,9 @@ import (
 
 	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/code-ready/crc/pkg/crc/errors"
-	"github.com/code-ready/crc/pkg/crc/output"
-
 	"github.com/code-ready/crc/pkg/crc/machine"
 	"github.com/code-ready/crc/pkg/crc/preflight"
+	"github.com/code-ready/crc/pkg/crc/logging"
 )
 
 func init() {
@@ -51,8 +50,8 @@ func runStart(arguments []string) {
 	}
 
 	commandResult, err := machine.Start(startConfig)
-	output.Out(commandResult.Status)
+	logging.InfoF(commandResult.Status)
 	if err != nil {
-		output.Out(err.Error())
+		logging.ErrorF(err.Error())
 	}
 }

--- a/pkg/crc/constants/constants.go
+++ b/pkg/crc/constants/constants.go
@@ -21,8 +21,9 @@ const (
 	//DefaultDriverLinux   = "libvirt"
 	//DefaultDriverWindows = "hyperv"
 	//DefaultDriverMacOS   = "hyperkit"
-	DefaultBundle   = "crc_libvirt_v4.1.0-rc0.tar.xz"
-	DefaultHostname = "crc-jtskh-master-0"
+	DefaultBundle        = "crc_libvirt_v4.1.0-rc0.tar.xz"
+	DefaultHostname      = "crc-jtskh-master-0"
+	DefaultWebConsoleURL = "https://console-openshift-console.apps.tt.testing"
 )
 
 var (

--- a/pkg/crc/machine/types.go
+++ b/pkg/crc/machine/types.go
@@ -15,10 +15,17 @@ type StartConfig struct {
 	Debug bool
 }
 
+type ClusterConfig struct {
+	KubeConfig    string
+	KubeAdminPass string
+	ClusterAPI    string
+}
+
 type StartResult struct {
-	Name   string
-	Status string
-	Error  string
+	Name          string
+	Status        string
+	Error         string
+	ClusterConfig ClusterConfig
 }
 
 type StopConfig struct {


### PR DESCRIPTION
Now a clean start should look like following.

```console
$ ./crc start -b /home/prkumar/Downloads/crc_libvirt_v4.1.0.rc0.tar.xz 
crc - Local OpenShift 4.0 clusters
INFO  Checking if Virtualization is enabled       
INFO  Checking if KVM is enabled                  
INFO  Checking if Libvirt is installed            
INFO  Checking if user is part of libvirt group   
INFO  Checking if Libvirt is enabled              
INFO  Checking if Libvirt daemon is running       
INFO  Checking if crc-driver-libvirt is installed 
INFO  Checking if default pool is available       
INFO  Checking if default pool has sufficient free space 
INFO  Checking if Libvirt crc network is available 
INFO  Checking if Libvirt crc network is active   
INFO  Checking if /etc/NetworkManager/dnsmasq.d/crc.conf exists 
INFO  Extracting the Bundle tarball ...           
INFO  Creating VM ...                             
INFO  Waiting 3m0s for the openshift cluster to be started ... 
INFO  To access the cluster as the system:admin user when using 'oc', run 'export KUBECONFIG=/home/prkumar/.crc/cache/crc_libvirt_v4.1.0.rc0/kubeconfig' 
INFO  Access the OpenShift web-console here: https://console-openshift-console.apps.tt.testing 
INFO  Login to the console with user: kubeadmin, password: DBgjT-T45U2-4yn3o-RiycE 
INFO Running    
```