### PR TITLE
Issue #544 Recognize if bundle is embedded or not in integration tests

### DIFF
--- a/test/integration/crcsuite/crcsuite.go
+++ b/test/integration/crcsuite/crcsuite.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	clicumber "github.com/code-ready/clicumber/testsuite"
+	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/code-ready/crc/pkg/crc/oc"
 )
 
@@ -223,7 +224,13 @@ func LoginToOcClusterSucceedsOrFails(expected string) error {
 
 func StartCRCWithDefaultBundleAndDefaultHypervisorSucceedsOrFails(expected string) error {
 
-	cmd := fmt.Sprintf("crc start -b %s -p '%s' --log-level debug", bundleName, pullSecretFile)
+	var cmd string
+	var extraBundleArgs string
+
+	if !constants.BundleEmbedded() {
+		extraBundleArgs = fmt.Sprintf("-b %s", bundleName)
+	}
+	cmd = fmt.Sprintf("crc start -p '%s' %s --log-level debug", pullSecretFile, extraBundleArgs)
 	err := clicumber.ExecuteCommandSucceedsOrFails(cmd, expected)
 
 	return err
@@ -231,7 +238,13 @@ func StartCRCWithDefaultBundleAndDefaultHypervisorSucceedsOrFails(expected strin
 
 func StartCRCWithDefaultBundleAndHypervisorSucceedsOrFails(hypervisor string, expected string) error {
 
-	cmd := fmt.Sprintf("crc start -b %s -d %s -p '%s' --log-level debug", bundleName, hypervisor, pullSecretFile)
+	var cmd string
+	var extraBundleArgs string
+
+	if !constants.BundleEmbedded() {
+		extraBundleArgs = fmt.Sprintf("-b %s", bundleName)
+	}
+	cmd = fmt.Sprintf("crc start -d %s -p '%s' %s --log-level debug", hypervisor, pullSecretFile, extraBundleArgs)
 	err := clicumber.ExecuteCommandSucceedsOrFails(cmd, expected)
 
 	return err

--- a/test/integration/features/basic.feature
+++ b/test/integration/features/basic.feature
@@ -60,7 +60,7 @@ Feature: Basic test
     
     @darwin @linux @windows
     Scenario: CRC status check
-        When with up to "10" retries with wait period of "1m" command "crc status" output should not contain "Stopped"
+        When with up to "15" retries with wait period of "1m" command "crc status" output should not contain "Stopped"
         And stdout should contain "Running"
 
     @darwin @linux @windows


### PR DESCRIPTION
I couldn't find any metadata of the `crc` binary that would identify an embedded bundle (except for file size). So, based on the output of `crc setup`, a variable `bundleEmbedded` is set to `true` or `false` and CRC is always started with `-b` flag if `false` and without it if `true`. 