### PR TITLE
Embed bundle in crc binary

### DIFF
--- a/cmd/crc/cmd/config/config.go
+++ b/cmd/crc/cmd/config/config.go
@@ -33,6 +33,8 @@ var (
 	// Preflight checks
 	SkipCheckVirtualBoxInstalled = createSetting("skip-check-virtualbox-installed", nil, []validationFnType{validations.ValidateBool})
 	WarnCheckVirtualBoxInstalled = createSetting("warn-check-virtualbox-installed", nil, []validationFnType{validations.ValidateBool})
+	SkipCheckBundleCached        = createSetting("skip-check-bundle-cached", nil, []validationFnType{validations.ValidateBool})
+	WarnCheckBundleCached        = createSetting("warn-check-bundle-cached", true, []validationFnType{validations.ValidateBool})
 )
 
 // CreateSetting returns a filled struct of ConfigSetting

--- a/cmd/crc/cmd/start.go
+++ b/cmd/crc/cmd/start.go
@@ -78,7 +78,7 @@ func runStart(arguments []string) {
 
 func initStartCmdFlagSet() *pflag.FlagSet {
 	flagSet := pflag.NewFlagSet("start", pflag.ExitOnError)
-	flagSet.StringP(config.Bundle.Name, "b", constants.GetDefaultBundle(), "The system bundle used for deployment of the OpenShift cluster.")
+	flagSet.StringP(config.Bundle.Name, "b", constants.DefaultBundlePath, "The system bundle used for deployment of the OpenShift cluster.")
 	flagSet.StringP(config.VMDriver.Name, "d", machine.DefaultDriver.Driver, fmt.Sprintf("The driver to use for the CRC VM. Possible values: %v", machine.SupportedDriverValues()))
 	flagSet.StringP(config.PullSecretFile.Name, "p", "", fmt.Sprintf("File path of Image pull secret for User (Download it from %s)", constants.DefaultPullSecretURL))
 	flagSet.IntP(config.CPUs.Name, "c", constants.DefaultCPUs, "Number of CPU cores to allocate to the CRC VM")

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/code-ready/crc
 require (
 	github.com/BurntSushi/toml v0.3.1 // indirect
 	github.com/DATA-DOG/godog v0.7.13
+	github.com/YourFin/binappend v0.0.0-20181105185800-0add4bf0b9ad
 	github.com/cavaliercoder/grab v2.0.0+incompatible
 	github.com/code-ready/clicumber v0.0.0-20190503113956-2563aed4ef12
 	github.com/code-ready/goodhosts v0.0.0-20190712111040-f090f3f77c26

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/DATA-DOG/godog v0.7.13 h1:JmgpKcra7Vf3yzI9vPsWyoQRx13tyKziHtXWDCUUgok
 github.com/DATA-DOG/godog v0.7.13/go.mod h1:z2OZ6a3X0/YAKVqLfVzYBwFt3j6uSt3Xrqa7XTtcQE0=
 github.com/Netflix/go-expect v0.0.0-20180615182759-c93bf25de8e8 h1:xzYJEypr/85nBpB11F9br+3HUrpgb+fcm5iADzXXYEw=
 github.com/Netflix/go-expect v0.0.0-20180615182759-c93bf25de8e8/go.mod h1:oX5x61PbNXchhh0oikYAH+4Pcfw5LKv21+Jnpr6r6Pc=
+github.com/YourFin/binappend v0.0.0-20181105185800-0add4bf0b9ad h1:OUogh+sUEo6yRwGEkqifcr3MfXNi0AtdCSwh7H8yTUM=
+github.com/YourFin/binappend v0.0.0-20181105185800-0add4bf0b9ad/go.mod h1:QhzJSct0NZ/q7HOtQrw867061u93HYPWa4KTotzdzls=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/bugsnag/bugsnag-go v1.5.1/go.mod h1:2oa8nejYd4cQ/b0hMIopN0lCRxU0bueqREvZLWFrtK8=
 github.com/bugsnag/panicwrap v1.2.0/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=

--- a/pkg/crc/constants/constants.go
+++ b/pkg/crc/constants/constants.go
@@ -38,6 +38,7 @@ var (
 	MachineCacheDir    = filepath.Join(MachineBaseDir, "cache")
 	MachineInstanceDir = filepath.Join(MachineBaseDir, "machines")
 	GlobalStatePath    = filepath.Join(CrcBaseDir, GlobalStateFile)
+	bundleEmbedded     = "false"
 )
 
 // GetHomeDir returns the home directory for the current user
@@ -65,4 +66,12 @@ func EnsureBaseDirExists() error {
 		return os.Mkdir(CrcBaseDir, 0755)
 	}
 	return nil
+}
+
+// IsBundleEmbedded returns true if the binary was compiled to contain the bundle
+func BundleEmbedded() bool {
+	if bundleEmbedded == "true" {
+		return true
+	}
+	return false
 }

--- a/pkg/crc/constants/constants_darwin.go
+++ b/pkg/crc/constants/constants_darwin.go
@@ -3,11 +3,16 @@ package constants
 import (
 	"fmt"
 	"github.com/code-ready/crc/pkg/crc/version"
+	"path/filepath"
 )
 
 const (
 	OcBinaryName = "oc"
 	DefaultOcURL = "https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/macosx/oc.tar.gz"
+)
+
+var (
+	DefaultBundlePath = filepath.Join(CrcBaseDir, GetDefaultBundle())
 )
 
 func GetDefaultBundle() string {

--- a/pkg/crc/constants/constants_linux.go
+++ b/pkg/crc/constants/constants_linux.go
@@ -3,11 +3,16 @@ package constants
 import (
 	"fmt"
 	"github.com/code-ready/crc/pkg/crc/version"
+	"path/filepath"
 )
 
 const (
 	OcBinaryName = "oc"
 	DefaultOcURL = "https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/linux/oc.tar.gz"
+)
+
+var (
+	DefaultBundlePath = filepath.Join(CrcBaseDir, GetDefaultBundle())
 )
 
 func GetDefaultBundle() string {

--- a/pkg/crc/constants/constants_windows.go
+++ b/pkg/crc/constants/constants_windows.go
@@ -3,11 +3,16 @@ package constants
 import (
 	"fmt"
 	"github.com/code-ready/crc/pkg/crc/version"
+	"path/filepath"
 )
 
 const (
 	OcBinaryName = "oc.exe"
 	DefaultOcURL = "https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/windows/oc.zip"
+)
+
+var (
+	DefaultBundlePath = filepath.Join(CrcBaseDir, GetDefaultBundle())
 )
 
 func GetDefaultBundle() string {

--- a/pkg/crc/preflight/preflight_checks_common.go
+++ b/pkg/crc/preflight/preflight_checks_common.go
@@ -1,0 +1,46 @@
+package preflight
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+
+	"github.com/YourFin/binappend"
+	"github.com/kardianos/osext"
+
+	"github.com/code-ready/crc/pkg/crc/constants"
+)
+
+func checkBundleCached() (bool, error) {
+	if _, err := os.Stat(constants.DefaultBundlePath); os.IsNotExist(err) {
+		return false, err
+	}
+	return true, nil
+}
+
+func fixBundleCached() (bool, error) {
+	if constants.BundleEmbedded() {
+		currentExecutable, err := osext.Executable()
+		if err != nil {
+			return false, err
+		}
+		extractor, err := binappend.MakeExtractor(currentExecutable)
+		if err != nil {
+			return false, err
+		}
+		f, err := os.Create(constants.DefaultBundlePath)
+		if err != nil {
+			return false, err
+		}
+		available := extractor.AvalibleData()
+		data, err := extractor.ByteArray(available[0])
+		if err != nil {
+			return false, err
+		}
+		w := bufio.NewWriter(f)
+		defer w.Flush()
+		w.Write(data)
+		return true, nil
+	}
+	return false, fmt.Errorf("CRC bundle is not embedded in the binary, see 'crc help' for more details.")
+}

--- a/pkg/crc/preflight/preflight_common.go
+++ b/pkg/crc/preflight/preflight_common.go
@@ -37,11 +37,6 @@ func preflightCheckAndFix(configuredToSkip bool, check, fix PreflightCheckFixFun
 	if ok {
 		return
 	}
-
-	if configuredToWarn {
-		logging.Warn(err.Error())
-		return
-	}
 	logging.Debug(err.Error())
 
 	ok, err = fix()
@@ -49,5 +44,9 @@ func preflightCheckAndFix(configuredToSkip bool, check, fix PreflightCheckFixFun
 		return
 	}
 
+	if configuredToWarn {
+		logging.Warn(err.Error())
+		return
+	}
 	logging.Fatal(err.Error())
 }

--- a/pkg/crc/preflight/preflight_darwin.go
+++ b/pkg/crc/preflight/preflight_darwin.go
@@ -45,6 +45,11 @@ func StartPreflightChecks(vmDriver string) {
 		fmt.Sprintf("Checking file permissions for %s", hostFile),
 		config.GetBool(cmdConfig.WarnCheckResolvConfFilePermissions.Name),
 	)
+	preflightCheckSucceedsOrFails(config.GetBool(cmdConfig.SkipCheckBundleCached.Name),
+		checkBundleCached,
+		"Checking if CRC bundle is cached in '$HOME/.crc'",
+		config.GetBool(cmdConfig.WarnCheckBundleCached.Name),
+	)
 }
 
 // SetupHost performs the prerequisite checks and setups the host to run the cluster
@@ -91,5 +96,11 @@ func SetupHost(vmDriver string) {
 		fixResolvConfFilePermissions,
 		fmt.Sprintf("Setting file permissions for %s", hostFile),
 		config.GetBool(cmdConfig.WarnCheckResolvConfFilePermissions.Name),
+	)
+	preflightCheckAndFix(config.GetBool(cmdConfig.SkipCheckBundleCached.Name),
+		checkBundleCached,
+		fixBundleCached,
+		"Unpacking bundle from the CRC binary",
+		config.GetBool(cmdConfig.WarnCheckBundleCached.Name),
 	)
 }

--- a/pkg/crc/preflight/preflight_linux.go
+++ b/pkg/crc/preflight/preflight_linux.go
@@ -67,6 +67,11 @@ func StartPreflightChecks(vmDriver string) {
 		"Checking if /etc/NetworkManager/dnsmasq.d/crc.conf exists",
 		config.GetBool(cmdConfig.WarnCheckCrcDnsmasqFile.Name),
 	)
+	preflightCheckSucceedsOrFails(config.GetBool(cmdConfig.SkipCheckBundleCached.Name),
+		checkBundleCached,
+		"Checking if CRC bundle is cached in '$HOME/.crc'",
+		config.GetBool(cmdConfig.WarnCheckBundleCached.Name),
+	)
 }
 
 // SetupHost performs the prerequisite checks and setups the host to run the cluster
@@ -142,5 +147,11 @@ func SetupHost(vmDriver string) {
 		fixCrcDnsmasqConfigFile,
 		"Writing dnsmasq config for crc",
 		config.GetBool(cmdConfig.WarnCheckCrcDnsmasqFile.Name),
+	)
+	preflightCheckAndFix(config.GetBool(cmdConfig.SkipCheckBundleCached.Name),
+		checkBundleCached,
+		fixBundleCached,
+		"Unpacking bundle from the CRC binary",
+		config.GetBool(cmdConfig.WarnCheckBundleCached.Name),
 	)
 }

