### PR TITLE
Bump crc release version to 1.3.0-dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@
 
 BUNDLE_VERSION = 4.2.8
 BUNDLE_EXTENSION = crcbundle
-CRC_VERSION = 1.1.0-dev
+CRC_VERSION = 1.3.0-dev
 COMMIT_SHA=$(shell git rev-parse --short HEAD)
 
 # Go and compilation related variables


### PR DESCRIPTION
Since we already cut the 1.2.0 branch our master should now `1.3.0-dev` branch.