### PR TITLE
Assorted fixes for preflight checks

### DIFF
--- a/cmd/crc/cmd/config/config.go
+++ b/cmd/crc/cmd/config/config.go
@@ -20,10 +20,8 @@ var (
 	PullSecretFile = cfg.AddSetting("pull-secret-file", nil, []cfg.ValidationFnType{cfg.ValidatePath}, []cfg.SetFn{cfg.SuccessfullyApplied})
 
 	// Preflight checks
-	SkipCheckVirtualBoxInstalled = cfg.AddSetting("skip-check-virtualbox-installed", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})
-	WarnCheckVirtualBoxInstalled = cfg.AddSetting("warn-check-virtualbox-installed", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})
-	SkipCheckBundleCached        = cfg.AddSetting("skip-check-bundle-cached", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})
-	WarnCheckBundleCached        = cfg.AddSetting("warn-check-bundle-cached", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})
+	SkipCheckBundleCached = cfg.AddSetting("skip-check-bundle-cached", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})
+	WarnCheckBundleCached = cfg.AddSetting("warn-check-bundle-cached", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})
 )
 
 var (

--- a/cmd/crc/cmd/config/config.go
+++ b/cmd/crc/cmd/config/config.go
@@ -23,7 +23,7 @@ var (
 	SkipCheckVirtualBoxInstalled = cfg.AddSetting("skip-check-virtualbox-installed", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})
 	WarnCheckVirtualBoxInstalled = cfg.AddSetting("warn-check-virtualbox-installed", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})
 	SkipCheckBundleCached        = cfg.AddSetting("skip-check-bundle-cached", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})
-	WarnCheckBundleCached        = cfg.AddSetting("warn-check-bundle-cached", true, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})
+	WarnCheckBundleCached        = cfg.AddSetting("warn-check-bundle-cached", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})
 )
 
 var (

--- a/cmd/crc/cmd/config/config_darwin.go
+++ b/cmd/crc/cmd/config/config_darwin.go
@@ -6,6 +6,8 @@ import (
 
 var (
 	// Preflight checks
+	SkipCheckVirtualBoxInstalled     = cfg.AddSetting("skip-check-virtualbox-installed", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})
+	WarnCheckVirtualBoxInstalled     = cfg.AddSetting("warn-check-virtualbox-installed", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})
 	SkipCheckResolverFilePermissions = cfg.AddSetting("skip-check-resolver-file-permissions", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})
 	WarnCheckResolverFilePermissions = cfg.AddSetting("warn-check-resolver-file-permissions", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})
 	SkipCheckHostsFilePermissions    = cfg.AddSetting("skip-check-hosts-file-permissions", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})

--- a/cmd/crc/cmd/config/config_windows.go
+++ b/cmd/crc/cmd/config/config_windows.go
@@ -1,0 +1,17 @@
+package config
+
+import (
+	cfg "github.com/code-ready/crc/pkg/crc/config"
+)
+
+var (
+	// Preflight checks
+	SkipCheckWindowsVersionCheck = cfg.AddSetting("skip-check-windows-version", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})
+	WarnCheckWindowsVersionCheck = cfg.AddSetting("warn-check-windows-version", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})
+	SkipCheckHyperVInstalled     = cfg.AddSetting("skip-check-hyperv-installed", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})
+	WarnCheckHyperVInstalled     = cfg.AddSetting("warn-check-hyperv-installed", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})
+	SkipCheckUserInHyperVGroup   = cfg.AddSetting("skip-check-user-in-hyperv-group", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})
+	WarnCheckUserInHyperVGroup   = cfg.AddSetting("warn-check-user-in-hyperv-group", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})
+	SkipCheckHyperVSwitch        = cfg.AddSetting("skip-check-hyperv-switch", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})
+	WarnCheckHyperVSwitch        = cfg.AddSetting("warn-check-hyperv-switch", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})
+)

