### PR TITLE
Issue #188 Change crc/errors with errors package

### DIFF
--- a/pkg/crc/init.go
+++ b/pkg/crc/init.go
@@ -10,6 +10,6 @@ func init() {
 	var err error
 	state.GlobalState, err = state.NewGlobalState(constants.GlobalStatePath)
 	if err != nil {
-		log.InfoF("Error loading global state: %s", err.Error())
+		log.DebugF("Error loading global state: %s", err.Error())
 	}
 }

--- a/pkg/crc/oc/oc_cache.go
+++ b/pkg/crc/oc/oc_cache.go
@@ -122,7 +122,7 @@ func (oc *OcCached) cacheOc() error {
 }
 
 func copy(src, dest string) error {
-	logging.InfoF(" Copying '%s' to '%s'\n", src, dest)
+	logging.DebugF("Copying '%s' to '%s'\n", src, dest)
 	srcFile, err := os.Open(src)
 	defer srcFile.Close()
 	if err != nil {

--- a/pkg/crc/preflight/preflight_checks_linux.go
+++ b/pkg/crc/preflight/preflight_checks_linux.go
@@ -2,6 +2,7 @@ package preflight
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -15,7 +16,6 @@ import (
 	"text/template"
 
 	"github.com/code-ready/crc/pkg/crc/constants"
-	"github.com/code-ready/crc/pkg/crc/errors"
 	"github.com/code-ready/crc/pkg/crc/logging"
 	"github.com/code-ready/crc/pkg/crc/machine/libvirt"
 	"github.com/code-ready/crc/pkg/crc/oc"
@@ -175,7 +175,7 @@ func checkUserPartOfLibvirtGroup() (bool, error) {
 		logging.Debug("Current user is already in the libvirt group")
 		return true, nil
 	}
-	return false, errors.NewF("%s not part of libvirtd group", currentUser.Username)
+	return false, fmt.Errorf("%s not part of libvirtd group", currentUser.Username)
 }
 
 func fixUserPartOfLibvirtGroup() (bool, error) {

--- a/pkg/crc/preflight/preflight_checks_windows.go
+++ b/pkg/crc/preflight/preflight_checks_windows.go
@@ -1,7 +1,9 @@
 package preflight
 
 import (
-	"github.com/code-ready/crc/pkg/crc/errors"
+	"errors"
+	"fmt"
+
 	"github.com/code-ready/crc/pkg/crc/logging"
 	"github.com/code-ready/crc/pkg/crc/oc"
 )
@@ -19,7 +21,7 @@ func checkOcBinaryCached() (bool, error) {
 func fixOcBinaryCached() (bool, error) {
 	oc := oc.OcCached{}
 	if err := oc.EnsureIsCached(); err != nil {
-		return false, errors.NewF("Not able to download oc %v", err)
+		return false, fmt.Errorf("Not able to download oc %v", err)
 	}
 	logging.Debug("oc binary cached")
 	return true, nil


### PR DESCRIPTION
Function/methods which need to return an error without
putting in the logs should be using fmt.ErrorF or error standard
package.