### PR TITLE
Rework cert expiry code

### DIFF
--- a/pkg/crc/machine/machine.go
+++ b/pkg/crc/machine/machine.go
@@ -131,16 +131,6 @@ func Start(startConfig StartConfig) (StartResult, error) {
 			return *result, errors.Newf("Error getting bundle metadata: %v", err)
 		}
 
-		// Check if certificate is going to expire in next 7 days
-		buildTime, err := crcBundleMetadata.GetBundleBuildTime()
-		if err != nil {
-			result.Error = err.Error()
-			return *result, errors.Newf("Error getting bundle build time: %v", err)
-		}
-		if goingToExpire, duration := cluster.CheckCertsValidityUsingBundleBuildTime(buildTime); goingToExpire {
-			logging.Warnf("Bundle certificates are going to expire in %d days, better to use new release", duration)
-		}
-
 		openshiftVersion := crcBundleMetadata.GetOpenshiftVersion()
 		if openshiftVersion == "" {
 			logging.Infof("Creating VM...")
@@ -257,13 +247,13 @@ func Start(startConfig StartConfig) (StartResult, error) {
 	// Check the certs validity inside the vm
 	needsCertsRenewal := false
 	logging.Info("Verifying validity of the cluster certificates ...")
-	expiringIn7Days, duration, err := cluster.CheckCertsValidity(sshRunner)
+	certExpiryState, err := cluster.CheckCertsValidity(sshRunner)
 	if err != nil {
-		needsCertsRenewal = true
-	} else if exists {
-		// Only show when VM is started from stopped state.
-		if expiringIn7Days {
-			logging.Warnf("Bundle certificates are going to expire in %d days, better to use new release", duration)
+		if certExpiryState == cluster.CertExpired {
+			needsCertsRenewal = true
+		} else {
+			result.Error = err.Error()
+			return *result, errors.New(err.Error())
 		}
 	}
 	// Add nameserver to VM if provided by User


### PR DESCRIPTION
This removes duplicated code, and tries to make the expiration tests easier to read.
This also fixes a bug with the warning when the check based on the bundle build time fails. Before this commit it could say that the bundle is going to expire in -5 days. Now this errors out in such situations.
The commit also adds a link to the documentation explaining how to solve certificate issues.
The custom errors/type matching might be a bit too sophisticated, I can rework this if needed.
