### PR TITLE
Issue #286 Bundle version taken from Makefile

### DIFF
--- a/test/integration/crcsuite/crcsuite.go
+++ b/test/integration/crcsuite/crcsuite.go
@@ -44,7 +44,7 @@ func FeatureContext(s *godog.Suite) {
 		StartCRCWithDefaultBundleAndDefaultHypervisorSucceedsOrFails)
 	s.Step(`^starting CRC with default bundle and hypervisor "(.*)" (succeeds|fails)$`,
 		StartCRCWithDefaultBundleAndHypervisorSucceedsOrFails)
-	s.Step(`^setting config property "(.*)" to value "(.*)" (succeeds$|fails)$`,
+	s.Step(`^setting config property "(.*)" to value "(.*)" (succeeds|fails)$`,
 		SetConfigPropertyToValueSucceedsOrFails)
 
 	// CRC file operations
@@ -124,6 +124,9 @@ func FileExistsInCRCHome(fileName string) error {
 
 func ConfigFileInCRCHomeContainsKeyMatchingValue(format string, configFile string, condition string, keyPath string, expectedValue string) error {
 
+	if expectedValue == "current bundle" {
+		expectedValue = bundleName
+	}
 	configPath := filepath.Join(CRCHome, configFile)
 
 	config, err := clicumber.GetFileContent(configPath)
@@ -188,6 +191,10 @@ func StartCRCWithDefaultBundleAndHypervisorSucceedsOrFails(hypervisor string, ex
 }
 
 func SetConfigPropertyToValueSucceedsOrFails(property string, value string, expected string) error {
+
+	if value == "current bundle" {
+		value = bundleName
+	}
 
 	cmd := "crc config set " + property + " " + value
 	err := clicumber.ExecuteCommandSucceedsOrFails(cmd, expected)

--- a/test/integration/features/config.feature
+++ b/test/integration/features/config.feature
@@ -13,7 +13,6 @@ Checks whether CRC `config set` command works as expected in conjunction with `c
         @darwin
         Examples: Config settings on Mac 
             | property  | value1                | value2                                     |
-            | bundle    | crc_vbox_4.1.3.tar.xz | /path/to/fake/bundle/crc_vbox_4.1.3.tar.xz |
             | cpus      | 4                     | 3                                          |
             | memory    | 8192                  | 4096                                       |
             | vm-driver | virtualbox            | libvirt                                    |
@@ -21,10 +20,15 @@ Checks whether CRC `config set` command works as expected in conjunction with `c
         @linux
         Examples: Config settings on Linux
             | property  | value1                   | value2                                               |
-            | bundle    | crc_libvirt_4.1.3.tar.xz | /path/to/nonexistent/bundle/crc_libvirt_4.1.3.tar.xz |
             | cpus      | 4                        | 3                                                    |
             | memory    | 8192                     | 4096                                                 |
             | vm-driver | libvirt                  | hyperkit                                             |
+
+    @darwin @linux
+    Scenario: CRC config checks (bundle version)
+        When setting config property "bundle" to value "current bundle" succeeds
+        And "JSON" config file "crc.json" in CRC home folder contains key "bundle" with value matching "current bundle"
+        And setting config property "bundle" to value "/path/to/nonexistent/bundle/crc_hypervisor_version.tar.xz" fails
 
 # WARNINGS
 


### PR DESCRIPTION
This removes the hardcoded bundle version from a feature file. Instead, the bundle is now taken to be the one that CRC was started with. 