### PR TITLE
Issue #698: Literal \n in crc.log

### DIFF
--- a/pkg/crc/preflight/preflight_checks_common.go
+++ b/pkg/crc/preflight/preflight_checks_common.go
@@ -58,7 +58,7 @@ func fixBundleCached() (bool, error) {
 func checkOcBinaryCached() (bool, error) {
 	oc := oc.OcCached{}
 	if !oc.IsCached() {
-		return false, errors.New("oc binary is not cached.")
+		return false, errors.New("oc binary is not cached")
 	}
 	logging.Debug("oc binary already cached")
 	return true, nil
@@ -67,7 +67,7 @@ func checkOcBinaryCached() (bool, error) {
 func fixOcBinaryCached() (bool, error) {
 	oc := oc.OcCached{}
 	if err := oc.EnsureIsCached(); err != nil {
-		return false, fmt.Errorf("Not able to download oc %v", err)
+		return false, fmt.Errorf("Unable to download oc %v", err)
 	}
 	logging.Debug("oc binary cached")
 	return true, nil

--- a/pkg/crc/preflight/preflight_checks_linux.go
+++ b/pkg/crc/preflight/preflight_checks_linux.go
@@ -155,7 +155,7 @@ func fixLibvirtVersion() (bool, error) {
 }
 
 func checkLibvirtVersion() (bool, error) {
-	logging.Debugf("Checking if libvirt version is >=%s\n", minSupportedLibvirtVersion)
+	logging.Debugf("Checking if libvirt version is >=%s", minSupportedLibvirtVersion)
 	stdOut, stdErr, err := crcos.RunWithDefaultLocale("virsh", "-v")
 	if err != nil {
 		return false, fmt.Errorf("%v : %s", err, stdErr)

--- a/pkg/download/download.go
+++ b/pkg/download/download.go
@@ -15,7 +15,7 @@ func Download(uri, destination string, mode os.FileMode) (string, error) {
 	client := grab.NewClient()
 	req, err := grab.NewRequest(destination, uri)
 	if err != nil {
-		return "", errors.Newf("Not able to get response from %s: %v", uri, err)
+		return "", errors.Newf("Unable to get response from %s: %v", uri, err)
 	}
 	defer func() {
 		if err != nil {
@@ -25,7 +25,7 @@ func Download(uri, destination string, mode os.FileMode) (string, error) {
 	resp := client.Do(req)
 	// check for errors
 	if err := resp.Err(); err != nil {
-		return "", errors.Newf("Download failed: %v\n", err)
+		return "", errors.Newf("Download failed: %v", err)
 	}
 
 	err = os.Chmod(resp.Filename, mode)
@@ -34,6 +34,6 @@ func Download(uri, destination string, mode os.FileMode) (string, error) {
 		return "", err
 	}
 
-	logging.Debugf("Download saved to %v \n", resp.Filename)
+	logging.Debugf("Download saved to %v", resp.Filename)
 	return resp.Filename, nil
 }

--- a/pkg/os/util.go
+++ b/pkg/os/util.go
@@ -63,7 +63,7 @@ func CurrentExecutable() (string, error) {
 }
 
 func CopyFileContents(src string, dst string, permission os.FileMode) error {
-	logging.Debugf("Copying '%s' to '%s'\n", src, dst)
+	logging.Debugf("Copying '%s' to '%s'", src, dst)
 	srcFile, err := os.Open(filepath.Clean(src))
 	if err != nil {
 		return fmt.Errorf("[%v] Cannot open src file '%s'", err, src)


### PR DESCRIPTION
This is a fix for somewhat of an antipattern in forming log entries. For example, this
```
logging.Debugf("Download saved to %v \n", resp.Filename)
```
results in 
```
time="2019-10-08T16:31:17-04:00" level=debug msg="Download saved to /tmp/crc316183009/oc.tar.gz \n"
```

The following is an analysis of why that happens. The parameters of logging.Debugf() don't produce a complete line of output but just the "msg" field of a log entry. The logger takes care of terminating lines by adding a linebreak at the end of a log entry:
https://github.com/sirupsen/logrus/blob/de736cf91b921d56253b4010270681d33fdf7cb5/text_formatter.go#L218

But why do we end up with a literal \n in the output? Look here:
https://github.com/sirupsen/logrus/blob/de736cf91b921d56253b4010270681d33fdf7cb5/text_formatter.go#L318

f.needsQuoting() returns true due to the trailing linebreak in value and our log message runs through fmt.Sprintf("%q", stringVal), which turns the linebreak back into "\n"

Just so it's as clear as possible, this is the msg log field going into the fmt.Sprintf("%q", stringVal):

```
(dlv) print stringVal
"Download saved to /tmp/crc285030223/oc.tar.gz \n"
(dlv) print []byte(stringVal)
[]uint8 len: 47, cap: 47, [68,111,119,110,108,111,97,100,32,115,97,118,101,100,32,116,111,32,47,116,109,112,47,99,114,99,50,56,53,48,51,48,50,50,51,47,111,99,46,116,97,114,46,103,122,32,10]
(dlv)
```

Note that dlv prints out ASCII 10 as \n.

And here is what is returned from fmt.Sprintf("%q", stringVal):

```
(dlv) print s
"\"Download saved to /tmp/crc285030223/oc.tar.gz \\n\""
(dlv) print []byte(s)
[]uint8 len: 50, cap: 50, [34,68,111,119,110,108,111,97,100,32,115,97,118,101,100,32,116,111,32,47,116,109,112,47,99,114,99,50,56,53,48,51,48,50,50,51,47,111,99,46,116,97,114,46,103,122,32,92,110,34]
(dlv)
```

and we end up with a log entry that looks like this:
```
time="2019-10-08T20:57:58-04:00" level=debug msg="Download saved to /tmp/crc285030223/oc.tar.gz \n"
```