### PR TITLE
Add proxy variables to oc-env

### DIFF
--- a/cmd/crc/cmd/oc_env.go
+++ b/cmd/crc/cmd/oc_env.go
@@ -16,8 +16,6 @@ var ocEnvCmd = &cobra.Command{
 	Use:   "oc-env",
 	Short: "Add the 'oc' binary to PATH",
 	Long:  `Add the OpenShift client binary 'oc' to PATH`,
-	// This is required to make sure root command Persistent PreRun not run.
-	PersistentPreRun: func(cmd *cobra.Command, args []string) {},
 	Run: func(cmd *cobra.Command, args []string) {
 		userShell, err := shell.GetShell(forceShell)
 		if err != nil {

--- a/cmd/crc/cmd/oc_env.go
+++ b/cmd/crc/cmd/oc_env.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/code-ready/crc/pkg/crc/errors"
+	"github.com/code-ready/crc/pkg/crc/machine"
 	"github.com/code-ready/crc/pkg/crc/output"
 	"github.com/code-ready/crc/pkg/os/shell"
 	"github.com/spf13/cobra"
@@ -22,7 +23,16 @@ var ocEnvCmd = &cobra.Command{
 			errors.ExitWithMessage(1, "Error running the oc-env command: %s", err.Error())
 		}
 
+		proxyConfig, err := machine.GetProxyConfig(constants.DefaultName)
+		if err != nil {
+			errors.Exit(1)
+		}
 		output.Outln(shell.GetPathEnvString(userShell, constants.CrcBinDir))
+		if proxyConfig.IsEnabled() {
+			output.Outln(shell.GetEnvString(userShell, "HTTP_PROXY", proxyConfig.HttpProxy))
+			output.Outln(shell.GetEnvString(userShell, "HTTPS_PROXY", proxyConfig.HttpsProxy))
+			output.Outln(shell.GetEnvString(userShell, "NO_PROXY", proxyConfig.GetNoProxyString()))
+		}
 		output.Outln(shell.GenerateUsageHint(userShell, "crc oc-env"))
 	},
 }

--- a/cmd/crc/cmd/oc_env.go
+++ b/cmd/crc/cmd/oc_env.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/code-ready/crc/pkg/crc/errors"
+	"github.com/code-ready/crc/pkg/crc/output"
 	"github.com/code-ready/crc/pkg/os/shell"
 	"github.com/spf13/cobra"
 )
@@ -19,6 +20,7 @@ var (
 )
 
 type OcShellConfig struct {
+	UserShell string
 	shell.ShellConfig
 	OcDirPath string
 	UsageHint string
@@ -34,6 +36,7 @@ func getOcShellConfig(ocPath string, forcedShell string) (*OcShellConfig, error)
 
 	shellCfg := &OcShellConfig{
 		OcDirPath: ocPath,
+		UserShell: userShell,
 	}
 
 	shellCfg.UsageHint = shell.GenerateUsageHint(userShell, cmdLine)
@@ -59,7 +62,9 @@ var ocEnvCmd = &cobra.Command{
 		if err != nil {
 			errors.Exit(1)
 		}
-		_ = executeOcTemplateStdout(shellCfg)
+
+		output.Outln(shell.GetPathEnvString(shellCfg.UserShell, constants.CrcBinDir))
+		output.Outln(shellCfg.UsageHint)
 	},
 }
 

--- a/cmd/crc/cmd/root.go
+++ b/cmd/crc/cmd/root.go
@@ -90,14 +90,11 @@ func exitIfMachineMissing(name string) {
 }
 
 func setProxyDefaults() {
-	network.DefaultProxy = &network.ProxyConfig{
-		HttpProxy:  config.GetString(cmdConfig.HttpProxy.Name),
-		HttpsProxy: config.GetString(cmdConfig.HttpsProxy.Name),
-		NoProxy:    config.GetString(cmdConfig.NoProxy.Name),
-	}
+	httpProxy := config.GetString(cmdConfig.HttpProxy.Name)
+	httpsProxy := config.GetString(cmdConfig.HttpsProxy.Name)
+	noProxy := config.GetString(cmdConfig.NoProxy.Name)
 
-	proxyConfig, err := network.NewProxyConfig()
-
+	proxyConfig, err := network.NewProxyDefaults(httpProxy, httpsProxy, noProxy)
 	if err != nil {
 		errors.ExitWithMessage(1, err.Error())
 	}

--- a/pkg/crc/machine/machine.go
+++ b/pkg/crc/machine/machine.go
@@ -721,7 +721,7 @@ func configProxyForCluster(ocConfig oc.OcConfig, sshRunner *crcssh.SSHRunner, sd
 			}
 		}()
 
-		proxy.AddNoProxy([]string{fmt.Sprintf(".%s", baseDomainName), instanceIP})
+		proxy.AddNoProxy(fmt.Sprintf(".%s", baseDomainName), instanceIP)
 		proxy.ApplyToEnvironment()
 
 		logging.Info("Adding proxy configuration to the cluster ...")

--- a/pkg/crc/machine/machine.go
+++ b/pkg/crc/machine/machine.go
@@ -732,10 +732,10 @@ func configProxyForCluster(ocConfig oc.OcConfig, sshRunner *crcssh.SSHRunner, sd
 				}
 			}
 		}()
-		proxy.AddNoProxy(instanceIP)
 		proxy.ApplyToEnvironment()
 
 		logging.Info("Adding proxy configuration to the cluster ...")
+		proxy.AddNoProxy(instanceIP)
 		if err := cluster.AddProxyConfigToCluster(ocConfig, proxy); err != nil {
 			return err
 		}

