### PR TITLE
Download 'oc' binary to ~/.crc/bin/

### DIFF
--- a/cmd/crc/cmd/oc_env.go
+++ b/cmd/crc/cmd/oc_env.go
@@ -56,7 +56,7 @@ var ocEnvCmd = &cobra.Command{
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {},
 	Run: func(cmd *cobra.Command, args []string) {
 		var shellCfg *OcShellConfig
-		shellCfg, err := getOcShellConfig(constants.OcCacheDir, forceShell)
+		shellCfg, err := getOcShellConfig(constants.CrcBinDir, forceShell)
 		if err != nil {
 			errors.ExitWithMessage(1, fmt.Sprintf("Error running the oc-env command: %s", err.Error()))
 		}

--- a/pkg/crc/constants/constants.go
+++ b/pkg/crc/constants/constants.go
@@ -34,7 +34,6 @@ var (
 	MachineBaseDir     = CrcBaseDir
 	MachineCertsDir    = filepath.Join(MachineBaseDir, "certs")
 	MachineCacheDir    = filepath.Join(MachineBaseDir, "cache")
-	OcCacheDir         = filepath.Join(MachineCacheDir, "oc")
 	MachineInstanceDir = filepath.Join(MachineBaseDir, "machines")
 	GlobalStatePath    = filepath.Join(CrcBaseDir, GlobalStateFile)
 )

--- a/pkg/crc/oc/oc.go
+++ b/pkg/crc/oc/oc.go
@@ -17,7 +17,7 @@ type OcConfig struct {
 // UseOcWithConfig return the oc binary along with valid kubeconfig
 func UseOCWithConfig(machineName string) OcConfig {
 	oc := OcConfig{
-		OcBinaryPath:   filepath.Join(constants.OcCacheDir, constants.OcBinaryName),
+		OcBinaryPath:   filepath.Join(constants.CrcBinDir, constants.OcBinaryName),
 		KubeconfigPath: filepath.Join(constants.MachineInstanceDir, machineName, "kubeconfig"),
 	}
 	return oc

--- a/pkg/crc/oc/oc_cache.go
+++ b/pkg/crc/oc/oc_cache.go
@@ -37,7 +37,7 @@ func (oc *OcCached) EnsureIsCached() error {
 }
 
 func (oc *OcCached) IsCached() bool {
-	if _, err := os.Stat(filepath.Join(constants.OcCacheDir, constants.OcBinaryName)); os.IsNotExist(err) {
+	if _, err := os.Stat(filepath.Join(constants.CrcBinDir, constants.OcBinaryName)); os.IsNotExist(err) {
 		return false
 	}
 	return true
@@ -96,7 +96,7 @@ func (oc *OcCached) cacheOc() error {
 		binaryPath = filepath.Join(binaryPath, binaryName)
 
 		// Copy the requested asset into its final destination
-		outputPath := constants.OcCacheDir
+		outputPath := constants.CrcBinDir
 		err = os.MkdirAll(outputPath, 0755)
 		if err != nil && !os.IsExist(err) {
 			return errors.Wrap(err, "Cannot create the target directory.")


### PR DESCRIPTION
It's currently put in ~/.crc/cache/oc/, but since now we have a
dedicated directory for binaries, we can put 'oc' there too.