### PR TITLE
Embed the binaries we need in 'crc' to support offline installs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ GOPATH ?= $(shell go env GOPATH)
 ORG := github.com/code-ready
 REPOPATH ?= $(ORG)/crc
 
-PACKAGES := go list ./... | grep -v /out
+PACKAGES := go list ./...
 SOURCES := $(shell git ls-files  *.go ":^vendor")
 
 RELEASE_INFO := release-info.json

--- a/cmd/crc-embedder/cmd/embed.go
+++ b/cmd/crc-embedder/cmd/embed.go
@@ -1,0 +1,116 @@
+package cmd
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"runtime"
+
+	"github.com/code-ready/crc/pkg/crc/constants"
+	"github.com/code-ready/crc/pkg/crc/logging"
+	"github.com/code-ready/crc/pkg/download"
+
+	"github.com/code-ready/crc/pkg/crc/machine/hyperkit"
+	"github.com/code-ready/crc/pkg/crc/machine/libvirt"
+
+	"github.com/YourFin/binappend"
+	"github.com/spf13/cobra"
+)
+
+var (
+	bundleDir string
+	goos      string
+)
+
+func init() {
+	embedCmd.Flags().StringVar(&bundleDir, "bundle-dir", constants.MachineCacheDir, "Directory where the OpenShift bundle can be found")
+	embedCmd.Flags().StringVar(&goos, "goos", runtime.GOOS, "Target platform (darwin, linux or windows)")
+	rootCmd.AddCommand(embedCmd)
+}
+
+var embedCmd = &cobra.Command{
+	Use:   "embed",
+	Short: "Embed data files in crc binary",
+	Long:  `Embed the OpenShift bundle and the binaries needed at runtime in the crc binary`,
+	Run: func(cmd *cobra.Command, args []string) {
+		runEmbed(args)
+	},
+}
+
+func runEmbed(args []string) {
+	if len(args) != 1 {
+		logging.Fatalf("embed takes exactly one argument")
+	}
+	binaryPath := args[0]
+	destDir, err := ioutil.TempDir("", "crc-embedder")
+	if err != nil {
+		logging.Errorf(fmt.Sprintf("Failed to create temporary directory: %v", err))
+	}
+	defer os.RemoveAll(destDir)
+	downloadedFiles, err := downloadDataFiles(goos, destDir)
+	if err != nil {
+		logging.Errorf(fmt.Sprintf("Failed to download data files: %v", err))
+	}
+
+	bundlePath := path.Join(bundleDir, constants.GetDefaultBundleForOs(goos))
+	downloadedFiles = append(downloadedFiles, bundlePath)
+	err = embedFiles(binaryPath, downloadedFiles)
+	if err != nil {
+		logging.Errorf(fmt.Sprintf("Failed to embed data files: %v", err))
+	}
+}
+
+func embedFiles(binary string, filenames []string) error {
+	appender, err := binappend.MakeAppender(binary)
+	if err != nil {
+		return err
+	}
+	defer appender.Close()
+	for _, filename := range filenames {
+		logging.Debugf("Embedding %s in %s", filename, binary)
+		f, err := os.Open(filename) // #nosec G304
+		if err != nil {
+			return fmt.Errorf("Failed to open %s: %v", filename, err)
+		}
+		defer f.Close()
+
+		err = appender.AppendStreamReader(path.Base(filename), f, false)
+		if err != nil {
+			return fmt.Errorf("Failed to append %s to %s: %v", filename, binary, err)
+		}
+	}
+
+	return nil
+}
+
+var (
+	dataFileUrls = map[string][]string{
+		"darwin": []string{
+			hyperkit.MachineDriverDownloadUrl,
+			hyperkit.HyperkitDownloadUrl,
+			constants.GetOcUrlForOs("darwin"),
+		},
+		"linux": []string{
+			libvirt.MachineDriverDownloadUrl,
+			constants.GetOcUrlForOs("linux"),
+		},
+		"windows": []string{
+			constants.GetOcUrlForOs("windows"),
+		},
+	}
+)
+
+func downloadDataFiles(goos string, destDir string) ([]string, error) {
+	downloadedFiles := []string{}
+	downloads := dataFileUrls[goos]
+	for _, url := range downloads {
+		filename, err := download.Download(url, destDir, 0644)
+		if err != nil {
+			return nil, err
+		}
+		downloadedFiles = append(downloadedFiles, filename)
+	}
+
+	return downloadedFiles, nil
+}

