### PR TITLE
Issue #865: update output of a help string for crc config

### DIFF
--- a/cmd/crc/cmd/config/config.go
+++ b/cmd/crc/cmd/config/config.go
@@ -38,7 +38,7 @@ var (
 
 func init() {
 	ConfigCmd.Long = `Modifies crc configuration properties.
-Configurable properties (enter as SUBCOMMAND): ` + "\n\n" + configurableFields()
+Configurable properties (enter after SUBCOMMAND): ` + "\n\n" + configurableFields()
 }
 
 func isPreflightKey(key string) bool {


### PR DESCRIPTION
Suggested alteration to the `crc config --help` output. Other alternatives would be:
- (use in conjunction with a SUBCOMMAND)
- (enter with SUBCOMMAND)
- ...