### PR TITLE
Issue #618 Make /etc/hosts file in mac user writeable.

### DIFF
--- a/pkg/crc/preflight/preflight_checks_darwin.go
+++ b/pkg/crc/preflight/preflight_checks_darwin.go
@@ -264,7 +264,7 @@ func addFileWritePermissionToUser(filename string) (bool, error) {
 		return false, fmt.Errorf("Unable to change ownership of the filename: %s %v: %s", stdOut, err, stdErr)
 	}
 
-	err = os.Chmod(filename, 0500)
+	err = os.Chmod(filename, 0600)
 	if err != nil {
 		return false, fmt.Errorf("Unable to change permissions of the filename: %s %v: %s", stdOut, err, stdErr)
 	}


### PR DESCRIPTION
During the refactor to add gosec in our CI we changed the file
permission from `655` to `500` and this file should be write able
by the user so permission should be `0600`