### PR TITLE
Add more integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,8 +92,9 @@ clean: clean_docs
 
 .PHONY: integration ## Run integration tests
 integration: GODOG_OPTS = --godog.tags=$(GOOS)
+integration: BUNDLE_LOCATION = http://cdk-builds.usersys.redhat.com/builds/crc/4.1.3/libvirt/crc_libvirt_4.1.3.tar.xz
 integration:
-	go test --timeout=60m $(REPOPATH)/test/integration -v --tags=integration $(GODOG_OPTS) $(BUNDLE_LOCATION)
+	go test $(REPOPATH)/test/integration -v --timeout=60m --tags=integration $(GODOG_OPTS) --bundle=$(BUNDLE_LOCATION)
 
 .PHONY: fmt
 fmt:

--- a/centos_ci.sh
+++ b/centos_ci.sh
@@ -138,7 +138,7 @@ if [[ "$UID" = 0 ]]; then
 	prepare_ci_user
 	runuser -l crc_ci -c "/bin/bash centos_ci.sh"
 else
-	source ~/jenkins-env # Source environment variables for minishift_ci user
+	source ~/jenkins-env # Source environment variables for crc_ci user
 	export TERM=xterm-256color
 	get_bundle
 	setup_golang

--- a/test/integration/crcsuite/prepare.go
+++ b/test/integration/crcsuite/prepare.go
@@ -13,18 +13,17 @@ import (
 	"github.com/code-ready/crc/pkg/download"
 )
 
