### PR TITLE
Issue #652: doc: Add missing 'oc login'

### DIFF
--- a/docs/source/getting-started/content/con_understanding-codeready-containers.adoc
+++ b/docs/source/getting-started/content/con_understanding-codeready-containers.adoc
@@ -6,6 +6,8 @@ This cluster provides a minimal environment for development and testing purposes
 It's mainly targetted at running on developers' desktops.
 For other use cases, such as headless, multi-developer/team-based setups, ..., use of the link:https://cloud.redhat.com/openshift/install/[full-fledged OpenShift installer] is recommended.
 
+You can refer to the link:https://docs.openshift.com/container-platform/latest/welcome/index.html#developer-activities[OpenShift documentation] for a more in-depth introduction to OpenShift.
+
 {prod} includes the [command]`{bin}` command-line interface (CLI) to interact with the {prod} virtual machine running the OpenShift cluster.
 
 = Differences with a production OpenShift install

--- a/docs/source/getting-started/content/proc_accessing-the-openshift-cluster.adoc
+++ b/docs/source/getting-started/content/proc_accessing-the-openshift-cluster.adoc
@@ -12,11 +12,18 @@ For more information, see <<starting-the-virtual-machine_{context}>>.
 
   . Run [command]`{bin} console`. This will open your web browser and direct it to the web console.
 
-  . Log in to the OpenShift web console as the `kubeadmin` user with the password printed in the output of the [command]`{bin} start` command.
+  . Log in to the OpenShift web console as the `developer` user with the password printed in the output of the [command]`{bin} start` command.
 +
 [NOTE]
 ====
-You can also view the password for the `kubeadmin` user by running [command]`{bin} console --credentials`.
+You can also view the password for the `developer` user by running [command]`{bin} console --credentials`.
+====
++
+[NOTE]
+====
+The cluster can initially be accessed through either the `kubeadmin` or `developer` user.
+For creating projects or OpenShift applications, and for application deployment, the `developer` user should be used.
+The `kubeadmin` user should only be used for administrative tasks such as creating new users, setting roles, and so on.
 ====
 +
 See <<troubleshooting-codeready-containers_{context}>> if you cannot access the {prod} OpenShift cluster.

--- a/docs/source/getting-started/content/proc_accessing-the-openshift-cluster.adoc
+++ b/docs/source/getting-started/content/proc_accessing-the-openshift-cluster.adoc
@@ -39,6 +39,14 @@ $ crc oc-env
 
   . Run the printed command.
 
+  . Log in by running the [command]`oc login -u developer https://api.crc.testing:6443` command.
++
+[NOTE]
+====
+The password for the `developer` user was printed in the output of the [command]`{bin} start` command.
+You can also view it by running the [command]`{bin} console --credentials` command.
+====
++
   . You can now use `oc` to interact with your OpenShift cluster. For example, to verify that the OpenShift cluster operators are available using the [command]`oc get co` command:
 +
 [subs="+quotes,attributes"]

--- a/docs/source/getting-started/content/proc_accessing-the-openshift-cluster.adoc
+++ b/docs/source/getting-started/content/proc_accessing-the-openshift-cluster.adoc
@@ -26,6 +26,8 @@ For creating projects or OpenShift applications, and for application deployment,
 The `kubeadmin` user should only be used for administrative tasks such as creating new users, setting roles, and so on.
 ====
 +
+  . The link:https://docs.openshift.com/container-platform/latest/applications/projects/working-with-projects.html[OpenShift documentation] covers the creation of projects and applications.
++
 See <<troubleshooting-codeready-containers_{context}>> if you cannot access the {prod} OpenShift cluster.
 
 * To access the OpenShift cluster via the [command]`oc` command, follow these steps:
@@ -85,5 +87,7 @@ storage                              4.1.0-rc.0   True        False         Fals
 The `machine-config` and `marketplace` cluster operators are expected to report `False` availability.
 The `monitoring` cluster operator is expected to report `Unknown` availability.
 ====
++
+  . The link:https://docs.openshift.com/container-platform/latest/applications/projects/working-with-projects.html[OpenShift documentation] covers the creation of projects and applications.
 +
 See <<troubleshooting-codeready-containers_{context}>> if you cannot access the {prod} OpenShift cluster.


### PR DESCRIPTION
Before interacting with the cluster with 'oc', the user must run 'oc
login' first, this is not mentioned in the documentation.

This fixes https://github.com/code-ready/crc/issues/652