### PR TITLE
Issue #611 Don't include release dir to generated sha256 sum.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,17 +156,16 @@ release: fmtcheck embed_bundle build_docs_pdf
 	@mkdir -p $(BUILD_DIR)/crc-macos-$(CRC_VERSION)-amd64
 	@cp LICENSE $(DOCS_BUILD_DIR)/doc.pdf $(BUILD_DIR)/macos-amd64/crc $(BUILD_DIR)/crc-macos-$(CRC_VERSION)-amd64
 	tar cJSf $(RELEASE_DIR)/crc-macos-amd64.tar.xz -C $(BUILD_DIR) crc-macos-$(CRC_VERSION)-amd64
-	sha256sum $(RELEASE_DIR)/crc-macos-amd64.tar.xz > $(RELEASE_DIR)/sha256sum.txt
 
 	@mkdir -p $(BUILD_DIR)/crc-linux-$(CRC_VERSION)-amd64
 	@cp LICENSE $(DOCS_BUILD_DIR)/doc.pdf $(BUILD_DIR)/linux-amd64/crc $(BUILD_DIR)/crc-linux-$(CRC_VERSION)-amd64
 	tar cJSf $(RELEASE_DIR)/crc-linux-amd64.tar.xz -C $(BUILD_DIR) crc-linux-$(CRC_VERSION)-amd64
-	sha256sum $(RELEASE_DIR)/crc-linux-amd64.tar.xz >> $(RELEASE_DIR)/sha256sum.txt
 	
 	@mkdir -p $(BUILD_DIR)/crc-windows-$(CRC_VERSION)-amd64
 	@cp LICENSE $(DOCS_BUILD_DIR)/doc.pdf $(BUILD_DIR)/windows-amd64/crc.exe $(BUILD_DIR)/crc-windows-$(CRC_VERSION)-amd64
 	cd $(BUILD_DIR) && zip -r $(CURDIR)/$(RELEASE_DIR)/crc-windows-amd64.zip crc-windows-$(CRC_VERSION)-amd64
-	sha256sum $(RELEASE_DIR)/crc-windows-amd64.zip >> $(RELEASE_DIR)/sha256sum.txt
+
+	pushd $(RELEASE_DIR) && sha256sum * > sha256sum.txt && popd
 
 HYPERKIT_BUNDLENAME = $(BUNDLE_DIR)/crc_hyperkit_$(BUNDLE_VERSION).$(BUNDLE_EXTENSION)
 HYPERV_BUNDLENAME = $(BUNDLE_DIR)/crc_hyperv_$(BUNDLE_VERSION).$(BUNDLE_EXTENSION)


### PR DESCRIPTION
The hashes of sha256sum.txt are referencing items in a 'release' directory.
```
49f30e59d1b66feb7e406ead155a2cd8b6808dc60488b7f147fc52a0fa641a51  release/crc-macos-amd64.tar.xz
```
It makes hard to verify directly using the sha256sum.txt file on the content.

```
$ sha256sum --check sha256sum.txt
sha256sum: release/crc-macos-amd64.tar.xz: No such file or directory
release/crc-macos-amd64.tar.xz: FAILED open or read
sha256sum: release/crc-linux-amd64.tar.xz: No such file or directory
release/crc-linux-amd64.tar.xz: FAILED open or read
sha256sum: release/crc-windows-amd64.zip: No such file or directory
release/crc-windows-amd64.zip: FAILED open or read
sha256sum: release/crc_virtualbox_4.1.14.crcbundle: No such file or directory
release/crc_virtualbox_4.1.14.crcbundle: FAILED open or read
sha256sum: WARNING: 4 listed files could not be read
```