### PR TITLE
Issue #349 Add separate hooks for stderr/stdout for logrus

### DIFF
--- a/pkg/crc/logging/file_hook.go
+++ b/pkg/crc/logging/file_hook.go
@@ -1,0 +1,43 @@
+package logging
+
+import (
+	"io"
+
+	"github.com/sirupsen/logrus"
+)
+
+// This is file Hook to send everything in the log file.
+type fileHook struct {
+	file      io.Writer
+	formatter logrus.Formatter
+	level     logrus.Level
+}
+
+func newFileHook(file io.Writer, level logrus.Level, formatter logrus.Formatter) *fileHook {
+	return &fileHook{
+		file:      file,
+		formatter: formatter,
+		level:     level,
+	}
+}
+
+func (h fileHook) Levels() []logrus.Level {
+	var levels []logrus.Level
+	for _, level := range logrus.AllLevels {
+		if level <= h.level {
+			levels = append(levels, level)
+		}
+	}
+
+	return levels
+}
+
+func (h *fileHook) Fire(entry *logrus.Entry) error {
+	line, err := h.formatter.Format(entry)
+	if err != nil {
+		return err
+	}
+
+	_, err = h.file.Write(line)
+	return err
+}

--- a/pkg/crc/logging/stderr_hook.go
+++ b/pkg/crc/logging/stderr_hook.go
@@ -1,0 +1,47 @@
+package logging
+
+import (
+	"io"
+	"os"
+
+	"github.com/sirupsen/logrus"
+)
+
+// This is stdErrHook to send error to the stdErr.
+type stdErrHook struct {
+	stderr    io.Writer
+	formatter logrus.Formatter
+	level     logrus.Level
+}
+
+func newstdErrHook(level logrus.Level, formatter logrus.Formatter) *stdErrHook {
+	return &stdErrHook{
+		stderr:    os.Stderr,
+		formatter: formatter,
+		level:     level,
+	}
+}
+
+func (h stdErrHook) Levels() []logrus.Level {
+	var levels []logrus.Level
+	for _, level := range logrus.AllLevels {
+		if level <= h.level {
+			// Only capture error and Fatal logs.
+			if level == logrus.ErrorLevel || level == logrus.FatalLevel {
+				levels = append(levels, level)
+			}
+		}
+	}
+
+	return levels
+}
+
+func (h *stdErrHook) Fire(entry *logrus.Entry) error {
+	line, err := h.formatter.Format(entry)
+	if err != nil {
+		return err
+	}
+
+	_, err = h.stderr.Write(line)
+	return err
+}

--- a/pkg/crc/logging/stdout_hook.go
+++ b/pkg/crc/logging/stdout_hook.go
@@ -1,0 +1,48 @@
+package logging
+
+import (
+	"io"
+	"os"
+
+	"github.com/sirupsen/logrus"
+)
+
+// This is stdOutHook to send everything except error and Fatal to standard output.
+type stdOutHook struct {
+	stdout    io.Writer
+	formatter logrus.Formatter
+	level     logrus.Level
+}
+
+func newstdOutHook(level logrus.Level, formatter logrus.Formatter) *stdOutHook {
+	return &stdOutHook{
+		stdout:    os.Stdout,
+		formatter: formatter,
+		level:     level,
+	}
+}
+
+func (h stdOutHook) Levels() []logrus.Level {
+	var levels []logrus.Level
+	for _, level := range logrus.AllLevels {
+		if level <= h.level {
+			// Ignore the Error and Fatal logs from stdout
+			if level == logrus.ErrorLevel || level == logrus.FatalLevel {
+				continue
+			}
+			levels = append(levels, level)
+		}
+	}
+
+	return levels
+}
+
+func (h *stdOutHook) Fire(entry *logrus.Entry) error {
+	line, err := h.formatter.Format(entry)
+	if err != nil {
+		return err
+	}
+
+	_, err = h.stdout.Write(line)
+	return err
+}

--- a/test/integration/features/config.feature
+++ b/test/integration/features/config.feature
@@ -122,7 +122,7 @@ Checks whether CRC `config set` command works as expected in conjunction with `c
        And executing "crc config set skip-check-crc-network-active true" succeeds
        # Start CRC
        Then starting CRC with default bundle and default hypervisor fails
-       And stdout contains "Network not found: no network with matching name 'crc'"
+       And stderr contains "Network not found: no network with matching name 'crc'"
 
    @linux
    Scenario: Clean-up


### PR DESCRIPTION
As of now, we are dumping everything in the stdout which
means the error logs are also part of it instead part of
stderr which makes integration testing tedious and not
we should do as per unix standards.