### PR TITLE
Issue #529 Prevent Hyper-V specific setup when vbox is used

### DIFF
--- a/pkg/crc/services/dns/dns_windows.go
+++ b/pkg/crc/services/dns/dns_windows.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/code-ready/crc/pkg/crc/errors"
+	"github.com/code-ready/crc/pkg/crc/output"
 	"github.com/code-ready/crc/pkg/crc/services"
 
 	"github.com/code-ready/crc/pkg/os/windows/powershell"
@@ -14,6 +15,13 @@ import (
 )
 
 func runPostStartForOS(serviceConfig services.ServicePostStartConfig, result *services.ServicePostStartResult) (services.ServicePostStartResult, error) {
+	// bailout for Virtualbox
+	if serviceConfig.Driver.DriverName() == "virtualbox" {
+		output.Out("Please follow instructions in the documentation about setting hostnames for Virtualbox.")
+		result.Success = true
+		return *result, nil
+	}
+
 	// TODO: localize
 	networkInterface := "vEthernet (Default Switch)" //getMainInterface()
 


### PR DESCRIPTION
Fixes #529

Needs to be tested, but all it should do is to prevent the DNS setup for Virtualbox. This has to be a manual step instead ... 