### PR TITLE
Issue #477 Add warn if cert going to expire in 7 days.

### DIFF
--- a/pkg/crc/cluster/cluster.go
+++ b/pkg/crc/cluster/cluster.go
@@ -22,21 +22,44 @@ func WaitForSsh(driver drivers.Driver) error {
 	return errors.RetryAfter(10, checkSshConnectivity, time.Second)
 }
 
-// CheckCertsValidity checks if the cluster certs have expired
-func CheckCertsValidity(driver drivers.Driver) error {
+// CheckCertsValidityUsingBundleBuildTime check if the cluster certs going to expire soon.
+func CheckCertsValidityUsingBundleBuildTime(buildTime time.Time) (bool, int) {
+	certExpiryDate := buildTime.AddDate(0, 1, 0)
+	// Warn user if the cert expiry going to happen starting of the 7 days
+	timeAfter7Days := time.Now().AddDate(0, 0, 7)
+	return timeAfter7Days.After(certExpiryDate), int(time.Until(certExpiryDate).Hours()) / 24
+}
+
+// CheckCertsValidity checks if the cluster certs have expired or going to expire in next 7 days
+func CheckCertsValidity(driver drivers.Driver) (bool, int, error) {
+	certExpiryDate, err := getcertExipryDateFromVM(driver)
+	if err != nil {
+		return false, 0, err
+	}
+	if time.Now().After(certExpiryDate) {
+		return false, 0, fmt.Errorf("Certs have expired, they were valid till: %s", certExpiryDate.Format(time.RFC822))
+	}
+
+	// Warn user if the cert expiry going to happen starting of the 7 days
+	timeAfter7Days := time.Now().AddDate(0, 0, 7)
+	if timeAfter7Days.After(certExpiryDate) {
+		return true, int(time.Until(certExpiryDate).Hours()) / 24, nil
+	}
+	return false, 0, nil
+}
+
+func getcertExipryDateFromVM(driver drivers.Driver) (time.Time, error) {
+	certExpiryDate := time.Time{}
 	certExpiryDateCmd := `date --date="$(sudo openssl x509 -in /var/lib/kubelet/pki/kubelet-client-current.pem -noout -enddate | cut -d= -f 2)" --iso-8601=seconds`
 	output, err := drivers.RunSSHCommandFromDriver(driver, certExpiryDateCmd)
 	if err != nil {
-		return err
+		return certExpiryDate, err
 	}
-	certExpiryDate, err := time.Parse(time.RFC3339, strings.TrimSpace(output))
+	certExpiryDate, err = time.Parse(time.RFC3339, strings.TrimSpace(output))
 	if err != nil {
-		return err
+		return certExpiryDate, err
 	}
-	if time.Now().After(certExpiryDate) {
-		return fmt.Errorf("Certs have expired, they were valid till: %s", certExpiryDate.Format(time.RFC822))
-	}
-	return nil
+	return certExpiryDate, nil
 }
 
 // Return size of disk, used space in bytes and the mountpoint

--- a/pkg/crc/machine/bundle/metadata.go
+++ b/pkg/crc/machine/bundle/metadata.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 )
 
 // Metadata structure to unmarshal the crc-bundle-info.json file
@@ -124,4 +125,8 @@ func (bundle *CrcBundleInfo) GetInitramfsPath() string {
 func (bundle *CrcBundleInfo) GetKubeadminPassword() (string, error) {
 	rawData, err := ioutil.ReadFile(bundle.resolvePath(bundle.ClusterInfo.KubeadminPasswordFile))
 	return string(rawData), err
+}
+
+func (bundle *CrcBundleInfo) GetBundleBuildTime() (time.Time, error) {
+	return time.Parse(time.RFC3339, strings.TrimSpace(bundle.BuildInfo.BuildTime))
 }

--- a/pkg/crc/machine/machine.go
+++ b/pkg/crc/machine/machine.go
@@ -107,6 +107,16 @@ func Start(startConfig StartConfig) (StartResult, error) {
 			return *result, errors.Newf("Error getting bundle metadata: %v", err)
 		}
 
+		// Check if certificate is going to expire in next 7 days
+		buildTime, err := crcBundleMetadata.GetBundleBuildTime()
+		if err != nil {
+			result.Error = err.Error()
+			return *result, errors.Newf("Error getting bundle build time: %v", err)
+		}
+		if goingToExpire, duration := cluster.CheckCertsValidityUsingBundleBuildTime(buildTime); goingToExpire {
+			logging.Warnf("Bundle certificates are going to expire in %d days, better to use new release", duration)
+		}
+
 		logging.Infof("Creating VM ...")
 		// Retrieve metadata info
 		diskPath := crcBundleMetadata.GetDiskImagePath()
@@ -205,9 +215,16 @@ func Start(startConfig StartConfig) (StartResult, error) {
 
 	// Check the certs validity inside the vm
 	logging.Info("Verifying validity of the cluster certificates ...")
-	if err := cluster.CheckCertsValidity(host.Driver); err != nil {
+	expiringIn7Days, duration, err := cluster.CheckCertsValidity(host.Driver)
+	if err != nil {
 		result.Error = err.Error()
 		return *result, errors.New(err.Error())
+	}
+	// Only show when VM is started from stopped state.
+	if exists {
+		if expiringIn7Days {
+			logging.Warnf("Bundle certificates are going to expire in %d days, better to use new release", duration)
+		}
 	}
 	// Add nameserver to VM if provided by User
 	if startConfig.NameServer != "" {


### PR DESCRIPTION
If a user start VM from a clean state then check the bundle build
time and warn user about cert expiry. If user start a stopped VM
then from the VM check the validation of cert and warn the user.