### PR TITLE
Issue #235 Copy kubeconfig file from cache to instance dir

### DIFF
--- a/pkg/crc/constants/constants.go
+++ b/pkg/crc/constants/constants.go
@@ -27,14 +27,15 @@ const (
 )
 
 var (
-	CrcBaseDir      = filepath.Join(GetHomeDir(), ".crc")
-	ConfigPath      = filepath.Join(CrcBaseDir, ConfigFile)
-	LogFilePath     = filepath.Join(CrcBaseDir, LogFile)
-	MachineBaseDir  = CrcBaseDir
-	MachineCertsDir = filepath.Join(MachineBaseDir, "certs")
-	MachineCacheDir = filepath.Join(MachineBaseDir, "cache")
-	OcCacheDir      = filepath.Join(MachineCacheDir, "oc")
-	GlobalStatePath = filepath.Join(CrcBaseDir, GlobalStateFile)
+	CrcBaseDir         = filepath.Join(GetHomeDir(), ".crc")
+	ConfigPath         = filepath.Join(CrcBaseDir, ConfigFile)
+	LogFilePath        = filepath.Join(CrcBaseDir, LogFile)
+	MachineBaseDir     = CrcBaseDir
+	MachineCertsDir    = filepath.Join(MachineBaseDir, "certs")
+	MachineCacheDir    = filepath.Join(MachineBaseDir, "cache")
+	OcCacheDir         = filepath.Join(MachineCacheDir, "oc")
+	MachineInstanceDir = filepath.Join(MachineBaseDir, "machines")
+	GlobalStatePath    = filepath.Join(CrcBaseDir, GlobalStateFile)
 )
 
 // GetHomeDir returns the home directory for the current user

--- a/pkg/crc/oc/oc_cache.go
+++ b/pkg/crc/oc/oc_cache.go
@@ -2,17 +2,18 @@ package oc
 
 import (
 	"fmt"
-	"github.com/code-ready/crc/pkg/crc/constants"
-	"github.com/code-ready/crc/pkg/crc/logging"
-	"github.com/code-ready/crc/pkg/download"
-	"github.com/code-ready/crc/pkg/extract"
-	"github.com/pkg/errors"
-	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
+
+	"github.com/code-ready/crc/pkg/crc/constants"
+	"github.com/code-ready/crc/pkg/crc/logging"
+	"github.com/code-ready/crc/pkg/download"
+	"github.com/code-ready/crc/pkg/extract"
+	crcos "github.com/code-ready/crc/pkg/os"
+	"github.com/pkg/errors"
 )
 
 const (
@@ -102,7 +103,7 @@ func (oc *OcCached) cacheOc() error {
 		}
 
 		finalBinaryPath := filepath.Join(outputPath, binaryName)
-		copy(binaryPath, finalBinaryPath)
+		crcos.CopyFileContents(binaryPath, finalBinaryPath, 0755)
 		if err != nil {
 			return err
 		}
@@ -114,33 +115,6 @@ func (oc *OcCached) cacheOc() error {
 
 		return nil
 	}
-	return nil
-}
-
-func copy(src, dest string) error {
-	logging.DebugF("Copying '%s' to '%s'\n", src, dest)
-	srcFile, err := os.Open(src)
-	defer srcFile.Close()
-	if err != nil {
-		return errors.Wrapf(err, "Cannot open src file '%s'", src)
-	}
-
-	destFile, err := os.Create(dest)
-	defer destFile.Close()
-	if err != nil {
-		return errors.Wrapf(err, "Cannot create dst file '%s'", dest)
-	}
-
-	_, err = io.Copy(destFile, srcFile)
-	if err != nil {
-		return errors.Wrapf(err, "Cannot copy '%s' to '%s'", src, dest)
-	}
-
-	err = destFile.Sync()
-	if err != nil {
-		return errors.Wrapf(err, "Cannot copy '%s' to '%s'", src, dest)
-	}
-
 	return nil
 }
 

--- a/pkg/os/util.go
+++ b/pkg/os/util.go
@@ -2,9 +2,12 @@ package os
 
 import (
 	"fmt"
+	"io"
+	"os"
 	"runtime"
 	"strings"
 
+	"github.com/code-ready/crc/pkg/crc/logging"
 	"github.com/kardianos/osext"
 )
 
@@ -54,4 +57,31 @@ func CurrentExecutable() (string, error) {
 		return "", err
 	}
 	return currentExec, nil
+}
+
+func CopyFileContents(src string, dst string, permission os.FileMode) error {
+	logging.DebugF("Copying '%s' to '%s'\n", src, dst)
+	srcFile, err := os.Open(src)
+	defer srcFile.Close()
+	if err != nil {
+		return fmt.Errorf("[%v] Cannot open src file '%s'", err, src)
+	}
+
+	destFile, err := os.OpenFile(dst, os.O_RDWR|os.O_CREATE, permission)
+	defer destFile.Close()
+	if err != nil {
+		return fmt.Errorf("[%v] Cannot create dst file '%s'", err, dst)
+	}
+
+	_, err = io.Copy(destFile, srcFile)
+	if err != nil {
+		return fmt.Errorf("[%v] Cannot copy '%s' to '%s'", err, src, dst)
+	}
+
+	err = destFile.Sync()
+	if err != nil {
+		return fmt.Errorf("[%v] Cannot sync '%s' to '%s'", err, src, dst)
+	}
+
+	return nil
 }


### PR DESCRIPTION
This kubeconfig file is system:admin role and this should
be used for cluster admin operations like resource creation
on different namespace or getting the information. Sometime
User just export it from cache dir just after installation
and this will be bloated if they start login to different
clusters without unsetting it.