### PR TITLE
Use golangci-lint in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,6 +37,9 @@ jobs:
         name: Make fmtcheck
         command: make fmtcheck
     - run:
+        name: Run golangci-lint
+        command: make lint
+    - run:
         name: Make cross
         command: make cross
     - run:
@@ -71,7 +74,9 @@ jobs:
         command: podman info
     - run:
         name: Make build_docs
-        command: make build_docs
+        # force GOPATH to a sane value as the image we are using has an older go version
+        # with a 'go env GOPATH' output which causes make failures
+        command: make GOPATH="/home/circleci/go" build_docs
     - persist_to_workspace:
         root: docs/build
         paths: index.html

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,5 @@ go:
 script:
 - make
 - make fmtcheck
+- make lint
 - make cross

--- a/Makefile
+++ b/Makefile
@@ -155,7 +155,7 @@ release: fmtcheck embed_bundle build_docs_pdf
 	sha256sum $(RELEASE_DIR)/crc-windows-amd64.zip >> $(RELEASE_DIR)/sha256sum.txt
 
 BUNDLES := $(BUNDLE_DIR)/crc_libvirt_$(BUNDLE_VERSION).$(BUNDLE_EXTENSION) \
-	   $(BUNDLE_DIR)/crc_libvirt_$(BUNDLE_VERSION).$(BUNDLE_EXTENSION) \
+	   $(BUNDLE_DIR)/crc_hyperkit_$(BUNDLE_VERSION).$(BUNDLE_EXTENSION) \
 	   $(BUNDLE_DIR)/crc_hyperv_$(BUNDLE_VERSION).$(BUNDLE_EXTENSION)
 
 .PHONY: embed_bundle check_bundledir

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ DOCS_BUILD_TARGET ?= /docs/source/getting-started/master.adoc
 
 GOOS ?= $(shell go env GOOS)
 GOARCH ?= $(shell go env GOARCH)
+GOPATH ?= $(shell go env GOPATH)
 ORG := github.com/code-ready
 REPOPATH ?= $(ORG)/crc
 
@@ -125,6 +126,14 @@ fmt:
 .PHONY: fmtcheck
 fmtcheck: ## Checks for style violation using gofmt
 	@gofmt -l $(SOURCE_DIRS) | grep ".*\.go"; if [ "$$?" = "0" ]; then exit 1; fi
+
+$(GOPATH)/bin/golangci-lint:
+	GO111MODULE=on go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.17.1
+
+# Run golangci-lint against code
+.PHONY: lint
+lint: $(GOPATH)/bin/golangci-lint
+	$(GOPATH)/bin/golangci-lint run
 
 .PHONY: release
 release: fmtcheck embed_bundle build_docs_pdf

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ vendor:
 	GO111MODULE=on go mod vendor
 
 # Get binappend
-binappend:
+$(GOPATH)/bin/binappend-cli:
 	GO111MODULE=off go get -u github.com/yourfin/binappend-cli
 
 # Start of the actual build targets
@@ -163,7 +163,7 @@ check_bundledir:
 	@$(call check_defined, BUNDLE_DIR, "Embedding bundle requires BUNDLE_DIR set to a directory containing CRC bundles for all hypervisors")
 
 embed_bundle: LDFLAGS += $(BUNDLE_EMBEDDED)
-embed_bundle: clean cross binappend-cli check_bundledir $(HYPERKIT_BUNDLENAME) $(HYPERV_BUNDLENAME) $(LIBVIRT_BUNDLENAME)
-	binappend-cli write $(BUILD_DIR)/linux-amd64/crc $(LIBVIRT_BUNDLENAME)
-	binappend-cli write $(BUILD_DIR)/macos-amd64/crc $(HYPERKIT_BUNDLENAME)
-	binappend-cli write $(BUILD_DIR)/windows-amd64/crc.exe $(HYPERV_BUNDLENAME)
+embed_bundle: clean cross $(GOPATH)/bin/binappend-cli check_bundledir $(HYPERKIT_BUNDLENAME) $(HYPERV_BUNDLENAME) $(LIBVIRT_BUNDLENAME)
+	$(GOPATH)/bin/binappend-cli write $(BUILD_DIR)/linux-amd64/crc $(LIBVIRT_BUNDLENAME)
+	$(GOPATH)/bin/binappend-cli write $(BUILD_DIR)/macos-amd64/crc $(HYPERKIT_BUNDLENAME)
+	$(GOPATH)/bin/binappend-cli write $(BUILD_DIR)/windows-amd64/crc.exe $(HYPERV_BUNDLENAME)

