### PR TITLE
Issue #467 Ignore Upgradeable status from debug message

### DIFF
--- a/pkg/crc/oc/clusteroperator.go
+++ b/pkg/crc/oc/clusteroperator.go
@@ -59,6 +59,8 @@ func GetClusterOperatorStatus(oc OcConfig) (bool, error) {
 					logging.Debug(c.Metadata.Name, " operator is still progressing, Reason: ", con.Reason)
 					allAvailable = false
 				}
+			case "Upgradeable":
+				continue
 			default:
 				logging.Debugf("Unexpected operator status for %s: %s", c.Metadata.Name, con.Type)
 			}


### PR DESCRIPTION
Any cluster operator have 4 different status message `available`,
`progressing`, `degraded` and `upgradeable`. `crc status` is not
interested on the `upgradeable` status when fetch the json dump data
so better to ignore it since those messages are part of debug logs.