### PR TITLE
Remove vbox preflights

### DIFF
--- a/cmd/crc/cmd/config/config_darwin.go
+++ b/cmd/crc/cmd/config/config_darwin.go
@@ -8,8 +8,6 @@ var (
 	// Preflight checks
 	SkipCheckRootUser                = cfg.AddSetting("skip-check-root-user", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})
 	WarnCheckRootUser                = cfg.AddSetting("warn-check-root-user", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})
-	SkipCheckVirtualBoxInstalled     = cfg.AddSetting("skip-check-virtualbox-installed", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})
-	WarnCheckVirtualBoxInstalled     = cfg.AddSetting("warn-check-virtualbox-installed", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})
 	SkipCheckResolverFilePermissions = cfg.AddSetting("skip-check-resolver-file-permissions", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})
 	WarnCheckResolverFilePermissions = cfg.AddSetting("warn-check-resolver-file-permissions", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})
 	SkipCheckHostsFilePermissions    = cfg.AddSetting("skip-check-hosts-file-permissions", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})

--- a/cmd/crc/cmd/setup.go
+++ b/cmd/crc/cmd/setup.go
@@ -32,7 +32,7 @@ func runSetup(arguments []string) {
 	if err := validateSetupFlags(); err != nil {
 		errors.Exit(1)
 	}
-	preflight.SetupHost(vmDriver)
+	preflight.SetupHost()
 	var bundle string
 	if !constants.BundleEmbedded() {
 		bundle = " -b $bundlename"

--- a/cmd/crc/cmd/start.go
+++ b/cmd/crc/cmd/start.go
@@ -47,7 +47,7 @@ func runStart(arguments []string) {
 
 	checkIfNewVersionAvailable(crcConfig.GetBool(config.DisableUpdateCheck.Name))
 
-	preflight.StartPreflightChecks(crcConfig.GetString(config.VMDriver.Name))
+	preflight.StartPreflightChecks()
 
 	startConfig := machine.StartConfig{
 		Name:          constants.DefaultName,

--- a/pkg/crc/preflight/preflight_darwin.go
+++ b/pkg/crc/preflight/preflight_darwin.go
@@ -19,25 +19,16 @@ func StartPreflightChecks(vmDriver string) {
 		false,
 	)
 
-	switch vmDriver {
-	case "virtualbox":
-		preflightCheckSucceedsOrFails(config.GetBool(cmdConfig.SkipCheckVirtualBoxInstalled.Name),
-			checkVirtualBoxInstalled,
-			"Checking if VirtualBox is Installed",
-			config.GetBool(cmdConfig.WarnCheckVirtualBoxInstalled.Name),
-		)
-	case "hyperkit":
-		preflightCheckSucceedsOrFails(config.GetBool(cmdConfig.SkipCheckHyperKitInstalled.Name),
-			checkHyperKitInstalled,
-			"Checking if HyperKit is installed",
-			config.GetBool(cmdConfig.WarnCheckHyperKitInstalled.Name),
-		)
-		preflightCheckSucceedsOrFails(config.GetBool(cmdConfig.SkipCheckHyperKitDriver.Name),
-			checkMachineDriverHyperKitInstalled,
-			"Checking if crc-driver-hyperkit is installed",
-			config.GetBool(cmdConfig.WarnCheckHyperKitDriver.Name),
-		)
-	}
+	preflightCheckSucceedsOrFails(config.GetBool(cmdConfig.SkipCheckHyperKitInstalled.Name),
+		checkHyperKitInstalled,
+		"Checking if HyperKit is installed",
+		config.GetBool(cmdConfig.WarnCheckHyperKitInstalled.Name),
+	)
+	preflightCheckSucceedsOrFails(config.GetBool(cmdConfig.SkipCheckHyperKitDriver.Name),
+		checkMachineDriverHyperKitInstalled,
+		"Checking if crc-driver-hyperkit is installed",
+		config.GetBool(cmdConfig.WarnCheckHyperKitDriver.Name),
+	)
 
 	preflightCheckSucceedsOrFails(config.GetBool(cmdConfig.SkipCheckHostsFilePermissions.Name),
 		checkHostsFilePermissions,
@@ -67,28 +58,18 @@ func SetupHost(vmDriver string) {
 		false,
 	)
 
-	switch vmDriver {
-	case "virtualbox":
-		preflightCheckAndFix(config.GetBool(cmdConfig.SkipCheckVirtualBoxInstalled.Name),
-			checkVirtualBoxInstalled,
-			fixVirtualBoxInstallation,
-			"Setting up virtualization with VirtualBox",
-			config.GetBool(cmdConfig.WarnCheckVirtualBoxInstalled.Name),
-		)
-	case "hyperkit":
-		preflightCheckAndFix(config.GetBool(cmdConfig.SkipCheckHyperKitInstalled.Name),
-			checkHyperKitInstalled,
-			fixHyperKitInstallation,
-			"Setting up virtualization with HyperKit",
-			config.GetBool(cmdConfig.WarnCheckHyperKitInstalled.Name),
-		)
-		preflightCheckAndFix(config.GetBool(cmdConfig.SkipCheckHyperKitDriver.Name),
-			checkMachineDriverHyperKitInstalled,
-			fixMachineDriverHyperKitInstalled,
-			"Installing crc-machine-hyperkit",
-			config.GetBool(cmdConfig.WarnCheckHyperKitDriver.Name),
-		)
-	}
+	preflightCheckAndFix(config.GetBool(cmdConfig.SkipCheckHyperKitInstalled.Name),
+		checkHyperKitInstalled,
+		fixHyperKitInstallation,
+		"Setting up virtualization with HyperKit",
+		config.GetBool(cmdConfig.WarnCheckHyperKitInstalled.Name),
+	)
+	preflightCheckAndFix(config.GetBool(cmdConfig.SkipCheckHyperKitDriver.Name),
+		checkMachineDriverHyperKitInstalled,
+		fixMachineDriverHyperKitInstalled,
+		"Installing crc-machine-hyperkit",
+		config.GetBool(cmdConfig.WarnCheckHyperKitDriver.Name),
+	)
 
 	preflightCheckAndFix(config.GetBool(cmdConfig.SkipCheckResolverFilePermissions.Name),
 		checkResolverFilePermissions,

--- a/pkg/crc/preflight/preflight_darwin.go
+++ b/pkg/crc/preflight/preflight_darwin.go
@@ -7,7 +7,7 @@ import (
 )
 
 // StartPreflightChecks performs the preflight checks before starting the cluster
-func StartPreflightChecks(vmDriver string) {
+func StartPreflightChecks() {
 	preflightCheckSucceedsOrFails(config.GetBool(cmdConfig.SkipCheckRootUser.Name),
 		checkIfRunningAsNormalUser,
 		"Checking if running as non-root",
@@ -44,7 +44,7 @@ func StartPreflightChecks(vmDriver string) {
 }
 
 // SetupHost performs the prerequisite checks and setups the host to run the cluster
-func SetupHost(vmDriver string) {
+func SetupHost() {
 	preflightCheckAndFix(config.GetBool(cmdConfig.SkipCheckRootUser.Name),
 		checkIfRunningAsNormalUser,
 		fixRunAsNormalUser,

--- a/pkg/crc/preflight/preflight_linux.go
+++ b/pkg/crc/preflight/preflight_linux.go
@@ -6,7 +6,7 @@ import (
 )
 
 // StartPreflightChecks performs the preflight checks before starting the cluster
-func StartPreflightChecks(vmDriver string) {
+func StartPreflightChecks() {
 	preflightCheckSucceedsOrFails(config.GetBool(cmdConfig.SkipCheckRootUser.Name),
 		checkIfRunningAsNormalUser,
 		"Checking if running as non-root",
@@ -90,7 +90,7 @@ func StartPreflightChecks(vmDriver string) {
 }
 
 // SetupHost performs the prerequisite checks and setups the host to run the cluster
-func SetupHost(vmDriver string) {
+func SetupHost() {
 	preflightCheckAndFix(config.GetBool(cmdConfig.SkipCheckRootUser.Name),
 		checkIfRunningAsNormalUser,
 		fixRunAsNormalUser,

--- a/pkg/crc/preflight/preflight_windows.go
+++ b/pkg/crc/preflight/preflight_windows.go
@@ -6,7 +6,7 @@ import (
 )
 
 // StartPreflightChecks performs the preflight checks before starting the cluster
-func StartPreflightChecks(vmDriver string) {
+func StartPreflightChecks() {
 	preflightCheckSucceedsOrFails(config.GetBool(cmdConfig.SkipCheckAdministratorUser.Name),
 		checkIfRunningAsNormalUserInWindows,
 		"Checking if running as normal user",
@@ -18,32 +18,30 @@ func StartPreflightChecks(vmDriver string) {
 		config.GetBool(cmdConfig.WarnCheckWindowsVersionCheck.Name),
 	)
 
-	if vmDriver == "hyperv" {
-		preflightCheckSucceedsOrFails(config.GetBool(cmdConfig.SkipCheckWindowsVersionCheck.Name),
-			checkVersionOfWindowsUpdate,
-			"Check Windows 10 release",
-			config.GetBool(cmdConfig.WarnCheckWindowsVersionCheck.Name),
-		)
-		preflightCheckSucceedsOrFails(config.GetBool(cmdConfig.SkipCheckHyperVInstalled.Name),
-			checkHyperVInstalled,
-			"Hyper-V installed and operational",
-			config.GetBool(cmdConfig.WarnCheckHyperVInstalled.Name),
-		)
-		preflightCheckSucceedsOrFails(config.GetBool(cmdConfig.SkipCheckUserInHyperVGroup.Name),
-			checkIfUserPartOfHyperVAdmins,
-			"Is user a member of the Hyper-V Administrators group",
-			config.GetBool(cmdConfig.WarnCheckUserInHyperVGroup.Name),
-		)
-		preflightCheckSucceedsOrFails(config.GetBool(cmdConfig.SkipCheckHyperVSwitch.Name),
-			checkIfHyperVVirtualSwitchExists,
-			"Does the Hyper-V virtual switch exist",
-			config.GetBool(cmdConfig.WarnCheckHyperVSwitch.Name),
-		)
-	}
+	preflightCheckSucceedsOrFails(config.GetBool(cmdConfig.SkipCheckWindowsVersionCheck.Name),
+		checkVersionOfWindowsUpdate,
+		"Check Windows 10 release",
+		config.GetBool(cmdConfig.WarnCheckWindowsVersionCheck.Name),
+	)
+	preflightCheckSucceedsOrFails(config.GetBool(cmdConfig.SkipCheckHyperVInstalled.Name),
+		checkHyperVInstalled,
+		"Hyper-V installed and operational",
+		config.GetBool(cmdConfig.WarnCheckHyperVInstalled.Name),
+	)
+	preflightCheckSucceedsOrFails(config.GetBool(cmdConfig.SkipCheckUserInHyperVGroup.Name),
+		checkIfUserPartOfHyperVAdmins,
+		"Is user a member of the Hyper-V Administrators group",
+		config.GetBool(cmdConfig.WarnCheckUserInHyperVGroup.Name),
+	)
+	preflightCheckSucceedsOrFails(config.GetBool(cmdConfig.SkipCheckHyperVSwitch.Name),
+		checkIfHyperVVirtualSwitchExists,
+		"Does the Hyper-V virtual switch exist",
+		config.GetBool(cmdConfig.WarnCheckHyperVSwitch.Name),
+	)
 }
 
 // SetupHost performs the prerequisite checks and setups the host to run the cluster
-func SetupHost(vmDriver string) {
+func SetupHost() {
 	preflightCheckAndFix(config.GetBool(cmdConfig.SkipCheckAdministratorUser.Name),
 		checkIfRunningAsNormalUserInWindows,
 		fixRunAsNormalUserInWindows,
@@ -63,32 +61,30 @@ func SetupHost(vmDriver string) {
 		config.GetBool(cmdConfig.WarnCheckBundleCached.Name),
 	)
 
-	if vmDriver == "hyperv" {
-		preflightCheckAndFix(config.GetBool(cmdConfig.SkipCheckWindowsVersionCheck.Name),
-			checkVersionOfWindowsUpdate,
-			fixVersionOfWindowsUpdate,
-			"Check Windows 10 release",
-			config.GetBool(cmdConfig.WarnCheckWindowsVersionCheck.Name),
-		)
-		preflightCheckAndFix(config.GetBool(cmdConfig.SkipCheckHyperVInstalled.Name),
-			checkHyperVInstalled,
-			fixHyperVInstalled,
-			"Hyper-V installed",
-			config.GetBool(cmdConfig.WarnCheckHyperVInstalled.Name),
-		)
-		preflightCheckAndFix(config.GetBool(cmdConfig.SkipCheckUserInHyperVGroup.Name),
-			// Workaround to an issue the check returns "True"
-			checkIfUserPartOfHyperVAdmins,
-			fixUserPartOfHyperVAdmins,
-			"Is user a member of the Hyper-V Administrators group",
-			config.GetBool(cmdConfig.WarnCheckUserInHyperVGroup.Name),
-		)
+	preflightCheckAndFix(config.GetBool(cmdConfig.SkipCheckWindowsVersionCheck.Name),
+		checkVersionOfWindowsUpdate,
+		fixVersionOfWindowsUpdate,
+		"Check Windows 10 release",
+		config.GetBool(cmdConfig.WarnCheckWindowsVersionCheck.Name),
+	)
+	preflightCheckAndFix(config.GetBool(cmdConfig.SkipCheckHyperVInstalled.Name),
+		checkHyperVInstalled,
+		fixHyperVInstalled,
+		"Hyper-V installed",
+		config.GetBool(cmdConfig.WarnCheckHyperVInstalled.Name),
+	)
+	preflightCheckAndFix(config.GetBool(cmdConfig.SkipCheckUserInHyperVGroup.Name),
+		// Workaround to an issue the check returns "True"
+		checkIfUserPartOfHyperVAdmins,
+		fixUserPartOfHyperVAdmins,
+		"Is user a member of the Hyper-V Administrators group",
+		config.GetBool(cmdConfig.WarnCheckUserInHyperVGroup.Name),
+	)
 
-		preflightCheckAndFix(config.GetBool(cmdConfig.SkipCheckHyperVSwitch.Name),
-			checkIfHyperVVirtualSwitchExists,
-			fixHyperVVirtualSwitch,
-			"Does the Hyper-V virtual switch exist",
-			config.GetBool(cmdConfig.WarnCheckHyperVSwitch.Name),
-		)
-	}
+	preflightCheckAndFix(config.GetBool(cmdConfig.SkipCheckHyperVSwitch.Name),
+		checkIfHyperVVirtualSwitchExists,
+		fixHyperVVirtualSwitch,
+		"Does the Hyper-V virtual switch exist",
+		config.GetBool(cmdConfig.WarnCheckHyperVSwitch.Name),
+	)
 }

--- a/test/integration/features/config.feature
+++ b/test/integration/features/config.feature
@@ -75,7 +75,6 @@ Checks whether CRC `config set` command works as expected in conjunction with `c
             | warn-check-hyperkit-installed        | true   | false  |
             | warn-check-resolver-file-permissions | true   | false  |
             | warn-check-root-user                 | true   | false  |
-            | warn-check-virtualbox-installed      | true   | false  |
 
         @linux
         Examples: Config warnings on Linux
@@ -130,7 +129,6 @@ Checks whether CRC `config set` command works as expected in conjunction with `c
             | skip-check-hyperkit-installed        | true   | false  |
             | skip-check-resolver-file-permissions | true   | false  |
             | skip-check-root-user                 | true   | false  |
-            | skip-check-virtualbox-installed      | true   | false  |
 
         @linux
         Examples:


### PR DESCRIPTION
We don't have automated setup of virtualbox even on macos, so it's quite misleading to have vbox-related preflights. This PR removes these.