--- a/Makefile
+++ b/Makefile
@@ -154,16 +154,16 @@ release: fmtcheck embed_bundle build_docs_pdf
 	cd $(BUILD_DIR) && zip -r $(CURDIR)/$(RELEASE_DIR)/crc-windows-amd64.zip crc-windows-$(CRC_VERSION)-amd64
 	sha256sum $(RELEASE_DIR)/crc-windows-amd64.zip >> $(RELEASE_DIR)/sha256sum.txt
 
-BUNDLES := $(BUNDLE_DIR)/crc_libvirt_$(BUNDLE_VERSION).$(BUNDLE_EXTENSION) \
-	   $(BUNDLE_DIR)/crc_hyperkit_$(BUNDLE_VERSION).$(BUNDLE_EXTENSION) \
-	   $(BUNDLE_DIR)/crc_hyperv_$(BUNDLE_VERSION).$(BUNDLE_EXTENSION)
+HYPERKIT_BUNDLENAME = $(BUNDLE_DIR)/crc_hyperkit_$(BUNDLE_VERSION).$(BUNDLE_EXTENSION)
+HYPERV_BUNDLENAME = $(BUNDLE_DIR)/crc_hyperv_$(BUNDLE_VERSION).$(BUNDLE_EXTENSION)
+LIBVIRT_BUNDLENAME = $(BUNDLE_DIR)/crc_libvirt_$(BUNDLE_VERSION).$(BUNDLE_EXTENSION)
 
 .PHONY: embed_bundle check_bundledir
 check_bundledir:
 	@$(call check_defined, BUNDLE_DIR, "Embedding bundle requires BUNDLE_DIR set to a directory containing CRC bundles for all hypervisors")
 
 embed_bundle: LDFLAGS += $(BUNDLE_EMBEDDED)
-embed_bundle: clean cross binappend check_bundledir $(BUNDLES)
-	binappend-cli write $(BUILD_DIR)/linux-amd64/crc $(BUNDLE_DIR)/crc_libvirt_$(BUNDLE_VERSION).$(BUNDLE_EXTENSION)
-	binappend-cli write $(BUILD_DIR)/macos-amd64/crc $(BUNDLE_DIR)/crc_hyperkit_$(BUNDLE_VERSION).$(BUNDLE_EXTENSION)
-	binappend-cli write $(BUILD_DIR)/windows-amd64/crc.exe $(BUNDLE_DIR)/crc_hyperv_$(BUNDLE_VERSION).$(BUNDLE_EXTENSION)
+embed_bundle: clean cross binappend-cli check_bundledir $(HYPERKIT_BUNDLENAME) $(HYPERV_BUNDLENAME) $(LIBVIRT_BUNDLENAME)
+	binappend-cli write $(BUILD_DIR)/linux-amd64/crc $(LIBVIRT_BUNDLENAME)
+	binappend-cli write $(BUILD_DIR)/macos-amd64/crc $(HYPERKIT_BUNDLENAME)
+	binappend-cli write $(BUILD_DIR)/windows-amd64/crc.exe $(HYPERV_BUNDLENAME)

--- a/cmd/crc/cmd/config/config.go
+++ b/cmd/crc/cmd/config/config.go
@@ -50,7 +50,7 @@ var (
 		Use:   "config SUBCOMMAND [flags]",
 		Short: "Modifies crc configuration properties.",
 		Run: func(cmd *cobra.Command, args []string) {
-			cmd.Help()
+			_ = cmd.Help()
 		},
 	}
 )

--- a/cmd/crc/cmd/console.go
+++ b/cmd/crc/cmd/console.go
@@ -56,5 +56,5 @@ func runConsole(arguments []string) {
 		return
 	}
 	output.Out("Opening the OpenShift Web console in the default browser...")
