### PR TITLE
Don't crash when machine.createHost() fails

### DIFF
--- a/pkg/crc/machine/machine.go
+++ b/pkg/crc/machine/machine.go
@@ -94,6 +94,7 @@ func Start(startConfig StartConfig) (StartResult, error) {
 		if err != nil {
 			logging.ErrorF("Error creating host: %v", err)
 			result.Error = err.Error()
+			return *result, err
 		}
 
 		vmState, err := host.Driver.GetState()


### PR DESCRIPTION
There are plenty of reasons why this function may fail, and when this
happens, we get a nil 'host'. As we try to use 'host' just after
calling machine.createHost(), we need to return otherwise we'll get a
crash.

This should resolve #219
https://github.com/code-ready/crc/issues/219

INFO Creating VM ...
ERRO Error occured: Error creating the VM. [Error with pre-create check: "VBoxManage not found. Make sure VirtualBox is installed and VBoxManage is in the path"]
ERRO Error creating host: Error creating the VM. Error with pre-create check: "VBoxManage not found. Make sure VirtualBox is installed and VBoxManage is in the path"
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x14639a6]

goroutine 1 [running]:
github.com/code-ready/crc/pkg/crc/machine.Start(0x164d6b0, 0x3, 0xc0000d8720, 0x1d, 0x7ffeefbffc19, 0xa, 0x2000, 0x4, 0x0, 0x0, ...)
        /Users/teuf/go/src/github.com/code-ready/crc/pkg/crc/machine/machine.go:99 +0x20a6
github.com/code-ready/crc/cmd/crc/cmd.runStart(0xc0001a6000, 0x0, 0x2)
        /Users/teuf/go/src/github.com/code-ready/crc/cmd/crc/cmd/start.go:55 +0x258
github.com/code-ready/crc/cmd/crc/cmd.glob..func6(0x1b5d520, 0xc0001a6000, 0x0, 0x2)
        /Users/teuf/go/src/github.com/code-ready/crc/cmd/crc/cmd/start.go:31 +0x3f
github.com/code-ready/crc/vendor/github.com/spf13/cobra.(*Command).execute(0x1b5d520, 0xc0000bffe0, 0x2, 0x2, 0x1b5d520, 0xc0000bffe0)
        /Users/teuf/go/src/github.com/code-ready/crc/vendor/github.com/spf13/cobra/command.go:766 +0x2ae
github.com/code-ready/crc/vendor/github.com/spf13/cobra.(*Command).ExecuteC(0x1b5dea0, 0x100775f, 0xc000092058, 0x0)
        /Users/teuf/go/src/github.com/code-ready/crc/vendor/github.com/spf13/cobra/command.go:852 +0x2ec
github.com/code-ready/crc/vendor/github.com/spf13/cobra.(*Command).Execute(...)
        /Users/teuf/go/src/github.com/code-ready/crc/vendor/github.com/spf13/cobra/command.go:800
github.com/code-ready/crc/cmd/crc/cmd.Execute()
        /Users/teuf/go/src/github.com/code-ready/crc/cmd/crc/cmd/root.go:63 +0x2e
main.main()
        /Users/teuf/go/src/github.com/code-ready/crc/cmd/crc/main.go:10 +0x25