### PR TITLE
Issue #644 Add regex to crc stop -f integration test

### DIFF
--- a/test/integration/features/story_health.feature
+++ b/test/integration/features/story_health.feature
@@ -56,6 +56,6 @@ Feature:
     Scenario: Clean up
         Given executing "oc delete project testproj" succeeds
         When executing "crc stop -f" succeeds
-        Then stdout should contain "CodeReady Containers instance stopped"
+        Then stdout should match "CodeReady Containers instance(.*)stopped"
         When executing "crc delete" succeeds
         Then stdout should contain "CodeReady Containers instance deleted"


### PR DESCRIPTION
`crc stop -f` can provide `CodeReady Containers instance stopped` or
 `CodeReady Containers instance forcefully stopped` if instance is
stopped gracefully or not. Better to use regex then absolute string.

- https://regex101.com/r/UkT6En/1

It was missed during 3199fb8ac22c8daab436dd89d0b70898ea137529 commit