### PR TITLE
Issue #735 Skip showing '-b $BundleName' after setup

### DIFF
--- a/cmd/crc/cmd/setup.go
+++ b/cmd/crc/cmd/setup.go
@@ -34,7 +34,7 @@ func runSetup(arguments []string) {
 	}
 	preflight.SetupHost(vmDriver)
 	var bundle string
-	if constants.BundleEmbedded() {
+	if !constants.BundleEmbedded() {
 		bundle = " -b $bundlename"
 	}
 	output.Outf("Setup is complete, you can now run 'crc start%s' to start the OpenShift cluster\n", bundle)


### PR DESCRIPTION
Show this option only when bundle is not embedded

Fixes #735 