### PR TITLE
Issue #501: integration: Check we are getting enough arguments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,6 +117,8 @@ clean: clean_docs
 .PHONY: integration ## Run integration tests
 integration: GODOG_OPTS = --godog.tags=$(GOOS)
 integration:
+	@$(call check_defined, BUNDLE_LOCATION, "'make integration' requires BUNDLE_LOCATION to contain the full path to a bundle file")
+	@$(call check_defined, PULL_SECRET_FILE, "'make integration' requires PULL_SECRET_FILE to point to a file with the pull secret to use")
 	@go test --timeout=60m $(REPOPATH)/test/integration -v --tags=integration $(GODOG_OPTS) $(BUNDLE_LOCATION) $(PULL_SECRET_FILE)
 
 .PHONY: fmt

--- a/test/integration/crcsuite/prepare.go
+++ b/test/integration/crcsuite/prepare.go
@@ -61,6 +61,10 @@ func DownloadBundle(bundleLocation string, bundleDestination string) (string, er
 func ParseFlags() {
 
 	flag.Parse()
+	if flag.NArg() < 2 {
+		fmt.Printf("Invalid number of arguments, the paths to the bundle file and to the pull secret file are required\n")
+		os.Exit(1)
+	}
 	bundleURL = flag.Args()[0]
 	_, bundleName = filepath.Split(bundleURL)
 	pullSecretFile = flag.Args()[1]


### PR DESCRIPTION
Running 'make integration' without setting BUNDLE_LOCATION and PULL_SECRET_FILE
results in a segfault because there are not enough arguments:

$ make integration
panic: runtime error: index out of range

goroutine 1 [running]:
github.com/code-ready/crc/test/integration/crcsuite.ParseFlags()
        /home/teuf/go/src/github.com/code-ready/crc/test/integration/crcsuite/prepare.go:64 +0x154
github.com/code-ready/crc/test/integration.parseFlags()
        /home/teuf/go/src/github.com/code-ready/crc/test/integration/integration_test.go:62 +0x25
github.com/code-ready/crc/test/integration.TestMain(0xc0000b1f10)
        /home/teuf/go/src/github.com/code-ready/crc/test/integration/integration_test.go:33 +0x34
main.main()
        _testmain.go:38 +0x10f
FAIL    github.com/code-ready/crc/test/integration      0.015s
make: *** [Makefile:120: integration] Error 1

This commit adds an error message + os.Exit(1) so that it's easier to know what's going on.

This fixes https://github.com/code-ready/crc/issues/501