### PR TITLE
Use openshift version from bundle in more places

### DIFF
--- a/pkg/crc/machine/bundle/metadata.go
+++ b/pkg/crc/machine/bundle/metadata.go
@@ -22,6 +22,7 @@ type CrcBundleInfo struct {
 		SncVersion                string `json:"sncVersion"`
 	} `json:"buildInfo"`
 	ClusterInfo struct {
+		OpenShiftVersion      string `json:"openshiftVersion"`
 		ClusterName           string `json:"clusterName"`
 		BaseDomain            string `json:"baseDomain"`
 		AppsDomain            string `json:"appsDomain"`
@@ -129,4 +130,8 @@ func (bundle *CrcBundleInfo) GetKubeadminPassword() (string, error) {
 
 func (bundle *CrcBundleInfo) GetBundleBuildTime() (time.Time, error) {
 	return time.Parse(time.RFC3339, strings.TrimSpace(bundle.BuildInfo.BuildTime))
+}
+
+func (bundle *CrcBundleInfo) GetOpenshiftVersion() string {
+	return bundle.ClusterInfo.OpenShiftVersion
 }

--- a/pkg/crc/machine/machine.go
+++ b/pkg/crc/machine/machine.go
@@ -177,7 +177,7 @@ func Start(startConfig StartConfig) (StartResult, error) {
 			return *result, errors.Newf("Error loading bundle metadata: %v", err)
 		}
 		if bundleName != filepath.Base(startConfig.BundlePath) {
-			logging.Warnf("Bundle '%s' was requested, but loaded VM is using '%s'",
+			logging.Fatalf("Bundle '%s' was requested, but loaded VM is using '%s'",
 				filepath.Base(startConfig.BundlePath), bundleName)
 		}
 		if host.Driver.DriverName() != startConfig.VMDriver {

--- a/pkg/crc/machine/machine.go
+++ b/pkg/crc/machine/machine.go
@@ -518,8 +518,14 @@ func Status(statusConfig ClusterStatusConfig) (ClusterStatusResult, error) {
 			return *result, errors.New(err.Error())
 		}
 		if operatorsRunning {
-			// TODO:get openshift version as well and add to status
-			openshiftStatus = fmt.Sprintf("Running (v4.x)")
+			openshiftVersion := "4.x"
+			_, crcBundleMetadata, err := getBundleMetadataFromDriver(host.Driver)
+			if err != nil {
+				logging.Debugf("Failed to load bundle metadata: %s", err.Error())
+			} else if crcBundleMetadata.GetOpenshiftVersion() != "" {
+				openshiftVersion = crcBundleMetadata.GetOpenshiftVersion()
+			}
+			openshiftStatus = fmt.Sprintf("Running (v%s)", openshiftVersion)
 		}
 		sshRunner := crcssh.CreateRunner(host.Driver)
 		diskSize, diskUse, err = cluster.GetRootPartitionUsage(sshRunner)

--- a/pkg/crc/machine/machine.go
+++ b/pkg/crc/machine/machine.go
@@ -128,7 +128,13 @@ func Start(startConfig StartConfig) (StartResult, error) {
 			logging.Warnf("Bundle certificates are going to expire in %d days, better to use new release", duration)
 		}
 
-		logging.Infof("Creating VM ...")
+		openshiftVersion := crcBundleMetadata.GetOpenshiftVersion()
+		if openshiftVersion == "" {
+			logging.Infof("Creating VM...")
+		} else {
+			logging.Infof("Creating CodeReady Containers VM for OpenShift %s...", openshiftVersion)
+		}
+
 		// Retrieve metadata info
 		diskPath := crcBundleMetadata.GetDiskImagePath()
 		machineConfig.DiskPathURL = fmt.Sprintf("file://%s", filepath.ToSlash(diskPath))
@@ -181,12 +187,23 @@ func Start(startConfig StartConfig) (StartResult, error) {
 			return *result, errors.Newf("Error getting the state for host: %v", err)
 		}
 		if vmState == state.Running {
+			openshiftVersion := crcBundleMetadata.GetOpenshiftVersion()
+			if openshiftVersion == "" {
+				logging.Infof("A CodeReady Containers VM is already running")
+			} else {
+				logging.Infof("A CodeReady Containers VM for OpenShift %s is already running", openshiftVersion)
+			}
 			result.Status = vmState.String()
 			return *result, nil
 		}
 
 		if vmState != state.Running {
-			logging.Infof("Starting stopped VM ...")
+			openshiftVersion := crcBundleMetadata.GetOpenshiftVersion()
+			if openshiftVersion == "" {
+				logging.Infof("Starting CodeReady Containers VM ...")
+			} else {
+				logging.Infof("Starting CodeReady Containers VM for OpenShift %s...", openshiftVersion)
+			}
 			if err := host.Driver.Start(); err != nil {
 				result.Error = err.Error()
 				return *result, errors.Newf("Error starting stopped VM: %v", err)

--- a/test/integration/features/story_health.feature
+++ b/test/integration/features/story_health.feature
@@ -8,7 +8,7 @@ Feature:
         When starting CRC with default bundle and hypervisor "<vm-driver>" succeeds
         Then stdout should contain "CodeReady Containers instance is running"
         And executing "eval $(crc oc-env)" succeeds
-        When with up to "4" retries with wait period of "2m" command "crc status" output should contain "Running (v4.x)"
+        When with up to "4" retries with wait period of "2m" command "crc status" output should contain "Running (v4."
         Then login to the oc cluster succeeds
 
     @darwin
@@ -24,7 +24,7 @@ Feature:
     @darwin @linux 
     Scenario: Check cluster health
         Given executing "crc status" succeeds
-        And stdout contains "Running (v4.x)"
+        And stdout contains "Running (v4."
         When executing "oc get nodes"
         Then stdout contains "Ready" 
         And stdout does not contain "Not ready"

--- a/test/integration/features/story_registry.feature
+++ b/test/integration/features/story_registry.feature
@@ -11,7 +11,7 @@ Feature: Local image to image-registry to deployment
         When starting CRC with default bundle and hypervisor "<vm-driver>" succeeds
         Then stdout should contain "CodeReady Containers instance is running"
         And executing "eval $(crc oc-env)" succeeds
-        When with up to "4" retries with wait period of "2m" command "crc status" output should contain "Running (v4.x)"
+        When with up to "4" retries with wait period of "2m" command "crc status" output should contain "Running (v4."
         Then login to the oc cluster succeeds
 
         Examples:


### PR DESCRIPTION
Now that it's available in the bundle metadata, we can print it in more places.