### PR TITLE
Issue #459 Add NetworkManager preflight checks for libvirt

### DIFF
--- a/cmd/crc/cmd/config/config_linux.go
+++ b/cmd/crc/cmd/config/config_linux.go
@@ -30,4 +30,8 @@ var (
 	WarnCheckCrcDnsmasqFile          = createSetting("warn-check-crc-dnsmasq-file", nil, []validationFnType{validations.ValidateBool})
 	SkipCheckCrcNetworkManagerConfig = createSetting("skip-check-network-manager-config", nil, []validationFnType{validations.ValidateBool})
 	WarnCheckCrcNetworkManagerConfig = createSetting("warn-check-network-manager-config", nil, []validationFnType{validations.ValidateBool})
+	WarnCheckNetworkManagerInstalled = createSetting("warn-check-network-manager-installed", nil, []validationFnType{validations.ValidateBool})
+	SkipCheckNetworkManagerInstalled = createSetting("skip-check-network-manager-installed", nil, []validationFnType{validations.ValidateBool})
+	WarnCheckNetworkManagerRunning   = createSetting("warn-check-network-manager-running", nil, []validationFnType{validations.ValidateBool})
+	SkipCheckNetworkManagerRunning   = createSetting("skip-check-network-manager-running", nil, []validationFnType{validations.ValidateBool})
 )

--- a/pkg/crc/preflight/preflight_checks_linux.go
+++ b/pkg/crc/preflight/preflight_checks_linux.go
@@ -455,3 +455,34 @@ func fixCrcNetworkManagerConfig() (bool, error) {
 	logging.Debug("NetworkManager configuration fixed")
 	return true, nil
 }
+func checkNetworkManagerInstalled() (bool, error) {
+	logging.Debug("Checking if 'nmcli' is available")
+	path, err := exec.LookPath("nmcli")
+	if err != nil {
+		return false, errors.New("NetworkManager cli nmcli was not found in path")
+	}
+	logging.Debug("'nmcli' was found in ", path)
+	return true, nil
+}
+func fixNetworkManagerInstalled() (bool, error) {
+	return false, fmt.Errorf("NetworkManager is required and must be installed manually")
+}
+func CheckNetworkManagerIsRunning() (bool, error) {
+	logging.Debug("Checking if NetworkManager.service is running")
+	path, err := exec.LookPath("systemctl")
+	if err != nil {
+		return false, err
+	}
+	stdOut, stdErr, err := crcos.RunWithDefaultLocale(path, "is-active", "NetworkManager")
+	if err != nil {
+		return false, fmt.Errorf("%v : %s", err, stdErr)
+	}
+	if strings.TrimSpace(stdOut) != "active" {
+		return false, errors.New("NetworkManager.service is not running")
+	}
+	logging.Debug("NetworkManager.service is already running")
+	return true, nil
+}
+func fixNetworkManagerIsRunning() (bool, error) {
+	return false, fmt.Errorf("NetworkManager is required. Please make sure it is installed and running manually")
+}

--- a/pkg/crc/preflight/preflight_linux.go
+++ b/pkg/crc/preflight/preflight_linux.go
@@ -7,6 +7,16 @@ import (
 
 // StartPreflightChecks performs the preflight checks before starting the cluster
 func StartPreflightChecks(vmDriver string) {
+	preflightCheckSucceedsOrFails(config.GetBool(cmdConfig.SkipCheckNetworkManagerInstalled.Name),
+		checkNetworkManagerInstalled,
+		"Checking if NetworkManager is installed",
+		config.GetBool(cmdConfig.WarnCheckNetworkManagerInstalled.Name),
+	)
+	preflightCheckSucceedsOrFails(config.GetBool(cmdConfig.SkipCheckNetworkManagerRunning.Name),
+		CheckNetworkManagerIsRunning,
+		"Checking if NetworkManager service is running",
+		config.GetBool(cmdConfig.WarnCheckNetworkManagerRunning.Name),
+	)
 	preflightCheckSucceedsOrFails(false,
 		checkOcBinaryCached,
 		"Checking if oc binary is cached",
@@ -76,6 +86,18 @@ func StartPreflightChecks(vmDriver string) {
 
 // SetupHost performs the prerequisite checks and setups the host to run the cluster
 func SetupHost(vmDriver string) {
+	preflightCheckAndFix(config.GetBool(cmdConfig.SkipCheckNetworkManagerInstalled.Name),
+		checkNetworkManagerInstalled,
+		fixNetworkManagerInstalled,
+		"Checking if NetworkManager is installed",
+		config.GetBool(cmdConfig.WarnCheckNetworkManagerInstalled.Name),
+	)
+	preflightCheckAndFix(config.GetBool(cmdConfig.SkipCheckNetworkManagerRunning.Name),
+		CheckNetworkManagerIsRunning,
+		fixNetworkManagerIsRunning,
+		"Checking if NetworkManager service is running",
+		config.GetBool(cmdConfig.WarnCheckNetworkManagerRunning.Name),
+	)
 	preflightCheckAndFix(false,
 		checkOcBinaryCached,
 		fixOcBinaryCached,


### PR DESCRIPTION
NetworkManager is required to setup the dnsmasq for application
domain which should be used by the applications created on crc.
Sometime headless os doesn't have NetworkManager by default so
we should warn user before even start.