### PR TITLE
More documentation updates

### DIFF
--- a/docs/source/common-content/attributes.adoc
+++ b/docs/source/common-content/attributes.adoc
@@ -16,6 +16,8 @@
 :centos: CentOS
 :mac: macOS
 :msw: Microsoft Windows
+:debian: Debian
+:ubuntu: Ubuntu
 
 // Product naming
 :prod: CodeReady Containers

--- a/docs/source/getting-started/content/assembly_troubleshooting.adoc
+++ b/docs/source/getting-started/content/assembly_troubleshooting.adoc
@@ -1,4 +1,11 @@
 [id="troubleshooting-codeready-containers_{context}"]
 = Troubleshooting {rh-prod}
 
+[NOTE]
+====
+The goal of {rh-prod} is to deliver an OpenShift environment for development and testing purposes.
+Issues occurring during installation or usage of specific OpenShift applications are outside of the scope of {prod} and should be reported to the relevant project.
+For example, OpenShift issues are tracked on link:https://github.com/openshift/origin/issues[GitHub].
+====
+
 include::proc_basic-troubleshooting.adoc[leveloffset=+1]

--- a/docs/source/getting-started/content/con_understanding-codeready-containers.adoc
+++ b/docs/source/getting-started/content/con_understanding-codeready-containers.adoc
@@ -2,6 +2,9 @@
 = Understanding {prod}
 
 {rh-prod} brings a minimal OpenShift 4.0 or newer cluster to your local computer.
+This cluster provides a minimal environment for development and testing purposes.
+It's mainly targetted at running on developers' desktops.
+For other use cases, such as headless, multi-developer/team-based setups, ..., use of the link:https://cloud.redhat.com/openshift/install/[full-fledged OpenShift installer] is recommended.
 
 {prod} includes the [command]`{bin}` command-line interface (CLI) to interact with the {prod} virtual machine running the OpenShift cluster.
 
@@ -12,4 +15,6 @@
 * It uses a single node which behaves both as a master and as a worker node.
 * The `machine-config`, `marketplace` and `monitoring` Operators are disabled by default.
 * These disabled Operators will cause the corresponding parts of the web console to be non functional.
+* For the same reason, there is currently no upgrade path to newer OpenShift versions.
+* Due to technical limitations, the {prod} cluster is ephemeral and will need to be recreated from scratch once a month using a newer release.
 * The OpenShift instance is running in a virtual machine, which could cause some other differences, in particular in relation with external networking.

--- a/docs/source/getting-started/content/proc_installing-codeready-containers.adoc
+++ b/docs/source/getting-started/content/proc_installing-codeready-containers.adoc
@@ -31,22 +31,3 @@ See <<required-software-packages_{context}>> to install the required packages fo
 .Procedure
 
 . Download the link:{crc-download-url}[latest release of {prod}] for your platform and extract the contents of the archive to a location in your `_PATH_`.
-
-. **On Debian or Ubuntu,** perform the following steps:
-.. Add your user to the `libvirtd` group:
-+
-----
-$ sudo usermod -aG libvirtd $(whoami)
-----
-
-.. Update your current session to apply the group change:
-+
-----
-$ newgrp libvirtd
-----
-
-.. Disable the `libvirt` group check performed by the `{bin} start` command:
-+
-----
-$ crc config set skip-check-user-in-libvirt-group true
-----

--- a/docs/source/getting-started/content/proc_installing-codeready-containers.adoc
+++ b/docs/source/getting-started/content/proc_installing-codeready-containers.adoc
@@ -20,6 +20,8 @@ Other applications running on top of OpenShift may require additional resources 
 * On {mac}, {prod} requires macOS 10.12 Sierra or newer.
 {prod} does not work on earlier versions of {mac}.
 
+* On Linux, {prod} is only supported on {rhel}/{centos} 7.5 or newer (including 8.x versions) and on the latest two stable {fed} releases.
+{ubuntu} 18.04 LTS or newer and {debian} 10 or newer are not officially supported and may require manual set up of the host machine.
 * On Linux, {prod} requires installation of the following software packages:
 ** [package]`NetworkManager`
 

--- a/docs/source/getting-started/content/ref_required-software-packages.adoc
+++ b/docs/source/getting-started/content/ref_required-software-packages.adoc
@@ -10,5 +10,5 @@ Consult the following table to determine the command used to install these packa
 |Linux Distribution|Installation command
 |{fed}|`sudo dnf install NetworkManager`
 |{rhel}/{centos}|`su -c 'yum install NetworkManager'`
-|Debian/Ubuntu|`sudo apt install qemu-kvm libvirt-daemon libvirt-daemon-system network-manager`
+|{debian}/{ubuntu}|`sudo apt install qemu-kvm libvirt-daemon libvirt-daemon-system network-manager`
 |====

--- a/pkg/crc/preflight/preflight_checks_linux.go
+++ b/pkg/crc/preflight/preflight_checks_linux.go
@@ -200,7 +200,6 @@ func checkUserPartOfLibvirtGroup() (bool, error) {
 
 func fixUserPartOfLibvirtGroup() (bool, error) {
 	logging.Debug("Adding current user to the libvirt group")
-	// Add user to libvirt/libvirtd group based on distro
 	currentUser, err := user.Current()
 	if err != nil {
 		return false, err


### PR DESCRIPTION
This removes the obsolete mentions of 'libvirtd' group on ubuntu/debian, add minimum version requirements for misc distros, and try to document better what our goal is.