### PR TITLE
Issue #65 create minimal getting started guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 out/
+docs/build/

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,11 @@ COMMIT_SHA=$(shell git rev-parse --short HEAD)
 # Go and compilation related variables
 BUILD_DIR ?= out
 
+# Docs build related variables
+DOCS_BUILD_DIR ?= $(CURDIR)/docs/build
+DOCS_BUILD_CONTAINER ?= registry.gitlab.com/gbraad/asciidoctor-centos:latest
+DOCS_BUILD_TARGET ?= /docs/source/getting-started/master.adoc
+
 GOOS ?= $(shell go env GOOS)
 GOARCH ?= $(shell go env GOARCH)
 ORG := github.com/code-ready
@@ -70,8 +75,16 @@ cross: $(BUILD_DIR)/darwin-amd64/crc $(BUILD_DIR)/linux-amd64/crc $(BUILD_DIR)/w
 test:
 	go test -v -ldflags="$(VERSION_VARIABLES)" $(shell $(PACKAGES))
 
+.PHONY: build_docs
+build_docs:
+	podman run -v $(CURDIR)/docs:/docs --rm $(DOCS_BUILD_CONTAINER) -b html5 -D $(DOCS_BUILD_DIR) $(DOCS_BUILD_TARGET)
+
+.PHONY: clean_docs
+clean_docs:
+	rm -rf $(DOCS_BUILD_DIR)
+
 .PHONY: clean ## Remove all build artifacts
-clean:
+clean: clean_docs
 	rm -rf $(BUILD_DIR)
 	rm -f $(GOPATH)/bin/crc
 

--- a/docs/source/common-content/attributes.adoc
+++ b/docs/source/common-content/attributes.adoc
@@ -1,0 +1,26 @@
+// AsciiDoc rendering
+:source-highlighter: prettify
+:last-update-label!:
+:attribute-missing: warn
+:toc: left
+:toclevels: 3
+:numbered:
+:sectanchors:
+:sectlinks:
+:experimental:
+
+// Platforms
+:rh: Red{nbsp}Hat
+:rhel: {rh} Enterprise{nbsp}Linux
+:fed: Fedora
+:centos: CentOS
+:mac: macOS
+:msw: Microsoft Windows
+
+// Product naming
+:prod: CodeReady Containers
+:rh-prod: {rh} {prod}
+:bin: crc
+
+// URLs
+:oc-download-url: https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/

--- a/docs/source/getting-started/common-content
+++ b/docs/source/getting-started/common-content
@@ -1,0 +1,1 @@
+../common-content

--- a/docs/source/getting-started/content/assembly_getting-started.adoc
+++ b/docs/source/getting-started/content/assembly_getting-started.adoc
@@ -1,0 +1,14 @@
+[id="getting-started-with-codeready-containers_{context}"]
+= Getting started with {rh-prod}
+
+include::con_understanding-codeready-containers.adoc[leveloffset=+1]
+
+include::proc_setting-up-codeready-containers.adoc[leveloffset=+1]
+
+include::proc_starting-the-virtual-machine.adoc[leveloffset=+1]
+
+include::proc_accessing-the-openshift-cluster.adoc[leveloffset=+1]
+
+include::proc_stopping-the-virtual-machine.adoc[leveloffset=+1]
+
+include::proc_deleting-the-virtual-machine.adoc[leveloffset=+1]

--- a/docs/source/getting-started/content/assembly_troubleshooting.adoc
+++ b/docs/source/getting-started/content/assembly_troubleshooting.adoc
@@ -1,0 +1,4 @@
+[id="troubleshooting-codeready-containers_{context}"]
+= Troubleshooting {rh-prod}
+
+include::proc_basic-troubleshooting.adoc[leveloffset=+1]

--- a/docs/source/getting-started/content/con_understanding-codeready-containers.adoc
+++ b/docs/source/getting-started/content/con_understanding-codeready-containers.adoc
@@ -1,0 +1,11 @@
+[id="understanding-codeready-containers_{context}"]
+= Understanding {prod}
+
+[IMPORTANT]
+====
+{rh-prod} currently runs on the {rhel}, {centos}, and {fed} operating systems using the `libvirt` driver.
+====
+
+{rh-prod} brings a minimal OpenShift 4.0 or newer cluster to your local computer.
+
+{prod} includes the [command]`{bin}` command-line interface (CLI) to interact with the {prod} virtual machine running the OpenShift cluster.

