### PR TITLE
preflight: Ensure `crc` network is accessible from session libvirt

### DIFF
--- a/cmd/crc/cmd/config/config_linux.go
+++ b/cmd/crc/cmd/config/config_linux.go
@@ -38,4 +38,6 @@ var (
 	SkipCheckNetworkManagerInstalled = cfg.AddSetting("skip-check-network-manager-installed", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})
 	WarnCheckNetworkManagerRunning   = cfg.AddSetting("warn-check-network-manager-running", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})
 	SkipCheckNetworkManagerRunning   = cfg.AddSetting("skip-check-network-manager-running", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})
+	WarnCheckSystemLibvirtVM         = cfg.AddSetting("warn-check-system-libvirt-vm", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})
+	SkipCheckSystemLibvirtVM         = cfg.AddSetting("skip-check-system-libvirt-vm", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})
 )

--- a/cmd/crc/cmd/config/config_linux.go
+++ b/cmd/crc/cmd/config/config_linux.go
@@ -1,0 +1,41 @@
+package config
+
+import (
+	cfg "github.com/code-ready/crc/pkg/crc/config"
+)
+
+var (
+	// Preflight checks
+	SkipCheckRootUser                = cfg.AddSetting("skip-check-root-user", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})
+	WarnCheckRootUser                = cfg.AddSetting("warn-check-root-user", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})
+	SkipCheckVirtEnabled             = cfg.AddSetting("skip-check-virt-enabled", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})
+	WarnCheckVirtEnabled             = cfg.AddSetting("warn-check-virt-enabled", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})
+	SkipCheckKvmEnabled              = cfg.AddSetting("skip-check-kvm-enabled", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})
+	WarnCheckKvmEnabled              = cfg.AddSetting("warn-check-kvm-enabled", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})
+	SkipCheckLibvirtInstalled        = cfg.AddSetting("skip-check-libvirt-installed", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})
+	WarnCheckLibvirtInstalled        = cfg.AddSetting("warn-check-libvirt-installed", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})
+	SkipCheckLibvirtEnabled          = cfg.AddSetting("skip-check-libvirt-enabled", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})
+	WarnCheckLibvirtEnabled          = cfg.AddSetting("warn-check-libvirt-enabled", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})
+	SkipCheckLibvirtRunning          = cfg.AddSetting("skip-check-libvirt-running", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})
+	WarnCheckLibvirtVersionCheck     = cfg.AddSetting("warn-check-libvirt-version", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})
+	SkipCheckLibvirtVersionCheck     = cfg.AddSetting("skip-check-libvirt-version", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})
+	WarnCheckLibvirtRunning          = cfg.AddSetting("warn-check-libvirt-running", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})
+	SkipCheckUserInLibvirtGroup      = cfg.AddSetting("skip-check-user-in-libvirt-group", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})
+	WarnCheckUserInLibvirtGroup      = cfg.AddSetting("warn-check-user-in-libvirt-group", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})
+	SkipCheckLibvirtDriver           = cfg.AddSetting("skip-check-libvirt-driver", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})
+	WarnCheckLibvirtDriver           = cfg.AddSetting("warn-check-libvirt-driver", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})
+	SkipCheckCrcNetwork              = cfg.AddSetting("skip-check-crc-network", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})
+	WarnCheckCrcNetwork              = cfg.AddSetting("warn-check-crc-network", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})
+	SkipCheckCrcNetworkActive        = cfg.AddSetting("skip-check-crc-network-active", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})
+	WarnCheckCrcNetworkActive        = cfg.AddSetting("warn-check-crc-network-active", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})
+	SkipCheckCrcBridgePermissions    = cfg.AddSetting("skip-check-crc-network-permissions", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})
+	WarnCheckCrcBridgePermissions    = cfg.AddSetting("warn-check-crc-network-permissions", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})
+	SkipCheckCrcDnsmasqFile          = cfg.AddSetting("skip-check-crc-dnsmasq-file", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})
+	WarnCheckCrcDnsmasqFile          = cfg.AddSetting("warn-check-crc-dnsmasq-file", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})
+	SkipCheckCrcNetworkManagerConfig = cfg.AddSetting("skip-check-network-manager-config", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})
+	WarnCheckCrcNetworkManagerConfig = cfg.AddSetting("warn-check-network-manager-config", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})
+	WarnCheckNetworkManagerInstalled = cfg.AddSetting("warn-check-network-manager-installed", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})
+	SkipCheckNetworkManagerInstalled = cfg.AddSetting("skip-check-network-manager-installed", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})
+	WarnCheckNetworkManagerRunning   = cfg.AddSetting("warn-check-network-manager-running", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})
+	SkipCheckNetworkManagerRunning   = cfg.AddSetting("skip-check-network-manager-running", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})
+)

