### PR TITLE
Add required go version to modules file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,3 +24,5 @@ require (
 	golang.org/x/sys v0.0.0-20190712062909-fae7ac547cb7
 	gopkg.in/AlecAivazis/survey.v1 v1.8.5
 )
+
+go 1.12


### PR DESCRIPTION
This is so that go 1.13 stops modifying the file to add version info.