### PR TITLE
Issue #272 Verify the user provide bundle against released one

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 BUNDLE_VERSION = 4.1.0
-CRC_VERSION = 0.87.0-alpha-$(BUNDLE_VERSION)
+CRC_VERSION = 0.87.0-alpha
 COMMIT_SHA=$(shell git rev-parse --short HEAD)
 
 # Go and compilation related variables
@@ -37,6 +37,7 @@ PACKAGES := go list ./... | grep -v /out
 
 # Linker flags
 VERSION_VARIABLES := -X $(REPOPATH)/pkg/crc.crcVersion=$(CRC_VERSION) \
+    -X $(REPOPATH)/pkg/crc.bundleVersion=$(BUNDLE_VERSION) \
 	-X $(REPOPATH)/pkg/crc.commitSha=$(COMMIT_SHA)
 
 # https://golang.org/cmd/link/

--- a/cmd/crc/cmd/version.go
+++ b/cmd/crc/cmd/version.go
@@ -37,5 +37,5 @@ var versionCmd = &cobra.Command{
 }
 
 func runPrintVersion(arguments []string) {
-	fmt.Printf("version: %s+%s\n", crcPkg.GetCRCVersion(), crcPkg.GetCommitSha())
+	fmt.Printf("version: %s-%s+%s\n", crcPkg.GetCRCVersion(), crcPkg.GetBundleVersion(), crcPkg.GetCommitSha())
 }

--- a/pkg/crc/machine/machine.go
+++ b/pkg/crc/machine/machine.go
@@ -11,7 +11,6 @@ import (
 	"github.com/code-ready/crc/pkg/crc/errors"
 	"github.com/code-ready/crc/pkg/crc/logging"
 
-	// host and instance related
 	"github.com/code-ready/crc/pkg/crc/network"
 	"github.com/code-ready/crc/pkg/crc/systemd"
 	crcos "github.com/code-ready/crc/pkg/os"
@@ -53,7 +52,7 @@ func Start(startConfig StartConfig) (StartResult, error) {
 		Memory:     startConfig.Memory,
 	}
 
-	logging.InfoF("Extracting the Bundle tarball ...")
+	logging.InfoF("Extracting the %s Bundle tarball ...", filepath.Base(machineConfig.BundlePath))
 	crcBundleMetadata, extractedPath, err := bundle.GetCrcBundleInfo(machineConfig)
 	if err != nil {
 		logging.ErrorF("Error to get bundle Metadata %v", err)

--- a/pkg/crc/validation/validation.go
+++ b/pkg/crc/validation/validation.go
@@ -1,8 +1,12 @@
 package validation
 
 import (
+	"fmt"
 	"os"
+	"path/filepath"
+	"strings"
 
+	"github.com/code-ready/crc/pkg/crc"
 	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/code-ready/crc/pkg/crc/errors"
 	"github.com/code-ready/crc/pkg/crc/machine"
@@ -38,6 +42,12 @@ func ValidateMemory(value int) error {
 func ValidateBundle(bundle string) error {
 	if _, err := os.Stat(bundle); os.IsNotExist(err) {
 		return errors.NewF("Expected file %s does not exist", bundle)
+	}
+	// Check if the version of the bundle provided by user is same as what is released with crc.
+	releaseBundleVersion := crc.GetBundleVersion()
+	userProvidedBundleVersion := filepath.Base(bundle)
+	if !strings.Contains(userProvidedBundleVersion, fmt.Sprintf("%s.tar.xz", releaseBundleVersion)) {
+		return errors.NewF("%s bundle is not supported for this release use updated one (crc_<hypervisor>_%s.tar.xz)", userProvidedBundleVersion, releaseBundleVersion)
 	}
 	return nil
 }

--- a/pkg/crc/version.go
+++ b/pkg/crc/version.go
@@ -23,6 +23,9 @@ var (
 
 	// The SHA-1 of the commit this binary is build off
 	commitSha = "sha-unset"
+
+	// Bundle version which used for the release.
+	bundleVersion = "0.0.0-unset"
 )
 
 func GetCRCVersion() string {
@@ -31,4 +34,8 @@ func GetCRCVersion() string {
 
 func GetCommitSha() string {
 	return commitSha
+}
+
+func GetBundleVersion() string {
+	return bundleVersion
 }


### PR DESCRIPTION
Most of the time user using older version of crc bundle with new
release and this give an unexpected error to the user. We always
need to use the bundle version which released as part of the release.
This check make sure user is going to use the updated one.

Minor refactor around getting bundle info as part of version.