### PR TITLE
Issue #588 Remove bundle version from version section.

### DIFF
--- a/cmd/crc/cmd/version.go
+++ b/cmd/crc/cmd/version.go
@@ -38,7 +38,7 @@ var versionCmd = &cobra.Command{
 }
 
 func runPrintVersion(arguments []string) {
-	fmt.Printf("version: %s-%s+%s\n", version.GetCRCVersion(), version.GetBundleVersion(), version.GetCommitSha())
+	fmt.Printf("version: %s+%s\n", version.GetCRCVersion(), version.GetCommitSha())
 	var embedded string
 	if constants.BundleEmbedded() {
 		embedded = "embedded in binary"


### PR DESCRIPTION
Without this `version` output look following, which doesn't make sense
since now Openshift version is part of version command and contain
this detail.

```
$ ./crc version
version: 1.0.0-beta.2-4.1.11+a0732c0
OpenShift version: 4.1.11 (not embedded in binary)
```

With this change, now it looks bit sane.

```
$ ./crc version
version: 1.0.0-beta.2+a0732c0
OpenShift version: 4.1.11 (not embedded in binary)
```