### PR TITLE
Retry reading the content of the resolv.conf until time-out reached

### DIFF
--- a/pkg/crc/network/nameservers.go
+++ b/pkg/crc/network/nameservers.go
@@ -59,17 +59,12 @@ func addNameserverToInstance(driver drivers.Driver, nameserver NameServer) {
 
 func GetResolvValuesFromHost() (*ResolvFileValues, error) {
 	// TODO: we need to add runtime OS in case of windows.
-	fInfo, err := crcos.GetFilePath("/etc/resolv.conf")
-	if err != nil {
-		return nil, err
-	}
-	out, err := ioutil.ReadFile(fInfo)
+	out, err := ioutil.ReadFile("/etc/resolv.conf")
 	if crcos.CurrentOS() == crcos.WINDOWS {
 		// TODO: we need to add logic in case of windows.
 	}
 
 	if err != nil {
-		fmt.Println("This is the error here")
 		return nil, fmt.Errorf("Failed to read resolv.conf: %v", err)
 	}
 	return parseResolveConfFile(string(out))

--- a/pkg/crc/services/dns/dns_darwin.go
+++ b/pkg/crc/services/dns/dns_darwin.go
@@ -101,12 +101,20 @@ func restartNetwork() error {
 
 // Wait for Network wait till the network is up, since it is required to resolve external dnsquery
 func waitForNetwork() error {
-	hostResolv, err := network.GetResolvValuesFromHost()
+	var hostResolv *network.ResolvFileValues
+	var err error
+
+	for i := 1; i <= 5; i++ {
+		hostResolv, err = network.GetResolvValuesFromHost()
+		if err == nil {
+			break
+		}
+		time.Sleep(1 * time.Second)
+	}
 	if err != nil {
-		// wait and retry
 		return fmt.Errorf("Unable to read host resolv file (%v)", err)
 	}
-	// retry for 5 times
+	// retry up to 5 times
 	for i := 0; i < 5; i++ {
 		for _, ns := range hostResolv.NameServers {
 			_, _, err := crcos.RunWithDefaultLocale("ping", "-c4", ns.IPAddress)

--- a/pkg/os/util.go
+++ b/pkg/os/util.go
@@ -88,18 +88,6 @@ func CopyFileContents(src string, dst string, permission os.FileMode) error {
 	return nil
 }
 
-// GetFilePath returns the file path even it is symlink
-func GetFilePath(path string) (string, error) {
-	fInfo, err := os.Lstat(path)
-	if err != nil {
-		return path, err
-	}
-	if fInfo.Mode()&os.ModeSymlink != 0 {
-		return os.Readlink(path)
-	}
-	return path, nil
-}
-
 func WriteFileIfContentChanged(path string, new_content []byte, perm os.FileMode) (bool, error) {
 	old_content, err := ioutil.ReadFile(path)
 	if (err == nil) && (bytes.Equal(old_content, new_content)) {


### PR DESCRIPTION
Right now, we are blocking the start in case of a mac host is not able to reach to the network
after network restart. If a host offline then it will block start forever which we don't want.

In current logic if a host is initially connected to vpn and then network restart happen, that means host
now have a different nameserver than before and this test will fail.

Making it non blocking allow us to overcome both the situation without much compromise.

In case of a host connected to vpn restart of network going to change the host nameserver and that will surely fail to ping the previous stored nameservers. If we are changing it to a well known nameserver at least 90% case it will succeed, going to fail only if a organisation block icmp from this nameserver.