### PR TITLE
Misc cmdline interface and doc improvement around `crc console`

### DIFF
--- a/cmd/crc/cmd/config/get.go
+++ b/cmd/crc/cmd/config/get.go
@@ -19,7 +19,7 @@ var configGetCmd = &cobra.Command{
 to the options that you set when you run the 'crc start' command.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) < 1 {
-			output.Out("Please provide a configuration property to retrieve")
+			output.Outln("Please provide a configuration property to retrieve")
 			os.Exit(1)
 		}
 		runConfigGet(args[0])
@@ -31,5 +31,5 @@ func runConfigGet(key string) {
 	if err != nil {
 		errors.ExitWithMessage(1, err.Error())
 	}
-	output.Out(key, ":", v)
+	output.Outln(key, ":", v)
 }

--- a/cmd/crc/cmd/config/set.go
+++ b/cmd/crc/cmd/config/set.go
@@ -36,6 +36,6 @@ func runConfigSet(key string, value interface{}) {
 	}
 
 	if setMessage != "" {
-		output.Out(setMessage)
+		output.Outln(setMessage)
 	}
 }

--- a/cmd/crc/cmd/config/unset.go
+++ b/cmd/crc/cmd/config/unset.go
@@ -35,6 +35,6 @@ func runConfigUnset(key string) {
 	}
 
 	if unsetMsg != "" {
-		output.Out(unsetMsg)
+		output.Outln(unsetMsg)
 	}
 }

--- a/cmd/crc/cmd/console.go
+++ b/cmd/crc/cmd/console.go
@@ -23,11 +23,13 @@ import (
 )
 
 var (
-	consoleURLMode bool
+	consoleURLMode          bool
+	consolePrintCredentials bool
 )
 
 func init() {
 	consoleCmd.Flags().BoolVar(&consoleURLMode, "url", false, "Prints the OpenShift Web Console URL to the console.")
+	consoleCmd.Flags().BoolVar(&consolePrintCredentials, "credentials", false, "Prints the credentials which can be used to connect to the OpenShift Web Console.")
 	rootCmd.AddCommand(consoleCmd)
 }
 
@@ -53,6 +55,12 @@ func runConsole(arguments []string) {
 
 	if consoleURLMode {
 		output.Outln(result.ClusterConfig.WebConsoleURL)
+	}
+	if consolePrintCredentials {
+		output.Outln("To login as a normal user, username is 'developer' and password is 'developer'.")
+		output.Outf("To login as an admin, username is 'kubeadmin' and password is '%s'.\n", result.ClusterConfig.KubeAdminPass)
+	}
+	if consoleURLMode || consolePrintCredentials {
 		return
 	}
 	output.Outln("Opening the OpenShift Web console in the default browser...")

--- a/cmd/crc/cmd/console.go
+++ b/cmd/crc/cmd/console.go
@@ -63,6 +63,10 @@ func runConsole(arguments []string) {
 	if consoleURLMode || consolePrintCredentials {
 		return
 	}
+
+	if !machine.IsRunning(result.State) {
+		errors.ExitWithMessage(1, "CodeReady Containers instance is not running, cannot open the OpenShift Web Console.")
+	}
 	output.Outln("Opening the OpenShift Web console in the default browser...")
 	_ = browser.OpenURL(result.ClusterConfig.WebConsoleURL)
 }

--- a/cmd/crc/cmd/console.go
+++ b/cmd/crc/cmd/console.go
@@ -52,9 +52,9 @@ func runConsole(arguments []string) {
 	}
 
 	if consoleURLMode {
-		output.Outln(result.URL)
+		output.Outln(result.ClusterConfig.WebConsoleURL)
 		return
 	}
 	output.Outln("Opening the OpenShift Web console in the default browser...")
-	_ = browser.OpenURL(result.URL)
+	_ = browser.OpenURL(result.ClusterConfig.WebConsoleURL)
 }

--- a/cmd/crc/cmd/console.go
+++ b/cmd/crc/cmd/console.go
@@ -68,5 +68,8 @@ func runConsole(arguments []string) {
 		errors.ExitWithMessage(1, "CodeReady Containers instance is not running, cannot open the OpenShift Web Console.")
 	}
 	output.Outln("Opening the OpenShift Web console in the default browser...")
-	_ = browser.OpenURL(result.ClusterConfig.WebConsoleURL)
+	err = browser.OpenURL(result.ClusterConfig.WebConsoleURL)
+	if err != nil {
+		errors.ExitWithMessage(1, "Failed to open the OpenShift Web Console, you can access it by opening %s in your web browser.", result.ClusterConfig.WebConsoleURL)
+	}
 }

