### PR TITLE
[WIP] Issue #442 Print exp for changing encoding to UTF-8 in posh

### DIFF
--- a/pkg/os/shell/shell.go
+++ b/pkg/os/shell/shell.go
@@ -40,7 +40,7 @@ func GenerateUsageHint(userShell, cmdLine string) string {
 
 	switch userShell {
 	case "powershell":
-		cmd = fmt.Sprintf("& %s | Invoke-Expression", cmdLine)
+		cmd = fmt.Sprintf("[System.Console]::OutputEncoding = [Text.UTF8Encoding]::UTF8; & %s | Invoke-Expression", cmdLine)
 	case "cmd":
 		cmd = fmt.Sprintf("\t@FOR /f \"tokens=*\" %%i IN ('%s') DO @call %%i", cmdLine)
 		comment = "REM"


### PR DESCRIPTION
Posh does not use UTF encoding by default, which leads to
malformed paths in $Env:Path when user tries to add oc to
path using oc-env command. this only happens when there
are accented chars or any special chars are present.

Fixes #442  /cc @tsedmik 