### PR TITLE
Issue #473 setup golang env for build_docs job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,8 +49,28 @@ jobs:
   build_docs:
     machine:
       image: ubuntu-1604:201903-01
+    environment:
+      GOVERSION: "1.11.6"
     steps:
     - checkout
+    - run:
+        name: Configure GOPATH
+        command: echo 'export GOPATH=$HOME/go' >> $BASH_ENV
+    - run:
+        name: Configure Path
+        command: echo 'export PATH=$GOPATH/bin:/usr/local/go/bin/:$PATH' >> $BASH_ENV
+    - run:
+        name: Cleanup GOROOT
+        command: sudo rm -rf /usr/local/go
+    - run:
+        name: Install go
+        command: curl https://dl.google.com/go/go${GOVERSION}.linux-amd64.tar.gz | sudo tar -C /usr/local -xz
+    - run:
+        name: List go version
+        command: go version
+    - run:
+        name: List go environment
+        command: go env
     - run:
         name: Update repo
         command: sudo apt -y update


### PR DESCRIPTION
As we are using `go env` commands in our makefile
we need a working golang env for it to work.

Fixes #473 