### PR TITLE
Issue #482 Use DefaultBundlePath to check if needs unpacking

### DIFF
--- a/pkg/crc/preflight/preflight_checks_common.go
+++ b/pkg/crc/preflight/preflight_checks_common.go
@@ -9,15 +9,13 @@ import (
 	"github.com/YourFin/binappend"
 	"github.com/kardianos/osext"
 
-	cmdConfig "github.com/code-ready/crc/cmd/crc/cmd/config"
-	"github.com/code-ready/crc/pkg/crc/config"
 	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/code-ready/crc/pkg/crc/logging"
 	"github.com/code-ready/crc/pkg/crc/oc"
 )
 
 func checkBundleCached() (bool, error) {
-	if _, err := os.Stat(config.GetString(cmdConfig.Bundle.Name)); os.IsNotExist(err) {
+	if _, err := os.Stat(constants.DefaultBundlePath); os.IsNotExist(err) {
 		return false, err
 	}
 	return true, nil

--- a/pkg/crc/preflight/preflight_darwin.go
+++ b/pkg/crc/preflight/preflight_darwin.go
@@ -45,11 +45,6 @@ func StartPreflightChecks(vmDriver string) {
 		fmt.Sprintf("Checking file permissions for %s", hostFile),
 		config.GetBool(cmdConfig.WarnCheckResolvConfFilePermissions.Name),
 	)
-	preflightCheckSucceedsOrFails(config.GetBool(cmdConfig.SkipCheckBundleCached.Name),
-		checkBundleCached,
-		"Checking if CRC bundle is cached in '$HOME/.crc'",
-		config.GetBool(cmdConfig.WarnCheckBundleCached.Name),
-	)
 }
 
 // SetupHost performs the prerequisite checks and setups the host to run the cluster

--- a/pkg/crc/preflight/preflight_linux.go
+++ b/pkg/crc/preflight/preflight_linux.go
@@ -77,11 +77,6 @@ func StartPreflightChecks(vmDriver string) {
 		"Checking if /etc/NetworkManager/dnsmasq.d/crc.conf exists",
 		config.GetBool(cmdConfig.WarnCheckCrcDnsmasqFile.Name),
 	)
-	preflightCheckSucceedsOrFails(config.GetBool(cmdConfig.SkipCheckBundleCached.Name),
-		checkBundleCached,
-		"Checking if CRC bundle is cached in '$HOME/.crc'",
-		config.GetBool(cmdConfig.WarnCheckBundleCached.Name),
-	)
 }
 
 // SetupHost performs the prerequisite checks and setups the host to run the cluster

--- a/pkg/crc/preflight/preflight_windows.go
+++ b/pkg/crc/preflight/preflight_windows.go
@@ -14,11 +14,6 @@ func StartPreflightChecks(vmDriver string) {
 		"Checking if oc binary is cached",
 		false,
 	)
-	preflightCheckSucceedsOrFails(config.GetBool(cmdConfig.SkipCheckBundleCached.Name),
-		checkBundleCached,
-		"Checking if CRC bundle is cached in '$HOME/.crc'",
-		config.GetBool(cmdConfig.WarnCheckBundleCached.Name),
-	)
 
 	if vmDriver == "hyperv" {
 		preflightCheckSucceedsOrFails(false,


### PR DESCRIPTION
Use DefaultBundlePath to check if needs unpacking in crc setup command, on crc start bundle config is set use the configured value, otherwise use DefaultBundlePath.