### PR TITLE
Issue #609 Create release info file in json format

### DIFF
--- a/cmd/crc/cmd/config/config.go
+++ b/cmd/crc/cmd/config/config.go
@@ -19,6 +19,8 @@ var (
 	NameServer     = cfg.AddSetting("nameserver", nil, []cfg.ValidationFnType{cfg.ValidateIpAddress}, []cfg.SetFn{cfg.SuccessfullyApplied})
 	PullSecretFile = cfg.AddSetting("pull-secret-file", nil, []cfg.ValidationFnType{cfg.ValidatePath}, []cfg.SetFn{cfg.SuccessfullyApplied})
 
+	DisableUpdateCheck = cfg.AddSetting("disable-update-check", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})
+
 	// Preflight checks
 	SkipCheckVirtualBoxInstalled = cfg.AddSetting("skip-check-virtualbox-installed", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})
 	WarnCheckVirtualBoxInstalled = cfg.AddSetting("warn-check-virtualbox-installed", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})

--- a/cmd/crc/cmd/start.go
+++ b/cmd/crc/cmd/start.go
@@ -72,7 +72,7 @@ func initStartCmdFlagSet() *pflag.FlagSet {
 	flagSet := pflag.NewFlagSet("start", pflag.ExitOnError)
 	flagSet.StringP(config.Bundle.Name, "b", constants.DefaultBundlePath, "The system bundle used for deployment of the OpenShift cluster.")
 	flagSet.StringP(config.VMDriver.Name, "d", machine.DefaultDriver.Driver, fmt.Sprintf("The driver to use for the CRC VM. Possible values: %v", machine.SupportedDriverValues()))
-	flagSet.StringP(config.PullSecretFile.Name, "p", "", fmt.Sprintf("File path of Image pull secret for User (Download it from %s)", constants.DefaultPullSecretURL))
+	flagSet.StringP(config.PullSecretFile.Name, "p", "", fmt.Sprintf("File path of Image pull secret for User (Download it from %s)", constants.CrcLandingPageURL))
 	flagSet.IntP(config.CPUs.Name, "c", constants.DefaultCPUs, "Number of CPU cores to allocate to the CRC VM")
 	flagSet.IntP(config.Memory.Name, "m", constants.DefaultMemory, "MiB of Memory to allocate to the CRC VM")
 	flagSet.StringP(config.NameServer.Name, "n", "", "Specify nameserver to use for the instance. (i.e. 8.8.8.8)")
@@ -113,7 +113,7 @@ func getPullSecretFileContent() (string, error) {
 
 	// In case user doesn't provide a file in start command or in config then ask for it.
 	if crcConfig.GetString(config.PullSecretFile.Name) == "" {
-		pullsecret, err = input.PromptUserForSecret("Image pull secret", fmt.Sprintf("Copy it from %s", constants.DefaultPullSecretURL))
+		pullsecret, err = input.PromptUserForSecret("Image pull secret", fmt.Sprintf("Copy it from %s", constants.CrcLandingPageURL))
 		// This is just to provide a new line after user enter the pull secret.
 		fmt.Println()
 		if err != nil {

--- a/pkg/crc/constants/constants.go
+++ b/pkg/crc/constants/constants.go
@@ -23,7 +23,7 @@ const (
 	ConfigFile           = "crc.json"
 	LogFile              = "crc.log"
 	GlobalStateFile      = "globalstate.json"
-	DefaultPullSecretURL = "https://cloud.redhat.com/openshift/install/crc/installer-provisioned" // #nosec G101
+	CrcLandingPageURL    = "https://cloud.redhat.com/openshift/install/crc/installer-provisioned" // #nosec G101
 	PullSecretFile       = "pullsecret.json"
 )
 

--- a/pkg/crc/version/version.go
+++ b/pkg/crc/version/version.go
@@ -16,6 +16,15 @@ limitations under the License.
 
 package version
 
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/Masterminds/semver"
+	"io/ioutil"
+	"net/http"
+	"time"
+)
+
 // The following variables are private fields and should be set when compiling with ldflags, for example --ldflags="-X github.com/code-ready/crc/pkg/version.crcVersion=vX.Y.Z
 var (
 	// The current version of minishift
@@ -28,6 +37,16 @@ var (
 	bundleVersion = "0.0.0-unset"
 )
 
+const (
+	releaseInfoLink = "https://mirror.openshift.com/pub/openshift-v4/clients/crc/latest/release-info.json"
+)
+
+type CrcReleaseInfo struct {
+	Version struct {
+		LatestVersion string `json:"crcVersion"`
+	}
+}
+
 func GetCRCVersion() string {
 	return crcVersion
 }
@@ -38,4 +57,41 @@ func GetCommitSha() string {
 
 func GetBundleVersion() string {
 	return bundleVersion
+}
+
+func getCRCLatestVersionFromMirror() (*semver.Version, error) {
+	var releaseInfo CrcReleaseInfo
+	client := &http.Client{
+		Timeout: 5 * time.Second,
+	}
+	response, err := client.Get(releaseInfoLink)
+	if err != nil {
+		return nil, err
+	}
+	defer response.Body.Close()
+	releaseMetaData, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return nil, err
+	}
+	err = json.Unmarshal(releaseMetaData, &releaseInfo)
+	if err != nil {
+		return nil, fmt.Errorf("Error unmarshaling JSON metadata: %v", err)
+	}
+	version, err := semver.NewVersion(releaseInfo.Version.LatestVersion)
+	if err != nil {
+		return nil, err
+	}
+	return version, nil
+}
+
+func NewVersionAvailable() (bool, string, error) {
+	latestVersion, err := getCRCLatestVersionFromMirror()
+	if err != nil {
+		return false, "", err
+	}
+	currentVersion, err := semver.NewVersion(GetCRCVersion())
+	if err != nil {
+		return false, "", err
+	}
+	return latestVersion.GreaterThan(currentVersion), latestVersion.String(), nil
 }

--- a/release-info.json.sample
+++ b/release-info.json.sample
@@ -1,0 +1,7 @@
+{
+	"version": {
+		"crcVersion": @CRC_VERSION@,
+		"gitSha": @GIT_COMMIT_SHA@,
+		"openshiftVersion": @OPENSHIFT_VERSION@
+	}
+}


### PR DESCRIPTION
What this PR does is add a message about available update when the user runs `crc start` command, and asks if he wants to keep using the current version or stop the current version (to download the newer one).
When a new version is available in mirror.openshift.com, and the user starts crc, he'll get a prompt like following:

```
❯ crc start -b ~/Downloads/crc_archives/crc_libvirt_4.1.14.crcbundle -p ~/Documents/pull-secret --log-level debug
INFO A new version (1.0.0-beta.6) has been published 
Would you like to continue using the current version? [y/N]: 
```
If answered No, it prints the URL to download the latest version of `crc`. (going forward we'd automatically download the latest version but that is for later.)

```
❯ crc start -b ~/Downloads/crc_archives/crc_libvirt_4.1.14.crcbundle -p ~/Documents/pull-secret --log-level debug
INFO A new version (1.0.0-beta.6) has been published 
Would you like to continue using the current version? [y/N]: n
Please download the new version from https://cloud.redhat.com/openshift/install/crc/installer-provisioned
```
Note: it'll always interrupt the start once a new version is available

However in https://github.com/code-ready/crc/pull/619#discussion_r328507543 it is mentioned that prompting the user like this, is disruptive, and a WARN msg would be enough.

Fixes #609 