### PR TITLE
Improve bundle extraction

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/code-ready/machine v0.0.0-20190904103148-0fde37b5d95b
 	github.com/docker/go-units v0.4.0
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
-	github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0
 	github.com/mattn/go-colorable v0.0.9
 	github.com/pborman/uuid v1.2.0
 	github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4

--- a/pkg/crc/constants/constants.go
+++ b/pkg/crc/constants/constants.go
@@ -37,6 +37,7 @@ var (
 	MachineCacheDir    = filepath.Join(MachineBaseDir, "cache")
 	MachineInstanceDir = filepath.Join(MachineBaseDir, "machines")
 	GlobalStatePath    = filepath.Join(CrcBaseDir, GlobalStateFile)
+	DefaultBundlePath  = filepath.Join(CrcBaseDir, GetDefaultBundle())
 	bundleEmbedded     = "false"
 )
 

--- a/pkg/crc/constants/constants.go
+++ b/pkg/crc/constants/constants.go
@@ -37,7 +37,7 @@ var (
 	MachineCacheDir    = filepath.Join(MachineBaseDir, "cache")
 	MachineInstanceDir = filepath.Join(MachineBaseDir, "machines")
 	GlobalStatePath    = filepath.Join(CrcBaseDir, GlobalStateFile)
-	DefaultBundlePath  = filepath.Join(CrcBaseDir, GetDefaultBundle())
+	DefaultBundlePath  = filepath.Join(MachineCacheDir, GetDefaultBundle())
 	bundleEmbedded     = "false"
 )
 

--- a/pkg/crc/constants/constants_darwin.go
+++ b/pkg/crc/constants/constants_darwin.go
@@ -3,16 +3,11 @@ package constants
 import (
 	"fmt"
 	"github.com/code-ready/crc/pkg/crc/version"
-	"path/filepath"
 )
 
 const (
 	OcBinaryName = "oc"
 	DefaultOcURL = "https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/macosx/oc.tar.gz"
-)
-
-var (
-	DefaultBundlePath = filepath.Join(CrcBaseDir, GetDefaultBundle())
 )
 
 func GetDefaultBundle() string {

--- a/pkg/crc/constants/constants_linux.go
+++ b/pkg/crc/constants/constants_linux.go
@@ -3,16 +3,11 @@ package constants
 import (
 	"fmt"
 	"github.com/code-ready/crc/pkg/crc/version"
-	"path/filepath"
 )
 
 const (
 	OcBinaryName = "oc"
 	DefaultOcURL = "https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/linux/oc.tar.gz"
-)
-
-var (
-	DefaultBundlePath = filepath.Join(CrcBaseDir, GetDefaultBundle())
 )
 
 func GetDefaultBundle() string {

--- a/pkg/crc/constants/constants_windows.go
+++ b/pkg/crc/constants/constants_windows.go
@@ -3,16 +3,11 @@ package constants
 import (
 	"fmt"
 	"github.com/code-ready/crc/pkg/crc/version"
-	"path/filepath"
 )
 
 const (
 	OcBinaryName = "oc.exe"
 	DefaultOcURL = "https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/windows/oc.zip"
-)
-
-var (
-	DefaultBundlePath = filepath.Join(CrcBaseDir, GetDefaultBundle())
 )
 
 func GetDefaultBundle() string {

--- a/pkg/crc/preflight/preflight_checks_common.go
+++ b/pkg/crc/preflight/preflight_checks_common.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 
 	"github.com/YourFin/binappend"
-	"github.com/kardianos/osext"
 
 	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/code-ready/crc/pkg/crc/logging"
@@ -27,7 +26,7 @@ func checkBundleCached() (bool, error) {
 
 func fixBundleCached() (bool, error) {
 	if constants.BundleEmbedded() {
-		currentExecutable, err := osext.Executable()
+		currentExecutable, err := os.Executable()
 		if err != nil {
 			return false, err
 		}

--- a/pkg/crc/preflight/preflight_checks_common.go
+++ b/pkg/crc/preflight/preflight_checks_common.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/YourFin/binappend"
 	"github.com/kardianos/osext"
@@ -33,6 +34,12 @@ func fixBundleCached() (bool, error) {
 		extractor, err := binappend.MakeExtractor(currentExecutable)
 		if err != nil {
 			return false, err
+		}
+
+		bundleDir := filepath.Base(constants.DefaultBundlePath)
+		err = os.MkdirAll(bundleDir, 0600)
+		if err != nil && !os.IsExist(err) {
+			return false, fmt.Errorf("Cannot create directory %s", bundleDir)
 		}
 		f, err := os.Create(constants.DefaultBundlePath)
 		if err != nil {

--- a/pkg/os/util.go
+++ b/pkg/os/util.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 
 	"github.com/code-ready/crc/pkg/crc/logging"
-	"github.com/kardianos/osext"
 )
 
 const (
@@ -52,14 +51,6 @@ func ReplaceEnv(variables []string, varName string, value string) []string {
 	}
 
 	return result
-}
-
-func CurrentExecutable() (string, error) {
-	currentExec, err := osext.Executable()
-	if err != nil {
-		return "", err
-	}
-	return currentExec, nil
 }
 
 func CopyFileContents(src string, dst string, permission os.FileMode) error {


### PR DESCRIPTION
Currently, bundle extraction is done by reading the full bundle in memory, and then writing it to disk.
This patch series uses an ioreader instead so that data can directly be copied from the bundle to disk.