-// Download bundle for testing
-func DownloadBundle(bundleLocation string, bundleDestination string) (string, error) {
+// Get the bundle for testing
+func GetBundle(bundleLocation string, bundleDestination string) (string, error) {
 
+	// Copy the bundle locally
 	if bundleLocation[:4] != "http" {
-
-		// copy the file locall
 
 		if bundleDestination == "." {
 			bundleDestination, _ = os.Getwd()
 		}
 		fmt.Printf("Copying bundle from %s to %s.\n", bundleLocation, bundleDestination)
-		bundleDestination = filepath.Join(bundleDestination, bundleName)
+		bundleDestination = filepath.Join(bundleDestination, BundleName)
 
 		source, err := os.Open(bundleLocation)
 		if err != nil {
@@ -48,6 +47,7 @@ func DownloadBundle(bundleLocation string, bundleDestination string) (string, er
 		return bundleDestination, err
 	}
 
+	// Download the bundle over http
 	filename, err := download.Download(bundleLocation, bundleDestination)
 	fmt.Printf("Downloading bundle from %s to %s.\n", bundleLocation, bundleDestination)
 	if err != nil {
@@ -57,12 +57,10 @@ func DownloadBundle(bundleLocation string, bundleDestination string) (string, er
 	return filename, nil
 }
 
-// Parse GODOG flags (in feature files)
 func ParseFlags() {
 
-	flag.Parse()
-	bundleURL = flag.Args()[0]
-	_, bundleName = filepath.Split(bundleURL)
+	flag.StringVar(&BundleLocation, "bundle", "", "Bundle URL or filepath")
+
 }
 
 // Set CRCHome var to ~/.crc
@@ -70,4 +68,10 @@ func SetCRCHome() string {
 	usr, _ := user.Current()
 	crcHome := filepath.Join(usr.HomeDir, ".crc")
 	return crcHome
+}
+
+func SetBundleName() string {
+
+	_, bname := filepath.Split(BundleLocation)
+	return bname
 }

--- a/test/integration/crcsuite/util.go
+++ b/test/integration/crcsuite/util.go
@@ -10,13 +10,27 @@ import (
 )
 
 // Delete CRC instance
-func DeleteCRC() error {
+func DeleteCRC() {
 
 	command := "crc delete"
-	_ = clicumber.ExecuteCommand(command)
+	err := clicumber.ExecuteCommandSucceedsOrFails(command, "succeeds")
+	if err != nil {
+		fmt.Errorf("Failed to delete CRC.\n")
+	} else {
+		fmt.Printf("Deleted CRC instance (if one existed).\n")
+	}
+}
 
-	fmt.Printf("Deleted CRC instance (if one existed).\n")
-	return nil
+// Delete CRC instance
+func ForceStopCRC() {
+
+	command := "crc stop -f"
+	err := clicumber.ExecuteCommandSucceedsOrFails(command, "succeeds")
+	if err != nil {
+		fmt.Errorf("Failed to forcibly stop CRC.\n")
+	} else {
+		fmt.Printf("Forcibly stopped CRC instance (if one was running).\n")
+	}
 }
 
 // Remove CRC home folder ~/.crc

--- a/test/integration/features/basic.feature
+++ b/test/integration/features/basic.feature
@@ -48,9 +48,14 @@ Feature: Basic test
     Scenario: CRC start on Mac
         When starting CRC with default bundle and hypervisor "virtualbox" succeeds
         Then stdout should contain "CodeReady Containers instance is running"
-    
+
     @darwin @linux @windows
-    Scenario: CRC kill
+    Scenario: CRC IP
+        When executing "crc ip" succeeds
+        Then stdout should match "\d+\.\d+\.\d+\.\d+"
+
+    @darwin @linux @windows
+    Scenario: CRC forcible stop
         When executing "crc stop -f"
         Then stdout should contain "CodeReady Containers instance stopped"
     

--- a/test/integration/features/oc.feature
+++ b/test/integration/features/oc.feature
@@ -1,0 +1,108 @@
+Feature:
+    Health check of the cluster after CRC start.
+
+    Scenario Outline: Set-up
+        Given executing "crc setup" succeeds
+        When starting CRC with default bundle and hypervisor "<vm-driver>" succeeds
+        Then stdout should contain "CodeReady Containers instance is running"
+        And executing "eval $(crc oc-env)" succeeds
+        And executing "oc login --insecure-skip-tls-verify -u kubeadmin -p ehbg7-zu5i6-JKt7V-PvJsm https://api.crc.testing:6443" succeeds
+
+        @darwin
+        Examples:
+        | vm-driver  |
+        | virtualbox |
+
+        @linux
+        Examples:
+        | vm-driver |
+        | libvirt   |
+
+    # Nodes
+    @darwin @linux @windows
+    Scenario: Checking master-worker node
+        When executing "oc get nodes" succeeds
+        Then stdout should contain "Ready"
+        And stdout should not contain "Not Ready"
+       
+
+    # Cluster operators
+    @darwin @linux @windows
+    Scenario Outline: Checking cluster operators available
+        Given check at most "2" times with delay of "60s" that cluster operator "<name>" is available
+
+        Examples:
+            | name                               |
+            | authentication                     |
+            | cloud-credential                   |
+            | cluster-autoscaler                 |
+            | console                            |
+            | dns                                |
+            | image-registry                     |
+            | ingress                            |
+            | kube-apiserver                     |
+            | kube-controller-manager            |
+            | kube-scheduler                     |
+            | machine-api                        |
+            | marketplace                        |
+            | monitoring                         |
+            | node-tuning                        |
+            | openshift-apiserver                |
+            | openshift-controller-manager       |
+            | openshift-samples                  |
+            | operator-lifecycle-manager         |
+            | operator-lifecycle-manager-catalog |
+            | service-ca                         |
+            | service-catalog-apiserver          |
+            | service-catalog-controller-manager |
+            | storage                            |
+
+    # machine-config is special: never available
+    @darwin @linux @windows
+    Scenario Outline: Checking cluster operators not available
+        Given check at most "2" times with delay of "60s" that cluster operator "<name>" is not available
+
+        Examples:
+            | name           |
+            | machine-config |
+
+    # machine-config is special: forever progressing
+    @darwin @linux @windows
+    Scenario Outline: Checking cluster operators not progressing
+        Given check at most "5" times with delay of "60s" that cluster operator "<name>" is not progressing
+
+        Examples:
+            | name                               |
+            | authentication                     |
+            | cloud-credential                   |
+            | cluster-autoscaler                 |
+            | console                            |
+            | dns                                |
+            | image-registry                     |
+            | ingress                            |
+            | kube-apiserver                     |
+            | kube-controller-manager            |
+            | kube-scheduler                     |
+            | machine-api                        |
+            | marketplace                        |
+            | monitoring                         |
+            | node-tuning                        |
+            | openshift-apiserver                |
+            | openshift-controller-manager       |
+            | openshift-samples                  |
+            | operator-lifecycle-manager         |
+            | operator-lifecycle-manager-catalog |
+            | service-ca                         |
+            | service-catalog-apiserver          |
+            | service-catalog-controller-manager |
+            | storage                            |
+
+    @darwin @linux @windows
+    Scenario: CRC stop
+        When executing "crc stop -f" succeeds
+        Then stdout should contain "CodeReady Containers instance stopped"
+       
+    @darwin @linux @windows
+    Scenario: CRC delete
+        When executing "crc delete" succeeds
+        Then stdout should contain "CodeReady Containers instance deleted"

--- a/test/integration/features/story.feature
+++ b/test/integration/features/story.feature
@@ -1,0 +1,49 @@
+Feature: 
+    End-to-end health check. Set-up and start CRC. Then create a
+    project and deploy an app. Check on the app and delete the
+    project. Stop and delete CRC.
+
+    Scenario Outline: Start CRC
+        Given executing "crc setup" succeeds
+        When starting CRC with default bundle and hypervisor "<vm-driver>" succeeds
+        Then stdout should contain "CodeReady Containers instance is running"
+        And executing "eval $(crc oc-env)" succeeds
+        And executing "oc login --insecure-skip-tls-verify -u kubeadmin -p ehbg7-zu5i6-JKt7V-PvJsm https://api.crc.testing:6443" succeeds
+        
+    @darwin
+        Examples:
+            | vm-driver  |
+            | virtualbox |
+            |            |
+    @linux
+        Examples:
+            | vm-driver |
+            | libvirt   |
+
+    @darwin @linux
+    Scenario: Create new project
+        When executing "oc new-project testproj" succeeds
+        Then stdout should contain
+            """
+            Now using project "testproj" on server "https://api.crc.testing:6443".
+            """
+        And stdout should contain "You can add applications to this project with the 'new-app' command."
+
+    @darwin @linux
+    Scenario: Create new app
+        When executing "oc new-app cakephp-mysql-example" succeeds
+        Then stdout should contain "Creating resources"
+        And stdout should contain
+            """
+            service "cakephp-mysql-example" created
+            """
+        And check at most "20" times with delay of "60s" that pod "cakephp-mysql-example-1-build" is initialized
+        And with up to "10" retries with wait period of "60s" command "curl -kI http://cakephp-mysql-example-testproj.apps-crc.testing" output should contain "HTTP/1.1 200 OK"
+
+    Scenario: Clean up project
+        Given executing "oc delete project testproj" succeeds
+        When executing "crc stop -f" succeeds
+        Then stdout should contain "CodeReady Containers instance stopped"
+        When executing "crc delete" succeeds
+        Then stdout should contain "CodeReady Containers instance deleted"
+

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -47,17 +47,21 @@ func TestMain(m *testing.M) {
 }
 
 func getFeatureContext(s *godog.Suite) {
-	// load default step definitions of clicumber testsuite
-	testsuite.FeatureContext(s)
 
-	// here you can load additional step definitions, for example:
+	// NOTE:
+	// Preserve the order in which FeatureContexts are loaded.
+
+	testsuite.FeatureContext(s) // Clicumber step definitions
+
 	crcsuite.FeatureContext(s) // CRC specific step definitions
+
 }
 
 func parseFlags() {
-	// get flag values for clicumber testsuite
+
+	// NOTE:
+	// testsuite.ParseFlags() needs to be last - it calls flag.Parse()
+	crcsuite.ParseFlags()
 	testsuite.ParseFlags()
 
-	// here you can get additional flag values if needed, for example:
-	crcsuite.ParseFlags()
 }


### PR DESCRIPTION
This PR contains new integration tests. This is wip and I'll be glad to hear what to add/replace/remove/rework. 

- interaction with oc command (in `oc.feature`)
- end-to-end story creating an app (in `story.feature`)

The `oc` command interaction is only basic as we'll adopt OpenShift extended tests and we do not want to duplicate much work. The story is a very simple health check of the cluster (if an app can be deployed then at least something has to be working :) ). 

Thanks for feedback!