--- a/cmd/crc-embedder/cmd/extract.go
+++ b/cmd/crc-embedder/cmd/extract.go
@@ -1,0 +1,36 @@
+package cmd
+
+import (
+	"github.com/code-ready/crc/pkg/crc/logging"
+	"github.com/code-ready/crc/pkg/crc/output"
+	"github.com/code-ready/crc/pkg/embed"
+
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(extractCmd)
+}
+
+var extractCmd = &cobra.Command{
+	Use:   "extract",
+	Short: "Extract data file embedded in the crc binary",
+	Long:  `Extract a data file wich is embedded in the crc binary`,
+	Run: func(cmd *cobra.Command, args []string) {
+		runExtract(args)
+	},
+}
+
+func runExtract(args []string) {
+	if len(args) != 3 {
+		logging.Fatalf("extract takes exactly three arguments")
+	}
+	binaryPath := args[0]
+	embedName := args[1]
+	destFile := args[2]
+	err := embed.ExtractFromBinary(binaryPath, embedName, destFile)
+	if err != nil {
+		logging.Fatalf("Could not extract data embedded in %s: %v", binaryPath, err)
+	}
+	output.Outf("Successfully copied embedded '%s' from %s to %s: %v", embedName, binaryPath, destFile, err)
+}

--- a/cmd/crc-embedder/cmd/list.go
+++ b/cmd/crc-embedder/cmd/list.go
@@ -1,0 +1,37 @@
+package cmd
+
+import (
+	"github.com/code-ready/crc/pkg/crc/logging"
+	"github.com/code-ready/crc/pkg/crc/output"
+
+	"github.com/YourFin/binappend"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(listCmd)
+}
+
+var listCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List data files embedded in the crc binary",
+	Long:  `List all the data files wich were embedded in the crc binary`,
+	Run: func(cmd *cobra.Command, args []string) {
+		runList(args)
+	},
+}
+
+func runList(args []string) {
+	if len(args) != 1 {
+		logging.Fatalf("list takes exactly one argument")
+	}
+	binaryPath := args[0]
+	extractor, err := binappend.MakeExtractor(binaryPath)
+	if err != nil {
+		logging.Fatalf("Could not access data embedded in %s: %v", binaryPath, err)
+	}
+	output.Outf("Data files embedded in %s:\n", binaryPath)
+	for _, name := range extractor.AvalibleData() {
+		output.Outln("\t", name)
+	}
+}

--- a/cmd/crc-embedder/cmd/root.go
+++ b/cmd/crc-embedder/cmd/root.go
@@ -1,0 +1,51 @@
+package cmd
+
+import (
+	"github.com/code-ready/crc/pkg/crc/constants"
+	"github.com/code-ready/crc/pkg/crc/logging"
+	"github.com/code-ready/crc/pkg/crc/output"
+
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "crc-embedder [list|embed|extract]",
+	Short: "Build helper for crc for binary embedding",
+	Long: `crc-embedder is a command line utility for listing or appending binary data
+when building the crc binary for release`,
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		runPrerun()
+	},
+	Run: func(cmd *cobra.Command, args []string) {
+		runRoot()
+		_ = cmd.Help()
+	},
+	PersistentPostRun: func(cmd *cobra.Command, args []string) {
+		runPostrun()
+	},
+}
+
+func init() {
+	rootCmd.PersistentFlags().StringVar(&logging.LogLevel, "log-level", constants.DefaultLogLevel, "log level (e.g. \"debug | info | warn | error\")")
+}
+
+func Execute() {
+	if err := rootCmd.Execute(); err != nil {
+		logging.Fatal(err)
+	}
+}
+
+func runPrerun() {
+	// Setting up logrus
+	logging.InitLogrus(logging.LogLevel)
+	logging.SetupFileHook()
+}
+
+func runRoot() {
+	output.Outln("No command given")
+	output.Outln("")
+}
+
+func runPostrun() {
+	logging.CloseLogging()
+}

