### PR TITLE
Issue #439: Install libvirt driver in ~/.crc/bin

### DIFF
--- a/pkg/crc/machine/driver_linux.go
+++ b/pkg/crc/machine/driver_linux.go
@@ -1,6 +1,7 @@
 package machine
 
 import (
+	"github.com/code-ready/crc/pkg/crc/constants"
 	crcos "github.com/code-ready/crc/pkg/os"
 )
 
@@ -10,6 +11,7 @@ func init() {
 		Platform:      crcos.LINUX,
 		Driver:        "libvirt",
 		UseDNSService: false,
+		DriverPath:    constants.CrcBinDir,
 	}
 
 	VirtualBoxLinuxDriver := MachineDriver{

--- a/pkg/crc/preflight/preflight_checks_linux.go
+++ b/pkg/crc/preflight/preflight_checks_linux.go
@@ -248,6 +248,32 @@ func fixMachineDriverLibvirtInstalled() (bool, error) {
 	return true, nil
 }
 
+/* These 2 checks can be removed after a few releases */
+func checkOldMachineDriverLibvirtInstalled() (bool, error) {
+	logging.Debugf("Checking if an older libvirt driver %s is installed", libvirtDriverCommand)
+	oldLibvirtDriverPath := filepath.Join("/usr/local/bin/", libvirtDriverCommand)
+	if _, err := os.Stat(oldLibvirtDriverPath); !os.IsNotExist(err) {
+		return false, fmt.Errorf("Found old system-wide crc-machine-driver binary")
+	}
+	logging.Debugf("No older %s installation found", libvirtDriverCommand)
+
+	return true, nil
+}
+
+func fixOldMachineDriverLibvirtInstalled() (bool, error) {
+	oldLibvirtDriverPath := filepath.Join("/usr/local/bin/", libvirtDriverCommand)
+	logging.Debugf("Removing %s", oldLibvirtDriverPath)
+	_, _, err := crcos.RunWithPrivilege("rm", "-f", oldLibvirtDriverPath)
+	if err != nil {
+		logging.Debugf("Removal of %s failed", oldLibvirtDriverPath)
+		/* Ignoring error, an obsolete file being still present is not a fatal error */
+	} else {
+		logging.Debugf("%s successfully removed", oldLibvirtDriverPath)
+	}
+
+	return true, nil
+}
+
 func checkLibvirtCrcNetworkAvailable() (bool, error) {
 	logging.Debug("Checking if libvirt 'crc' network exists")
 	stdOut, stdErr, err := crcos.RunWithDefaultLocale("virsh", "--connect", "qemu:///system", "net-list")

--- a/pkg/crc/preflight/preflight_linux.go
+++ b/pkg/crc/preflight/preflight_linux.go
@@ -124,6 +124,12 @@ func SetupHost(vmDriver string) {
 		"Installing crc-driver-libvirt",
 		config.GetBool(cmdConfig.WarnCheckLibvirtDriver.Name),
 	)
+	preflightCheckAndFix(false,
+		checkOldMachineDriverLibvirtInstalled,
+		fixOldMachineDriverLibvirtInstalled,
+		"Removing older system-wide crc-driver-libvirt",
+		false,
+	)
 	preflightCheckAndFix(config.GetBool(cmdConfig.SkipCheckCrcNetwork.Name),
 		checkLibvirtCrcNetworkAvailable,
 		fixLibvirtCrcNetworkAvailable,


### PR DESCRIPTION
It's currently installed in /usr/local/bin, but since the changes for
the hyperkit driver, we can install the machine drivers in a private
location (~/.crc/bin). This commit changes the libvirt driver to go
there as well, as this means less priviledged operation to do at crc
setup time.

This fixes https://github.com/code-ready/crc/issues/439