### PR TITLE
Revert "Issue #854 Add host->cluster DNS checks"

### DIFF
--- a/pkg/crc/machine/machine.go
+++ b/pkg/crc/machine/machine.go
@@ -313,14 +313,6 @@ func Start(startConfig StartConfig) (StartResult, error) {
 		logging.Warnf("Failed public DNS query from the cluster: %v : %s", err, queryOutput)
 	}
 
-	// Check DNS lookup from host to VM
-	logging.Info("Check DNS query from host ...")
-	if err := network.CheckCRCLocalDNSReachableFromHost(crcBundleMetadata.ClusterInfo.ClusterName,
-		crcBundleMetadata.ClusterInfo.BaseDomain, crcBundleMetadata.ClusterInfo.AppsDomain); err != nil {
-		result.Error = err.Error()
-		return *result, errors.Newf("Failed to query DNS from host: %v", err)
-	}
-
 	// Additional steps to perform after newly created VM is up
 	if !exists {
 		if err := updateSSHKeyPair(sshRunner); err != nil {

--- a/pkg/crc/network/utils.go
+++ b/pkg/crc/network/utils.go
@@ -2,7 +2,6 @@ package network
 
 import (
 	"fmt"
-	"github.com/code-ready/crc/pkg/crc/logging"
 	"net"
 	"net/url"
 
@@ -92,18 +91,4 @@ func UriStringForDisplay(uri string) (string, error) {
 		return fmt.Sprintf("%s://%s:xxx@%s", u.Scheme, u.User.Username(), u.Host), nil
 	}
 	return uri, nil
-}
-
-func CheckCRCLocalDNSReachableFromHost(clusterName, domainName, appsDomainName string) error {
-	ip, err := net.LookupIP(fmt.Sprintf("api.%s.%s", clusterName, domainName))
-	if err != nil {
-		return err
-	}
-	logging.Debugf("api.%s.%s resolved to %s", clusterName, domainName, ip)
-	ip, err = net.LookupIP(fmt.Sprintf("foo.%s", appsDomainName))
-	if err != nil {
-		return err
-	}
-	logging.Debugf("foo.%s resolved to %s", appsDomainName, ip)
-	return nil
 }


### PR DESCRIPTION
Since this commit adds regression for macos because of mac
resolver doesn't allow to resolve from `/etc/resolver/testing`
if cross build binary is in used.

This reverts commit e3ad19871fd5146435ae33dd6fbbad4f41339e09.