--- a/cmd/crc-embedder/crc-embedder.go
+++ b/cmd/crc-embedder/crc-embedder.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"github.com/code-ready/crc/cmd/crc-embedder/cmd"
+)
+
+func main() {
+	cmd.Execute()
+}

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,6 @@ github.com/code-ready/clicumber v0.0.0-20190801094041-02a92c8f7ece h1:ZuvFtsdv+H
 github.com/code-ready/clicumber v0.0.0-20190801094041-02a92c8f7ece/go.mod h1:bjcKpFX8OebrlwSDgDAf0KAqpdVPGQssQk+IcVwlcog=
 github.com/code-ready/goodhosts v0.0.0-20190712111040-f090f3f77c26 h1:rNdqNBHRAAuGv68zZCX0rQAekl0g4qwnseA8OFM2j54=
 github.com/code-ready/goodhosts v0.0.0-20190712111040-f090f3f77c26/go.mod h1:kc1Z2UDuIlxPOo7VWCIkYPOaD55KPX0t5qS5cmLBe8Y=
-github.com/code-ready/machine v0.0.0-20190904103148-0fde37b5d95b h1:uDsea77LGyGm5kDFi4N8xyi2k06dlCKvK09or3BGsUA=
-github.com/code-ready/machine v0.0.0-20190904103148-0fde37b5d95b/go.mod h1:x/y5No186t4X+Z9fQafLByNoo+K4MyNzxgcKKq76N+U=
 github.com/code-ready/machine v0.0.0-20191115055627-b284f794e910 h1:roFnY4xZrCGYgzxymOxCONENB6VOZICijEPsN+2x5zw=
 github.com/code-ready/machine v0.0.0-20191115055627-b284f794e910/go.mod h1:x/y5No186t4X+Z9fQafLByNoo+K4MyNzxgcKKq76N+U=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=

--- a/pkg/crc/constants/constants.go
+++ b/pkg/crc/constants/constants.go
@@ -1,6 +1,7 @@
 package constants
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -25,7 +26,23 @@ const (
 	GlobalStateFile      = "globalstate.json"
 	CrcLandingPageURL    = "https://cloud.redhat.com/openshift/install/crc/installer-provisioned" // #nosec G101
 	PullSecretFile       = "pullsecret.json"
+
+	DefaultOcUrlBase = "https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest"
 )
