### PR TITLE
Issue #669 Check if crc VM exist before executing cmd functions.

### DIFF
--- a/cmd/crc/cmd/console.go
+++ b/cmd/crc/cmd/console.go
@@ -48,6 +48,9 @@ func runConsole(arguments []string) {
 	consoleConfig := machine.ConsoleConfig{
 		Name: constants.DefaultName,
 	}
+
+	exitIfMachineMissing(consoleConfig.Name)
+
 	result, err := machine.GetConsoleURL(consoleConfig)
 	if err != nil {
 		errors.Exit(1)

--- a/cmd/crc/cmd/delete.go
+++ b/cmd/crc/cmd/delete.go
@@ -34,6 +34,9 @@ func runDelete(arguments []string) {
 	deleteConfig := machine.DeleteConfig{
 		Name: constants.DefaultName,
 	}
+
+	exitIfMachineMissing(deleteConfig.Name)
+
 	if clearCache {
 		deleteCache()
 	}

--- a/cmd/crc/cmd/ip.go
+++ b/cmd/crc/cmd/ip.go
@@ -28,6 +28,8 @@ func runIP(arguments []string) {
 		Debug: isDebugLog(),
 	}
 
+	exitIfMachineMissing(ipConfig.Name)
+
 	result, err := machine.Ip(ipConfig)
 	if err != nil {
 		errors.Exit(1)

--- a/cmd/crc/cmd/root.go
+++ b/cmd/crc/cmd/root.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"github.com/code-ready/crc/pkg/crc/errors"
+	"github.com/code-ready/crc/pkg/crc/machine"
 	"github.com/code-ready/crc/pkg/crc/output"
 	"github.com/spf13/cobra"
 
@@ -71,4 +73,14 @@ func Execute() {
 
 func setConfigDefaults() {
 	config.SetDefaults()
+}
+
+func exitIfMachineMissing(name string) {
+	exists, err := machine.MachineExists(name)
+	if err != nil {
+		errors.ExitWithMessage(1, err.Error())
+	}
+	if !exists {
+		errors.ExitWithMessage(1, "Machine \"crc\" does not exist. Use \"crc start\" to add a new one.")
+	}
 }

--- a/cmd/crc/cmd/status.go
+++ b/cmd/crc/cmd/status.go
@@ -43,6 +43,9 @@ type Status struct {
 
 func runStatus() {
 	statusConfig := machine.ClusterStatusConfig{Name: constants.DefaultName}
+
+	exitIfMachineMissing(statusConfig.Name)
+
 	clusterStatus, err := machine.Status(statusConfig)
 	if err != nil {
 		errors.Exit(1)

--- a/cmd/crc/cmd/stop.go
+++ b/cmd/crc/cmd/stop.go
@@ -35,6 +35,8 @@ func runStop(arguments []string) {
 		Name: constants.DefaultName,
 	}
 
+	exitIfMachineMissing(stopConfig.Name)
+
 	output.Outln("Stopping CodeReady Containers instance... this may take a few minutes")
 	commandResult, err := machine.Stop(stopConfig)
 	if err != nil {

--- a/pkg/crc/machine/machine.go
+++ b/pkg/crc/machine/machine.go
@@ -489,20 +489,20 @@ func Ip(ipConfig IpConfig) (IpResult, error) {
 
 func Status(statusConfig ClusterStatusConfig) (ClusterStatusResult, error) {
 	result := &ClusterStatusResult{Name: statusConfig.Name, Success: true}
-	api := libmachine.NewClient(constants.MachineBaseDir, constants.MachineCertsDir)
-	_, err := api.Exists(statusConfig.Name)
+	libMachineAPIClient := libmachine.NewClient(constants.MachineBaseDir, constants.MachineCertsDir)
+	_, err := libMachineAPIClient.Exists(statusConfig.Name)
 	if err != nil {
 		result.Success = false
 		result.Error = err.Error()
 		return *result, errors.New(err.Error())
 	}
-	defer api.Close()
+	defer libMachineAPIClient.Close()
 
 	openshiftStatus := "Stopped"
 	var diskUse int64
 	var diskSize int64
 
-	host, err := api.Load(statusConfig.Name)
+	host, err := libMachineAPIClient.Load(statusConfig.Name)
 	if err != nil {
 		result.Success = false
 		result.Error = err.Error()

--- a/pkg/crc/machine/machine.go
+++ b/pkg/crc/machine/machine.go
@@ -400,6 +400,7 @@ func Stop(stopConfig StopConfig) (StopResult, error) {
 		result.Error = err.Error()
 		return *result, errors.New(err.Error())
 	}
+	defer libMachineAPIClient.Close()
 
 	result.State, _ = host.Driver.GetState()
 
@@ -424,6 +425,7 @@ func PowerOff(PowerOff PowerOffConfig) (PowerOffResult, error) {
 		result.Error = err.Error()
 		return *result, errors.New(err.Error())
 	}
+	defer libMachineAPIClient.Close()
 
 	if err := host.Kill(); err != nil {
 		result.Success = false
@@ -446,6 +448,7 @@ func Delete(deleteConfig DeleteConfig) (DeleteResult, error) {
 		result.Error = err.Error()
 		return *result, errors.New(err.Error())
 	}
+	defer libMachineAPIClient.Close()
 
 	m := errors.MultiError{}
 	m.Collect(host.Driver.Remove())
@@ -475,6 +478,7 @@ func Ip(ipConfig IpConfig) (IpResult, error) {
 		result.Error = err.Error()
 		return *result, errors.New(err.Error())
 	}
+	defer libMachineAPIClient.Close()
 	if result.IP, err = host.Driver.GetIP(); err != nil {
 		result.Success = false
 		result.Error = err.Error()
@@ -492,6 +496,7 @@ func Status(statusConfig ClusterStatusConfig) (ClusterStatusResult, error) {
 		result.Error = err.Error()
 		return *result, errors.New(err.Error())
 	}
+	defer api.Close()
 
 	openshiftStatus := "Stopped"
 	var diskUse int64

--- a/pkg/crc/machine/machine.go
+++ b/pkg/crc/machine/machine.go
@@ -106,7 +106,7 @@ func Start(startConfig StartConfig) (StartResult, error) {
 	var privateKeyPath string
 	var pullSecret string
 	driverInfo, _ := getDriverInfo(startConfig.VMDriver)
-	exists, err := existVM(libMachineAPIClient, startConfig.Name)
+	exists, err := MachineExists(startConfig.Name)
 	if !exists {
 		machineConfig := config.MachineConfig{
 			Name:       startConfig.Name,
@@ -544,8 +544,10 @@ func Status(statusConfig ClusterStatusConfig) (ClusterStatusResult, error) {
 	return *result, nil
 }
 
-func existVM(api libmachine.API, name string) (bool, error) {
-	exists, err := api.Exists(name)
+func MachineExists(name string) (bool, error) {
+	libMachineAPIClient := libmachine.NewClient(constants.MachineBaseDir, constants.MachineCertsDir)
+	defer libMachineAPIClient.Close()
+	exists, err := libMachineAPIClient.Exists(name)
 	if err != nil {
 		return false, fmt.Errorf("Error checking if the host exists: %s", err)
 	}

--- a/test/integration/features/basic.feature
+++ b/test/integration/features/basic.feature
@@ -24,7 +24,7 @@ Feature: Basic test
         When executing "crc status" fails
         Then stderr should contain 
         """
-        Machine \"crc\" does not exist. Use \"crc start\" to add a new one.
+        Machine "crc" does not exist. Use "crc start" to add a new one.
         """
 
     @linux


### PR DESCRIPTION
Commands which require user input or expose some message should check
if crc vm exist, before display the message (or take user input).

```
$ ./crc stop
Stopping CodeReady Containers instance... this may take a few minutes
ERRO Error occurred: Machine "crc" does not exist. Use "crc start" to add a new one.

$ ./crc delete
Do you want to delete the crc VM? [y/N]: y
ERRO Error occurred: Machine "crc" does not exist. Use "crc start" to add a new one.
```