### PR TITLE
Issue #673, #647 Integration tests use specific binary and run with embedded bundle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,11 +122,19 @@ clean: clean_docs
        
 
 .PHONY: integration ## Run integration tests
-integration: GODOG_OPTS = --godog.tags=$(GOOS)
 integration:
-	@$(call check_defined, BUNDLE_LOCATION, "'make integration' requires BUNDLE_LOCATION to contain the full path to a bundle file")
-	@$(call check_defined, PULL_SECRET_FILE, "'make integration' requires PULL_SECRET_FILE to point to a file with the pull secret to use")
-	@go test --timeout=90m $(REPOPATH)/test/integration -v --tags=integration $(GODOG_OPTS) $(BUNDLE_LOCATION) $(PULL_SECRET_FILE)
+GODOG_OPTS = --godog.tags=$(GOOS)
+ifndef PULL_SECRET_FILE
+	PULL_SECRET_FILE = --pull-secret-file=$(HOME)/Downloads/crc-pull-secret
+endif
+ifndef BUNDLE_LOCATION
+	BUNDLE_LOCATION = --bundle-location=$(HOME)/Downloads/crc_libvirt_$(BUNDLE_VERSION).$(BUNDLE_EXTENSION)
+endif
+ifndef CRC_BINARY
+	CRC_BINARY = --crc-binary=$(GOPATH)/bin
+endif
+integration:
+	@go test --timeout=90m $(REPOPATH)/test/integration -v $(PULL_SECRET_FILE) $(BUNDLE_LOCATION) $(CRC_BINARY) --bundle-version=$(BUNDLE_VERSION) --tags=integration $(GODOG_OPTS)
 
 .PHONY: fmt
 fmt:

--- a/centos_ci.sh
+++ b/centos_ci.sh
@@ -130,7 +130,9 @@ function run_tests() {
   set +e
   # In Jenkins slave we have pull secret file in the $HOME/payload/crc_pull_secret
   # this is copied over using https://github.com/minishift/minishift-ci-jobs/blob/master/minishift-ci-index.yaml#L99
-  make integration BUNDLE_LOCATION=$HOME/Downloads/$BUNDLE PULL_SECRET_FILE=$HOME/payload/crc_pull_secret
+  export PULL_SECRET_FILE=--pull-secret-file=$HOME/payload/crc_pull_secret
+  export BUNDLE_LOCATION=--bundle-location=$HOME/Downloads/$BUNDLE 
+  make integration 
   if [[ $? -ne 0 ]]; then
     upload_logs $1
     exit 1

--- a/developing.adoc
+++ b/developing.adoc
@@ -60,14 +60,16 @@ Clicumber allows running commands in a persistent shell instance (`bash`, `tcsh`
 [[how-to-run-integration-tests]]
 === How to run
 
-To start integration tests, run:
+First, one needs to set the following flags in `Makefile`, under `integration` target:
 
+- `--pull-secret-file`: absolute path to your OpenShift pull secret.
+- `--bundle-location`: if bundle is embedded, this flag should be set to `--bundle-location=embedded` or not passed at all; if bundle is not embedded, then absolute path to the bundle should be passed.
+- `--crc-binary`: if `crc` binary resides in `$GOPATH/bin`, then this flag needs not be passed; otherwise absolute path to the `crc` binary should be passed.
+
+To start integrationt tests, run:
 ```bash
-$ make integration BUNDLE_LOCATION=<bundle location> PULL_SECRET_FILE=<pull secret path>
+$ make integration
 ```
-where `<bundle location>` is either the bundle's URL or its path in the filesystem,
-and `<pull secret path>` is the path to a file containing your OpenShift pull secret.
-The paths must be absolute paths.
 
 ===== How to run only a subset of all integration tests
 

--- a/test/integration/crcsuite/crcsuite.go
+++ b/test/integration/crcsuite/crcsuite.go
@@ -68,6 +68,8 @@ func FeatureContext(s *godog.Suite) {
 		CheckHTTPResponseWithRetry)
 	s.Step(`^with up to "(\d+)" retries with wait period of "(\d*(?:ms|s|m))" command "(.*)" output (?:should match|matches) "(.*)"$`,
 		CheckOutputMatchWithRetry)
+	s.Step(`stdout (?:should contain|contains) "(.*)" if bundle (is|is not) embedded$`,
+		StdoutContainsIfBundleEmbeddedOrNot)
 
 	// CRC file operations
 	s.Step(`^file "([^"]*)" exists in CRC home folder$`,
@@ -377,6 +379,24 @@ func StartCRCWithDefaultBundleAndNameServerSucceedsOrFails(nameserver string, ex
 	err := clicumber.ExecuteCommandSucceedsOrFails(cmd, expected)
 
 	return err
+}
+
+func StdoutContainsIfBundleEmbeddedOrNot(value string, expected string) error {
+
+	if expected == "is" { // expect embedded
+		if bundleEmbedded { // really embedded
+			return clicumber.CommandReturnShouldContain("stdout", value)
+		} else {
+			return clicumber.CommandReturnShouldNotContain("stdout", value)
+		}
+	} else { // expect not embedded
+		if !bundleEmbedded { // really not embedded
+			return clicumber.CommandReturnShouldContain("stdout", value)
+		} else {
+			return clicumber.CommandReturnShouldNotContain("stdout", value)
+		}
+	}
+
 }
 
 func SetConfigPropertyToValueSucceedsOrFails(property string, value string, expected string) error {

--- a/test/integration/crcsuite/prepare.go
+++ b/test/integration/crcsuite/prepare.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/user"
 	"path/filepath"
 
 	"github.com/code-ready/crc/pkg/download"
@@ -57,22 +56,10 @@ func DownloadBundle(bundleLocation string, bundleDestination string) (string, er
 	return filename, nil
 }
 
-// Parse GODOG flags (in feature files)
 func ParseFlags() {
 
-	flag.Parse()
-	if flag.NArg() < 2 {
-		fmt.Printf("Invalid number of arguments, the paths to the bundle file and to the pull secret file are required\n")
-		os.Exit(1)
-	}
-	bundleURL = flag.Args()[0]
-	_, bundleName = filepath.Split(bundleURL)
-	pullSecretFile = flag.Args()[1]
-}
-
-// Set CRCHome var to ~/.crc
-func SetCRCHome() string {
-	usr, _ := user.Current()
-	crcHome := filepath.Join(usr.HomeDir, ".crc")
-	return crcHome
+	flag.StringVar(&bundleURL, "bundle-location", "embedded", "Path to the bundle to be used in tests")
+	flag.StringVar(&pullSecretFile, "pull-secret-file", "", "Path to the file containing pull secret")
+	flag.StringVar(&CRCBinary, "crc-binary", "", "Path to the CRC binary to be tested")
+	flag.StringVar(&bundleVersion, "bundle-version", "", "Version of the bundle used in tests")
 }

--- a/test/integration/features/basic.feature
+++ b/test/integration/features/basic.feature
@@ -60,7 +60,8 @@ Feature: Basic test
         And stdout should contain "Will use root access: execute systemctl daemon-reload command"
         And stdout should contain "Will use root access: execute systemctl stop/start command"
         And stdout should contain "Unpacking bundle from the CRC binary"
-        And stdout should contain "Setup is complete"
+        And stdout should contain "Setup is complete, you can now run 'crc start -b $bundlename' to start the OpenShift cluster" if bundle is not embedded
+        And stdout should contain "Setup is complete, you can now run 'crc start' to start the OpenShift cluster" if bundle is embedded
 
     @darwin
     Scenario: CRC setup on Mac

--- a/test/integration/features/story_registry.feature
+++ b/test/integration/features/story_registry.feature
@@ -41,3 +41,13 @@ Feature: Local image to image-registry to deployment
         When executing "oc logs -f dc/hello" succeeds
         Then stdout should contain "Hello, it works!"
 
+    Scenario: Clean up
+        Given executing "sudo podman images" succeeds
+        When stdout contains "localhost/hello"
+        Then executing "sudo podman image rm localhost/hello:test" succeeds
+        And executing "oc delete project testproj-img" succeeds
+        When executing "crc stop -f" succeeds
+        Then stdout should match "(.*)[Ss]topped the OpenShift cluster"
+        And executing "crc delete -f" succeeds
+        Then stdout should contain "Deleted the OpenShift cluster"
+

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -55,9 +55,9 @@ func getFeatureContext(s *godog.Suite) {
 }
 
 func parseFlags() {
-	// get flag values for clicumber testsuite
-	testsuite.ParseFlags()
 
-	// here you can get additional flag values if needed, for example:
+	// NOTE:
+	// testsuite.ParseFlags() needs to be last: it calls flag.Parse()
 	crcsuite.ParseFlags()
+	testsuite.ParseFlags()
 }


### PR DESCRIPTION
1. Addresses Issue #673 so the tests work with embedded bundle
2. Updates how we pass arguments to `make integration`.
3. User can specify the location of the binary they want to use with tests: Issue #647.

More details:
1. Unless the `--bundle-location` flag is used, the bundle is assumed to be embedded.
2. Arguments pertinent to integration tests are now passed via Go flags. The following 4 are defined:
   - `--bundle-location`: default is embedded
   - `--bundle-version`
   - `--pull-secret-file`
   - `--crc-binary`
3. The crc binary is assumed to be called `crc`. The way the binary is specified for the tests is by prepending `PATH` with the user provided binary location. The reason for not wrapping all `crc` commands is greater transparency/readability: this way the commands will be in plain view in the feature files.