--- a/cmd/crc/cmd/console.go
+++ b/cmd/crc/cmd/console.go
@@ -67,7 +67,7 @@ func runConsole(arguments []string) {
 	if !machine.IsRunning(result.State) {
 		errors.ExitWithMessage(1, "CodeReady Containers instance is not running, cannot open the OpenShift Web Console.")
 	}
-	output.Outln("Opening the OpenShift Web console in the default browser...")
+	output.Outln("Opening the OpenShift Web Console in the default browser...")
 	err = browser.OpenURL(result.ClusterConfig.WebConsoleURL)
 	if err != nil {
 		errors.ExitWithMessage(1, "Failed to open the OpenShift Web Console, you can access it by opening %s in your web browser.", result.ClusterConfig.WebConsoleURL)

--- a/cmd/crc/cmd/console.go
+++ b/cmd/crc/cmd/console.go
@@ -52,9 +52,9 @@ func runConsole(arguments []string) {
 	}
 
 	if consoleURLMode {
-		output.Out(result.URL)
+		output.Outln(result.URL)
 		return
 	}
-	output.Out("Opening the OpenShift Web console in the default browser...")
+	output.Outln("Opening the OpenShift Web console in the default browser...")
 	_ = browser.OpenURL(result.URL)
 }

--- a/cmd/crc/cmd/delete.go
+++ b/cmd/crc/cmd/delete.go
@@ -42,7 +42,7 @@ func runDelete(arguments []string) {
 	if err != nil {
 		errors.Exit(1)
 	}
-	output.Out("CodeReady Containers instance deleted")
+	output.Outln("CodeReady Containers instance deleted")
 }
 
 func deleteCache() {

--- a/cmd/crc/cmd/ip.go
+++ b/cmd/crc/cmd/ip.go
@@ -32,5 +32,5 @@ func runIP(arguments []string) {
 	if err != nil {
 		errors.Exit(1)
 	}
-	output.Out(result.IP)
+	output.Outln(result.IP)
 }

--- a/cmd/crc/cmd/root.go
+++ b/cmd/crc/cmd/root.go
@@ -60,7 +60,7 @@ func runPostrun() {
 }
 
 func runRoot() {
-	output.Out("No command given")
+	output.Outln("No command given")
 }
 
 func Execute() {

--- a/cmd/crc/cmd/setup.go
+++ b/cmd/crc/cmd/setup.go
@@ -34,9 +34,9 @@ func runSetup(arguments []string) {
 	}
 	preflight.SetupHost(vmDriver)
 	if constants.BundleEmbedded() {
-		output.Out("Setup is complete, you can now run 'crc start' to start a CodeReady Containers instance")
+		output.Outln("Setup is complete, you can now run 'crc start' to start a CodeReady Containers instance")
 	} else {
-		output.Out("Setup is complete, you can now run 'crc start -b $bundlename' to start a CodeReady Containers instance")
+		output.Outln("Setup is complete, you can now run 'crc start -b $bundlename' to start a CodeReady Containers instance")
 	}
 }
 

--- a/cmd/crc/cmd/start.go
+++ b/cmd/crc/cmd/start.go
@@ -62,7 +62,7 @@ func runStart(arguments []string) {
 		errors.Exit(1)
 	}
 	if commandResult.Status == "Running" {
-		output.Out("CodeReady Containers instance is running")
+		output.Outln("CodeReady Containers instance is running")
 	} else {
 		logging.Warnf("Unexpected status: %s", commandResult.Status)
 	}

--- a/cmd/crc/cmd/stop.go
+++ b/cmd/crc/cmd/stop.go
@@ -35,7 +35,7 @@ func runStop(arguments []string) {
 		Name: constants.DefaultName,
 	}
 
-	output.Out("Stopping CodeReady Containers instance... this may take a few minutes")
+	output.Outln("Stopping CodeReady Containers instance... this may take a few minutes")
 	commandResult, err := machine.Stop(stopConfig)
 	if err != nil {
 		// Here we are checking the VM state and if it is still running then
@@ -53,7 +53,7 @@ func runStop(arguments []string) {
 		errors.Exit(1)
 	}
 	if commandResult.Success {
-		output.Out("CodeReady Containers instance stopped")
+		output.Outln("CodeReady Containers instance stopped")
 	} else {
 		/* If we did not get an error, the status should be true */
 		logging.Warnf("Unexpected status %v", commandResult.Success)
@@ -65,5 +65,5 @@ func killVM(killConfig machine.PowerOffConfig) {
 	if err != nil {
 		errors.Exit(1)
 	}
-	output.Out("CodeReady Containers instance forcibly stopped")
+	output.Outln("CodeReady Containers instance forcibly stopped")
 }

--- a/docs/source/getting-started/content/proc_accessing-the-openshift-cluster.adoc
+++ b/docs/source/getting-started/content/proc_accessing-the-openshift-cluster.adoc
@@ -10,13 +10,7 @@ For more information, see <<starting-the-virtual-machine_{context}>>.
 
 * To access the OpenShift web console, follow these steps:
 
-  . Open the OpenShift web console URL printed in the output of the [command]`{bin} start` command:
-+
-[subs="+quotes,attributes"]
-----
-$ _browser_command_ https://console-openshift-console.apps-crc.testing
-----
-// Can we use `xdg-open` here instead?
+  . Run [command]`{bin} console`. This will open your web browser and direct it to the web console.
 
   . Log in to the OpenShift web console as the `kubeadmin` user with the password printed in the output of the [command]`{bin} start` command.
 +

--- a/docs/source/getting-started/content/proc_accessing-the-openshift-cluster.adoc
+++ b/docs/source/getting-started/content/proc_accessing-the-openshift-cluster.adoc
@@ -22,7 +22,7 @@ $ _browser_command_ https://console-openshift-console.apps-crc.testing
 +
 [NOTE]
 ====
-You can also view the password for the `kubeadmin` user in the [filename]`~/.crc/cache/crc_libvirt_v4.1.0.rc0/kubeadmin-password` file.
+You can also view the password for the `kubeadmin` user by running [command]`{bin} console --credentials`.
 ====
 +
 See <<troubleshooting-codeready-containers_{context}>> if you cannot access the {prod} OpenShift cluster.

--- a/pkg/crc/errors/atexit.go
+++ b/pkg/crc/errors/atexit.go
@@ -44,9 +44,9 @@ func Exit(code int) {
 // If the exit code is 0, the message is prints to stdout, otherwise to stderr.
 func ExitWithMessage(code int, text string, args ...interface{}) {
 	if code == 0 {
-		_, _ = output.OutW(os.Stdout, fmt.Sprintf(text, args...))
+		_, _ = output.Fout(os.Stdout, fmt.Sprintf(text, args...))
 	} else {
-		_, _ = output.OutW(os.Stderr, fmt.Sprintf(text, args...))
+		_, _ = output.Fout(os.Stderr, fmt.Sprintf(text, args...))
 	}
 	Exit(code)
 }

--- a/pkg/crc/input/input.go
+++ b/pkg/crc/input/input.go
@@ -13,7 +13,7 @@ func PromptUserForYesOrNo(message string, force bool) bool {
 		return true
 	}
 	var response string
-	output.OutF(message + "? [y/N]: ")
+	output.Outf(message + "? [y/N]: ")
 	fmt.Scanf("%s", &response)
 
 	return strings.ToLower(response) == "y"

--- a/pkg/crc/machine/machine.go
+++ b/pkg/crc/machine/machine.go
@@ -621,6 +621,15 @@ func GetConsoleURL(consoleConfig ConsoleConfig) (ConsoleResult, error) {
 		result.Error = err.Error()
 		return *result, errors.New(err.Error())
 	}
+
+	vmState, err := host.Driver.GetState()
+	if err != nil {
+		result.Success = false
+		result.Error = err.Error()
+		return *result, errors.Newf("Error getting the state for host: %v", err)
+	}
+	result.State = vmState
+
 	_, crcBundleMetadata, err := getBundleMetadataFromDriver(host.Driver)
 	if err != nil {
 		result.Error = err.Error()

--- a/pkg/crc/machine/machine.go
+++ b/pkg/crc/machine/machine.go
@@ -83,6 +83,10 @@ func getBundleMetadataFromDriver(driver drivers.Driver) (string, *bundle.CrcBund
 	return bundleName, metadata, err
 }
 
+func IsRunning(st state.State) bool {
+	return st == state.Running
+}
+
 func Start(startConfig StartConfig) (StartResult, error) {
 	var crcBundleMetadata *bundle.CrcBundleInfo
 	defer unsetMachineLogging()
@@ -191,7 +195,7 @@ func Start(startConfig StartConfig) (StartResult, error) {
 			result.Error = err.Error()
 			return *result, errors.Newf("Error getting the state for host: %v", err)
 		}
-		if vmState == state.Running {
+		if IsRunning(vmState) {
 			openshiftVersion := crcBundleMetadata.GetOpenshiftVersion()
 			if openshiftVersion == "" {
 				logging.Infof("A CodeReady Containers VM is already running")
@@ -200,9 +204,7 @@ func Start(startConfig StartConfig) (StartResult, error) {
 			}
 			result.Status = vmState.String()
 			return *result, nil
-		}
-
-		if vmState != state.Running {
+		} else {
 			openshiftVersion := crcBundleMetadata.GetOpenshiftVersion()
 			if openshiftVersion == "" {
 				logging.Infof("Starting CodeReady Containers VM ...")
@@ -508,7 +510,7 @@ func Status(statusConfig ClusterStatusConfig) (ClusterStatusResult, error) {
 		return *result, errors.New(err.Error())
 	}
 
-	if vmStatus == state.Running {
+	if IsRunning(vmStatus) {
 		// check if all the clusteroperators are running
 		ocConfig := oc.UseOCWithConfig(statusConfig.Name)
 		operatorsRunning, err := oc.GetClusterOperatorStatus(ocConfig)

--- a/pkg/crc/machine/types.go
+++ b/pkg/crc/machine/types.go
@@ -106,6 +106,7 @@ type ConsoleConfig struct {
 
 type ConsoleResult struct {
 	ClusterConfig ClusterConfig
+	State         state.State
 	Success       bool
 	Error         string
 }

--- a/pkg/crc/machine/types.go
+++ b/pkg/crc/machine/types.go
@@ -105,7 +105,7 @@ type ConsoleConfig struct {
 }
 
 type ConsoleResult struct {
-	URL     string
-	Success bool
-	Error   string
+	ClusterConfig ClusterConfig
+	Success       bool
+	Error         string
 }

--- a/pkg/crc/output/output.go
+++ b/pkg/crc/output/output.go
@@ -5,14 +5,14 @@ import (
 	"io"
 )
 
-func Out(args ...interface{}) {
+func Outln(args ...interface{}) {
 	fmt.Println(args...)
 }
 
-func OutF(s string, args ...interface{}) {
+func Outf(s string, args ...interface{}) {
 	fmt.Printf(s, args...)
 }
 
-func OutW(w io.Writer, args ...interface{}) (n int, err error) {
+func Fout(w io.Writer, args ...interface{}) (n int, err error) {
 	return fmt.Fprintln(w, args...)
 }

--- a/pkg/crc/services/dns/dns_windows.go
+++ b/pkg/crc/services/dns/dns_windows.go
@@ -18,7 +18,7 @@ import (
 func runPostStartForOS(serviceConfig services.ServicePostStartConfig, result *services.ServicePostStartResult) (services.ServicePostStartResult, error) {
 	// bailout for Virtualbox
 	if serviceConfig.DriverName == "virtualbox" {
-		output.Out("Please follow instructions in the documentation about setting hostnames for Virtualbox.")
+		output.Outln("Please follow instructions in the documentation about setting hostnames for Virtualbox.")
 		result.Success = true
 		return *result, nil
 	}

--- a/test/integration/features/basic.feature
+++ b/test/integration/features/basic.feature
@@ -85,6 +85,17 @@ Feature: Basic test
         Then stdout should match "\d+\.\d+\.\d+\.\d+"
 
     @darwin @linux @windows
+    Scenario: CRC console URL
+        When executing "crc console --url" succeeds
+        Then stdout should contain "https://console-openshift-console.apps-crc.testing"
+
+    @darwin @linux @windows
+    Scenario: CRC console credentials
+        When executing "crc console --credentials" succeeds
+        Then stdout should contain "To login as a normal user, username is 'developer' and password is 'developer'."
+        And stdout should contain "To login as an admin, username is 'kubeadmin' and password is "
+
+    @darwin @linux @windows
     Scenario: CRC forcible stop
         When executing "crc stop -f"
         Then stdout should contain "CodeReady Containers instance stopped"    
@@ -93,6 +104,13 @@ Feature: Basic test
     Scenario: CRC status check
         When with up to "2" retries with wait period of "1m" command "crc status" output should not contain "Running"
         And stdout should contain "Stopped"
+
+    @darwin @linux @windows
+    Scenario: CRC console check
+        Given executing "crc status" succeeds
+        And stdout contains "Stopped"
+        When executing "crc console"
+        Then stderr should contain "CodeReady Containers instance is not running, cannot open the OpenShift Web Console."
 
     @darwin @linux @windows
     Scenario: CRC delete


### PR DESCRIPTION
This PR discourages direct use of the openshift web console URL in favour of usage of `crc console`.