### PR TITLE
UX - copy paste and login as a kubeadmin

### DIFF
--- a/cmd/crc/cmd/console.go
+++ b/cmd/crc/cmd/console.go
@@ -60,8 +60,8 @@ func runConsole(arguments []string) {
 		output.Outln(result.ClusterConfig.WebConsoleURL)
 	}
 	if consolePrintCredentials {
-		output.Outln("To login as a regular user, username is 'developer' and password is 'developer'.")
-		output.Outf("To login as an admin, username is 'kubeadmin' and password is '%s'.\n", result.ClusterConfig.KubeAdminPass)
+		output.Outf("To login as a regular user, run 'oc login -u developer -p developer %s'.\n", result.ClusterConfig.ClusterAPI)
+		output.Outf("To login as an admin, run 'oc login -u kubeadmin -p %s %s'\n", result.ClusterConfig.KubeAdminPass, result.ClusterConfig.ClusterAPI)
 	}
 	if consolePrintURL || consolePrintCredentials {
 		return

--- a/pkg/crc/machine/machine.go
+++ b/pkg/crc/machine/machine.go
@@ -378,7 +378,7 @@ func Start(startConfig StartConfig) (StartResult, error) {
 		logging.Infof("")
 		logging.Infof("To access the cluster, first set up your environment by following 'crc oc-env' instructions")
 		logging.Infof("Then you can access it by running 'oc login -u developer -p developer %s'", result.ClusterConfig.ClusterAPI)
-		logging.Infof("To login as an admin, username is 'kubeadmin' and password is %s", result.ClusterConfig.KubeAdminPass)
+		logging.Infof("To login as an admin, run 'oc login -u kubeadmin -p %s %s'", result.ClusterConfig.KubeAdminPass, result.ClusterConfig.ClusterAPI)
 		logging.Infof("")
 		logging.Infof("You can now run 'crc console' and use these credentials to access the OpenShift web console")
 	}

--- a/test/integration/features/basic.feature
+++ b/test/integration/features/basic.feature
@@ -112,8 +112,8 @@ Feature: Basic test
     @darwin @linux @windows
     Scenario: CRC console credentials
         When executing "crc console --credentials" succeeds
-        Then stdout should contain "To login as a regular user, username is 'developer' and password is 'developer'."
-        And stdout should contain "To login as an admin, username is 'kubeadmin' and password is "
+        Then stdout should contain "To login as a regular user, run 'oc login -u developer -p developer"
+        And stdout should contain "To login as an admin, run 'oc login -u kubeadmin -p "
 
     @darwin @linux @windows
     Scenario: CRC forcible stop


### PR DESCRIPTION
After using the tool a couple of times it was always a little cumbersome to log in as an admin.

This way the user has only to copy-paste.