### PR TITLE
Issue #605: Check libvirt version as part of setup too

### DIFF
--- a/pkg/crc/preflight/preflight_checks_linux.go
+++ b/pkg/crc/preflight/preflight_checks_linux.go
@@ -150,6 +150,10 @@ func fixLibvirtEnabled() (bool, error) {
 	return true, nil
 }
 
+func fixLibvirtVersion() (bool, error) {
+	return false, fmt.Errorf("libvirt v%s or newer is required and must be updated manually", minSupportedLibvirtVersion)
+}
+
 func checkLibvirtVersion() (bool, error) {
 	logging.Debugf("Checking if libvirt version is >=%s\n", minSupportedLibvirtVersion)
 	stdOut, stdErr, err := crcos.RunWithDefaultLocale("virsh", "-v")

--- a/pkg/crc/preflight/preflight_linux.go
+++ b/pkg/crc/preflight/preflight_linux.go
@@ -139,6 +139,12 @@ func SetupHost(vmDriver string) {
 		"Starting libvirt service",
 		config.GetBool(cmdConfig.WarnCheckLibvirtRunning.Name),
 	)
+	preflightCheckAndFix(config.GetBool(cmdConfig.SkipCheckLibvirtVersionCheck.Name),
+		checkLibvirtVersion,
+		fixLibvirtVersion,
+		"Checking if a supported libvirt version is installed",
+		config.GetBool(cmdConfig.WarnCheckLibvirtVersionCheck.Name),
+	)
 	preflightCheckAndFix(config.GetBool(cmdConfig.SkipCheckLibvirtDriver.Name),
 		checkMachineDriverLibvirtInstalled,
 		fixMachineDriverLibvirtInstalled,


### PR DESCRIPTION
We currently only check libvirt version at "crc start" time, it's more
consistent to also check it at "crc setup" time, which is when we
install libvirt, and the crc-machine-driver binary.

https://github.com/code-ready/crc/issues/605