### PR TITLE
Update for 1.1.0 release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-BUNDLE_VERSION = 4.2.0
+BUNDLE_VERSION = 4.2.2
 BUNDLE_EXTENSION = crcbundle
-CRC_VERSION = 1.0.0-dev
+CRC_VERSION = 1.1.0-dev
 COMMIT_SHA=$(shell git rev-parse --short HEAD)
 
 # Go and compilation related variables

--- a/centos_ci.sh
+++ b/centos_ci.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # bundle location
-BUNDLE_VERSION=4.2.0
+BUNDLE_VERSION=4.2.2
 BUNDLE=crc_libvirt_$BUNDLE_VERSION.crcbundle
 
 # Output command before executing


### PR DESCRIPTION
This backports
https://github.com/code-ready/crc/commit/95966a959fa739826f8a75e619098487cf1e097e
to the master branch.