### PR TITLE
Issue #278 install podman before make build_docs

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -31,7 +31,7 @@ See the link:https://code-ready.github.io/crc/[Red Hat CodeReady Containers Gett
 
 You can find the source files for the documentation in the link:./docs/source[docs/source] directory.
 
-To build the formatted documentation, use the following:
+To build the formatted documentation, link:https://github.com/containers/libpod/blob/master/install.md[install podman] then use the following:
 
 ```bash
 $ git clone https://github.com/code-ready/crc


### PR DESCRIPTION
For new contributors and people not familiar with podman this small change in the README will make thigs a little clear when generating the locall documentation