### PR TITLE
Issue #799 Update golang version to 1.12.8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
     macos:
       xcode: "10.0.0"
     environment:
-      GOVERSION: "1.11.6"
+      GOVERSION: "1.12.8"
 
 ## Build crc
     steps:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-- 1.11.6
+- 1.12.8
 
 script:
 - make


### PR DESCRIPTION
RHEL-8 which is used to build the release bits of crc have
1.12.8 version of golang and currently our CI is using the
older major version.