### PR TITLE
Issue #281 Add vm driver flag for setup command

### DIFF
--- a/cmd/crc/cmd/setup.go
+++ b/cmd/crc/cmd/setup.go
@@ -1,11 +1,19 @@
 package cmd
 
 import (
-	"github.com/code-ready/crc/pkg/crc/preflight"
+	"fmt"
 	"github.com/spf13/cobra"
+
+	"github.com/code-ready/crc/cmd/crc/cmd/config"
+	"github.com/code-ready/crc/pkg/crc/errors"
+	"github.com/code-ready/crc/pkg/crc/machine"
+	"github.com/code-ready/crc/pkg/crc/preflight"
+	"github.com/code-ready/crc/pkg/crc/validation"
 )
 
 func init() {
+	setupCmd.Flags().StringVarP(&vmDriver, config.VMDriver.Name, "d",
+		machine.DefaultDriver.Driver, fmt.Sprintf("The driver to use for the CRC VM. Possible values: %v", machine.SupportedDriverValues()))
 	rootCmd.AddCommand(setupCmd)
 }
 
@@ -19,5 +27,17 @@ var setupCmd = &cobra.Command{
 }
 
 func runSetup(arguments []string) {
-	preflight.SetupHost()
+	if err := validateSetupFlags(); err != nil {
+		errors.Exit(1)
+	}
+	preflight.SetupHost(vmDriver)
+}
+
+var vmDriver string
+
+func validateSetupFlags() error {
+	if err := validation.ValidateDriver(vmDriver); err != nil {
+		return err
+	}
+	return nil
 }

--- a/cmd/crc/cmd/start.go
+++ b/cmd/crc/cmd/start.go
@@ -42,7 +42,7 @@ func runStart(arguments []string) {
 		errors.Exit(1)
 	}
 
-	preflight.StartPreflightChecks()
+	preflight.StartPreflightChecks(crcConfig.GetString(config.VMDriver.Name))
 
 	startConfig := machine.StartConfig{
 		Name:       constants.DefaultName,

--- a/pkg/crc/preflight/preflight_darwin.go
+++ b/pkg/crc/preflight/preflight_darwin.go
@@ -7,17 +7,21 @@ import (
 )
 
 // StartPreflightChecks performs the preflight checks before starting the cluster
-func StartPreflightChecks() {
+func StartPreflightChecks(vmDriver string) {
 	preflightCheckSucceedsOrFails(false,
 		checkOcBinaryCached,
 		"Checking if oc binary is cached",
 		false,
 	)
-	preflightCheckSucceedsOrFails(config.GetBool(cmdConfig.SkipCheckVirtualBoxInstalled.Name),
-		checkVirtualBoxInstalled,
-		"Checking if VirtualBox is Installed",
-		config.GetBool(cmdConfig.WarnCheckVirtualBoxInstalled.Name),
-	)
+
+	switch vmDriver {
+	case "virtualbox":
+		preflightCheckSucceedsOrFails(config.GetBool(cmdConfig.SkipCheckVirtualBoxInstalled.Name),
+			checkVirtualBoxInstalled,
+			"Checking if VirtualBox is Installed",
+			config.GetBool(cmdConfig.WarnCheckVirtualBoxInstalled.Name),
+		)
+	}
 
 	preflightCheckSucceedsOrFails(config.GetBool(cmdConfig.SkipCheckResolverFilePermissions.Name),
 		checkResolverFilePermissions,
@@ -33,19 +37,23 @@ func StartPreflightChecks() {
 }
 
 // SetupHost performs the prerequisite checks and setups the host to run the cluster
-func SetupHost() {
+func SetupHost(vmDriver string) {
 	preflightCheckAndFix(false,
 		checkOcBinaryCached,
 		fixOcBinaryCached,
 		"Caching oc binary",
 		false,
 	)
-	preflightCheckAndFix(config.GetBool(cmdConfig.SkipCheckVirtualBoxInstalled.Name),
-		checkVirtualBoxInstalled,
-		fixVirtualBoxInstallation,
-		"Setting up virtualization",
-		config.GetBool(cmdConfig.WarnCheckVirtualBoxInstalled.Name),
-	)
+
+	switch vmDriver {
+	case "virtualbox":
+		preflightCheckAndFix(config.GetBool(cmdConfig.SkipCheckVirtualBoxInstalled.Name),
+			checkVirtualBoxInstalled,
+			fixVirtualBoxInstallation,
+			"Setting up virtualization",
+			config.GetBool(cmdConfig.WarnCheckVirtualBoxInstalled.Name),
+		)
+	}
 
 	preflightCheckAndFix(config.GetBool(cmdConfig.SkipCheckResolverFilePermissions.Name),
 		checkResolverFilePermissions,

--- a/pkg/crc/preflight/preflight_linux.go
+++ b/pkg/crc/preflight/preflight_linux.go
@@ -6,7 +6,7 @@ import (
 )
 
 // StartPreflightChecks performs the preflight checks before starting the cluster
-func StartPreflightChecks() {
+func StartPreflightChecks(vmDriver string) {
 	preflightCheckSucceedsOrFails(false,
 		checkOcBinaryCached,
 		"Checking if oc binary is cached",
@@ -70,7 +70,7 @@ func StartPreflightChecks() {
 }
 
 // SetupHost performs the prerequisite checks and setups the host to run the cluster
-func SetupHost() {
+func SetupHost(vmDriver string) {
 	preflightCheckAndFix(false,
 		checkOcBinaryCached,
 		fixOcBinaryCached,

--- a/pkg/crc/preflight/preflight_windows.go
+++ b/pkg/crc/preflight/preflight_windows.go
@@ -1,7 +1,7 @@
 package preflight
 
 // StartPreflightChecks performs the preflight checks before starting the cluster
-func StartPreflightChecks() {
+func StartPreflightChecks(vmDriver string) {
 	preflightCheckSucceedsOrFails(false,
 		checkOcBinaryCached,
 		"Checking if oc binary is cached",
@@ -10,7 +10,7 @@ func StartPreflightChecks() {
 }
 
 // SetupHost performs the prerequisite checks and setups the host to run the cluster
-func SetupHost() {
+func SetupHost(vmDriver string) {
 	preflightCheckAndFix(false,
 		checkOcBinaryCached,
 		fixOcBinaryCached,


### PR DESCRIPTION
Right now we are doing setup for single hypervisor but in
case of mac we have virtualbox and hyperkit supported so
we need to add setup functionality for both hypervisor and
to do we need a driver flag using that we can make decision
about which hypervisor we need to set.