### PR TITLE
Update proc_starting-the-virtual-machine.adoc

### DIFF
--- a/docs/source/getting-started/content/assembly_troubleshooting.adoc
+++ b/docs/source/getting-started/content/assembly_troubleshooting.adoc
@@ -11,3 +11,5 @@ For example, OpenShift issues are tracked on link:https://github.com/openshift/o
 include::proc_basic-troubleshooting.adoc[leveloffset=+1]
 
 include::proc_troubleshooting-expired-certificates.adoc[leveloffset=+1]
+
+include::proc_troubleshooting-bundle-version-mismatch.adoc[leveloffset=+1]

--- a/docs/source/getting-started/content/proc_setting-up-codeready-containers.adoc
+++ b/docs/source/getting-started/content/proc_setting-up-codeready-containers.adoc
@@ -11,8 +11,10 @@ This procedure will create the [filename]`~/.crc` directory if it does not alrea
 
 [NOTE]
 ====
-The `{bin}` binary should not be run as `root` (or Administrator).
+* The `{bin}` binary should not be run as `root` (or Administrator).
 The `{bin}` binary should always be run with your user account.
+* If you are setting up a new version, capture any changes made to the instance before 
+setting up a new {prod} release.  
 ====
 
 .Procedure

--- a/docs/source/getting-started/content/proc_starting-the-virtual-machine.adoc
+++ b/docs/source/getting-started/content/proc_starting-the-virtual-machine.adoc
@@ -38,5 +38,5 @@ $ {bin} start --vm-driver virtualbox --bundle _path_to_system_bundle_
 [NOTE]
 ====
 * The cluster takes a minimum of four minutes to start the necessary containers and operators before serving a request.
-* If errors are encountered on the start command due to a mismatch in the hyperkit bundle, use the '{bin} delete' command to remove older versions.  These older versions may have user data and care should be taken before issuing the command to insure past work is not lost. 
+* If errors are encountered on the start command due to a mismatch in dependencies (such as the hyperkit bundle), use the '{bin} delete' command to remove older versions.  These older versions may have user data and care should be taken before issuing the command to insure past work is not lost. 
 ====

--- a/docs/source/getting-started/content/proc_starting-the-virtual-machine.adoc
+++ b/docs/source/getting-started/content/proc_starting-the-virtual-machine.adoc
@@ -37,5 +37,6 @@ $ {bin} start --vm-driver virtualbox --bundle _path_to_system_bundle_
 
 [NOTE]
 ====
-The cluster takes a minimum of four minutes to start the necessary containers and operators before serving a request.
+* The cluster takes a minimum of four minutes to start the necessary containers and operators before serving a request.
+* If errors are encountered on the start command due to a mismatch in the hyperkit bundle, use the '{bin} delete' command to remove older versions.  These older versions may have user data and care should be taken before issuing the command to insure past work is not lost. 
 ====

--- a/docs/source/getting-started/content/proc_starting-the-virtual-machine.adoc
+++ b/docs/source/getting-started/content/proc_starting-the-virtual-machine.adoc
@@ -38,5 +38,5 @@ $ {bin} start --vm-driver virtualbox --bundle _path_to_system_bundle_
 [NOTE]
 ====
 * The cluster takes a minimum of four minutes to start the necessary containers and operators before serving a request.
-* If errors are encountered on the start command due to a mismatch in dependencies (such as the hyperkit bundle), use the '{bin} delete' command to remove older versions.  These older versions may have user data and care should be taken before issuing the command to insure past work is not lost. 
+* If errors are encountered on the start, check the Troubleshooting section for potential solutions. 
 ====

--- a/docs/source/getting-started/content/proc_starting-the-virtual-machine.adoc
+++ b/docs/source/getting-started/content/proc_starting-the-virtual-machine.adoc
@@ -38,5 +38,5 @@ $ {bin} start --vm-driver virtualbox --bundle _path_to_system_bundle_
 [NOTE]
 ====
 * The cluster takes a minimum of four minutes to start the necessary containers and operators before serving a request.
-* If errors are encountered on the start, check the Troubleshooting section for potential solutions. 
+* If errors are encountered on the start, check the <<troubleshooting-codeready-containers_{context}>> section for potential solutions. 
 ====

--- a/docs/source/getting-started/content/proc_troubleshooting-bundle-version-mismatch.adoc
+++ b/docs/source/getting-started/content/proc_troubleshooting-bundle-version-mismatch.adoc
@@ -1,7 +1,10 @@
 [id="troubleshooting-bundle-version-mismatch_{context}"]
 = Troubleshooting bundle version mismatch
 
