### PR TITLE
Docs: add common tasks section, start with running prometheus

### DIFF
--- a/docs/source/getting-started/content/assembly_common-tasks.adoc
+++ b/docs/source/getting-started/content/assembly_common-tasks.adoc
@@ -1,0 +1,4 @@
+[id="common-tasks_{context}"]
+= Common tasks
+
+include::proc_starting-monitoring-alerting-telemetry.adoc[leveloffset=+1]

--- a/docs/source/getting-started/content/proc_starting-monitoring-alerting-telemetry.adoc
+++ b/docs/source/getting-started/content/proc_starting-monitoring-alerting-telemetry.adoc
@@ -1,0 +1,19 @@
+[id="starting-monitoring-alerting-telemetry_{context}"]
+= Starting Monitoring, Alerting, and Telemetry
+
+In order to make sure {prod} can run on a typical laptop, some resource–heavy services get disabled by default.
+One of these is Prometheus and all the related monitoring, alerting, and telemetry functionality, with the latter being responsible for your cluster being listed in the link:https://cloud.redhat.com/openshift[Red Hat OpenShift Cluster Manager].
+
+.Prerequisites
+
+* A running {prod} virtual machine and a working [command]`oc` command.
+For more information, see <<accessing-the-openshift-cluster_{context}>>.
+
+.Procedure
+
+. Start monitoring, alerting, and telemetry services:
++
+[subs="+quotes,attributes"]
+----
+$ oc scale --replicas=1 statefulset --all -n openshift-monitoring; oc scale --replicas=1 deployment --all -n openshift-monitoring
+----

--- a/docs/source/getting-started/master.adoc
+++ b/docs/source/getting-started/master.adoc
@@ -6,4 +6,6 @@ include::common-content/attributes.adoc[]
 
 include::content/assembly_getting-started.adoc[leveloffset=+1]
 
+include::content/assembly_common-tasks.adoc[leveloffset=+1]
+
 include::content/assembly_troubleshooting.adoc[leveloffset=+1]


### PR DESCRIPTION
Let's make sure all the steps required for configuring your crc instance into more of a full-featured openshift cluster are in one place.

(Next patch should be for bumping memory and cpu allocation.)