### PR TITLE
Issue #362 Abstract retry logic

### DIFF
--- a/pkg/crc/errors/multierror.go
+++ b/pkg/crc/errors/multierror.go
@@ -3,6 +3,9 @@ package errors
 import (
 	"fmt"
 	"strings"
+	"time"
+
+	"github.com/code-ready/crc/pkg/crc/logging"
 )
 
 type MultiError struct {
@@ -25,4 +28,35 @@ func (m MultiError) ToError() error {
 		errStrings = append(errStrings, err.Error())
 	}
 	return fmt.Errorf(strings.Join(errStrings, "\n"))
+}
+
+// RetriableError is an error that can be tried again
+type RetriableError struct {
+	Err error
+}
+
+func (r RetriableError) Error() string {
+	return "Temporary Error: " + r.Err.Error()
+}
+
+// RetryAfter retries a number of attempts, after a delay
+func RetryAfter(attempts int, callback func() error, d time.Duration) (err error) {
+	m := MultiError{}
+	for i := 0; i < attempts; i++ {
+		if i > 0 {
+			logging.Debugf("retry loop %d", i)
+		}
+		err = callback()
+		if err == nil {
+			return nil
+		}
+		m.Collect(err)
+		if _, ok := err.(*RetriableError); !ok {
+			logging.Debugf("non-retriable error: %v", err)
+			return m.ToError()
+		}
+		logging.Debugf("error: %v - sleeping %s", err, d)
+		time.Sleep(d)
+	}
+	return m.ToError()
 }


### PR DESCRIPTION
Multiple places, `for i; i < num; i++` logic is used to
have retry which is non abstracted and also doesn't collect
errors if a function have multiple error. Abstracting this
logic now make it possible to have a callback function which
can be retried for a specific interval.