--- a/pkg/crc/preflight/preflight_windows.go
+++ b/pkg/crc/preflight/preflight_windows.go
@@ -1,11 +1,21 @@
 package preflight
 
+import (
+	cmdConfig "github.com/code-ready/crc/cmd/crc/cmd/config"
+	"github.com/code-ready/crc/pkg/crc/config"
+)
+
 // StartPreflightChecks performs the preflight checks before starting the cluster
 func StartPreflightChecks(vmDriver string) {
 	preflightCheckSucceedsOrFails(false,
 		checkOcBinaryCached,
 		"Checking if oc binary is cached",
 		false,
+	)
+	preflightCheckSucceedsOrFails(config.GetBool(cmdConfig.SkipCheckBundleCached.Name),
+		checkBundleCached,
+		"Checking if CRC bundle is cached in '$HOME/.crc'",
+		config.GetBool(cmdConfig.WarnCheckBundleCached.Name),
 	)
 }
 
@@ -16,5 +26,11 @@ func SetupHost(vmDriver string) {
 		fixOcBinaryCached,
 		"Caching oc binary",
 		false,
+	)
+	preflightCheckAndFix(config.GetBool(cmdConfig.SkipCheckBundleCached.Name),
+		checkBundleCached,
+		fixBundleCached,
+		"Unpacking bundle from the CRC binary",
+		config.GetBool(cmdConfig.WarnCheckBundleCached.Name),
 	)
 }

