### PR TITLE
Add dnsmasq with container and use the container IP as DNS server.

### DIFF
--- a/cmd/crc/cmd/daemon/dns.go
+++ b/cmd/crc/cmd/daemon/dns.go
@@ -1,9 +1,8 @@
 package daemon
 
 import (
-	"github.com/spf13/cobra"
-
 	"github.com/code-ready/crc/pkg/crc/services/dns"
+	"github.com/spf13/cobra"
 )
 
 var (


### PR DESCRIPTION
So we can use podman `ip` option to run a container with specific ip, so we are now running a dnsmasq container on `10.88.0.8` and binding it to host 53/udp using as privileged container. As part of our VM setting we using the `crc.testing` as search option and also container IP as 1st nameserver. Now all the `crc.testing` query resolved by that container and also openshift dns container not complain about not having an upstream server.

Moving forward we need to convert this as systemd service.
