### PR TITLE
Issue 656: validation: Replace "<hypervisor>" with actual hypervisor name

### DIFF
--- a/pkg/crc/validation/validation.go
+++ b/pkg/crc/validation/validation.go
@@ -53,7 +53,7 @@ func ValidateBundle(bundle string) error {
 	releaseBundleVersion := version.GetBundleVersion()
 	userProvidedBundleVersion := filepath.Base(bundle)
 	if !strings.Contains(userProvidedBundleVersion, fmt.Sprintf("%s.crcbundle", releaseBundleVersion)) {
-		return errors.Newf("%s bundle is not supported by this binary, please use crc_<hypervisor>_%s.crcbundle", userProvidedBundleVersion, releaseBundleVersion)
+		return errors.Newf("%s bundle is not supported by this binary, please use %s", userProvidedBundleVersion, constants.GetDefaultBundle())
 	}
 	return nil
 }


### PR DESCRIPTION
When the bundle version is not correct, we currently print a message
referring to "crc_<hypervisor>_4.2.8.crcbundle". However, now that
virtualbox support has been dropped, we can directly mention the native
hypervisor in the message.

This fixes https://github.com/code-ready/crc/issues/656