### PR TITLE
darwin: Only restart network when needed

### DIFF
--- a/pkg/os/util.go
+++ b/pkg/os/util.go
@@ -1,8 +1,10 @@
 package os
 
 import (
+	"bytes"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"runtime"
 	"strings"
@@ -96,4 +98,18 @@ func GetFilePath(path string) (string, error) {
 		return os.Readlink(path)
 	}
 	return path, nil
+}
+
+func WriteFileIfContentChanged(path string, new_content []byte, perm os.FileMode) (bool, error) {
+	old_content, err := ioutil.ReadFile(path)
+	if (err == nil) && (bytes.Equal(old_content, new_content)) {
+		return false, nil
+	}
+	/* Intentionally ignore errors, just try to write the file if we can't read it */
+
+	err = ioutil.WriteFile(path, new_content, perm)
+	if err != nil {
+		return false, err
+	}
+	return true, nil
 }


### PR DESCRIPTION
We currently have to restart macos network in order so that the changes we
make in /etc/resolver as a regular are used by the OS.
However, this also has the side-effect of killing VPN connections, it
can lead to IP address changes and loss of SSH connectivity, ...
As long as the VM IP did not change, we do not need to modify anything
in /etc/resolver/. This commit takes advantage of that to minimize
network restarts, they only get triggered when the content of
/etc/resolver/ changed.

This is related to https://github.com/code-ready/crc/issues/322