### PR TITLE
Issue #789 Use fix UUID instead regenerate it.

### DIFF
--- a/pkg/crc/machine/hyperkit/driver_darwin.go
+++ b/pkg/crc/machine/hyperkit/driver_darwin.go
@@ -4,7 +4,6 @@ import (
 	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/code-ready/crc/pkg/crc/machine/config"
 	"github.com/code-ready/machine/libmachine/drivers"
-	"github.com/pborman/uuid"
 	"path/filepath"
 )
 
@@ -34,7 +33,7 @@ func CreateHost(config config.MachineConfig) *hyperkitDriver {
 		},
 		Memory:      config.Memory,
 		CPU:         config.CPUs,
-		UUID:        uuid.NewUUID().String(),
+		UUID:        "c3d68012-0208-11ea-9fd7-f2189899ab08",
 		Cmdline:     config.KernelCmdLine,
 		VmlinuzPath: config.Kernel,
 		InitrdPath:  config.Initramfs,


### PR DESCRIPTION
At the moment, each time we recreate the crc VM (after a crc delete),
we generate a new random UUID for the VM. This causes the VM mac address to change,
so it gets a new IP address. When this happens, we need to reload /etc/resolver/testing,
which we do by restarting the network, which can have side effects on other processes
running at the same time. Since we are only running once crc instance at a time, we
could always reuse the same UUID, which would minimize the number of network restarts which are needed.