### PR TITLE
Issue #840 Use tagged image instead fetching from registry

### DIFF
--- a/pkg/crc/machine/cert-renewal.go
+++ b/pkg/crc/machine/cert-renewal.go
@@ -51,7 +51,7 @@ func (recoveryPod recoveryPod) Run(args ...string) (string, string, error) {
 }
 
 func (recoveryPod *recoveryPod) runPodCommand(cmd string) (string, error) {
-	podmanCmd := fmt.Sprintf("sudo podman run -it --network=host -v /etc/kubernetes/:/etc/kubernetes/:Z --entrypoint=/usr/bin/cluster-kube-apiserver-operator '%s'", recoveryPod.kaoImage)
+	podmanCmd := fmt.Sprintf("sudo podman run -it --rm --network=host -v /etc/kubernetes/:/etc/kubernetes/:Z --entrypoint=/usr/bin/cluster-kube-apiserver-operator '%s'", recoveryPod.kaoImage)
 	podmanCmd = podmanCmd + " " + cmd
 	return recoveryPod.sshRunner.Run(podmanCmd)
 }

--- a/pkg/crc/machine/machine.go
+++ b/pkg/crc/machine/machine.go
@@ -341,12 +341,6 @@ func Start(startConfig StartConfig) (StartResult, error) {
 			result.Error = err.Error()
 			return *result, errors.Newf("Error copying kubeconfig file  %v", err)
 		}
-
-		err = pullsecret.AddPullSecretToInstanceDisk(sshRunner, pullSecret)
-		if err != nil {
-			result.Error = err.Error()
-			return *result, errors.Newf("Failed to update user pull secret or cluster ID: %v", err)
-		}
 	}
 
 	if needsCertsRenewal {

--- a/pkg/crc/pullsecret/pullsecret.go
+++ b/pkg/crc/pullsecret/pullsecret.go
@@ -62,7 +62,7 @@ func AddPullSecretAndClusterID(sshRunner *ssh.SSHRunner, pullSec string, kubecon
 	}
 
 	// Add user pull secret to the instance
-	if err := AddPullSecretToInstanceDisk(sshRunner, pullSec); err != nil {
+	if err := addPullSecretToInstanceDisk(sshRunner, pullSec); err != nil {
 		return err
 	}
 	return nil
@@ -78,7 +78,7 @@ func addpullSecretSpecToInstance(sshRunner *ssh.SSHRunner, pullSec string) error
 	return nil
 }
 
-func AddPullSecretToInstanceDisk(sshRunner *ssh.SSHRunner, pullSec string) error {
+func addPullSecretToInstanceDisk(sshRunner *ssh.SSHRunner, pullSec string) error {
 	output, err := sshRunner.Run(fmt.Sprintf("cat <<EOF | sudo tee /var/lib/kubelet/config.json\n%s\nEOF", pullSec))
 	if err != nil {
 		return err


### PR DESCRIPTION
We already tag cluster kube-apiserver-operator image as part of our
bundle generation script. Using the tag is going to avoid fetching
the image details from quay registry instead directly use of this tag.