--- a/docs/source/getting-started/content/proc_accessing-the-openshift-cluster.adoc
+++ b/docs/source/getting-started/content/proc_accessing-the-openshift-cluster.adoc
@@ -1,0 +1,80 @@
+[id="accessing-the-openshift-cluster_{context}"]
+= Accessing the OpenShift cluster
+
+.Prerequisites
+
+* A running {prod} virtual machine.
+For more information, see <<starting-the-virtual-machine_{context}>>.
+* The link:{oc-download-url}[latest OpenShift client binary] ([command]`oc`) in your `_PATH_`.
+
+.Procedure
+
+* To access the OpenShift web console, follow these steps:
+
+  . Open the OpenShift web console URL printed in the output of the [command]`{bin} start` command:
++
+[subs="+quotes,attributes"]
+----
+$ _browser_command_ https://console-openshift-console.apps.tt.testing
+----
+// Can we use `xdg-open` here instead?
+
+  . Log in to the OpenShift web console as the `kubeadmin` user with the password printed in the output of the [command]`{bin} start` command.
++
+[NOTE]
+====
+You can also view the password for the `kubeadmin` user in the [filename]`~/.crc/cache/crc_libvirt_v4.1.0.rc0/kubeadmin-password` file.
+====
++
+See <<troubleshooting-codeready-containers_{context}>> if you cannot access the {prod} OpenShift cluster.
+
+* To access the OpenShift cluster via the [command]`oc` command, follow these steps:
+
+// TODO: Use attributes for the path here. Avoids manually maintaining it.
+  . Export the Kubernetes configuration for the {prod} OpenShift cluster:
++
+[subs="+quotes,attributes"]
+----
+$ export KUBECONFIG="$HOME/.crc/cache/crc_libvirt_v4.1.0.rc0/kubeconfig"
+----
+
+  . Verify that the OpenShift cluster operators are available using the [command]`oc get co` command:
++
+[subs="+quotes,attributes"]
+----
+$ oc get co
+NAME                                 VERSION      AVAILABLE   PROGRESSING   FAILING   SINCE
+authentication                       4.1.0-rc.0   True        False         False     6d6h
+cloud-credential                     4.1.0-rc.0   True        False         False     6d6h
+cluster-autoscaler                   4.1.0-rc.0   True        False         False     6d6h
+console                              4.1.0-rc.0   True        False         False     6d6h
+dns                                  4.1.0-rc.0   True        False         False     89m
+image-registry                       4.1.0-rc.0   True        False         False     6d6h
+ingress                              4.1.0-rc.0   True        False         False     89m
+kube-apiserver                       4.1.0-rc.0   True        False                   6d6h
+kube-controller-manager              4.1.0-rc.0   True        False                   6d6h
+kube-scheduler                       4.1.0-rc.0   True        False                   6d6h
+machine-api                          4.1.0-rc.0   True        False         False     6d6h
+machine-config                       4.1.0-rc.0   False       False         True      6d6h
+marketplace                          4.1.0-rc.0   False       False         True      6d6h
+monitoring                                        Unknown     True          Unknown   6d6h
+network                              4.1.0-rc.0   True        False                   6d6h
+node-tuning                          4.1.0-rc.0   True        False         False     89m
+openshift-apiserver                  4.1.0-rc.0   True        False                   6d6h
+openshift-controller-manager         4.1.0-rc.0   True        False                   5d11h
+openshift-samples                    4.1.0-rc.0   True        False         False     6d6h
+operator-lifecycle-manager           4.1.0-rc.0   True        False         False     6d6h
+operator-lifecycle-manager-catalog   4.1.0-rc.0   True        False         False     6d6h
+service-ca                           4.1.0-rc.0   True        False         False     6d6h
+service-catalog-apiserver            4.1.0-rc.0   True        False         False     88m
+service-catalog-controller-manager   4.1.0-rc.0   True        False         False     88m
+storage                              4.1.0-rc.0   True        False         False     6d6h
+----
++
+[NOTE]
+====
+The `machine-config` and `marketplace` cluster operators are expected to report `False` availability.
+The `monitoring` cluster operator is expected to report `Unknown` availability.
+====
++
+See <<troubleshooting-codeready-containers_{context}>> if you cannot access the {prod} OpenShift cluster.

