### PR TITLE
Issue #174: Add link to download page in README.md

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -21,6 +21,10 @@ Check back for updates, we plan to have something available "soon".
 [[documentation]]
 == Documentation
 
+=== Getting CodeReady Containers
+
+CodeReady Containers binaries with an embedded OpenShift disk image can be downloaded from link:https://cloud.redhat.com/openshift/install/crc/installer-provisioned[this page].
+
 === Using CodeReady Containers
 
 The documentation for CodeReady Containers is currently hosted by GitHub Pages.


### PR DESCRIPTION
Now that we have publicly available images, we can link to them in our
README file.

This fixes https://github.com/code-ready/crc/issues/174