### PR TITLE
Issue #475 Add stderr to returned err for libvirt driver version check

### DIFF
--- a/pkg/crc/preflight/preflight_checks_linux.go
+++ b/pkg/crc/preflight/preflight_checks_linux.go
@@ -228,7 +228,7 @@ func checkMachineDriverLibvirtInstalled() (bool, error) {
 	// Check the version of driver if it matches to supported one
 	stdOut, stdErr, err := crcos.RunWithDefaultLocale(libvirtDriverPath, "version")
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("%v : %s", err, stdErr)
 	}
 	if !strings.Contains(stdOut, libvirtDriverVersion) {
 		return false, fmt.Errorf("crc-driver-libvirt does not have right version \n Required: %s \n Got: %s use 'crc setup' command.\n %v\n", libvirtDriverVersion, stdOut, stdErr)


### PR DESCRIPTION
$ crc start -b .crc/crc_libvirt_4.1.9.crcbundle Issue #475
[...]
INFO Checking if crc-driver-libvirt is installed
FATA exit status 1

$ crc-driver-libvirt -v
crc-driver-libvirt: /lib64/libvirt.so.0: version `LIBVIRT_3.4.0' not found (required by crc-driver-libvirt)

No explaination given to user if they are using libvirt < 3.4.0, why it happened,
since we are not adding stderr to the error message.