--- a/vendor/github.com/YourFin/binappend/.gitignore
+++ b/vendor/github.com/YourFin/binappend/.gitignore
@@ -1,0 +1,12 @@
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, build with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out

--- a/vendor/github.com/YourFin/binappend/LICENCE
+++ b/vendor/github.com/YourFin/binappend/LICENCE
@@ -1,0 +1,23 @@
+MIT License
+
+Copyright (c) 2018 - Present Patrick Nuckolls
+
+All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/YourFin/binappend/README.md
+++ b/vendor/github.com/YourFin/binappend/README.md
@@ -1,0 +1,48 @@
+# binappend
+Library for packing binary data onto the end of files, targeted at adding adding static assets to executables after they're compiled.
+
+A cli tool for reading and writing this "file format" can be found [here](https://github.com/yourfin/binappend-cli).
+
+
+
+The following is copied from [this issue](https://github.com/gobuffalo/packr/issues/74) on github.com/gobuffalo/packr:
+
+## Background
+For one of [my own projects](https://github.com/yourfin/transcodebot), I ran into the problem that the memory overhead for embedding some of the files involved was unacceptably high over the potential lifetime of the program. I still wanted self contained binaries though, so I did some digging and ran into [this](https://stackoverflow.com/questions/5795446/appending-data-to-an-exe) on stackoverflow, and as it turns out [none of the major operating systems care if you dump crap at the end of an executable.](https://oroboro.com/packing-data-compiled-binar/) This, combined with the discovery of [the osext](https://github.com/kardianos/osext) library for finding the path to the current executable prompted the development of the following scheme for embedding files, which I have working as far as I need for my own purposes at this point.
+
+## High level description
+
+1. Compile the binary normally
+2. Write each file to embed to the end of the binary through a `gzip.writer`, noting the start and end point on the file.
+3. Write the gathered start and end points, along with their names (paths) out to a json-encoded metadata block at the end of binary
+4. Write the start position of said json data out as a magic number for the last 8 bytes of the file.
+
+The self-extraction process looks like this, then:
+1. Find the path to the source of the current process
+2. Open the file
+3. Read the last 8 bytes
+4. Open a json.Decoder at the position written to the last 8 bytes
+5. Decode the json into a struct in memory
+6. Close the file
+
+Then, when the process wants to access some of the data in the file, a file reader is opened on it that is simply started at $start_ptr and is limited to reading $size bytes
+
+## Visualization:
+
+    0                        400                       500              7000
+    +------------------------+-------------------------+----------------+---------------------+--------------+
+    | Executable Binary Data | Embeded File ./assets/A | Embeded Data B | Json metadata block | Magic Number |
+    +------------------------+-------------------------+----------------+---------------------+--------------+
+
+In this case the json would look something like this:
+
+    {
+      "Version": "0.1",
+      "Data":
+      {
+        "./assets/A": { "start_ptr": 400, "size": 100 },
+        "B":          { "start_ptr": 500, "size": 6500 }
+      }
+    }
+
+And the magic number would be 7000

--- a/vendor/github.com/YourFin/binappend/reading.go
+++ b/vendor/github.com/YourFin/binappend/reading.go
@@ -1,0 +1,271 @@
+// Copyright © 2018 Patrick Nuckolls <nuckollsp at gmail>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package binappend
+
+import (
+	"os"
+	"io"
+	"io/ioutil"
+	"encoding/json"
+	"encoding/binary"
+	"compress/gzip"
+
+	"github.com/pkg/errors"
+)
+
+// Type:
+//  Extractor
+// Purpose:
+//  To provide an concurrent interface for reading
+//  files tacked on the end of a binary
+type Extractor struct {
+	filename string
+	metadata appendedMetadata
+}
+
+// Procedure:
+//  MakeExtractor
+// Purpose:
+//  To create a Extractor for a given file
+// Parameters:
+//  The file to open: filename string
+// Produces:
+//  A pointer to a Extractor: reader *Extractor
+//  Any errors that occur: err error
+// Preconditions:
+//  filename exists on the filesystem
+//  filename was appended to with by a er
+// Postconditions:
+//  reader is initialized to grab the files from files
+func MakeExtractor(filename string) (reader *Extractor, err error) {
+	reader = &Extractor{}
+	reader.filename = filename
+	fileHandle, err := os.Open(filename)
+	if err != nil {
+		_ = fileHandle.Close()
+		return nil, errors.Wrapf(err, "Open file \"%s\"", filename)
+	}
+
+	//Read in metadata pointer magic number
+	_, err = fileHandle.Seek(-8, io.SeekEnd)
+	if err != nil {
+		_ = fileHandle.Close()
+		return nil, errors.Wrapf(err, "Seek in file \"%s\" to location %d before end", filename, 8)
+	}
+
+	metadataPtrBytes := make([]byte, 8)
+	count, err := fileHandle.Read(metadataPtrBytes)
+	if err != nil {
+		_ = fileHandle.Close()
+		return nil, errors.Wrap(err, "Read metadata pointer")
+	}
+	if count != 8 {
+		_ = fileHandle.Close()
+		return nil, errors.Errorf("Read %d bytes instead of 8 for metadata pointer location", count)
+	}
+	metadataPtr := int64(binary.LittleEndian.Uint64(metadataPtrBytes))
+
+	//Read in metadata
+	_, err = fileHandle.Seek(metadataPtr, io.SeekStart)
+	if err != nil {
+		_ = fileHandle.Close()
+		return nil, errors.Wrapf(err, "Seek in file \"%s\" to location %d before end (metadata location)", filename, 8)
+	}
+
+	err = json.NewDecoder(fileHandle).Decode(&(reader.metadata))
+	if err != nil {
+		_ = fileHandle.Close()
+		return nil, errors.Wrap(err, "Json Decode")
+	}
+	if reader.metadata.Version != METADATA_VERSION {
+		_ = fileHandle.Close()
+		return nil, errors.Errorf(
+			"BinAppender reader version \"%s\" does not match version \"%s\" on file \"%s\" ",
+			METADATA_VERSION,
+			reader.metadata.Version,
+			filename,
+		)
+	}
+
+	err = fileHandle.Close()
+	if err != nil {
+		return nil, errors.Wrapf(err, "Closing %s", filename)
+	}
+
+	return reader, nil
+}
+
+// Procedure:
+//  *Extractor.GetDataReader
+// Purpose:
+//  To return provide a reader matching a data name appended to
+//  reader's file
+// Parameters:
+//  The *Extractor being called: reader
+//  The name of the data given: dataName string
+// Produces:
+//  A reader for the data by the same name: reader *Reader
+//  Errors produced: err error
+// Preconditions:
+//  dataName is a name that exists and has data associated with it
+// Postconditions:
+//  The returned reader will decompress and read back the data with $dataName
+//  err will only exist:
+//   - When any filesystem errors in opening and seeking in the underlying binary
+//   - When $dataName does not match any names in the file
+func (extractor *Extractor) GetReader(dataName string) (reader *Reader, err error) {
+	if _, exists := extractor.metadata.Data[dataName]; !exists {
+		return nil, errors.Errorf("Could not find name %s", dataName)
+	}
+	reader = &Reader{}
+	reader.fileHandle, err = os.Open(extractor.filename)
+	if err != nil {
+		return nil, errors.Wrap(err, "opening reader filehandle")
+	}
+	_, err = reader.fileHandle.Seek(extractor.metadata.Data[dataName].StartFilePtr, io.SeekStart)
+	if err != nil {
+		_ = reader.fileHandle.Close()
+		return nil, errors.Wrap(err, "seeking in file")
+	}
+	limitReader := io.LimitReader(reader.fileHandle, extractor.metadata.Data[dataName].BlockSize)
+	if extractor.metadata.Data[dataName].Zipped {
+		reader.reader, err = gzip.NewReader(limitReader)
+		if err != nil {
+			_ = reader.fileHandle.Close()
+			return nil, errors.Wrap(err, "creating gzip reader")
+		}
+	} else {
+		reader.reader = limitReader
+	}
+	return reader, nil
+}
+
+// Procedure:
+//  *Extractor.ByteArray
+// Purpose:
+//  To read all of a block of appended data to a byte array
+// Parameters:
+//  The parent *Extractor: extractor
+//  The name of the data to retrieve: dataName string
+// Produces:
+//  The data named dataName: data []byte
+//  Any errors raised:       err error
+// Preconditions:
+//  The extractor is has some data named $dataName
+// Postconditions:
+//  data contains all the data named $dataName in the extractor
+//  err will be a file system error, gzip error, or due to $dataName not existing
+func (extractor *Extractor) ByteArray(dataName string) ([]byte, error) {
+	reader, err := extractor.GetReader(dataName)
+	defer func() { _ = reader.Close() }()
+	if err != nil {
+		return nil, errors.Wrap(err, "Generating reader for reading ByteArray")
+	}
+
+	data, err := ioutil.ReadAll(reader)
+	if err != nil {
+		return nil, errors.Wrap(err, "Reading all data in")
+	}
+
+	err = reader.Close()
+	if err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+
+// Procedure:
+//  *Extractor.AvalibleData
+// Purpose:
+//  To return all avalible names to read
+// Parameters:
+//  The *Reader being acted upon: reader
+// Produces:
+//  A list of all names of data that can be read: names []string
+// Preconditions:
+//  No additional
+// Postconditions:
+//  All the name keys of avalible data are in $names
+func (extractor *Extractor) AvalibleData() []string {
+	names := make([]string, len(extractor.metadata.Data))
+	counter := 0
+	for key := range extractor.metadata.Data {
+		names[counter] = key
+		counter += 1
+	}
+	return names
+}
+
+// Type:
+//  Reader
+// Purpose:
+//  Generated by Extractor to provide an interface to read
+//  appended data
+// Explicitly implements:
+//  io.Reader
+//  io.Closer
+//  io.ReadCloser
+// Postconditions:
+//  Must be closed so the underlying *os.File can be freed
+type Reader struct {
+	//The name of the data as inputed by the Writer
+	Name string
+
+	// reader wraps the limitReader which wraps the underlying fileHandle
+
+	fileHandle *os.File
+	reader io.Reader
+}
+
+// Procedure:
+//  *Reader.Read
+// Purpose:
+//  To read bytes out of a Reader
+// Parameters:
+//  The *Reader being acted upon: reader
+//  The byte array to place read bytes into: p []byte
+// Produces:
+//  The number of bytes read: n int
+//  Any errors in reading: err error
+// Preconditions:
+//  No additional
+// Postconditions:
+//  See the documentation for io.Reader
+func (reader *Reader) Read(p []byte) (n int, err error) {
+	return reader.reader.Read(p)
+}
+
+// Procedure:
+//  *Reader.Close
+// Purpose:
+//  To clean up the file handle for a Reader
+// Parameters:
+//  The *Reader being acted upon: reader
+//  None
+// Produces:
+//  Any errors in closing the underlying filesystem handle: err error
+// Preconditions:
+//  No additonal
+// Postconditions:
+//  All resources for the Reader have been closed
+func (reader *Reader) Close() error {
+	return reader.fileHandle.Close()
+}

--- a/vendor/github.com/YourFin/binappend/writing.go
+++ b/vendor/github.com/YourFin/binappend/writing.go
@@ -1,0 +1,271 @@
+// Copyright © 2018 Patrick Nuckolls <nuckollsp at gmail>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package binappend
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/binary"
+	"encoding/json"
+	"io"
+	"os"
+	"sync"
+
+	"github.com/pkg/errors"
+)
+
+type appendedData struct {
+	StartFilePtr int64 `json:"start_file_pointer"`
+	BlockSize    int64 `json:"block_size"`
+	Zipped       bool  `json:"zipped"`
+}
+
+const METADATA_VERSION string = "0.2"
+
+type appendedMetadata struct {
+	Version string
+	Data    map[string]appendedData
+}
+
+type Appender struct {
+	fileHandle *os.File
+	metadata   appendedMetadata
+	mux        *sync.Mutex
+	filename   string
+}
+
+// Procedure:
+//  MakeAppender
+// Purpose:
+//  To create an Appender
+// Parameters:
+//  The name of the file to append to: filename string
+//  A function that wraps an io.Writer: writeWrapper
+//    This can be used to pre-process data before insertion
+//    Note: this function will be called every time a file/stream is added
+// Produces:
+//  A pointer to a new Appender: output *Appender
+//  Any filesystem errors that occur in opening $filename: err error
+// Preconditions:
+//  The file at filename exists and can be written to
+// Postconditions:
+//  An appender is created that will append to filename through writeWrapper
+//  The caller of this function closes the created Appender
+func MakeAppender(filename string) (*Appender, error) {
+	var err error
+	output := Appender{}
+	output.fileHandle, err = os.OpenFile(filename, os.O_RDWR, 0755)
+	if err != nil {
+		return nil, errors.Wrap(err, "Opening file (RW)")
+	}
+	output.mux = &sync.Mutex{}
+	output.metadata = appendedMetadata{}
+	output.metadata.Data = make(map[string]appendedData)
+	output.metadata.Version = METADATA_VERSION
+	output.filename = filename
+	return &output, nil
+}
+
+// Procedure:
+//  *Appender.FileName
+// Purpose:
+//  To retrieve the filename associated with an Appender
+// Parameters:
+//  None
+// Produces:
+//  filename, a string
+// Preconditions:
+//  None.
+// Postconditions:
+//  Returns the filename private field
+func (appender *Appender) FileName() string {
+	return appender.filename
+}
+
+// Procedure:
+//  *Appender.AppendStreamReader
+// Purpose:
+//  To append the entirety of a stream in an appended file block
+// Parameters:
+//  The parent *Appender: appender
+//  The unique name of the stream: name string
+//  The reader to pull data out of: source io.Reader
+//  Whether to compress the stream: compressed bool
+// Produces:
+//  Side effects
+//  Any errors in writing to the filesystem: err error
+// Preconditions:
+//  reader has a finite amount of data to read
+//  $appender.Close() has not been called
+// Postconditions:
+//  All of the data that reader can read has been written to
+//    appender's internal writer at the end of its file
+//  appender's internal metadata has been updated to reflect the addition
+//  Errors will be filesystem related
+//
+//  if $compressed: bash equivalent is executed:
+//    $source | gzip >> $appender.file
+//  else
+//    $source >> $appender.file
+//
+//  $appender.file.ByteArray()[$appender.metadata[$name].StartFilePtr[:$appender].metadata[$name].[BlockSize].gunzip() == $source.ByteArray[]
+func (appender *Appender) AppendStreamReader(name string, source io.Reader, compressed bool) error {
+	appender.mux.Lock()
+	defer appender.mux.Unlock()
+
+	startPtr, err := appender.fileHandle.Seek(0, io.SeekEnd)
+	if err != nil {
+		return errors.Wrap(err, "Seeking to end of file (1)")
+	}
+	if compressed {
+		gzWriter := gzip.NewWriter(appender.fileHandle)
+		_, err = io.Copy(gzWriter, source)
+		if err != nil {
+			return errors.Wrap(err, "Writing data to file")
+		}
+
+		gzWriter.Close()
+	} else {
+		_, err = io.Copy(appender.fileHandle, source)
+		if err != nil {
+			return errors.Wrap(err, "Writing data to file")
+		}
+	}
+
+	endPtr, err := appender.fileHandle.Seek(0, io.SeekEnd)
+	if err != nil {
+		return errors.Wrap(err, "Output corrupted. Seeking to end of file error")
+	}
+
+	fileMetadata := appendedData{}
+	fileMetadata.StartFilePtr = startPtr
+	fileMetadata.BlockSize = endPtr - startPtr
+	fileMetadata.Zipped = compressed
+
+	appender.metadata.Data[name] = fileMetadata
+	return nil
+}
+
+// Procedure:
+//  *Appender.AppendFile
+// Purpose:
+//  To gzip and pack a file onto the end of the Appender's file
+// Parameters:
+//  The calling Appender: appender Appender
+//  The file to append: source string
+//  Whether or not to compress the file: compressed bool
+// Produces:
+//  Side effects:
+//    filesystem
+//    internal state changes
+//  Any errors in writing to the filesystem: err error
+// Preconditions:
+//  $source exists and is readable in the file system
+//  $source has not been appended already nor has $appender.AppendStreamReader(name, _)
+//    been called with name == $source
+//  $appender.Close() has not been called
+// Postconditions:
+//  A reader stream from $source will be passed to $appender.AppendStreamReader,
+//    with the name parameter as source
+func (appender *Appender) AppendFile(source string, compressed bool) error {
+	sourceHandle, err := os.Open(source)
+	if err != nil {
+		return errors.Wrapf(err, "Opening file: %s", source)
+	}
+
+	appender.mux.Lock()
+	if _, exists := appender.metadata.Data[source]; exists {
+		appender.mux.Unlock()
+		return errors.Errorf("File %s has already been added to appender", source)
+	}
+	appender.mux.Unlock()
+
+	err = appender.AppendStreamReader(source, sourceHandle, compressed)
+	if err != nil {
+		return errors.Wrap(err, "Appending file stream")
+	}
+	return sourceHandle.Close()
+}
+
+// Procedure:
+//  *Appender.AppendByteArray
+// Purpose:
+//  To append a bytearray to a file
+// Parameters:
+//  The name of the data: name string
+//  The data to append: data []byte
+//  Whether to compress the data: compressed bool
+// Produces:
+//  Side effects:
+//    filesystem
+//    internal state changes
+//  Any errors in writing to the filesystem: err error
+// Preconditions:
+//  No additional, although you should probably make sure that data is not empty
+// Postconditions:
+//  AppendSteamReader is called with a reader wrapped around data.
+func (appender *Appender) AppendByteArray(name string, data []byte, compressed bool) error {
+	return appender.AppendStreamReader(name, bytes.NewReader(data), compressed)
+}
+
+// Procedure:
+//  *Appender.Close()
+// Purpose:
+//  To finish writing to the file being appended to
+//    and free it for use elsewhere
+// Parameters:
+//   The Appender being acted upon: appender
+// Produces:
+//   Any filesystem errors: err error
+// Preconditions:
+//  $appender.Close() has not been called
+// Postconditions:
+//  The json-encoded metadata about the appended files has been
+//    written out to the end of file being appended to
+//  The start of said json block is encoded in the final 8 bytes of
+//    the file being appended to as a little endian int64
+//  The internal file handle for the file being appended to has been closed
+func (appender *Appender) Close() error {
+	appender.mux.Lock()
+	defer appender.mux.Unlock()
+
+	jsonPtr, err := appender.fileHandle.Seek(0, io.SeekEnd)
+	if err != nil {
+		return errors.Wrap(err, "Seeking to end of file")
+	}
+	jsonPtrBytes := make([]byte, 8)
+	binary.LittleEndian.PutUint64(jsonPtrBytes, uint64(jsonPtr))
+
+	jsonBytes, err := json.Marshal(appender.metadata)
+	//Should not happen
+	if err != nil {
+		return errors.Wrap(err, "Marshaling metadata")
+	}
+	_, err = appender.fileHandle.Write(jsonBytes)
+	if err != nil {
+		return errors.Wrap(err, "Writing metadata")
+	}
+	_, err = appender.fileHandle.Write(jsonPtrBytes)
+	if err != nil {
+		return errors.Wrap(err, "Writing metadata location")
+	}
+	return appender.fileHandle.Close()
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -2,6 +2,8 @@
 github.com/DATA-DOG/godog
 github.com/DATA-DOG/godog/gherkin
 github.com/DATA-DOG/godog/colors
+# github.com/YourFin/binappend v0.0.0-20181105185800-0add4bf0b9ad
+github.com/YourFin/binappend
 # github.com/cavaliercoder/grab v2.0.0+incompatible
 github.com/cavaliercoder/grab
 # github.com/code-ready/clicumber v0.0.0-20190503113956-2563aed4ef12
@@ -10,9 +12,6 @@ github.com/code-ready/clicumber/util
 # github.com/code-ready/goodhosts v0.0.0-20190712111040-f090f3f77c26
 github.com/code-ready/goodhosts
 # github.com/code-ready/machine v0.0.0-20190717101121-b310e5ddb702
-github.com/code-ready/machine/libmachine/state
-github.com/code-ready/machine/libmachine/drivers
-# github.com/code-ready/machine v0.0.0-20190513092840-66a8c3b3c494
 github.com/code-ready/machine/libmachine/state
 github.com/code-ready/machine/libmachine/drivers
 github.com/code-ready/machine/libmachine


### PR DESCRIPTION
The following scenario should work for this PR

```
# Build the binaries with the bundle embedded by running
$ make embed_bundle BUNDLE_DIR=/path/to/dir/containing/bundles

# the binaries will be present inside out/, the following commands should work with them
$ out/linux-amd64/crc setup <== this will unpack the required bundle to $HOME/.crc/
$ out/linux-amd64/crc start
```
**Note**: Currently we are only embedding the bundle for the default hypervisor, for that platform, and not building binaries with VirtualBox bundles, which would be required for all the platforms.