### PR TITLE
Fix of golangci-lint warnings in dns_darwin.go

### DIFF
--- a/pkg/crc/services/dns/dns_darwin.go
+++ b/pkg/crc/services/dns/dns_darwin.go
@@ -75,7 +75,7 @@ func restartNetwork(serviceConfig services.ServicePostStartConfig) (bool, error)
 		return false, err
 	}
 	for _, netdevice := range strings.Split(netDeviceList, "\n")[1:] {
-		time.Sleep(2 * time.Nanosecond)
+		time.Sleep(2 * time.Second)
 		_, stderr, err := crcos.RunWithDefaultLocale("networksetup", "-setnetworkserviceenabled", netdevice, "off")
 		if err != nil {
 			return false, fmt.Errorf("%s: %v", stderr, err)


### PR DESCRIPTION
Fixed warnings:
```
pkg/crc/services/dns/dns_darwin.go:53:11: Error return value of `t.Execute` is not checked (errcheck)
    t.Execute(&resolverFile, values)
             ^
pkg/crc/services/dns/dns_darwin.go:31:2: ineffectual assignment to `success` (ineffassign)
    success, err := createResolverFile(serviceConfig.IP, filepath.Join("/", "etc", "resolver", serviceConfig.BundleMetadata.ClusterInfo.BaseDomain))
    ^
pkg/crc/services/dns/dns_darwin.go:72:6: ineffectual assignment to `stderr` (ineffassign)
	_, stderr, err := crcos.RunWithDefaultLocale("networksetup", "-setnetworkserviceenabled", netdevice, "off")
	   ^
pkg/crc/preflight/preflight_checks_darwin.go:40:3: ineffectual assignment to `path` (ineffassign)
	path, err = os.Readlink(path)

pkg/crc/services/dns/dns_darwin.go:71:14: SA1004: sleeping for 2 nanoseconds is probably a bug. Be explicit if it isn't: time.Sleep(2 * time.Nanosecond) (staticcheck)
	time.Sleep(2)
```
Reference issue https://github.com/code-ready/crc/issues/226