### PR TITLE
Issue #262 Fix typo in docs URL

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -23,6 +23,12 @@ Check back for updates, we plan to have something available "soon".
 
 === Using CodeReady Containers
 
+The documentation for CodeReady Containers is currently hosted by GitHub Pages.
+
+See the link:https//code-ready.github.io/crc/[Red Hat CodeReady Containers Getting Started Guide].
+
+=== Building the documentation
+
 You can find the source files for the documentation in the link:./docs/source[docs/source] directory.
 
 To build the formatted documentation, use the following:

--- a/README.adoc
+++ b/README.adoc
@@ -25,7 +25,7 @@ Check back for updates, we plan to have something available "soon".
 
 The documentation for CodeReady Containers is currently hosted by GitHub Pages.
 
-See the link:https//code-ready.github.io/crc/[Red Hat CodeReady Containers Getting Started Guide].
+See the link:https://code-ready.github.io/crc/[Red Hat CodeReady Containers Getting Started Guide].
 
 === Building the documentation
 


### PR DESCRIPTION
Apparently, there was a typo that I missed in the previous fix. This should fix the URL so that it appropriately leads to the published docs.