### PR TITLE
Issue #181 add instructions for building the user documentation as html

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -21,7 +21,23 @@ Check back for updates, we plan to have something available "soon".
 [[documentation]]
 == Documentation
 
-- link:./developing.adoc[Developing CodeReady Containers]
+=== Using CodeReady Containers
+
+You can find the source files for the documentation in the link:./docs/source[docs/source] directory.
+
+To build the formatted documentation, use the following:
+
+```bash
+$ git clone https://github.com/code-ready/crc
+$ cd crc
+$ make build_docs
+```
+
+This will create a [filename]`docs/build/master.html` file which you can view in your browser.
+
+=== Developing CodeReady Containers
+
+Developers who want to work on CodeReady Containers should visit the link:./developing.adoc[Developing CodeReady Containers] document.
 
 [[community]]
 == Community


### PR DESCRIPTION
This change adds simple instructions to the top-level README
for building the user documentation as html so that it's
nicely formatted and easily accessible. It also points to
the raw content if a user does not want to build the html.