### PR TITLE
Misc logs/comments improvements

### DIFF
--- a/cmd/crc/cmd/config/get.go
+++ b/cmd/crc/cmd/config/get.go
@@ -18,7 +18,7 @@ var configGetCmd = &cobra.Command{
 to the options that you set when you run the 'crc start' command.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) < 1 {
-			output.Out("Please a provide a configuration property to retrieve")
+			output.Out("Please provide a configuration property to retrieve")
 			os.Exit(1)
 		}
 		runConfigGet(args[0])

--- a/cmd/crc/cmd/config/set.go
+++ b/cmd/crc/cmd/config/set.go
@@ -18,7 +18,7 @@ var configSetCmd = &cobra.Command{
 to the options that you set when you run the 'crc start' command.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) < 2 {
-			errors.ExitWithMessage(1, "Please a provide a configuration property and value to set")
+			errors.ExitWithMessage(1, "Please provide a configuration property and value to set")
 		}
 		runConfigSet(args[0], args[1])
 	},

--- a/cmd/crc/cmd/delete.go
+++ b/cmd/crc/cmd/delete.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/code-ready/crc/pkg/crc/constants"
+	"github.com/code-ready/crc/pkg/crc/errors"
 	"github.com/code-ready/crc/pkg/crc/input"
 	"github.com/code-ready/crc/pkg/crc/machine"
 	"github.com/code-ready/crc/pkg/crc/output"
@@ -37,11 +38,11 @@ func runDelete(arguments []string) {
 		deleteCache()
 	}
 
-	commandResult, err := machine.Delete(deleteConfig)
-	output.Out(commandResult.Success)
+	_, err := machine.Delete(deleteConfig)
 	if err != nil {
-		output.Out(err.Error())
+		errors.ExitWithMessage(1, err.Error())
 	}