--- a/pkg/crc/preflight/preflight_checks_common.go
+++ b/pkg/crc/preflight/preflight_checks_common.go
@@ -15,6 +15,9 @@ import (
 )
 
 func checkBundleCached() (bool, error) {
+	if !constants.BundleEmbedded() {
+		return true, nil
+	}
 	if _, err := os.Stat(constants.DefaultBundlePath); os.IsNotExist(err) {
 		return false, err
 	}

--- a/pkg/crc/preflight/preflight_checks_windows.go
+++ b/pkg/crc/preflight/preflight_checks_windows.go
@@ -68,7 +68,8 @@ func fixHyperVInstalled() (bool, error) {
 	}
 
 	// We do need to error out as a restart might be needed (unfortunately no output redirect possible)
-	return true, errors.New("Please reboot your system")
+	logging.Error("Please reboot your system")
+	return true, nil
 }
 
 func checkIfUserPartOfHyperVAdmins() (bool, error) {

--- a/pkg/crc/preflight/preflight_windows.go
+++ b/pkg/crc/preflight/preflight_windows.go
@@ -12,32 +12,32 @@ func StartPreflightChecks(vmDriver string) {
 		"Checking if running as normal user",
 		false,
 	)
-	preflightCheckSucceedsOrFails(false,
+	preflightCheckSucceedsOrFails(config.GetBool(cmdConfig.SkipCheckWindowsVersionCheck.Name),
 		checkOcBinaryCached,
 		"Checking if oc binary is cached",
-		false,
+		config.GetBool(cmdConfig.WarnCheckWindowsVersionCheck.Name),
 	)
 
 	if vmDriver == "hyperv" {
-		preflightCheckSucceedsOrFails(false,
+		preflightCheckSucceedsOrFails(config.GetBool(cmdConfig.SkipCheckWindowsVersionCheck.Name),
 			checkVersionOfWindowsUpdate,
 			"Check Windows 10 release",
-			false,
+			config.GetBool(cmdConfig.WarnCheckWindowsVersionCheck.Name),
 		)
-		preflightCheckSucceedsOrFails(false,
+		preflightCheckSucceedsOrFails(config.GetBool(cmdConfig.SkipCheckHyperVInstalled.Name),
 			checkHyperVInstalled,
 			"Hyper-V installed and operational",
-			false,
+			config.GetBool(cmdConfig.WarnCheckHyperVInstalled.Name),
 		)
-		preflightCheckSucceedsOrFails(false,
+		preflightCheckSucceedsOrFails(config.GetBool(cmdConfig.SkipCheckUserInHyperVGroup.Name),
 			checkIfUserPartOfHyperVAdmins,
 			"Is user a member of the Hyper-V Administrators group",
-			false,
+			config.GetBool(cmdConfig.WarnCheckUserInHyperVGroup.Name),
 		)
-		preflightCheckSucceedsOrFails(false,
+		preflightCheckSucceedsOrFails(config.GetBool(cmdConfig.SkipCheckHyperVSwitch.Name),
 			checkIfHyperVVirtualSwitchExists,
 			"Does the Hyper-V virtual switch exist",
-			false,
+			config.GetBool(cmdConfig.WarnCheckHyperVSwitch.Name),
 		)
 	}
 }
@@ -64,31 +64,31 @@ func SetupHost(vmDriver string) {
 	)
 
 	if vmDriver == "hyperv" {
-		preflightCheckAndFix(false,
+		preflightCheckAndFix(config.GetBool(cmdConfig.SkipCheckWindowsVersionCheck.Name),
 			checkVersionOfWindowsUpdate,
 			fixVersionOfWindowsUpdate,
 			"Check Windows 10 release",
-			false,
+			config.GetBool(cmdConfig.WarnCheckWindowsVersionCheck.Name),
 		)
-		preflightCheckAndFix(false,
+		preflightCheckAndFix(config.GetBool(cmdConfig.SkipCheckHyperVInstalled.Name),
 			checkHyperVInstalled,
 			fixHyperVInstalled,
 			"Hyper-V installed",
-			false,
+			config.GetBool(cmdConfig.WarnCheckHyperVInstalled.Name),
 		)
-		preflightCheckAndFix(false,
+		preflightCheckAndFix(config.GetBool(cmdConfig.SkipCheckUserInHyperVGroup.Name),
 			// Workaround to an issue the check returns "True"
 			checkIfUserPartOfHyperVAdmins,
 			fixUserPartOfHyperVAdmins,
 			"Is user a member of the Hyper-V Administrators group",
-			false,
+			config.GetBool(cmdConfig.WarnCheckUserInHyperVGroup.Name),
 		)
 
-		preflightCheckAndFix(false,
+		preflightCheckAndFix(config.GetBool(cmdConfig.SkipCheckHyperVSwitch.Name),
 			checkIfHyperVVirtualSwitchExists,
 			fixHyperVVirtualSwitch,
 			"Does the Hyper-V virtual switch exist",
-			false,
+			config.GetBool(cmdConfig.WarnCheckHyperVSwitch.Name),
 		)
 	}
 }

--- a/test/integration/features/basic.feature
+++ b/test/integration/features/basic.feature
@@ -54,7 +54,6 @@ Feature: Basic test
 	And stdout should contain "Will use root access: execute systemctl daemon-reload command"
 	And stdout should contain "Will use root access: execute systemctl stop/start command"
         And stdout should contain "Unpacking bundle from the CRC binary"
-        And stdout should contain "CRC bundle is not embedded in the binary"
         And stdout should contain "Setup is complete, you can now run 'crc start -b $bundlename' to start a CodeReady Containers instance"
 
     @darwin


### PR DESCRIPTION
This PR removed unwanted warning when using a binary without an embedded bundle, and add missing preflight config options on Windows.