### PR TITLE
Issue #566: Rename {skip,warn}-check-resolv-conf-file-permissions

### DIFF
--- a/cmd/crc/cmd/config/config_darwin.go
+++ b/cmd/crc/cmd/config/config_darwin.go
@@ -6,12 +6,12 @@ import (
 
 var (
 	// Preflight checks
-	SkipCheckResolverFilePermissions   = cfg.AddSetting("skip-check-resolver-file-permissions", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})
-	WarnCheckResolverFilePermissions   = cfg.AddSetting("warn-check-resolver-file-permissions", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})
-	SkipCheckResolvConfFilePermissions = cfg.AddSetting("skip-check-resolv-conf-file-permissions", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})
-	WarnCheckResolvConfFilePermissions = cfg.AddSetting("warn-check-resolv-conf-file-permissions", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})
-	SkipCheckHyperKitDriver            = cfg.AddSetting("skip-check-hyperkit-installed", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})
-	WarnCheckHyperKitDriver            = cfg.AddSetting("warn-check-hyperkit-installed", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})
-	SkipCheckHyperKitInstalled         = cfg.AddSetting("skip-check-hyperkit-driver", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})
-	WarnCheckHyperKitInstalled         = cfg.AddSetting("warn-check-hyperkit-driver", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})
+	SkipCheckResolverFilePermissions = cfg.AddSetting("skip-check-resolver-file-permissions", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})
+	WarnCheckResolverFilePermissions = cfg.AddSetting("warn-check-resolver-file-permissions", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})
+	SkipCheckHostsFilePermissions    = cfg.AddSetting("skip-check-hosts-file-permissions", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})
+	WarnCheckHostsFilePermissions    = cfg.AddSetting("warn-check-hosts-file-permissions", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})
+	SkipCheckHyperKitDriver          = cfg.AddSetting("skip-check-hyperkit-installed", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})
+	WarnCheckHyperKitDriver          = cfg.AddSetting("warn-check-hyperkit-installed", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})
+	SkipCheckHyperKitInstalled       = cfg.AddSetting("skip-check-hyperkit-driver", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})
+	WarnCheckHyperKitInstalled       = cfg.AddSetting("warn-check-hyperkit-driver", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})
 )

--- a/pkg/crc/preflight/preflight_checks_darwin.go
+++ b/pkg/crc/preflight/preflight_checks_darwin.go
@@ -236,11 +236,11 @@ func fixResolverFilePermissions() (bool, error) {
 	return addFileWritePermissionToUser(resolverFile)
 }
 
-func checkResolvConfFilePermissions() (bool, error) {
+func checkHostsFilePermissions() (bool, error) {
 	return isUserHaveFileWritePermission(hostFile)
 }
 
-func fixResolvConfFilePermissions() (bool, error) {
+func fixHostsFilePermissions() (bool, error) {
 	return addFileWritePermissionToUser(hostFile)
 }
 

--- a/pkg/crc/preflight/preflight_darwin.go
+++ b/pkg/crc/preflight/preflight_darwin.go
@@ -39,16 +39,16 @@ func StartPreflightChecks(vmDriver string) {
 		)
 	}
 
-	preflightCheckSucceedsOrFails(config.GetBool(cmdConfig.SkipCheckResolverFilePermissions.Name),
-		checkResolverFilePermissions,
+	preflightCheckSucceedsOrFails(config.GetBool(cmdConfig.SkipCheckHostsFilePermissions.Name),
+		checkHostsFilePermissions,
 		fmt.Sprintf("Checking file permissions for %s", resolverFile),
-		config.GetBool(cmdConfig.WarnCheckResolverFilePermissions.Name),
+		config.GetBool(cmdConfig.WarnCheckHostsFilePermissions.Name),
 	)
 
-	preflightCheckSucceedsOrFails(config.GetBool(cmdConfig.SkipCheckResolvConfFilePermissions.Name),
-		checkResolvConfFilePermissions,
+	preflightCheckSucceedsOrFails(config.GetBool(cmdConfig.SkipCheckHostsFilePermissions.Name),
+		checkHostsFilePermissions,
 		fmt.Sprintf("Checking file permissions for %s", hostFile),
-		config.GetBool(cmdConfig.WarnCheckResolvConfFilePermissions.Name),
+		config.GetBool(cmdConfig.WarnCheckHostsFilePermissions.Name),
 	)
 }
 
@@ -97,11 +97,11 @@ func SetupHost(vmDriver string) {
 		config.GetBool(cmdConfig.WarnCheckResolverFilePermissions.Name),
 	)
 
-	preflightCheckAndFix(config.GetBool(cmdConfig.SkipCheckResolvConfFilePermissions.Name),
-		checkResolvConfFilePermissions,
-		fixResolvConfFilePermissions,
+	preflightCheckAndFix(config.GetBool(cmdConfig.SkipCheckHostsFilePermissions.Name),
+		checkHostsFilePermissions,
+		fixHostsFilePermissions,
 		fmt.Sprintf("Setting file permissions for %s", hostFile),
-		config.GetBool(cmdConfig.WarnCheckResolvConfFilePermissions.Name),
+		config.GetBool(cmdConfig.WarnCheckHostsFilePermissions.Name),
 	)
 	preflightCheckAndFix(config.GetBool(cmdConfig.SkipCheckBundleCached.Name),
 		checkBundleCached,


### PR DESCRIPTION
Since commit c426c9202, we are no longer using /etc/resolv.conf, but we
use /etc/hosts instead. However, the corresponding preflight configuration
keys were not renamed, which makes them misleading. This commit changes
"resolv-conf" to "hosts" in their naming.

This resolves https://github.com/code-ready/crc/issues/566