### PR TITLE
Add function to read symlink file.

### DIFF
--- a/pkg/crc/network/nameservers.go
+++ b/pkg/crc/network/nameservers.go
@@ -74,12 +74,17 @@ func HasNameserverConfiguredLocally(nameserver NameServer) (bool, error) {
 
 func GetResolvValuesFromHost() (*ResolvFileValues, error) {
 	// TODO: we need to add runtime OS in case of windows.
-	out, err := ioutil.ReadFile("/etc/resolv.conf")
+	fInfo, err := crcos.GetFilePath("/etc/resolv.conf")
+	if err != nil {
+		return nil, err
+	}
+	out, err := ioutil.ReadFile(fInfo)
 	if crcos.CurrentOS() == crcos.WINDOWS {
 		// TODO: we need to add logic in case of windows.
 	}
 
 	if err != nil {
+		fmt.Println("This is the error here")
 		return nil, fmt.Errorf("Failed to read resolv.conf: %v", err)
 	}
 	return parseResolveConfFile(string(out))

--- a/pkg/os/util.go
+++ b/pkg/os/util.go
@@ -85,3 +85,15 @@ func CopyFileContents(src string, dst string, permission os.FileMode) error {
 
 	return nil
 }
+
+// GetFilePath returns the file path even it is symlink
+func GetFilePath(path string) (string, error) {
+	fInfo, err := os.Lstat(path)
+	if err != nil {
+		return path, err
+	}
+	if fInfo.Mode()&os.ModeSymlink != 0 {
+		return os.Readlink(path)
+	}
+	return path, nil
+}


### PR DESCRIPTION
Most of users on mac have `/etc/resolv.conf` file symlink
to `/var/run/resolv.conf`. Also `waitforNetwork` function
try to read the file which is in updating state during network
reload so reading this file will fail. We need to get the host
nameservers before reloading the network.