### PR TITLE
Issue #426: oc: Add missing error assignment

### DIFF
--- a/pkg/crc/oc/oc_cache.go
+++ b/pkg/crc/oc/oc_cache.go
@@ -104,7 +104,7 @@ func (oc *OcCached) cacheOc() error {
 		}
 
 		finalBinaryPath := filepath.Join(outputPath, binaryName)
-		crcos.CopyFileContents(binaryPath, finalBinaryPath, 0755)
+		err = crcos.CopyFileContents(binaryPath, finalBinaryPath, 0755)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
oc.cacheOc() is seemingly checking crcos.CopyFileContents return value.
However, the CopyFileContents call is not setting 'err', so the 'err'
value we are checking is from a previous call and will always be nil.
This means error during the file copy will go undetected.

https://github.com/code-ready/crc/issues/426