### PR TITLE
Issue #434 Remove hardcoded block device name when getting disk usage

### DIFF
--- a/pkg/crc/cluster/cluster.go
+++ b/pkg/crc/cluster/cluster.go
@@ -40,10 +40,8 @@ func CheckCertsValidity(driver drivers.Driver) error {
 }
 
 // Return size of disk, used space in bytes and the mountpoint
-func GetDiskUsage(driver drivers.Driver, device string) (int64, int64, error) {
-	cmd := fmt.Sprintf(
-		"df -B1 --output=size,used,target %s | tail -1",
-		device)
+func GetRootPartitionUsage(driver drivers.Driver) (int64, int64, error) {
+	cmd := "df -B1 --output=size,used,target /sysroot | tail -1"
 
 	out, err := drivers.RunSSHCommandFromDriver(driver, cmd)
 

--- a/pkg/crc/machine/machine.go
+++ b/pkg/crc/machine/machine.go
@@ -424,7 +424,7 @@ func Status(statusConfig ClusterStatusConfig) (ClusterStatusResult, error) {
 			// TODO:get openshift version as well and add to status
 			openshiftStatus = fmt.Sprintf("Running (v4.x)")
 		}
-		diskSize, diskUse, err = cluster.GetDiskUsage(host.Driver, "/dev/vda3")
+		diskSize, diskUse, err = cluster.GetRootPartitionUsage(host.Driver)
 		if err != nil {
 			result.Success = false
 			result.Error = err.Error()


### PR DESCRIPTION
Get the usage details by grepping the mount point `/sysroot` instead
of depending on the device name.

Fixes #434 