--- a/docs/source/getting-started/content/proc_basic-troubleshooting.adoc
+++ b/docs/source/getting-started/content/proc_basic-troubleshooting.adoc
@@ -1,0 +1,41 @@
+[id="basic-troubleshooting_{context}"]
+= Basic troubleshooting
+
+The majority of issues can be resolved by stopping a running {prod} virtual machine, deleting the virtual machine, and starting a new instance of the virtual machine.
+
+.Prerequisites
+
+* The host machine has been set up using the [command]`{bin} setup` command.
+For more information, see <<setting-up-codeready-containers_{context}>>.
+* The virtual machine has been started using the [command]`{bin} start` command.
+For more information, see <<starting-the-virtual-machine_{context}>>.
+
+.Procedure
+
+To troubleshoot {prod}, perform the following steps:
+
+. Stop the {prod} virtual machine:
++
+[subs="+quotes,attributes"]
+----
+$ {bin} stop
+----
+
+. Delete the {prod} virtual machine:
++
+[subs="+quotes,attributes"]
+----
+$ {bin} delete
+----
+
+. Start the {prod} virtual machine:
++
+[subs="+quotes,attributes"]
+----
+$ {bin} start -b _path_to_system_bundle_
+----
+
+[NOTE]
+====
+The cluster takes a minimum of four minutes to start the necessary containers and operators before serving a request.
+====

--- a/docs/source/getting-started/content/proc_deleting-the-virtual-machine.adoc
+++ b/docs/source/getting-started/content/proc_deleting-the-virtual-machine.adoc
@@ -1,0 +1,13 @@
+[id="deleting-the-virtual-machine_{context}"]
+= Deleting the virtual machine
+
+The [command]`{bin} delete` command deletes an existing {prod} virtual machine.
+
+.Procedure
+
+* Delete the {prod} virtual machine:
++
+[subs="+quotes,attributes"]
+----
+$ {bin} delete
+----

--- a/docs/source/getting-started/content/proc_setting-up-codeready-containers.adoc
+++ b/docs/source/getting-started/content/proc_setting-up-codeready-containers.adoc
@@ -1,0 +1,20 @@
+[id="setting-up-codeready-containers_{context}"]
+= Setting up {prod}
+
+The [command]`{bin} setup` command performs operations to set up the environment of your host machine for the {prod} virtual machine.
+
+This procedure will create the [filename]`~/.crc` directory if it does not already exist.
+
+.Prerequisites
+
+// TODO: Verify that we need `sudo` permissions.
+* Your user account must have permission to use the [command]`sudo` command.
+
+.Procedure
+
+. Set up your host machine for {prod}:
++
+[subs="+quotes,attributes"]
+----
+$ {bin} setup
+----

--- a/docs/source/getting-started/content/proc_starting-the-virtual-machine.adoc
+++ b/docs/source/getting-started/content/proc_starting-the-virtual-machine.adoc
@@ -1,0 +1,24 @@
+[id="starting-the-virtual-machine_{context}"]
+= Starting the virtual machine
+
+The [command]`{bin} start` command starts the {prod} virtual machine and OpenShift cluster.
+
+.Prerequisites
+
+* The host machine has been set up using the [command]`{bin} setup` command.
+For more information, see <<setting-up-codeready-containers_{context}>>.
+* A valid OpenShift system bundle in the `.tar.xz` format.
+
+.Procedure
+
+* Start the {prod} virtual machine:
++
+[subs="+quotes,attributes"]
+----
+$ {bin} start -b _path_to_system_bundle_
+----
+
+[NOTE]
+====
+The cluster takes a minimum of four minutes to start the necessary containers and operators before serving a request.
+====

--- a/docs/source/getting-started/content/proc_stopping-the-virtual-machine.adoc
+++ b/docs/source/getting-started/content/proc_stopping-the-virtual-machine.adoc
@@ -1,0 +1,13 @@
+[id="stopping-the-virtual-machine_{context}"]
+= Stopping the virtual machine
+
+The [command]`{bin} stop` command stops the running {prod} virtual machine and OpenShift cluster.
+
+.Procedure
+
+* Stop the {prod} virtual machine and OpenShift cluster:
++
+[subs="+quotes,attributes"]
+----
+$ {bin} stop
+----

--- a/docs/source/getting-started/master.adoc
+++ b/docs/source/getting-started/master.adoc
@@ -1,0 +1,9 @@
+include::common-content/attributes.adoc[]
+
+:context: gsg
+
+= Getting Started Guide
+
+include::content/assembly_getting-started.adoc[leveloffset=+1]
+
+include::content/assembly_troubleshooting.adoc[leveloffset=+1]


### PR DESCRIPTION
Fixes #65. This PR creates a minimal getting started guide. This is more of a "quick start" guide at the moment.

This PR also addresses the initial documentation structure (#64). (**Note:** edited to avoid closing #64, as this PR does not fully address all of the needs.)

Fixes #66. This PR adds the `build_docs` target to the Makefile to build the documentation with AsciiDoctor via `podman` using the `registry.gitlab.com/gbraad/asciidoctor-centos:latest` container. Built docs are stored in `docs/build`, and `docs/build/` has been added to the `.gitignore` file for this repository.

Thank you!