### PR TITLE
Issue #431: Replace strings.Replace with filepath.ToSlash

### DIFF
--- a/pkg/crc/machine/machine.go
+++ b/pkg/crc/machine/machine.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/code-ready/crc/pkg/crc/pullsecret"
@@ -68,8 +67,7 @@ func Start(startConfig StartConfig) (StartResult, error) {
 
 	// Retrieve metadata info
 	diskPath := filepath.Join(extractedPath, crcBundleMetadata.Storage.DiskImages[0].Name)
-	// TODO: QnD Windows workaround hack
-	machineConfig.DiskPathURL = fmt.Sprintf("file://%s", strings.Replace(diskPath, "\\", "/", -1))
+	machineConfig.DiskPathURL = fmt.Sprintf("file://%s", filepath.ToSlash(diskPath))
 
 	machineConfig.SSHKeyPath = filepath.Join(extractedPath, crcBundleMetadata.ClusterInfo.SSHPrivateKeyFile)
 	machineConfig.KernelCmdLine = crcBundleMetadata.Nodes[0].KernelCmdLine


### PR DESCRIPTION
machine.go currently calls strings.Replace to change \ to / when
building an URI, but go has a builtin function for that, we can use it
to make our intent clearer.

This fixes https://github.com/code-ready/crc/issues/431