--- a/pkg/crc/machine/libvirt/templates_linux.go
+++ b/pkg/crc/machine/libvirt/templates_linux.go
@@ -9,7 +9,7 @@ const (
 		<port start='1024' end='65535'/>
 	  </nat>
 	</forward>
-	<bridge name='crc' stp='on' delay='0'/>
+	<bridge name='{{ .NetworkName }}' stp='on' delay='0'/>
 	<mac address='52:54:00:fd:be:d0'/>
 	<ip family='ipv4' address='192.168.130.1' prefix='24'>
 	  <dhcp>

--- a/pkg/crc/preflight/preflight_linux.go
+++ b/pkg/crc/preflight/preflight_linux.go
@@ -115,6 +115,13 @@ var libvirtPreflightChecks = [...]PreflightCheck{
 		fixDescription:   "Writing dnsmasq config for crc",
 		fix:              fixCrcDnsmasqConfigFile,
 	},
+	{
+		configKeySuffix:  "check-system-libvirt-vm",
+		checkDescription: "Checking for existing `crc` VM on system libvirt connection",
+		check:            checkSystemLibvirtVM,
+		fixDescription:   "Importing existing `crc` VM",
+		fix:              fixSystemLibvirtVM,
+	},
 }
 
 func getPreflightChecks() []PreflightCheck {

--- a/pkg/crc/preflight/preflight_linux.go
+++ b/pkg/crc/preflight/preflight_linux.go
@@ -81,6 +81,13 @@ var libvirtPreflightChecks = [...]PreflightCheck{
 		fix:              fixLibvirtCrcNetworkActive,
 	},
 	{
+		configKeySuffix:  "check-crc-network-permission",
+		checkDescription: "Checking for appropriate permissions on 'crc' network",
+		check:            checkLibvirtCrcBridgePermissions,
+		fixDescription:   "Setting appropriate permissions on 'crc' network",
+		fix:              fixLibvirtCrcBridgePermissions,
+	},
+	{
 		configKeySuffix:  "check-network-manager-installed",
 		checkDescription: "Checking if NetworkManager is installed",
 		check:            checkNetworkManagerInstalled,

--- a/pkg/os/util_linux.go
+++ b/pkg/os/util_linux.go
@@ -3,6 +3,7 @@ package os
 import (
 	"bytes"
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
 
@@ -31,4 +32,24 @@ func writeToFileAsRoot(reason, content, filepath string, append bool) error {
 		return fmt.Errorf("Failed writing to file as root: %s: %s: %v", filepath, buf.String(), err)
 	}
 	return nil
+}
+
+func GetFirstExistentPath(paths []string) (string, error) {
+	readablePath := ""
+	for _, path := range paths {
+		logging.Debug(fmt.Sprintf("Trying %s..", path))
+		_, err := os.Stat(path)
+		if err != nil {
+			logging.Debug(fmt.Sprintf("Failed to open %s: %s", path, err))
+		} else {
+			readablePath = path
+
+			break
+		}
+	}
+	if readablePath == "" {
+		return "", fmt.Errorf("Failed to find a readable file on any of these paths: %s", strings.Join(paths, ", "))
+	}
+
+	return readablePath, nil
 }

--- a/pkg/os/util_linux.go
+++ b/pkg/os/util_linux.go
@@ -10,8 +10,20 @@ import (
 )
 
 func WriteToFileAsRoot(reason, content, filepath string) error {
+	return writeToFileAsRoot(reason, content, filepath, false)
+}
+
+func AppendToFileAsRoot(reason, content, filepath string) error {
+	return writeToFileAsRoot(reason, content, filepath, true)
+}
+
+func writeToFileAsRoot(reason, content, filepath string, append bool) error {
 	logging.Infof("Will use root access: %s", reason)
-	cmd := exec.Command("sudo", "tee", filepath) // #nosec G204
+	append_option := ""
+	if append {
+		append_option = "-a"
+	}
+	cmd := exec.Command("sudo", "tee", append_option, filepath) // #nosec G204
 	cmd.Stdin = strings.NewReader(content)
 	buf := new(bytes.Buffer)
 	cmd.Stderr = buf

--- a/pkg/os/util_linux.go
+++ b/pkg/os/util_linux.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"os/user"
 	"strings"
 
 	"github.com/code-ready/crc/pkg/crc/logging"
@@ -52,4 +53,15 @@ func GetFirstExistentPath(paths []string) (string, error) {
 	}
 
 	return readablePath, nil
+}
+
+func ChownAsRoot(user *user.User, filepath string) error {
+	logging.Infof("Will use root access to change owner & group of file %s to %s", filepath, user.Username)
+	cmd := exec.Command("sudo", "chown", fmt.Sprintf("%s.%s", user.Uid, user.Gid), filepath) // #nosec G204
+	buf := new(bytes.Buffer)
+	cmd.Stderr = buf
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("Failed to change owner & group of %s to %s: %s: %s: %v", filepath, user.Username, buf.String(), err)
+	}
+	return nil
 }


### PR DESCRIPTION
This is needed to be able to switch to session libvirt, which will be through machine-driver-libvirt (See https://github.com/code-ready/machine-driver-libvirt/issues/20).