### PR TITLE
[Test] [WIP] Increase retries to 5 in integration test for cluster to be up

### DIFF
--- a/test/integration/features/story_registry.feature
+++ b/test/integration/features/story_registry.feature
@@ -11,7 +11,7 @@ Feature: Local image to image-registry to deployment
         When starting CRC with default bundle and hypervisor "<vm-driver>" succeeds
         Then stdout should contain "The OpenShift cluster is running"
         And executing "eval $(crc oc-env)" succeeds
-        When with up to "4" retries with wait period of "2m" command "crc status" output matches ".*Running \(v\d+\.\d+\.\d+.*\).*"
+        When with up to "5" retries with wait period of "2m" command "crc status" output matches ".*Running \(v\d+\.\d+\.\d+.*\).*"
         Then login to the oc cluster succeeds
 
         Examples:


### PR DESCRIPTION
the registry feature test is failing in CI, increasing the amount
of time we wait in the test for the cluster to become available.