-As {prod} releases are set up and started, instances are created with bundle information and instance data.  When a new {prod} release is setup, the bundle information and instance data is not updated due to the customization in the previous instance data.  This will lead to errors on [command]`{bin} start` command. The error will be similar to this:
+As {prod} releases are set up and started, instances are created with bundle information and instance data.  
+When a new {prod} release is setup, the bundle information and instance data is not updated due to the customization in the previous instance data.  
+This will lead to errors on [command]`{bin} start` command. 
+The error will be similar to this:
 
 ----
 $ {bin} start
@@ -26,6 +29,7 @@ $ {bin} delete
 
 [NOTE]
 ====
-The [command]`{bin} delete` command will result in the loss of data stored in the {prod} virtual machine. Steps should be taken to save any instance information before issuing the command. 
+The [command]`{bin} delete` command will result in the loss of data stored in the {prod} virtual machine. 
+Steps should be taken to save any instance information before issuing the command. 
 ====
 

--- a/docs/source/getting-started/content/proc_troubleshooting-bundle-version-mismatch.adoc
+++ b/docs/source/getting-started/content/proc_troubleshooting-bundle-version-mismatch.adoc
@@ -1,10 +1,7 @@
 [id="troubleshooting-bundle-version-mismatch_{context}"]
 = Troubleshooting bundle version mismatch
 
-As {prod} releases are setup and started, instances are created with bundle information 
-and instance data.  When a new {prod} release is setup, the bundle information and instance data
-is not updated due to the customization in the previous instance data.  This will lead to errors on 
-[command]`{bin} start` command 
+As {prod} releases are set up and started, instances are created with bundle information and instance data.  When a new {prod} release is setup, the bundle information and instance data is not updated due to the customization in the previous instance data.  This will lead to errors on [command]`{bin} start` command. The error will be similar to this:
 
 ----
 $ {bin} start
@@ -20,7 +17,7 @@ FATA Bundle 'crc_hyperkit_4.2.8.crcbundle' was requested, but the existing VM is
 
 .Procedure
 
-To resolve the error, use the [command]`{bin} delete` command:
+To resolve the error, issue the [command]`{bin} delete` command before attempting to start the instances:
 
 [subs="+quotes,attributes"]
 ----
@@ -29,6 +26,6 @@ $ {bin} delete
 
 [NOTE]
 ====
-The [command]`{bin} delete` command will result in the loss of data stored in the {prod} virtual machine.  
+The [command]`{bin} delete` command will result in the loss of data stored in the {prod} virtual machine. Steps should be taken to save any instance information before issuing the command. 
 ====
 

--- a/docs/source/getting-started/content/proc_troubleshooting-bundle-version-mismatch.adoc
+++ b/docs/source/getting-started/content/proc_troubleshooting-bundle-version-mismatch.adoc
@@ -1,0 +1,34 @@
+[id="troubleshooting-bundle-version-mismatch_{context}"]
+= Troubleshooting bundle version mismatch
+
+As {prod} releases are setup and started, instances are created with bundle information 
+and instance data.  When a new {prod} release is setup, the bundle information and instance data
+is not updated due to the customization in the previous instance data.  This will lead to errors on 
+[command]`{bin} start` command 
+
+----
+$ {bin} start
+INFO Checking if running as non-root
+INFO Checking if oc binary is cached
+INFO Checking if HyperKit is installed
+INFO Checking if crc-driver-hyperkit is installed
+INFO Checking file permissions for /etc/resolver/testing
+INFO Checking file permissions for /etc/hosts
+FATA Bundle 'crc_hyperkit_4.2.8.crcbundle' was requested, but the existing VM is using
+'crc_hyperkit_4.2.2.crcbundle'
+----
+
+.Procedure
+
+To resolve the error, use the [command]`{bin} delete` command:
+
+[subs="+quotes,attributes"]
+----
+$ {bin} delete
+----
+
+[NOTE]
+====
+The [command]`{bin} delete` command will result in the loss of data stored in the {prod} virtual machine.  
+====
+


### PR DESCRIPTION
Fixes #870 

added Note to setup instructions to account for problem such as  "Bundle 'crc_hyperkit_4.2.8.crcbundle' was requested, but the existing VM is using 'crc_hyperkit_4.2.2.crcbundle'"