### PR TITLE
Issue #248 Use dns server from VM to resolve domain in linux.

### DIFF
--- a/pkg/crc/constants/constants.go
+++ b/pkg/crc/constants/constants.go
@@ -16,7 +16,6 @@ const (
 
 	CrcEnvPrefix = "CRC"
 
-	DefaultHostname      = "crc-56mmj-master-0"
 	DefaultWebConsoleURL = "https://console-openshift-console.apps-crc.testing"
 	DefaultAPIURL        = "https://api.crc.testing:6443"
 	DefaultDiskImage     = "crc.disk"

--- a/pkg/crc/machine/driver.go
+++ b/pkg/crc/machine/driver.go
@@ -11,11 +11,10 @@ import (
 )
 
 type MachineDriver struct {
-	Name          string
-	Platform      crcos.OS
-	Driver        string
-	UseDNSService bool
-	DriverPath    string
+	Name       string
+	Platform   crcos.OS
+	Driver     string
+	DriverPath string
 }
 
 var (

--- a/pkg/crc/machine/driver_darwin.go
+++ b/pkg/crc/machine/driver_darwin.go
@@ -7,18 +7,16 @@ import (
 
 func init() {
 	HyperkitDriver := MachineDriver{
-		Name:          "Hyperkit",
-		Platform:      crcos.DARWIN,
-		Driver:        "hyperkit",
-		UseDNSService: true,
-		DriverPath:    constants.CrcBinDir,
+		Name:       "Hyperkit",
+		Platform:   crcos.DARWIN,
+		Driver:     "hyperkit",
+		DriverPath: constants.CrcBinDir,
 	}
 
 	VirtualBoxMacOSDriver := MachineDriver{
-		Name:          "VirtualBox",
-		Platform:      crcos.DARWIN,
-		Driver:        "virtualbox",
-		UseDNSService: true,
+		Name:     "VirtualBox",
+		Platform: crcos.DARWIN,
+		Driver:   "virtualbox",
 	}
 
 	SupportedDrivers = []MachineDriver{

--- a/pkg/crc/machine/driver_linux.go
+++ b/pkg/crc/machine/driver_linux.go
@@ -7,11 +7,10 @@ import (
 
 func init() {
 	LibvirtDriver := MachineDriver{
-		Name:          "Libvirt",
-		Platform:      crcos.LINUX,
-		Driver:        "libvirt",
-		UseDNSService: false,
-		DriverPath:    constants.CrcBinDir,
+		Name:       "Libvirt",
+		Platform:   crcos.LINUX,
+		Driver:     "libvirt",
+		DriverPath: constants.CrcBinDir,
 	}
 
 	SupportedDrivers = []MachineDriver{

--- a/pkg/crc/machine/driver_windows.go
+++ b/pkg/crc/machine/driver_windows.go
@@ -6,17 +6,15 @@ import (
 
 func init() {
 	HyperVDriver := MachineDriver{
-		Name:          "Microsoft Hyper-V",
-		Platform:      crcos.WINDOWS,
-		Driver:        "hyperv",
-		UseDNSService: true,
+		Name:     "Microsoft Hyper-V",
+		Platform: crcos.WINDOWS,
+		Driver:   "hyperv",
 	}
 
 	VirtualBoxWindowsDriver := MachineDriver{
-		Name:          "VirtualBox",
-		Platform:      crcos.WINDOWS,
-		Driver:        "virtualbox",
-		UseDNSService: true,
+		Name:     "VirtualBox",
+		Platform: crcos.WINDOWS,
+		Driver:   "virtualbox",
 	}
 
 	SupportedDrivers = []MachineDriver{

--- a/pkg/crc/machine/libvirt/templates.go
+++ b/pkg/crc/machine/libvirt/templates.go
@@ -13,7 +13,7 @@ const (
 	<mac address='52:54:00:fd:be:d0'/>
 	<ip family='ipv4' address='192.168.130.1' prefix='24'>
 	  <dhcp>
-		<host mac='{{ .MAC }}' name='{{ .HostName }}' ip='{{ .IP }}'/>
+		<host mac='{{ .MAC }}' ip='{{ .IP }}'/>
 	  </dhcp>
 	</ip>
   </network>`
@@ -21,7 +21,6 @@ const (
 
 type NetworkConfig struct {
 	NetworkName string
-	HostName    string
 	MAC         string
 	IP          string
 }

--- a/pkg/crc/machine/libvirt/templates.go
+++ b/pkg/crc/machine/libvirt/templates.go
@@ -11,15 +11,6 @@ const (
 	</forward>
 	<bridge name='crc' stp='on' delay='0'/>
 	<mac address='52:54:00:fd:be:d0'/>
-	<domain name='crc.testing' localOnly='yes'/>
-	<dns>
-	  <srv service='etcd-server-ssl' protocol='tcp' domain='crc.testing' target='etcd-0.crc.testing' port='2380' weight='10'/>
-	  <host ip='{{ .IP }}'>
-		<hostname>api.crc.testing</hostname>
-		<hostname>api-int.crc.testing</hostname>
-		<hostname>etcd-0.crc.testing</hostname>
-	  </host>
-	</dns>
 	<ip family='ipv4' address='192.168.130.1' prefix='24'>
 	  <dhcp>
 		<host mac='{{ .MAC }}' name='{{ .HostName }}' ip='{{ .IP }}'/>

--- a/pkg/crc/machine/machine.go
+++ b/pkg/crc/machine/machine.go
@@ -280,13 +280,12 @@ func Start(startConfig StartConfig) (StartResult, error) {
 		BundleMetadata: *crcBundleMetadata,
 	}
 
-	// If driver need dns service then start it
-	if driverInfo.UseDNSService {
-		if _, err := dns.RunPostStart(servicePostStartConfig); err != nil {
-			result.Error = err.Error()
-			return *result, errors.Newf("Error running post start: %v", err)
-		}
+	// Run the dns server inside the VM
+	if _, err := dns.RunPostStart(servicePostStartConfig); err != nil {
+		result.Error = err.Error()
+		return *result, errors.Newf("Error running post start: %v", err)
 	}
+
 	// Check DNS looksup before starting the kubelet
 	if queryOutput, err := dns.CheckCRCLocalDNSReachable(servicePostStartConfig); err != nil {
 		result.Error = err.Error()

--- a/pkg/crc/preflight/preflight_checks_linux.go
+++ b/pkg/crc/preflight/preflight_checks_linux.go
@@ -32,8 +32,8 @@ const (
 
 var (
 	crcDnsmasqConfigPath = filepath.Join(string(filepath.Separator), "etc", "NetworkManager", "dnsmasq.d", crcDnsmasqConfigFile)
-	crcDnsmasqConfig     = `server=/crc.testing/192.168.130.1
-address=/apps-crc.testing/192.168.130.11
+	crcDnsmasqConfig     = `server=/apps-crc.testing/192.168.130.11
+server=/crc.testing/192.168.130.11
 `
 	crcNetworkManagerConfigPath = filepath.Join(string(filepath.Separator), "etc", "NetworkManager", "conf.d", crcNetworkManagerConfigFile)
 	crcNetworkManagerConfig     = `[main]

--- a/pkg/crc/preflight/preflight_checks_linux.go
+++ b/pkg/crc/preflight/preflight_checks_linux.go
@@ -285,16 +285,6 @@ func checkLibvirtCrcNetworkAvailable() (bool, error) {
 		stdOut = strings.TrimSpace(stdOut)
 		if strings.HasPrefix(stdOut, "crc") {
 			logging.Debug("libvirt 'crc' network exists")
-			logging.Debug("Checking if libvirt 'crc' network definition contains ", constants.DefaultHostname)
-			// Check if the network have defined hostname. It might be possible that User already have an outdated crc network
-			stdOut, stdErr, err = crcos.RunWithDefaultLocale("virsh", "--connect", "qemu:///system", "net-dumpxml", libvirt.DefaultNetwork)
-			if err != nil {
-				return false, fmt.Errorf("%+v: %s", err, stdErr)
-			}
-			if !strings.Contains(stdOut, constants.DefaultHostname) {
-				return false, fmt.Errorf("crc network is not updated with %s hostname, use 'crc setup' to update it.", constants.DefaultHostname)
-			}
-			logging.Debug("libvirt 'crc' network definition contains ", constants.DefaultHostname)
 			return true, nil
 		}
 	}
@@ -305,7 +295,6 @@ func fixLibvirtCrcNetworkAvailable() (bool, error) {
 	logging.Debug("Creating libvirt 'crc' network")
 	config := libvirt.NetworkConfig{
 		NetworkName: libvirt.DefaultNetwork,
-		HostName:    constants.DefaultHostname,
 		MAC:         libvirt.MACAddress,
 		IP:          libvirt.IPAddress,
 	}


### PR DESCRIPTION
Now that we are running dnsmasq in the crc VM, we can have a simpler dnsmasq configuration on the host to directly add the dns server to /etc/resolv.conf

Don't spend time on review this change right now, I still have to figure out some of the missing parts.