+
+var ocUrlForOs = map[string]string{
+	"darwin":  fmt.Sprintf("%s/%s", DefaultOcUrlBase, "macosx/oc.tar.gz"),
+	"linux":   fmt.Sprintf("%s/%s", DefaultOcUrlBase, "linux/oc.tar.gz"),
+	"windows": fmt.Sprintf("%s/%s", DefaultOcUrlBase, "windows/oc.zip"),
+}
+
+func GetOcUrlForOs(os string) string {
+	return ocUrlForOs[os]
+}
+
+func GetOcUrl() string {
+	return GetOcUrlForOs(runtime.GOOS)
+}
 
 var (
 	CrcBaseDir         = filepath.Join(GetHomeDir(), ".crc")

--- a/pkg/crc/constants/constants.go
+++ b/pkg/crc/constants/constants.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+
+	"github.com/code-ready/crc/pkg/crc/version"
 )
 
 const (
@@ -42,6 +44,20 @@ func GetOcUrlForOs(os string) string {
 
 func GetOcUrl() string {
 	return GetOcUrlForOs(runtime.GOOS)
+}
+
+var defaultBundleForOs = map[string]string{
+	"darwin":  fmt.Sprintf("crc_hyperkit_%s.crcbundle", version.GetBundleVersion()),
+	"linux":   fmt.Sprintf("crc_libvirt_%s.crcbundle", version.GetBundleVersion()),
+	"windows": fmt.Sprintf("crc_hyperv_%s.crcbundle", version.GetBundleVersion()),
+}
+
+func GetDefaultBundleForOs(os string) string {
+	return defaultBundleForOs[os]
+}
+
+func GetDefaultBundle() string {
+	return GetDefaultBundleForOs(runtime.GOOS)
 }
 
 var (

--- a/pkg/crc/constants/constants_darwin.go
+++ b/pkg/crc/constants/constants_darwin.go
@@ -7,7 +7,6 @@ import (
 
 const (
 	OcBinaryName = "oc"
-	DefaultOcURL = "https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/macosx/oc.tar.gz"
 )
 
 func GetDefaultBundle() string {

--- a/pkg/crc/constants/constants_darwin.go
+++ b/pkg/crc/constants/constants_darwin.go
@@ -1,14 +1,5 @@
 package constants
 
-import (
-	"fmt"
-	"github.com/code-ready/crc/pkg/crc/version"
-)
-
 const (
 	OcBinaryName = "oc"
 )
-
-func GetDefaultBundle() string {
-	return fmt.Sprintf("crc_hyperkit_%s.crcbundle", version.GetBundleVersion())
-}

--- a/pkg/crc/constants/constants_linux.go
+++ b/pkg/crc/constants/constants_linux.go
@@ -7,7 +7,6 @@ import (
 
 const (
 	OcBinaryName = "oc"
-	DefaultOcURL = "https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/linux/oc.tar.gz"
 )
 
 func GetDefaultBundle() string {

--- a/pkg/crc/constants/constants_linux.go
+++ b/pkg/crc/constants/constants_linux.go
@@ -1,14 +1,5 @@
 package constants
 
-import (
-	"fmt"
-	"github.com/code-ready/crc/pkg/crc/version"
-)
-
 const (
 	OcBinaryName = "oc"
 )
-
-func GetDefaultBundle() string {
-	return fmt.Sprintf("crc_libvirt_%s.crcbundle", version.GetBundleVersion())
-}

--- a/pkg/crc/constants/constants_windows.go
+++ b/pkg/crc/constants/constants_windows.go
@@ -1,15 +1,5 @@
 package constants
 
-import (
-	"fmt"
-	"github.com/code-ready/crc/pkg/crc/version"
-)
-
 const (
 	OcBinaryName = "oc.exe"
 )
-
-func GetDefaultBundle() string {
-	// TODO: we will change once we have correct bundle for windows
-	return fmt.Sprintf("crc_hyperv_%s.crcbundle", version.GetBundleVersion())
-}

--- a/pkg/crc/constants/constants_windows.go
+++ b/pkg/crc/constants/constants_windows.go
@@ -7,7 +7,6 @@ import (
 
 const (
 	OcBinaryName = "oc.exe"
-	DefaultOcURL = "https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/windows/oc.zip"
 )
 
 func GetDefaultBundle() string {

--- a/pkg/crc/machine/hyperkit/constants.go
+++ b/pkg/crc/machine/hyperkit/constants.go
@@ -1,3 +1,5 @@
+//+build darwin build
+
 package hyperkit
 
 import "fmt"

--- a/pkg/crc/machine/hyperkit/constants_darwin.go
+++ b/pkg/crc/machine/hyperkit/constants_darwin.go
@@ -1,0 +1,13 @@
+package hyperkit
+
+import "fmt"
+
+const (
+	MachineDriverCommand = "crc-driver-hyperkit"
+	MachineDriverVersion = "0.12.6"
+)
+
+var (
+	HyperkitDownloadUrl      = fmt.Sprintf("https://github.com/code-ready/machine-driver-hyperkit/releases/download/v%s/hyperkit", MachineDriverVersion)
+	MachineDriverDownloadUrl = fmt.Sprintf("https://github.com/code-ready/machine-driver-hyperkit/releases/download/v%s/crc-driver-hyperkit", MachineDriverVersion)
+)

--- a/pkg/crc/machine/libvirt/constants.go
+++ b/pkg/crc/machine/libvirt/constants.go
@@ -1,3 +1,5 @@
+//+build linux build
+
 package libvirt
 
 import "fmt"

--- a/pkg/crc/machine/libvirt/constants_linux.go
+++ b/pkg/crc/machine/libvirt/constants_linux.go
@@ -1,5 +1,7 @@
 package libvirt
 
+import "fmt"
+
 const (
 	// Defaults
 	DefaultNetwork   = "crc"
@@ -9,4 +11,13 @@ const (
 	// Static addresses
 	MACAddress = "52:fd:fc:07:21:82"
 	IPAddress  = "192.168.130.11"
+)
+
+const (
+	MachineDriverCommand = "crc-driver-libvirt"
+	MachineDriverVersion = "0.12.6"
+)
+
+var (
+	MachineDriverDownloadUrl = fmt.Sprintf("https://github.com/code-ready/machine-driver-libvirt/releases/download/%s/crc-driver-libvirt", MachineDriverVersion)
 )

--- a/pkg/crc/oc/oc_cache.go
+++ b/pkg/crc/oc/oc_cache.go
@@ -8,6 +8,7 @@ import (
 	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/code-ready/crc/pkg/crc/logging"
 	"github.com/code-ready/crc/pkg/download"
+	"github.com/code-ready/crc/pkg/embed"
 	"github.com/code-ready/crc/pkg/extract"
 	crcos "github.com/code-ready/crc/pkg/os"
 	"github.com/pkg/errors"
@@ -44,17 +45,29 @@ func matchOcBinaryName(filename string) bool {
 	return filepath.Base(filename) == constants.OcBinaryName
 }
 
+func (oc *OcCached) getOc(destDir string) (string, error) {
+	logging.Debug("Trying to extract oc from crc binary")
+	archiveName := filepath.Base(constants.GetOcUrl())
+	destPath := filepath.Join(destDir, archiveName)
+	err := embed.Extract(archiveName, destPath)
+	if err != nil {
+		logging.Debug("Downloading oc")
+		return download.Download(constants.GetOcUrl(), destDir, 0600)
+	}
+
+	return destPath, err
+}
+
 // cacheOc downloads and caches the oc binary into the minishift directory
 func (oc *OcCached) cacheOc() error {
 	if !oc.IsCached() {
-		logging.Debug("Downloading oc")
 		// Create tmp dir to download the oc tarball
 		tmpDir, err := ioutil.TempDir("", "crc")
 		if err != nil {
 			return err
 		}
 		defer os.RemoveAll(tmpDir)
-		assetTmpFile, err := download.Download(constants.GetOcUrl(), tmpDir, 0600)
+		assetTmpFile, err := oc.getOc(tmpDir)
 		if err != nil {
 			return err
 		}

--- a/pkg/crc/oc/oc_cache.go
+++ b/pkg/crc/oc/oc_cache.go
@@ -54,7 +54,7 @@ func (oc *OcCached) cacheOc() error {
 			return err
 		}
 		defer os.RemoveAll(tmpDir)
-		assetTmpFile, err := download.Download(constants.DefaultOcURL, tmpDir, 0600)
+		assetTmpFile, err := download.Download(constants.GetOcUrl(), tmpDir, 0600)
 		if err != nil {
 			return err
 		}

--- a/pkg/crc/preflight/preflight_checks_darwin.go
+++ b/pkg/crc/preflight/preflight_checks_darwin.go
@@ -13,22 +13,15 @@ import (
 
 	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/code-ready/crc/pkg/crc/logging"
+	"github.com/code-ready/crc/pkg/crc/machine/hyperkit"
 	dl "github.com/code-ready/crc/pkg/download"
 	crcos "github.com/code-ready/crc/pkg/os"
 )
 
 const (
-	hyperkitDriverCommand = "crc-driver-hyperkit"
-	hyperkitDriverVersion = "0.12.6"
-
 	resolverDir  = "/etc/resolver"
 	resolverFile = "/etc/resolver/testing"
 	hostFile     = "/etc/hosts"
-)
-
-var (
-	hyperkitDownloadURL       = fmt.Sprintf("https://github.com/code-ready/machine-driver-hyperkit/releases/download/v%s/hyperkit", hyperkitDriverVersion)
-	hyperkitDriverDownloadURL = fmt.Sprintf("https://github.com/code-ready/machine-driver-hyperkit/releases/download/v%s/crc-driver-hyperkit", hyperkitDriverVersion)
 )
 
 // Add darwin specific checks
@@ -124,7 +117,7 @@ func checkHyperKitInstalled() error {
 }
 
 func fixHyperKitInstallation() error {
-	hyperkitFile, err := download(hyperkitDownloadURL, constants.CrcBinDir, 0755)
+	hyperkitFile, err := download(hyperkit.HyperkitDownloadUrl, constants.CrcBinDir, 0755)
 	if err != nil {
 		return err
 	}
@@ -133,8 +126,8 @@ func fixHyperKitInstallation() error {
 }
 
 func checkMachineDriverHyperKitInstalled() error {
-	logging.Debugf("Checking if %s is installed", hyperkitDriverCommand)
-	hyperkitPath := filepath.Join(constants.CrcBinDir, hyperkitDriverCommand)
+	logging.Debugf("Checking if %s is installed", hyperkit.MachineDriverCommand)
+	hyperkitPath := filepath.Join(constants.CrcBinDir, hyperkit.MachineDriverCommand)
 	err := unix.Access(hyperkitPath, unix.X_OK)
 	if err != nil {
 		return err
@@ -145,16 +138,16 @@ func checkMachineDriverHyperKitInstalled() error {
 	if err != nil {
 		return err
 	}
-	if !strings.Contains(stdOut, hyperkitDriverVersion) {
-		return fmt.Errorf("%s does not have right version \n Required: %s \n Got: %s use 'crc setup' command.\n %v\n", hyperkitDriverCommand, hyperkitDriverVersion, stdOut, stdErr)
+	if !strings.Contains(stdOut, hyperkit.MachineDriverVersion) {
+		return fmt.Errorf("%s does not have right version \n Required: %s \n Got: %s use 'crc setup' command.\n %v\n", hyperkit.MachineDriverCommand, hyperkit.MachineDriverVersion, stdOut, stdErr)
 	}
-	logging.Debugf("%s is already installed in %s", hyperkitDriverCommand, hyperkitPath)
+	logging.Debugf("%s is already installed in %s", hyperkit.MachineDriverCommand, hyperkitPath)
 
 	return checkSuid(hyperkitPath)
 }
 
 func fixMachineDriverHyperKitInstalled() error {
-	hyperkitDriverPath, err := download(hyperkitDriverDownloadURL, constants.CrcBinDir, 0755)
+	hyperkitDriverPath, err := download(hyperkit.MachineDriverDownloadUrl, constants.CrcBinDir, 0755)
 	if err != nil {
 		return err
 	}

--- a/pkg/crc/preflight/preflight_checks_linux.go
+++ b/pkg/crc/preflight/preflight_checks_linux.go
@@ -265,9 +265,12 @@ func checkMachineDriverLibvirtInstalled() error {
 
 func fixMachineDriverLibvirtInstalled() error {
 	logging.Debugf("Installing %s", libvirt.MachineDriverCommand)
-	_, err := download.Download(libvirt.MachineDriverDownloadUrl, constants.CrcBinDir, 0755)
+	_, err := extractBinary(libvirt.MachineDriverCommand)
 	if err != nil {
-		return err
+		_, err = download.Download(libvirt.MachineDriverDownloadUrl, constants.CrcBinDir, 0755)
+		if err != nil {
+			return err
+		}
 	}
 	logging.Debugf("%s is installed in %s", libvirt.MachineDriverCommand, constants.CrcBinDir)
 

--- a/pkg/crc/preflight/preflight_checks_linux.go
+++ b/pkg/crc/preflight/preflight_checks_linux.go
@@ -26,8 +26,6 @@ import (
 )
 
 const (
-	libvirtDriverCommand        = "crc-driver-libvirt"
-	libvirtDriverVersion        = "0.12.6"
 	crcDnsmasqConfigFile        = "crc.conf"
 	crcNetworkManagerConfigFile = "crc-nm-dnsmasq.conf"
 	// This is defined in https://github.com/code-ready/machine-driver-libvirt/blob/master/go.mod#L5
@@ -43,7 +41,6 @@ server=/crc.testing/192.168.130.11
 	crcNetworkManagerConfig     = `[main]
 dns=dnsmasq
 `
-	libvirtDriverDownloadURL = fmt.Sprintf("https://github.com/code-ready/machine-driver-libvirt/releases/download/%s/crc-driver-libvirt", libvirtDriverVersion)
 )
 
 func checkVirtualizationEnabled() error {
@@ -244,10 +241,10 @@ func fixLibvirtServiceRunning() error {
 }
 
 func checkMachineDriverLibvirtInstalled() error {
-	logging.Debugf("Checking if %s is installed", libvirtDriverCommand)
+	logging.Debugf("Checking if %s is installed", libvirt.MachineDriverCommand)
 
 	// Check if crc-driver-libvirt is available
-	libvirtDriverPath := filepath.Join(constants.CrcBinDir, libvirtDriverCommand)
+	libvirtDriverPath := filepath.Join(constants.CrcBinDir, libvirt.MachineDriverCommand)
 	err := unix.Access(libvirtDriverPath, unix.X_OK)
 	if err != nil {
 		logging.Debugf("%s not executable", libvirtDriverPath)
@@ -259,38 +256,38 @@ func checkMachineDriverLibvirtInstalled() error {
 	if err != nil {
 		return fmt.Errorf("%v : %s", err, stdErr)
 	}
-	if !strings.Contains(stdOut, libvirtDriverVersion) {
-		return fmt.Errorf("crc-driver-libvirt does not have right version \n Required: %s \n Got: %s use 'crc setup' command.\n %v\n", libvirtDriverVersion, stdOut, stdErr)
+	if !strings.Contains(stdOut, libvirt.MachineDriverVersion) {
+		return fmt.Errorf("crc-driver-libvirt does not have right version \n Required: %s \n Got: %s use 'crc setup' command.\n %v\n", libvirt.MachineDriverVersion, stdOut, stdErr)
 	}
-	logging.Debugf("%s is already installed in %s", libvirtDriverCommand, libvirtDriverPath)
+	logging.Debugf("%s is already installed in %s", libvirt.MachineDriverCommand, libvirtDriverPath)
 	return nil
 }
 
 func fixMachineDriverLibvirtInstalled() error {
-	logging.Debugf("Installing %s", libvirtDriverCommand)
-	_, err := download.Download(libvirtDriverDownloadURL, constants.CrcBinDir, 0755)
+	logging.Debugf("Installing %s", libvirt.MachineDriverCommand)
+	_, err := download.Download(libvirt.MachineDriverDownloadUrl, constants.CrcBinDir, 0755)
 	if err != nil {
 		return err
 	}
-	logging.Debugf("%s is installed in %s", libvirtDriverCommand, constants.CrcBinDir)
+	logging.Debugf("%s is installed in %s", libvirt.MachineDriverCommand, constants.CrcBinDir)
 
 	return nil
 }
 
 /* These 2 checks can be removed after a few releases */
 func checkOldMachineDriverLibvirtInstalled() error {
-	logging.Debugf("Checking if an older libvirt driver %s is installed", libvirtDriverCommand)
-	oldLibvirtDriverPath := filepath.Join("/usr/local/bin/", libvirtDriverCommand)
+	logging.Debugf("Checking if an older libvirt driver %s is installed", libvirt.MachineDriverCommand)
+	oldLibvirtDriverPath := filepath.Join("/usr/local/bin/", libvirt.MachineDriverCommand)
 	if _, err := os.Stat(oldLibvirtDriverPath); !os.IsNotExist(err) {
 		return fmt.Errorf("Found old system-wide crc-machine-driver binary")
 	}
-	logging.Debugf("No older %s installation found", libvirtDriverCommand)
+	logging.Debugf("No older %s installation found", libvirt.MachineDriverCommand)
 
 	return nil
 }
 
 func fixOldMachineDriverLibvirtInstalled() error {
-	oldLibvirtDriverPath := filepath.Join("/usr/local/bin/", libvirtDriverCommand)
+	oldLibvirtDriverPath := filepath.Join("/usr/local/bin/", libvirt.MachineDriverCommand)
 	logging.Debugf("Removing %s", oldLibvirtDriverPath)
 	_, _, err := crcos.RunWithPrivilege("remove old libvirt driver", "rm", "-f", oldLibvirtDriverPath)
 	if err != nil {

--- a/pkg/crc/preflight/preflight_checks_nonwin.go
+++ b/pkg/crc/preflight/preflight_checks_nonwin.go
@@ -5,8 +5,11 @@ package preflight
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
+	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/code-ready/crc/pkg/crc/logging"
+	"github.com/code-ready/crc/pkg/embed"
 )
 
 var nonWinPreflightChecks = [...]PreflightCheck{
@@ -25,4 +28,20 @@ func checkIfRunningAsNormalUser() error {
 	}
 	logging.Debug("Ran as root")
 	return fmt.Errorf("crc should be ran as a normal user")
+}
+
+func extractBinary(binaryName string) (string, error) {
+	destPath := filepath.Join(constants.CrcBinDir, binaryName)
+	err := embed.Extract(binaryName, destPath)
+	if err != nil {
+		return "", err
+	}
+
+	err = os.Chmod(destPath, 0500)
+	if err != nil {
+		os.Remove(destPath)
+		return "", err
+	}
+
+	return destPath, nil
 }

--- a/pkg/embed/embed.go
+++ b/pkg/embed/embed.go
@@ -1,0 +1,52 @@
+package embed
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/code-ready/crc/pkg/crc/logging"
+
+	"github.com/YourFin/binappend"
+)
+
+func openEmbeddedFile(binaryPath, embedName string) (*binappend.Reader, error) {
+	extractor, err := binappend.MakeExtractor(binaryPath)
+	if err != nil {
+		return nil, fmt.Errorf("Could not data embedded in %s: %v", binaryPath, err)
+	}
+	reader, err := extractor.GetReader(embedName)
+	if err != nil {
+		return nil, fmt.Errorf("Could not open embedded '%s' in %s: %v", embedName, binaryPath, err)
+	}
+	return reader, nil
+}
+
+func Extract(embedName, destFile string) error {
+	binaryPath, err := os.Executable()
+	if err != nil {
+		return err
+	}
+	return ExtractFromBinary(binaryPath, embedName, destFile)
+}
+
+func ExtractFromBinary(binaryPath, embedName, destFile string) error {
+	logging.Debugf("Extracting embedded '%s' from %s to %s", embedName, binaryPath, destFile)
+	reader, err := openEmbeddedFile(binaryPath, embedName)
+	if err != nil {
+		return err
+	}
+
+	defer reader.Close()
+	writer, err := os.Create(destFile)
+	if err != nil {
+		return fmt.Errorf("Could not create '%s': %v", destFile, err)
+	}
+	defer writer.Close()
+
+	_, err = io.Copy(writer, reader)
+	if err != nil {
+		return fmt.Errorf("Failed to copy embedded '%s' from %s to %s: %v", embedName, binaryPath, destFile, err)
+	}
+	return nil
+}


### PR DESCRIPTION
At the moment, crc needs external network access in order to download
and install oc and its machine drivers. This is not going to be possible
in some environment where external access is disabled.
This patch series adds a new helper used at build time which will download
the misc required binaries and embed them in the 'crc' binary. Then these
binaries will be used instead of downloading them.
This fixes #509 