### PR TITLE
Issue #644 Add regex to crc stop -f integration test

### DIFF
--- a/test/integration/features/basic.feature
+++ b/test/integration/features/basic.feature
@@ -98,7 +98,7 @@ Feature: Basic test
     @darwin @linux @windows
     Scenario: CRC forcible stop
         When executing "crc stop -f"
-        Then stdout should contain "CodeReady Containers instance stopped"    
+        Then stdout should match "CodeReady Containers instance(.*)stopped"
 
     @darwin @linux @windows
     Scenario: CRC status check


### PR DESCRIPTION
`crc stop -f` can provide `CodeReady Containers instance stopped` or
 `CodeReady Containers instance forcefully stopped` if instance is
stopped gracefully or not. Better to use regex then absolute string.

- https://regex101.com/r/UkT6En/1