### PR TITLE
Make resolv.conf modification more robust

### DIFF
--- a/pkg/crc/network/nameservers.go
+++ b/pkg/crc/network/nameservers.go
@@ -74,15 +74,15 @@ func HasNameserverConfiguredLocally(nameserver NameServer) (bool, error) {
 
 func GetResolvValuesFromHost() (*ResolvFileValues, error) {
 	// TODO: we need to add runtime OS in case of windows.
-	out, stderr, err := crcos.RunWithDefaultLocale("cat", "/etc/resolv.conf")
+	out, err := ioutil.ReadFile("/etc/resolv.conf")
 	if crcos.CurrentOS() == crcos.WINDOWS {
 		// TODO: we need to add logic in case of windows.
 	}
 
 	if err != nil {
-		return nil, fmt.Errorf("%s : %v", stderr, err)
+		return nil, fmt.Errorf("Failed to read resolv.conf: %v", err)
 	}
-	return parseResolveConfFile(out)
+	return parseResolveConfFile(string(out))
 }
 
 func parseResolveConfFile(resolvfile string) (*ResolvFileValues, error) {


### PR DESCRIPTION
This should fix the crash seen in issue #293. The issue is not fully resolved though, as I don't know why we are getting `cat: /etc/resolv.conf: No such file or directory`.