### PR TITLE
Issue #730 Use go ssh implementation only for windows host

### DIFF
--- a/pkg/crc/machine/machine.go
+++ b/pkg/crc/machine/machine.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
+	"runtime"
 	"time"
 
 	"github.com/code-ready/crc/pkg/crc/cluster"
@@ -35,8 +36,10 @@ import (
 )
 
 func init() {
-	// Force using the golang SSH implementation
-	ssh.SetDefaultClient(ssh.Native)
+	// Force using the golang SSH implementation for windows
+	if runtime.GOOS == crcos.WINDOWS.String() {
+		ssh.SetDefaultClient(ssh.Native)
+	}
 }
 
 func fillClusterConfig(bundleInfo *bundle.CrcBundleInfo, clusterConfig *ClusterConfig) error {


### PR DESCRIPTION
9c5750b changed to use go ssh implementation it for all the platform but
this PR is make use it only for windows since it also have issue in case
of connection timeout happen