### PR TITLE
Issue #193 Add kubeadmin user login info instead exporting system:admin kubeconfig

### DIFF
--- a/pkg/crc/constants/constants.go
+++ b/pkg/crc/constants/constants.go
@@ -19,6 +19,7 @@ const (
 	DefaultBundle        = "crc_libvirt_4.1.0-rc.5.tar.xz"
 	DefaultHostname      = "crc-g8g2v-master-0"
 	DefaultWebConsoleURL = "https://console-openshift-console.apps-crc.testing"
+	DefaultAPIURL        = "https://api.crc.testing:6443"
 	DefaultDiskImage     = "crc.disk"
 	DefaultLogLevel      = "info"
 	ConfigFile           = "crc.json"

--- a/pkg/crc/machine/machine.go
+++ b/pkg/crc/machine/machine.go
@@ -78,7 +78,8 @@ func Start(startConfig StartConfig) (StartResult, error) {
 	clusterConfig := ClusterConfig{
 		KubeConfig:    filepath.Join(extractedPath, crcBundleMetadata.ClusterInfo.KubeConfig),
 		KubeAdminPass: string(kubeadminPassword),
-		ClusterAPI:    constants.DefaultWebConsoleURL,
+		WebConsoleURL: constants.DefaultWebConsoleURL,
+		ClusterAPI:    constants.DefaultAPIURL,
 	}
 
 	result.ClusterConfig = clusterConfig
@@ -200,8 +201,8 @@ func Start(startConfig StartConfig) (StartResult, error) {
 	// If no error, return usage message
 	if result.Error == "" {
 		time.Sleep(time.Minute * 3)
-		logging.InfoF("To access the cluster as the system:admin user when using 'oc', run 'export KUBECONFIG=%s'", result.ClusterConfig.KubeConfig)
-		logging.InfoF("Access the OpenShift web-console here: %s", result.ClusterConfig.ClusterAPI)
+		logging.InfoF("To access the cluster using 'oc', run 'oc login -u kubeadmin -p %s %s'", result.ClusterConfig.KubeAdminPass, result.ClusterConfig.ClusterAPI)
+		logging.InfoF("Access the OpenShift web-console here: %s", result.ClusterConfig.WebConsoleURL)
 		logging.InfoF("Login to the console with user: kubeadmin, password: %s", result.ClusterConfig.KubeAdminPass)
 		if os.CurrentOS() == os.DARWIN {
 			logging.WarnF(fmt.Sprintf("Make sure add 'nameserver %s' as first entry to '/etc/resolv.conf' file", instanceIP))

--- a/pkg/crc/machine/types.go
+++ b/pkg/crc/machine/types.go
@@ -21,6 +21,7 @@ type ClusterConfig struct {
 	KubeConfig    string
 	KubeAdminPass string
 	ClusterAPI    string
+	WebConsoleURL string
 }
 
 type StartResult struct {

--- a/pkg/crc/services/dns/dns.go
+++ b/pkg/crc/services/dns/dns.go
@@ -67,9 +67,9 @@ func RunPostStart(serviceConfig services.ServicePostStartConfig) (services.Servi
 
 func CheckCRCLocalDNSReachable(serviceConfig services.ServicePostStartConfig) (string, error) {
 	appsURI := fmt.Sprintf("foo.%s", serviceConfig.BundleMetadata.ClusterInfo.AppsDomain)
-	return drivers.RunSSHCommandFromDriver(serviceConfig.Driver,fmt.Sprintf("host -R 3 %s", appsURI))
+	return drivers.RunSSHCommandFromDriver(serviceConfig.Driver, fmt.Sprintf("host -R 3 %s", appsURI))
 }
 
 func CheckCRCPublicDNSReachable(serviceConfig services.ServicePostStartConfig) (string, error) {
-	return drivers.RunSSHCommandFromDriver(serviceConfig.Driver,fmt.Sprintf("host -R 3 %s", publicDNSQueryURI))
+	return drivers.RunSSHCommandFromDriver(serviceConfig.Driver, fmt.Sprintf("host -R 3 %s", publicDNSQueryURI))
 }


### PR DESCRIPTION
Now output would be like.

```
INFO To access the cluster using 'oc', run 'oc login -u kubeadmin -p xxx.xxx.xxxx https://api.crc.testing:6443' 
INFO Access the OpenShift web-console here: https://console-openshift-console.apps-crc.testing 
INFO Login to the console with user: kubeadmin, password: xxxx-xxxx-xxxx-xxxx

```