### PR TITLE
Crc daemon

### DIFF
--- a/cmd/crc-embedder/cmd/root.go
+++ b/cmd/crc-embedder/cmd/root.go
@@ -38,7 +38,7 @@ func Execute() {
 func runPrerun() {
 	// Setting up logrus
 	logging.InitLogrus(logging.LogLevel)
-	logging.SetupFileHook()
+	logging.SetupFileHook(constants.LogFilePath)
 }
 
 func runRoot() {

--- a/cmd/crc/cmd/daemon.go
+++ b/cmd/crc/cmd/daemon.go
@@ -1,0 +1,33 @@
+package cmd
+
+import (
+	"github.com/code-ready/crc/pkg/crc/api"
+	"github.com/code-ready/crc/pkg/crc/constants"
+	"github.com/code-ready/crc/pkg/crc/logging"
+	"github.com/spf13/cobra"
+	"os"
+)
+
+func init() {
+	rootCmd.AddCommand(daemonCmd)
+}
+
+var daemonCmd = &cobra.Command{
+	Use:    "daemon",
+	Short:  "Run the crc daemon",
+	Long:   "Run the crc daemon",
+	Hidden: true,
+	Run: func(cmd *cobra.Command, args []string) {
+		runDaemon()
+	},
+}
+
+func runDaemon() {
+	// Remove if an old socket is present
+	os.Remove(constants.DaemonSocketPath)
+	crcApiServer, err := api.CreateApiServer(constants.DaemonSocketPath)
+	if err != nil {
+		logging.Fatal("Failed to launch daemon", err)
+	}
+	crcApiServer.Serve()
+}

--- a/cmd/crc/cmd/daemon.go
+++ b/cmd/crc/cmd/daemon.go
@@ -23,6 +23,11 @@ var daemonCmd = &cobra.Command{
 }
 
 func runDaemon() {
+	//setup separate logfile for daemon
+	logging.CloseLogging()
+	logging.InitLogrus(logging.LogLevel)
+	logging.SetupFileHook(constants.DaemonLogFilePath)
+
 	// Remove if an old socket is present
 	os.Remove(constants.DaemonSocketPath)
 	crcApiServer, err := api.CreateApiServer(constants.DaemonSocketPath)

--- a/cmd/crc/cmd/root.go
+++ b/cmd/crc/cmd/root.go
@@ -57,7 +57,7 @@ func init() {
 func runPrerun() {
 	// Setting up logrus
 	logging.InitLogrus(logging.LogLevel)
-	logging.SetupFileHook()
+	logging.SetupFileHook(constants.LogFilePath)
 	setProxyDefaults()
 }
 

--- a/pkg/crc/api/api.go
+++ b/pkg/crc/api/api.go
@@ -1,0 +1,93 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net"
+
+	"github.com/code-ready/crc/pkg/crc/logging"
+)
+
+type ArgsType map[string]string
+type handlerFunc func(ArgsType) string
+
+type CrcApiServer struct {
+	listener net.Listener
+	handlers map[string]handlerFunc // relates commands to handler func
+}
+
+// commandRequest struct is used to decode the json request from tray
+type commandRequest struct {
+	Command string            `json:"command"`
+	Args    map[string]string `json:"args,omitempty"`
+}
+
+func CreateApiServer(socketPath string) (CrcApiServer, error) {
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		logging.Error("Failed to create socket: ", err.Error())
+		return CrcApiServer{}, err
+	}
+	apiServer := CrcApiServer{
+		listener: listener,
+		handlers: map[string]handlerFunc{
+			"start":         startHandler,
+			"stop":          stopHandler,
+			"status":        statusHandler,
+			"delete":        deleteHandler,
+			"version":       versionHandler,
+			"webconsoleurl": webconsoleURLHandler,
+		},
+	}
+	return apiServer, nil
+}
+
+func (api CrcApiServer) Serve() {
+	for {
+		conn, err := api.listener.Accept()
+		if err != nil {
+			logging.Error("Error establishing communication: ", err.Error())
+			continue
+		}
+		go api.handleConnection(conn)
+	}
+}
+
+func (api CrcApiServer) handleConnection(conn net.Conn) {
+	defer conn.Close()
+	inBuffer := make([]byte, 1024)
+	var req commandRequest
+	numBytes, err := conn.Read(inBuffer)
+	if err != nil || numBytes == 0 || numBytes == cap(inBuffer) {
+		logging.Error("Error reading from socket")
+		return
+	}
+	logging.Debug("Received Request:", string(inBuffer[0:numBytes]))
+	err = json.Unmarshal(inBuffer[0:numBytes], &req)
+	if err != nil {
+		logging.Error("Error decoding request: ", err.Error())
+		return
+	}
+
+	if handler, ok := api.handlers[req.Command]; ok {
+		result := handler(req.Args)
+		writeStringToSocket(conn, result)
+	} else {
+		writeStringToSocket(conn, fmt.Sprintf("Unknown command supplied: %s", req.Command))
+	}
+}
+
+func writeStringToSocket(socket net.Conn, msg string) {
+	var outBuffer bytes.Buffer
+	_, err := outBuffer.WriteString(msg)
+	if err != nil {
+		logging.Error("Failed writing string to buffer", err.Error())
+		return
+	}
+	_, err = socket.Write(outBuffer.Bytes())
+	if err != nil {
+		logging.Error("Failed writing string to socket", err.Error())
+		return
+	}
+}

--- a/pkg/crc/api/handlers.go
+++ b/pkg/crc/api/handlers.go
@@ -1,0 +1,87 @@
+package api
+
+import (
+	"encoding/json"
+	"io/ioutil"
+
+	"github.com/code-ready/crc/cmd/crc/cmd/config"
+	crcConfig "github.com/code-ready/crc/pkg/crc/config"
+	"github.com/code-ready/crc/pkg/crc/constants"
+	"github.com/code-ready/crc/pkg/crc/logging"
+	"github.com/code-ready/crc/pkg/crc/machine"
+	"github.com/code-ready/crc/pkg/crc/validation"
+	"github.com/code-ready/crc/pkg/crc/version"
+)
+
+func statusHandler(_ ArgsType) string {
+	statusConfig := machine.ClusterStatusConfig{Name: constants.DefaultName}
+	clusterStatus, _ := machine.Status(statusConfig)
+	return encodeStructToJson(clusterStatus)
+}
+
+func stopHandler(_ ArgsType) string {
+	stopConfig := machine.StopConfig{
+		Name:  constants.DefaultName,
+		Debug: true,
+	}
+	commandResult, _ := machine.Stop(stopConfig)
+	return encodeStructToJson(commandResult)
+}
+
+func startHandler(_ ArgsType) string {
+	startConfig := machine.StartConfig{
+		Name:          constants.DefaultName,
+		BundlePath:    crcConfig.GetString(config.Bundle.Name),
+		VMDriver:      crcConfig.GetString(config.VMDriver.Name),
+		Memory:        crcConfig.GetInt(config.Memory.Name),
+		CPUs:          crcConfig.GetInt(config.CPUs.Name),
+		NameServer:    crcConfig.GetString(config.NameServer.Name),
+		GetPullSecret: getPullSecretFileContent,
+		Debug:         true,
+	}
+	status, _ := machine.Start(startConfig)
+	return encodeStructToJson(status)
+}
+
+func versionHandler(_ ArgsType) string {
+	v := &machine.VersionResult{
+		CrcVersion:       version.GetCRCVersion(),
+		CommitSha:        version.GetCommitSha(),
+		OpenshiftVersion: version.GetBundleVersion(),
+		Success:          true,
+	}
+	return encodeStructToJson(v)
+}
+
+func getPullSecretFileContent() (string, error) {
+	data, err := ioutil.ReadFile(crcConfig.GetString(config.PullSecretFile.Name))
+	if err != nil {
+		return "", err
+	}
+	pullsecret := string(data)
+	if err := validation.ImagePullSecret(pullsecret); err != nil {
+		return "", err
+	}
+	return pullsecret, nil
+}
+
+func deleteHandler(_ ArgsType) string {
+	delConfig := machine.DeleteConfig{Name: constants.DefaultName}
+	r, _ := machine.Delete(delConfig)
+	return encodeStructToJson(r)
+}
+
+func webconsoleURLHandler(_ ArgsType) string {
+	consoleConfig := machine.ConsoleConfig{Name: constants.DefaultName}
+	r, _ := machine.GetConsoleURL(consoleConfig)
+	return encodeStructToJson(r)
+}
+
+func encodeStructToJson(v interface{}) string {
+	s, err := json.Marshal(v)
+	if err != nil {
+		logging.Error(err.Error())
+		return "Failed"
+	}
+	return string(s)
+}

--- a/pkg/crc/constants/constants.go
+++ b/pkg/crc/constants/constants.go
@@ -25,6 +25,7 @@ const (
 	DefaultLogLevel      = "info"
 	ConfigFile           = "crc.json"
 	LogFile              = "crc.log"
+	DaemonLogFile        = "crcd.log"
 	GlobalStateFile      = "globalstate.json"
 	CrcLandingPageURL    = "https://cloud.redhat.com/openshift/install/crc/installer-provisioned" // #nosec G101
 	PullSecretFile       = "pullsecret.json"
@@ -65,6 +66,7 @@ var (
 	CrcBinDir          = filepath.Join(CrcBaseDir, "bin")
 	ConfigPath         = filepath.Join(CrcBaseDir, ConfigFile)
 	LogFilePath        = filepath.Join(CrcBaseDir, LogFile)
+	DaemonLogFilePath  = filepath.Join(CrcBaseDir, DaemonLogFile)
 	MachineBaseDir     = CrcBaseDir
 	MachineCertsDir    = filepath.Join(MachineBaseDir, "certs")
 	MachineCacheDir    = filepath.Join(MachineBaseDir, "cache")

--- a/pkg/crc/constants/constants.go
+++ b/pkg/crc/constants/constants.go
@@ -72,6 +72,7 @@ var (
 	GlobalStatePath    = filepath.Join(CrcBaseDir, GlobalStateFile)
 	DefaultBundlePath  = filepath.Join(MachineCacheDir, GetDefaultBundle())
 	bundleEmbedded     = "false"
+	DaemonSocketPath   = filepath.Join(CrcBaseDir, "crc.sock")
 )
 
 // GetHomeDir returns the home directory for the current user

--- a/pkg/crc/logging/logging.go
+++ b/pkg/crc/logging/logging.go
@@ -3,7 +3,6 @@ package logging
 import (
 	"io/ioutil"
 	"os"
-	"path/filepath"
 
 	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/pkg/errors"
@@ -17,22 +16,22 @@ var (
 	originalHooks = logrus.LevelHooks{}
 )
 
-func OpenLogFile() (*os.File, error) {
+func OpenLogFile(path string) (*os.File, error) {
 	err := constants.EnsureBaseDirExists()
 	if err != nil {
 		return nil, err
 	}
-	l, err := os.OpenFile(filepath.Join(constants.LogFilePath), os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0600)
+	l, err := os.OpenFile(path, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0600)
 	if err != nil {
 		return nil, err
 	}
 	return l, nil
 }
 
-func setupFileHook() error {
-	logfile, err := OpenLogFile()
+func SetupFileHook(path string) {
+	logfile, err := OpenLogFile(path)
 	if err != nil {
-		return err
+		logrus.Fatal(errors.Wrap(err, "Failed to open logfile"))
 	}
 
 	logrus.AddHook(newFileHook(logfile, logrus.TraceLevel, &logrus.TextFormatter{
@@ -41,14 +40,6 @@ func setupFileHook() error {
 		FullTimestamp:          true,
 		DisableLevelTruncation: false,
 	}))
-	return nil
-}
-
-func SetupFileHook() {
-	err := setupFileHook()
-	if err != nil {
-		logrus.Fatal(errors.Wrap(err, "Failed to open logfile"))
-	}
 }
 
 func RemoveFileHook() {

--- a/pkg/crc/machine/machine.go
+++ b/pkg/crc/machine/machine.go
@@ -597,7 +597,7 @@ func setMachineLogging(logs bool) error {
 	if !logs {
 		log.SetDebug(true)
 		logging.RemoveFileHook()
-		logfile, err := logging.OpenLogFile()
+		logfile, err := logging.OpenLogFile(constants.LogFilePath)
 		if err != nil {
 			return err
 		}
@@ -611,7 +611,7 @@ func setMachineLogging(logs bool) error {
 
 func unsetMachineLogging() {
 	logging.CloseLogFile()
-	logging.SetupFileHook()
+	logging.SetupFileHook(constants.LogFilePath)
 }
 
 func addNameServerToInstance(sshRunner *crcssh.SSHRunner, ns string) error {

--- a/pkg/crc/machine/types.go
+++ b/pkg/crc/machine/types.go
@@ -112,3 +112,10 @@ type ConsoleResult struct {
 	Success       bool
 	Error         string
 }
+
+type VersionResult struct {
+	CrcVersion       string
+	CommitSha        string
+	OpenshiftVersion string
+	Success          bool
+}


### PR DESCRIPTION
CRC Daemon for the tray. Fixes #796 

#### How to test
1. Build the binary from this PR
2. Configure the bundle and pull secret keys using `crc config`
3. run `crc daemon`
4. On another terminal `nc -U ~/.crc/crc.sock`
5. Now you can send commands to the daemon to act on. `e.g; {"command": "status"}, {"command": "start"}`

#### To test with the tray
1. [Download](https://github.com/anjannath/crc-macos-tray/releases/download/1.0.0-alpha/crc_tray_1.0.0-alpha.tar.gz) the tray app
2. run `crc daemon`
3. Launch the tray app and click around.