### PR TITLE
Issue #601 Adjust expected output in integration tests to match output of setup cmd

### DIFF
--- a/test/integration/features/basic.feature
+++ b/test/integration/features/basic.feature
@@ -13,6 +13,13 @@ Feature: Basic test
         When executing "crc --help" succeeds
         Then stdout should contain "Usage:"
         And stdout should contain "Available Commands:"
+        And stdout should contain "help"
+        And stdout should contain "version"
+        And stdout should contain "setup"
+        And stdout should contain "start"
+        And stdout should contain "stop"
+        And stdout should contain "delete"
+        And stdout should contain "status"
         And stdout should contain "Flags:"
         And stdout should contain 
             """

--- a/test/integration/features/basic.feature
+++ b/test/integration/features/basic.feature
@@ -47,22 +47,25 @@ Feature: Basic test
         And stdout should contain "Checking if NetworkManager is installed"
         And stdout should contain "Checking if NetworkManager service is running"
         And stdout should contain "Writing Network Manager config for crc"
-	And stdout should contain "Will use root access: write NetworkManager config in /etc/NetworkManager/conf.d/crc-nm-dnsmasq.conf"
+        And stdout should contain "Will use root access: write NetworkManager config in /etc/NetworkManager/conf.d/crc-nm-dnsmasq.conf"
         And stdout should contain "Will use root access: execute systemctl daemon-reload command"
         And stdout should contain "Will use root access: execute systemctl stop/start command"
         And stdout should contain "Writing dnsmasq config for crc"
-	And stdout should contain "Will use root access: write dnsmasq configuration in /etc/NetworkManager/dnsmasq.d/crc.conf"
-	And stdout should contain "Will use root access: execute systemctl daemon-reload command"
-	And stdout should contain "Will use root access: execute systemctl stop/start command"
+        And stdout should contain "Will use root access: write dnsmasq configuration in /etc/NetworkManager/dnsmasq.d/crc.conf"
+        And stdout should contain "Will use root access: execute systemctl daemon-reload command"
+        And stdout should contain "Will use root access: execute systemctl stop/start command"
         And stdout should contain "Unpacking bundle from the CRC binary"
-        And stdout should contain "Setup is complete, you can now run 'crc start -b $bundlename' to start a CodeReady Containers instance"
+        And stdout should contain "Setup is complete"
 
     @darwin
     Scenario: CRC setup on Mac
         When executing "crc setup" succeeds
-        Then stdout should contain "Caching oc binary"
+        Then stdout should contain "Checking if running as non-root" 
+        And stdout should contain "Caching oc binary"
         And stdout should contain "Setting up virtualization"
-        And stdout should contain "Setting file permissions for resolver"
+        And stdout should contain "Will use root access: change ownership"
+        And stdout should contain "Will use root access: set suid"
+        And stdout should contain "Setting file permissions"
 
     @linux
     Scenario: CRC start on Linux

--- a/test/integration/features/basic.feature
+++ b/test/integration/features/basic.feature
@@ -81,7 +81,7 @@ Feature: Basic test
 
     @darwin
     Scenario: CRC start on Mac
-        When starting CRC with default bundle and hypervisor "virtualbox" succeeds
+        When starting CRC with default bundle and hypervisor "hyperkit" succeeds
         Then stdout should contain "CodeReady Containers instance is running"
     
     @darwin @linux @windows


### PR DESCRIPTION
Did what it says on the tin, plus changed `virtualbox` hyperviser to `hyperkit` when passed as `-d` option to `crc start` in basic tests.