+	output.Out("CodeReady Containers instance deleted")
 }
 
 func deleteCache() {

--- a/cmd/crc/cmd/root.go
+++ b/cmd/crc/cmd/root.go
@@ -48,7 +48,6 @@ func init() {
 }
 
 func runPrerun() {
-	output.OutF("%s - %s\n", commandName, descriptionShort)
 	// Setting up logrus
 	logging.InitLogrus(logging.LogLevel)
 	logging.SetupFileHook()

--- a/cmd/crc/cmd/start.go
+++ b/cmd/crc/cmd/start.go
@@ -38,7 +38,7 @@ var (
 
 func runStart(arguments []string) {
 	if err := validateStartFlags(); err != nil {
-		errors.ExitWithMessage(1, err.Error())
+		errors.Exit(1)
 	}
 
 	preflight.StartPreflightChecks()
@@ -53,11 +53,10 @@ func runStart(arguments []string) {
 	}
 
 	commandResult, err := machine.Start(startConfig)
-	logging.InfoF(commandResult.Status)
 	if err != nil {
-		errors.ExitWithMessage(1, err.Error())
+		errors.Exit(1)
 	}
-
+	logging.InfoF(commandResult.Status)
 }
 
 func initStartCmdFlagSet() *pflag.FlagSet {

--- a/cmd/crc/cmd/start.go
+++ b/cmd/crc/cmd/start.go
@@ -12,6 +12,7 @@ import (
 	"github.com/code-ready/crc/pkg/crc/errors"
 	"github.com/code-ready/crc/pkg/crc/logging"
 	"github.com/code-ready/crc/pkg/crc/machine"
+	"github.com/code-ready/crc/pkg/crc/output"
 	"github.com/code-ready/crc/pkg/crc/preflight"
 	"github.com/code-ready/crc/pkg/crc/validation"
 )
@@ -56,7 +57,11 @@ func runStart(arguments []string) {
 	if err != nil {
 		errors.Exit(1)
 	}
-	logging.InfoF(commandResult.Status)
+	if commandResult.Status == "Running" {
+		output.Out("CodeReady Containers instance is running")
+	} else {
+		logging.WarnF("Unexpected status: %s", commandResult.Status)
+	}
 }
 
 func initStartCmdFlagSet() *pflag.FlagSet {

--- a/cmd/crc/cmd/stop.go
+++ b/cmd/crc/cmd/stop.go
@@ -4,6 +4,7 @@ import (
 	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/code-ready/crc/pkg/crc/errors"
 	"github.com/code-ready/crc/pkg/crc/input"
+	"github.com/code-ready/crc/pkg/crc/logging"
 	"github.com/code-ready/crc/pkg/crc/machine"
 	"github.com/code-ready/crc/pkg/crc/output"
 	"github.com/code-ready/machine/libmachine/state"
@@ -50,13 +51,18 @@ func runStop(arguments []string) {
 		}
 		errors.ExitWithMessage(1, err.Error())
 	}
-	output.Out(commandResult.Success)
+	if commandResult.Success {
+		output.Out("CodeReady Containers instance stopped")
+	} else {
+		/* If we did not get an error, the status should be true */
+		logging.WarnF("Unexpected status %v", commandResult.Success)
+	}
 }
 
 func killVM(killConfig machine.PowerOffConfig) {
-	commandResult, err := machine.PowerOff(killConfig)
-	output.Out(commandResult.Success)
+	_, err := machine.PowerOff(killConfig)
 	if err != nil {
 		errors.ExitWithMessage(1, err.Error())
 	}
+	output.Out("CodeReady Containers instance forcibly stopped")
 }

--- a/pkg/crc/config/validations.go
+++ b/pkg/crc/config/validations.go
@@ -17,7 +17,7 @@ func ValidateBool(value interface{}) (bool, string) {
 	return false, "true/false"
 }
 
-// ValidateDriver is check if driver is valid in the config
+// ValidateDriver checks if driver is valid in the config
 func ValidateDriver(value interface{}) (bool, string) {
 	if err := validation.ValidateDriver(value.(string)); err != nil {
 		return false, err.Error()
@@ -25,7 +25,7 @@ func ValidateDriver(value interface{}) (bool, string) {
 	return true, ""
 }
 
-// ValidateCPUs is check if provided cpus count is valid in the config
+// ValidateCPUs checks if provided cpus count is valid in the config
 func ValidateCPUs(value interface{}) (bool, string) {
 	v, err := strconv.Atoi(value.(string))
 	if err != nil {
@@ -37,7 +37,7 @@ func ValidateCPUs(value interface{}) (bool, string) {
 	return true, ""
 }
 
-// ValidateMemory is check if provided memory is valid in the config
+// ValidateMemory checks if provided memory is valid in the config
 func ValidateMemory(value interface{}) (bool, string) {
 	v, err := strconv.Atoi(value.(string))
 	if err != nil {
@@ -49,7 +49,7 @@ func ValidateMemory(value interface{}) (bool, string) {
 	return true, ""
 }
 
-// ValidateBundle is check if provided bundle path is valid
+// ValidateBundle checks if provided bundle path is valid
 func ValidateBundle(value interface{}) (bool, string) {
 	if err := validation.ValidateBundle(value.(string)); err != nil {
 		return false, err.Error()

--- a/pkg/crc/errors/error.go
+++ b/pkg/crc/errors/error.go
@@ -8,11 +8,11 @@ import (
 )
 
 func New(text string) error {
-	logging.Error(fmt.Sprintf("Error occured: %s", text))
+	logging.Error(fmt.Sprintf("Error occurred: %s", text))
 	return goerrors.New(text)
 }
 
 func NewF(text string, args ...interface{}) error {
-	logging.ErrorF(fmt.Sprintf("Error occured: %s", text), args...)
+	logging.ErrorF(fmt.Sprintf("Error occurred: %s", text), args...)
 	return fmt.Errorf(text, args...)
 }

--- a/pkg/crc/services/dns/dns.go
+++ b/pkg/crc/services/dns/dns.go
@@ -88,11 +88,11 @@ func RunPostStart(serviceConfig services.ServicePostStartConfig) (services.Servi
 
 func CheckCRCLocalDNSReachable(serviceConfig services.ServicePostStartConfig) (string, error) {
 	appsURI := fmt.Sprintf("foo.%s", serviceConfig.BundleMetadata.ClusterInfo.AppsDomain)
-	// Try 3 times for 1 second interval, In nested environment most of time crc failed to get
+	// Try 30 times for 1 second interval, In nested environment most of time crc failed to get
 	// Internal dns query resolved for some time.
 	var queryOutput string
 	var err error
-	for i := 0; i <= 3; i++ {
+	for i := 0; i <= 30; i++ {
 		time.Sleep(time.Second)
 		queryOutput, err = drivers.RunSSHCommandFromDriver(serviceConfig.Driver, fmt.Sprintf("host -R 3 %s", appsURI))
 		if err == nil {

--- a/pkg/crc/validation/validation.go
+++ b/pkg/crc/validation/validation.go
@@ -18,7 +18,7 @@ func ValidateDriver(driver string) error {
 	return errors.NewF("Unsupported driver: %s, use '--vm-driver' option to provide a supported driver %s\n", driver, machine.SupportedDriverValues())
 }
 
-// ValidateCPUs is check if provided cpus count is valid
+// ValidateCPUs checks if provided cpus count is valid
 func ValidateCPUs(value int) error {
 	if value < constants.DefaultCPUs {
 		return errors.NewF("CPUs required >=%d", constants.DefaultCPUs)
@@ -26,7 +26,7 @@ func ValidateCPUs(value int) error {
 	return nil
 }
 
-// ValidateMemory is check if provided Memory count is valid
+// ValidateMemory checks if provided Memory count is valid
 func ValidateMemory(value int) error {
 	if value < constants.DefaultMemory {
 		return errors.NewF("Memory required >=%d", constants.DefaultMemory)
@@ -34,10 +34,10 @@ func ValidateMemory(value int) error {
 	return nil
 }
 
-// ValidateBundle is check if provided bundle path exist
+// ValidateBundle checks if provided bundle path exist
 func ValidateBundle(bundle string) error {
 	if _, err := os.Stat(bundle); os.IsNotExist(err) {
-		return errors.NewF("Provided file %s does not exist", bundle)
+		return errors.NewF("Expected file %s does not exist", bundle)
 	}
 	return nil
 }

--- a/test/integration/features/basic.feature
+++ b/test/integration/features/basic.feature
@@ -32,12 +32,12 @@ Checks whether CRC top-level commands behave correctly.
   Scenario: CRC start
     When executing "crc start -b ~/Downloads/crc_libvirt_4.1.0.tar.xz" succeeds
     Then stdout should contain "Creating VM"
-    And stdout should contain "Running"
+    And stdout should contain "CodeReady Containers instance is running"
     
   Scenario: CRC stop
     When executing "crc stop -f" succeeds
-    Then stdout should contain "true"
+    Then stdout should contain "CodeReady Containers instance stopped"
     
   Scenario: CRC delete
     When executing "crc delete" succeeds
-    Then stdout should contain "true"
+    Then stdout should contain "CodeReady Containers instance deleted"


### PR DESCRIPTION
This pull request fixes a few typos, and improves user logs after running `crc start/stop/delete`. This is related to #224 even if this is not improving the specific command mentioned in the issue.