### PR TITLE
Issue #766 Increase retry for waitforssh from 10 to 60

### DIFF
--- a/pkg/crc/cluster/cluster.go
+++ b/pkg/crc/cluster/cluster.go
@@ -19,7 +19,7 @@ func WaitForSsh(sshRunner *ssh.SSHRunner) error {
 		return nil
 	}
 
-	return errors.RetryAfter(10, checkSshConnectivity, time.Second)
+	return errors.RetryAfter(60, checkSshConnectivity, time.Second)
 }
 
 // CheckCertsValidityUsingBundleBuildTime check if the cluster certs going to expire soon.


### PR DESCRIPTION
Our CI failing with following output.
```
17:21:18   Scenario Outline: Start CRC # features/story_registry.feature:9
17:21:18     When starting CRC with default bundle and hypervisor "libvirt" succeeds # features/story_registry.feature:11
17:21:18       Error: command 'crc start -d libvirt -p '/home/crc_ci/payload/crc_pull_secret' -b crc_libvirt_4.2.0.crcbundle --log-level debug', expected to succeed, exited with exit code: 1
17:21:18
17:21:18   Scenario: Push local image to OpenShift image registry # features/story_registry.feature:28
17:21:18     Given executing "oc new-project testproj-img" succeeds # features/story_registry.feature:29
17:21:18       Error: command 'oc new-project testproj-img', expected to succeed, exited with exit code: 127
17:21:18
17:21:18   Scenario: Deploy the image # features/story_registry.feature:34
17:21:18     Given executing "oc new-app testproj-img/hello:test" succeeds # features/story_registry.feature:35
17:21:18       Error: command 'oc new-app testproj-img/hello:test', expected to succeed, exited with exit code: 127
```

If we check the logs from the artifacts then it is following,
which means the ssh is not able to available in 10 retry and
this might be because of the nested virt and resources limitation.

```
time="2019-10-23T12:49:24+01:00" level=debug msg="retry loop 6"
time="2019-10-23T12:49:32+01:00" level=debug msg="error: Temporary Error: ssh command error:\ncommand : exit 0\nerr     : exit status 255\noutput  :  - sleeping 1s"
time="2019-10-23T12:49:33+01:00" level=debug msg="retry loop 7"
time="2019-10-23T12:49:41+01:00" level=debug msg="error: Temporary Error: ssh command error:\ncommand : exit 0\nerr     : exit status 255\noutput  :  - sleeping 1s"
time="2019-10-23T12:49:42+01:00" level=debug msg="retry loop 8"
time="2019-10-23T12:49:50+01:00" level=debug msg="error: Temporary Error: ssh command error:\ncommand : exit 0\nerr     : exit status 255\noutput  :  - sleeping 1s"
time="2019-10-23T12:49:51+01:00" level=debug msg="retry loop 9"
time="2019-10-23T12:49:59+01:00" level=debug msg="error: Temporary Error: ssh command error:\ncommand : exit 0\nerr     : exit status 255\noutput  :  - sleeping 1s"
time="2019-10-23T12:50:00+01:00" level=error msg="Failed to connect to the CRC VM with SSH"
```