--- a/pkg/crc/machine/types.go
+++ b/pkg/crc/machine/types.go
@@ -1,6 +1,7 @@
 package machine
 
 import (
+	"github.com/code-ready/crc/pkg/crc/network"
 	"github.com/code-ready/machine/libmachine/state"
 )
 
@@ -32,6 +33,7 @@ type ClusterConfig struct {
 	KubeAdminPass string
 	ClusterAPI    string
 	WebConsoleURL string
+	ProxyConfig   *network.ProxyConfig
 }
 
 type StartResult struct {

--- a/pkg/crc/network/proxy.go
+++ b/pkg/crc/network/proxy.go
@@ -79,7 +79,7 @@ func (p *ProxyConfig) HttpsProxyForDisplay() string {
 }
 
 // AddNoProxy appends the specified host to the list of no proxied hosts.
-func (p *ProxyConfig) AddNoProxy(host []string) {
+func (p *ProxyConfig) AddNoProxy(host ...string) {
 	host = append(host, p.NoProxy)
 	p.NoProxy = strings.Join(host, ",")
 }

--- a/pkg/os/shell/shell.go
+++ b/pkg/os/shell/shell.go
@@ -75,24 +75,3 @@ func GetPathEnvString(userShell string, prependedPath string) string {
 
 	return GetEnvString(userShell, "PATH", pathStr)
 }
-
-func GetPrefixSuffixDelimiterForSet(userShell string) (prefix, delimiter, suffix, pathSuffix string) {
-	switch userShell {
-	case "powershell":
-		prefix = "$Env:"
-		delimiter = " = \""
-		suffix = "\"\n"
-		pathSuffix = ";" + prefix + "PATH" + suffix
-	case "cmd":
-		prefix = "SET "
-		delimiter = "="
-		suffix = "\n"
-		pathSuffix = ";%PATH%" + suffix
-	default:
-		prefix = "export "
-		delimiter = "=\""
-		suffix = "\"\n"
-		pathSuffix = ":$PATH" + suffix
-	}
-	return
-}

--- a/pkg/os/shell/shell.go
+++ b/pkg/os/shell/shell.go
@@ -51,6 +51,31 @@ func GenerateUsageHint(userShell, cmdLine string) string {
 	return fmt.Sprintf("%s Run this command to configure your shell:\n%s %s\n", comment, comment, cmd)
 }
 
+func GetEnvString(userShell string, envName string, envValue string) string {
+	switch userShell {
+	case "powershell":
+		return fmt.Sprintf("$Env:%s = \"%s\"", envName, envValue)
+	case "cmd":
+		return fmt.Sprintf("SET %s=%s", envName, envValue)
+	default:
+		return fmt.Sprintf("export %s=\"%s\"", envName, envValue)
+	}
+}
+
+func GetPathEnvString(userShell string, prependedPath string) string {
+	var pathStr string
+	switch userShell {
+	case "powershell":
+		pathStr = fmt.Sprintf("%s;$Env:PATH", prependedPath)
+	case "cmd":
+		pathStr = fmt.Sprintf("%s;%%PATH%%", prependedPath)
+	default:
+		pathStr = fmt.Sprintf("%s:$PATH", prependedPath)
+	}
+
+	return GetEnvString(userShell, "PATH", pathStr)
+}
+
 func GetPrefixSuffixDelimiterForSet(userShell string) (prefix, delimiter, suffix, pathSuffix string) {
 	switch userShell {
 	case "powershell":

--- a/test/integration/features/story_health.feature
+++ b/test/integration/features/story_health.feature
@@ -66,11 +66,9 @@ Feature:
     @darwin @linux @windows
     Scenario: Stop and start CRC, then check app still runs
         Given with up to "2" retries with wait period of "60s" http response from "http://httpd-ex-testproj.apps-crc.testing" has status code "200"
-        When executing "crc stop --log-level debug -f" succeeds
-        And executing "virsh -c qemu:///system list --all"
-        And executing "virsh -c qemu:///system destroy crc"
+        When executing "crc stop" succeeds
         Then with up to "4" retries with wait period of "2m" command "crc status" output should contain "Stopped"
-        And starting CRC with default bundle and default hypervisor succeeds
+        When starting CRC with default bundle and default hypervisor succeeds
         Then with up to "4" retries with wait period of "2m" command "crc status" output should match ".*Running \(v\d+\.\d+\.\d+.*\).*"
         And with up to "2" retries with wait period of "60s" http response from "http://httpd-ex-testproj.apps-crc.testing" has status code "200"
 

--- a/test/integration/features/story_health.feature
+++ b/test/integration/features/story_health.feature
@@ -66,7 +66,7 @@ Feature:
     @darwin @linux @windows
     Scenario: Stop and start CRC, then check app still runs
         Given with up to "2" retries with wait period of "60s" http response from "http://httpd-ex-testproj.apps-crc.testing" has status code "200"
-        When executing "crc stop" succeeds
+        When executing "crc stop -f" succeeds
         Then with up to "4" retries with wait period of "2m" command "crc status" output should contain "Stopped"
         When starting CRC with default bundle and default hypervisor succeeds
         Then with up to "4" retries with wait period of "2m" command "crc status" output should match ".*Running \(v\d+\.\d+\.\d+.*\).*"


### PR DESCRIPTION
When a proxy is configured in crc, we should add http_proxy/https_proxy/no_proxy to the variables to set in `oc-env`
This pull request achieves that, though it starts by misc improvements to network.Proxy which are not strictly required for that change.