-	browser.OpenURL(result.URL)
+	_ = browser.OpenURL(result.URL)
 }

--- a/cmd/crc/cmd/oc_env.go
+++ b/cmd/crc/cmd/oc_env.go
@@ -59,7 +59,7 @@ var ocEnvCmd = &cobra.Command{
 		if err != nil {
 			errors.Exit(1)
 		}
-		executeOcTemplateStdout(shellCfg)
+		_ = executeOcTemplateStdout(shellCfg)
 	},
 }
 

--- a/cmd/crc/cmd/root.go
+++ b/cmd/crc/cmd/root.go
@@ -36,7 +36,9 @@ func init() {
 	if err := config.EnsureConfigFileExists(); err != nil {
 		logging.Fatal(err.Error())
 	}
-	config.InitViper()
+	if err := config.InitViper(); err != nil {
+		logging.Fatal(err.Error())
+	}
 
 	setConfigDefaults()
 

--- a/cmd/crc/cmd/root.go
+++ b/cmd/crc/cmd/root.go
@@ -20,7 +20,7 @@ var rootCmd = &cobra.Command{
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		runRoot()
-		cmd.Help()
+		_ = cmd.Help()
 	},
 	PersistentPostRun: func(cmd *cobra.Command, args []string) {
 		runPostrun()

--- a/cmd/crc/cmd/start.go
+++ b/cmd/crc/cmd/start.go
@@ -88,10 +88,7 @@ func initStartCmdFlagSet() *pflag.FlagSet {
 }
 
 func isDebugLog() bool {
-	if logging.LogLevel == "debug" {
-		return true
-	}
-	return false
+	return logging.LogLevel == "debug"
 }
 
 func validateStartFlags() error {

--- a/cmd/crc/cmd/start.go
+++ b/cmd/crc/cmd/start.go
@@ -39,7 +39,6 @@ var startCmd = &cobra.Command{
 
 var (
 	startCmdFlagSet = initStartCmdFlagSet()
-	pullSecretFile  string
 )
 
 func runStart(arguments []string) {

--- a/cmd/crc/cmd/start.go
+++ b/cmd/crc/cmd/start.go
@@ -25,7 +25,7 @@ func init() {
 	rootCmd.AddCommand(startCmd)
 	startCmd.Flags().AddFlagSet(startCmdFlagSet)
 
-	crcConfig.BindFlagSet(startCmd.Flags())
+	_ = crcConfig.BindFlagSet(startCmd.Flags())
 }
 
 var startCmd = &cobra.Command{

--- a/pkg/crc/config/viper_config.go
+++ b/pkg/crc/config/viper_config.go
@@ -58,7 +58,7 @@ func EnsureConfigFileExists() error {
 	if err != nil {
 		f, err := os.Create(constants.ConfigPath)
 		if err == nil {
-			f.WriteString("{}")
+			_, err = f.WriteString("{}")
 			f.Close()
 		}
 		return err

--- a/pkg/crc/config/viper_config.go
+++ b/pkg/crc/config/viper_config.go
@@ -52,16 +52,18 @@ func GetInt(key string) int {
 	return globalViper.GetInt(key)
 }
 
-// EnsureConfigFileExists creates the viper config file it does not exists
+// EnsureConfigFileExists creates the viper config file if it does not exists
 func EnsureConfigFileExists() error {
 	_, err := os.Stat(constants.ConfigPath)
 	if err != nil {
 		f, err := os.Create(constants.ConfigPath)
-		defer f.Close()
-		f.WriteString("{}")
+		if err == nil {
+			f.WriteString("{}")
+			f.Close()
+		}
 		return err
 	}
-	return err
+	return nil
 }
 
 // InitViper initializes viper

--- a/pkg/crc/constants/constants.go
+++ b/pkg/crc/constants/constants.go
@@ -70,8 +70,5 @@ func EnsureBaseDirExists() error {
 
 // IsBundleEmbedded returns true if the binary was compiled to contain the bundle
 func BundleEmbedded() bool {
-	if bundleEmbedded == "true" {
-		return true
-	}
-	return false
+	return bundleEmbedded == "true"
 }

--- a/pkg/crc/errors/atexit.go
+++ b/pkg/crc/errors/atexit.go
@@ -44,9 +44,9 @@ func Exit(code int) {
 // If the exit code is 0, the message is prints to stdout, otherwise to stderr.
 func ExitWithMessage(code int, text string, args ...interface{}) {
 	if code == 0 {
-		output.OutW(os.Stdout, fmt.Sprintf(text, args...))
+		_, _ = output.OutW(os.Stdout, fmt.Sprintf(text, args...))
 	} else {
-		output.OutW(os.Stderr, fmt.Sprintf(text, args...))
+		_, _ = output.OutW(os.Stderr, fmt.Sprintf(text, args...))
 	}
 	Exit(code)
 }

--- a/pkg/crc/input/input.go
+++ b/pkg/crc/input/input.go
@@ -15,10 +15,8 @@ func PromptUserForYesOrNo(message string, force bool) bool {
 	var response string
 	output.OutF(message + "? [y/N]: ")
 	fmt.Scanf("%s", &response)
-	if strings.ToLower(response) == "y" {
-		return true
-	}
-	return false
+
+	return strings.ToLower(response) == "y"
 }
 
 // PromptUserForSecret can be used for any kind of secret like image pull

--- a/pkg/crc/machine/bundle/extract.go
+++ b/pkg/crc/machine/bundle/extract.go
@@ -56,6 +56,7 @@ func Extract(sourcepath string) (*CrcBundleInfo, error) {
 			if err != nil {
 				return nil, err
 			}
+			defer writer.Close()
 
 			io.Copy(writer, tarBallReader)
 
@@ -64,8 +65,6 @@ func Extract(sourcepath string) (*CrcBundleInfo, error) {
 			if err != nil {
 				return nil, err
 			}
-
-			writer.Close()
 
 		default:
 			// ignore

--- a/pkg/crc/machine/bundle/extract.go
+++ b/pkg/crc/machine/bundle/extract.go
@@ -18,7 +18,7 @@ func Extract(sourcepath string) (*CrcBundleInfo, error) {
 	}
 	defer file.Close()
 
-	var fileReader io.Reader = file
+	var fileReader io.Reader
 
 	if fileReader, err = xz.NewReader(file, 0); err != nil {
 		return nil, err

--- a/pkg/crc/machine/bundle/extract.go
+++ b/pkg/crc/machine/bundle/extract.go
@@ -58,7 +58,11 @@ func Extract(sourcepath string) (*CrcBundleInfo, error) {
 			}
 			defer writer.Close()
 
-			io.Copy(writer, tarBallReader)
+			_, err = io.Copy(writer, tarBallReader)
+
+			if err != nil {
+				return nil, err
+			}
 
 			err = os.Chmod(filename, os.FileMode(header.Mode))
 

--- a/pkg/crc/machine/machine.go
+++ b/pkg/crc/machine/machine.go
@@ -211,7 +211,7 @@ func Start(startConfig StartConfig) (StartResult, error) {
 	}
 	// Add nameserver to VM if provided by User
 	if startConfig.NameServer != "" {
-		if addNameServerToInstance(host.Driver, startConfig.NameServer); err != nil {
+		if err = addNameServerToInstance(host.Driver, startConfig.NameServer); err != nil {
 			result.Error = err.Error()
 			return *result, errors.New(err.Error())
 		}

--- a/pkg/crc/machine/machine.go
+++ b/pkg/crc/machine/machine.go
@@ -486,6 +486,9 @@ func existVM(api libmachine.API, name string) (bool, error) {
 func createHost(api libmachine.API, driverPath string, machineConfig config.MachineConfig) (*host.Host, error) {
 	driverOptions := getDriverOptions(machineConfig)
 	jsonDriverConfig, err := json.Marshal(driverOptions)
+	if err != nil {
+		return nil, errors.New("marshal failed")
+	}
 
 	vm, err := api.NewHost(machineConfig.VMDriver, driverPath, jsonDriverConfig)
 

--- a/pkg/crc/network/nameservers.go
+++ b/pkg/crc/network/nameservers.go
@@ -6,7 +6,6 @@ import (
 	"io/ioutil"
 	"strings"
 
-	crcos "github.com/code-ready/crc/pkg/os"
 	"github.com/code-ready/machine/libmachine/drivers"
 )
 
@@ -60,9 +59,11 @@ func addNameserverToInstance(driver drivers.Driver, nameserver NameServer) {
 func GetResolvValuesFromHost() (*ResolvFileValues, error) {
 	// TODO: we need to add runtime OS in case of windows.
 	out, err := ioutil.ReadFile("/etc/resolv.conf")
-	if crcos.CurrentOS() == crcos.WINDOWS {
-		// TODO: we need to add logic in case of windows.
-	}
+	/*
+		if crcos.CurrentOS() == crcos.WINDOWS {
+			// TODO: we need to add logic in case of windows.
+		}
+	*/
 
 	if err != nil {
 		return nil, fmt.Errorf("Failed to read resolv.conf: %v", err)

--- a/pkg/crc/network/template.go
+++ b/pkg/crc/network/template.go
@@ -20,7 +20,10 @@ func CreateResolvFile(values ResolvFileValues) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	t.Execute(&resolvFile, values)
+	err = t.Execute(&resolvFile, values)
+	if err != nil {
+		return "", err
+	}
 
 	return resolvFile.String(), nil
 }

--- a/pkg/crc/output/output.go
+++ b/pkg/crc/output/output.go
@@ -14,5 +14,5 @@ func OutF(s string, args ...interface{}) {
 }
 
 func OutW(w io.Writer, args ...interface{}) (n int, err error) {
-	return fmt.Fprintln(w, args)
+	return fmt.Fprintln(w, args...)
 }

--- a/pkg/crc/preflight/preflight_checks_common.go
+++ b/pkg/crc/preflight/preflight_checks_common.go
@@ -44,7 +44,10 @@ func fixBundleCached() (bool, error) {
 		}
 		w := bufio.NewWriter(f)
 		defer w.Flush()
-		w.Write(data)
+		_, err = w.Write(data)
+		if err != nil {
+			return false, err
+		}
 		return true, nil
 	}
 	return false, fmt.Errorf("CRC bundle is not embedded in the binary, see 'crc help' for more details.")

--- a/pkg/crc/preflight/preflight_checks_linux.go
+++ b/pkg/crc/preflight/preflight_checks_linux.go
@@ -283,11 +283,7 @@ func checkLibvirtCrcNetworkAvailable() (bool, error) {
 	outputSlice := strings.Split(stdOut, "\n")
 	for _, stdOut = range outputSlice {
 		stdOut = strings.TrimSpace(stdOut)
-		match, err := regexp.MatchString("^crc\\s", stdOut)
-		if err != nil {
-			return false, err
-		}
-		if match {
+		if strings.HasPrefix(stdOut, "crc") {
 			logging.Debug("libvirt 'crc' network exists")
 			logging.Debug("Checking if libvirt 'crc' network definition contains ", constants.DefaultHostname)
 			// Check if the network have defined hostname. It might be possible that User already have an outdated crc network
@@ -352,11 +348,7 @@ func checkLibvirtCrcNetworkActive() (bool, error) {
 
 	for _, stdOut = range outputSlice {
 		stdOut = strings.TrimSpace(stdOut)
-		match, err := regexp.MatchString("^crc\\s", stdOut)
-		if err != nil {
-			return false, err
-		}
-		if match && strings.Contains(stdOut, "active") {
+		if strings.HasPrefix(stdOut, "crc") && strings.Contains(stdOut, "active") {
 			logging.Debug("libvirt 'crc' network is already active")
 			return true, nil
 		}

--- a/pkg/crc/preflight/preflight_checks_linux.go
+++ b/pkg/crc/preflight/preflight_checks_linux.go
@@ -322,9 +322,9 @@ func fixLibvirtCrcNetworkAvailable() (bool, error) {
 	// For time being we are going to override the crc network according what we have in our binary template.
 	// We also don't care about the error or output from those commands atm.
 	cmd := exec.Command("virsh", "--connect", "qemu:///system", "net-destroy", libvirt.DefaultNetwork)
-	cmd.Run()
+	_ = cmd.Run()
 	cmd = exec.Command("virsh", "--connect", "qemu:///system", "net-undefine", libvirt.DefaultNetwork)
-	cmd.Run()
+	_ = cmd.Run()
 	// Create the network according to our defined template
 	cmd = exec.Command("virsh", "--connect", "qemu:///system", "net-define", "/dev/stdin")
 	cmd.Stdin = strings.NewReader(netXMLDef.String())

--- a/pkg/crc/services/dns/dns.go
+++ b/pkg/crc/services/dns/dns.go
@@ -38,13 +38,13 @@ func RunPostStart(serviceConfig services.ServicePostStartConfig) (services.Servi
 		return *result, err
 	}
 
-	// Remove the dnsmasq container if exist during the VM stop cycle
-	drivers.RunSSHCommandFromDriver(serviceConfig.Driver, "sudo podman rm -f dnsmasq")
+	// Remove the dnsmasq container if it exists during the VM stop cycle
+	_, _ = drivers.RunSSHCommandFromDriver(serviceConfig.Driver, "sudo podman rm -f dnsmasq")
 
 	// Remove the CNI network definition forcefully
 	// https://github.com/containers/libpod/issues/2767
 	// TODO: We need to revisit it once podman update the CNI plugins.
-	drivers.RunSSHCommandFromDriver(serviceConfig.Driver, fmt.Sprintf("sudo rm -f /var/lib/cni/networks/podman/%s", dnsContainerIP))
+	_, _ = drivers.RunSSHCommandFromDriver(serviceConfig.Driver, fmt.Sprintf("sudo rm -f /var/lib/cni/networks/podman/%s", dnsContainerIP))
 
 	// Start the dnsmasq container
 	dnsServerRunCmd := fmt.Sprintf("sudo podman run  --ip %s --name dnsmasq -v %s:/etc/dnsmasq.conf -p 53:%d/udp --privileged -d %s",

--- a/pkg/crc/services/dns/dns_darwin.go
+++ b/pkg/crc/services/dns/dns_darwin.go
@@ -95,7 +95,7 @@ func restartNetwork() error {
 	}
 	for _, netdevice := range strings.Split(netDeviceList, "\n")[1:] {
 		time.Sleep(1 * time.Second)
-		stdout, stderr, err := crcos.RunWithDefaultLocale("networksetup", "-setnetworkserviceenabled", netdevice, "off")
+		stdout, stderr, _ := crcos.RunWithDefaultLocale("networksetup", "-setnetworkserviceenabled", netdevice, "off")
 		logging.Debugf("Disabling the %s Device (stdout: %s), (stderr: %s)", netdevice, stdout, stderr)
 		stdout, stderr, err = crcos.RunWithDefaultLocale("networksetup", "-setnetworkserviceenabled", netdevice, "on")
 		logging.Debugf("Enabling the %s Device (stdout: %s), (stderr: %s)", netdevice, stdout, stderr)

--- a/pkg/crc/services/dns/template.go
+++ b/pkg/crc/services/dns/template.go
@@ -70,6 +70,9 @@ func createDnsConfigFile(values dnsmasqConfFileValues) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	t.Execute(&dnsConfigFile, values)
+	err = t.Execute(&dnsConfigFile, values)
+	if err != nil {
+		return "", err
+	}
 	return dnsConfigFile.String(), nil
 }

--- a/pkg/crc/state/global.go
+++ b/pkg/crc/state/global.go
@@ -68,6 +68,9 @@ func (cfg *GlobalStateType) read() error {
 		return errors.New("Invalid JSON")
 	}
 
-	json.Unmarshal(raw, &cfg)
+	err = json.Unmarshal(raw, &cfg)
+	if err != nil {
+		return err
+	}
 	return nil
 }

--- a/pkg/crc/systemd/host.go
+++ b/pkg/crc/systemd/host.go
@@ -10,7 +10,6 @@ import (
 )
 
 type HostSystemdCommander struct {
-	commander SystemdCommander
 }
 
 func NewHostSystemdCommander() *HostSystemdCommander {

--- a/pkg/crc/systemd/host.go
+++ b/pkg/crc/systemd/host.go
@@ -41,7 +41,7 @@ func (c HostSystemdCommander) DaemonReload() (bool, error) {
 }
 
 func (c HostSystemdCommander) Reload(name string) (bool, error) {
-	c.DaemonReload()
+	_, _ = c.DaemonReload()
 	_, err := c.service(name, actions.Reload)
 
 	if err != nil {
@@ -51,7 +51,7 @@ func (c HostSystemdCommander) Reload(name string) (bool, error) {
 }
 
 func (c HostSystemdCommander) Restart(name string) (bool, error) {
-	c.DaemonReload()
+	_, _ = c.DaemonReload()
 	_, err := c.service(name, actions.Restart)
 
 	if err != nil {
@@ -61,7 +61,7 @@ func (c HostSystemdCommander) Restart(name string) (bool, error) {
 }
 
 func (c HostSystemdCommander) Start(name string) (bool, error) {
-	c.DaemonReload()
+	_, _ = c.DaemonReload()
 	_, err := c.service(name, actions.Start)
 	if err != nil {
 		return false, err

--- a/pkg/crc/systemd/instance.go
+++ b/pkg/crc/systemd/instance.go
@@ -45,7 +45,7 @@ func (c InstanceSystemdCommander) DaemonReload() (bool, error) {
 }
 
 func (c InstanceSystemdCommander) Restart(name string) (bool, error) {
-	c.DaemonReload()
+	_, _ = c.DaemonReload()
 	_, err := c.service(name, actions.Restart)
 	if err != nil {
 		return false, err
@@ -54,7 +54,7 @@ func (c InstanceSystemdCommander) Restart(name string) (bool, error) {
 }
 
 func (c InstanceSystemdCommander) Start(name string) (bool, error) {
-	c.DaemonReload()
+	_, _ = c.DaemonReload()
 	_, err := c.service(name, actions.Start)
 	if err != nil {
 		return false, err

--- a/pkg/extract/extract.go
+++ b/pkg/extract/extract.go
@@ -103,7 +103,10 @@ func Unzip(archive, target string) error {
 	for _, file := range reader.File {
 		path := filepath.Join(target, file.Name)
 		if file.FileInfo().IsDir() {
-			os.MkdirAll(path, file.Mode())
+			err = os.MkdirAll(path, file.Mode())
+			if err != nil {
+				return err
+			}
 			continue
 		}
 

--- a/pkg/os/shell/shell.go
+++ b/pkg/os/shell/shell.go
@@ -1,10 +1,10 @@
 package shell
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 
+	"github.com/code-ready/crc/pkg/crc/errors"
 	"github.com/code-ready/machine/libmachine/shell"
 )
 
@@ -18,7 +18,7 @@ type ShellConfig struct {
 func GetShell(userShell string) (string, error) {
 	if userShell != "" {
 		if !isSupportedShell(userShell) {
-			return "", errors.New(fmt.Sprintf("'%s' is not a supported shell.\nSupported shells are %s.", userShell, strings.Join(supportedShell, ", ")))
+			return "", errors.Newf("'%s' is not a supported shell.\nSupported shells are %s.", userShell, strings.Join(supportedShell, ", "))
 		}
 		return userShell, nil
 	}

--- a/pkg/os/util.go
+++ b/pkg/os/util.go
@@ -64,16 +64,16 @@ func CurrentExecutable() (string, error) {
 func CopyFileContents(src string, dst string, permission os.FileMode) error {
 	logging.Debugf("Copying '%s' to '%s'\n", src, dst)
 	srcFile, err := os.Open(src)
-	defer srcFile.Close()
 	if err != nil {
 		return fmt.Errorf("[%v] Cannot open src file '%s'", err, src)
 	}
+	defer srcFile.Close()
 
 	destFile, err := os.OpenFile(dst, os.O_RDWR|os.O_CREATE, permission)
-	defer destFile.Close()
 	if err != nil {
 		return fmt.Errorf("[%v] Cannot create dst file '%s'", err, dst)
 	}
+	defer destFile.Close()
 
 	_, err = io.Copy(destFile, srcFile)
 	if err != nil {


### PR DESCRIPTION
This patch series fixes the various issues reported by golangci-lint, and then enable it in the CI.
Some of these issues were actual bugs.