### PR TITLE
Issue #735 Basic integration tests check for bundle embeddedness 

### DIFF
--- a/test/integration/crcsuite/crcsuite.go
+++ b/test/integration/crcsuite/crcsuite.go
@@ -59,6 +59,8 @@ func FeatureContext(s *godog.Suite) {
 		CheckClusterOperatorsWithRetry)
 	s.Step(`^with up to "(\d+)" retries with wait period of "(\d*(?:ms|s|m))" http response from "(.*)" should have status code "(\d+)"$`,
 		CheckHTTPResponseWithRetry)
+	s.Step(`stdout (?:should contain|contains) "(.*)" if bundle (is|is not) embedded$`,
+		StdoutContainsIfBundleEmbeddedOrNot)
 
 	// CRC file operations
 	s.Step(`^file "([^"]*)" exists in CRC home folder$`,
@@ -281,6 +283,24 @@ func StartCRCWithDefaultBundleAndHypervisorSucceedsOrFails(hypervisor string, ex
 	err := clicumber.ExecuteCommandSucceedsOrFails(cmd, expected)
 
 	return err
+}
+
+func StdoutContainsIfBundleEmbeddedOrNot(value string, expected string) error {
+
+	if expected == "is" { // expect embedded
+		if constants.BundleEmbedded() { // really embedded
+			return clicumber.CommandReturnShouldContain("stdout", value)
+		} else {
+			return clicumber.CommandReturnShouldNotContain("stdout", value)
+		}
+	} else { // expect not embedded
+		if !constants.BundleEmbedded() { // really not embedded
+			return clicumber.CommandReturnShouldContain("stdout", value)
+		} else {
+			return clicumber.CommandReturnShouldNotContain("stdout", value)
+		}
+	}
+
 }
 
 func SetConfigPropertyToValueSucceedsOrFails(property string, value string, expected string) error {

--- a/test/integration/features/basic.feature
+++ b/test/integration/features/basic.feature
@@ -62,7 +62,8 @@ Feature: Basic test
         And stdout should contain "Will use root access: execute systemctl daemon-reload command"
         And stdout should contain "Will use root access: execute systemctl stop/start command"
         And stdout should contain "Unpacking bundle from the CRC binary"
-        And stdout should contain "Setup is complete"
+        And stdout should contain "Setup is complete, you can now run 'crc start -b $bundlename' to start the OpenShift cluster" if bundle is not embedded
+        And stdout should contain "Setup is complete, you can now run 'crc start' to start the OpenShift cluster" if bundle is embedded
 
     @darwin
     Scenario: CRC setup on Mac


### PR DESCRIPTION
Introduce cases when validating the output of `crc setup` in integration tests: embedded bundle, not embedded bundle.