### PR TITLE
[Hold] Issue #237 Wait for cluster operators to be available

### DIFF
--- a/pkg/crc/oc/clusteroperator.go
+++ b/pkg/crc/oc/clusteroperator.go
@@ -1,0 +1,78 @@
+package oc
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/code-ready/crc/pkg/crc/logging"
+	"time"
+)
+
+var ignoreClusterOperators = []string{"monitoring", "machine-config", "marketplace"}
+
+type ClusterOperator struct {
+	Items []struct {
+		Metadata struct {
+			Name string `json:"name"`
+		} `json:"metadata"`
+		Status struct {
+			Conditions []struct {
+				LastTransitionTime time.Time `json:"lastTransitionTime"`
+				Reason             string    `json:"reason"`
+				Status             string    `json:"status"`
+				Type               string    `json:"type"`
+			} `json:"conditions"`
+		} `json:"status,omitempty"`
+	} `json:"items"`
+}
+
+func GetClusterOperatorStatus(oc OC) (bool, error) {
+	allAvailable := true
+	data, stderr, err := oc.RunOcCommand("get", "co", "-ojson")
+	if err != nil {
+		return false, fmt.Errorf("%s - %v", stderr, err)
+	}
+
+	var co ClusterOperator
+
+	err = json.Unmarshal([]byte(data), &co)
+	if err != nil {
+		return false, err
+	}
+	for _, c := range co.Items {
+		if contains(c.Metadata.Name, ignoreClusterOperators) {
+			continue
+		}
+		for _, con := range c.Status.Conditions {
+			switch con.Type {
+			case "Available":
+				if con.Status != "True" {
+					logging.Info(c.Metadata.Name, "operator not available, retrying ...")
+					logging.Debug(c.Metadata.Name, "operator not available, Reason: ", con.Reason)
+					allAvailable = false
+				}
+			case "Degraded":
+				if con.Status != "False" {
+					logging.Info(c.Metadata.Name, "operator is degraded, retrying ...")
+					logging.Debug(c.Metadata.Name, "operator is degraded, Reason: ", con.Reason)
+					allAvailable = false
+				}
+			case "Progressing":
+				if con.Status != "False" {
+					logging.Info(c.Metadata.Name, "operator is still progressing ...")
+					logging.Debug(c.Metadata.Name, "operator is still progressing, Reason: ", con.Reason)
+					allAvailable = false
+				}
+			}
+		}
+	}
+	return allAvailable, nil
+}
+
+func contains(value string, list []string) bool {
+	for _, v := range list {
+		if v == value {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
User should know after 3 mins if any operator is still not completely
in the *Available* state then they should wait before putting workload.