### PR TITLE
Issue #854 Add host->cluster DNS checks

### DIFF
--- a/pkg/crc/machine/machine.go
+++ b/pkg/crc/machine/machine.go
@@ -313,6 +313,14 @@ func Start(startConfig StartConfig) (StartResult, error) {
 		logging.Warnf("Failed public DNS query from the cluster: %v : %s", err, queryOutput)
 	}
 
+	// Check DNS lookup from host to VM
+	logging.Info("Check DNS query from host ...")
+	if err := network.CheckCRCLocalDNSReachableFromHost(crcBundleMetadata.ClusterInfo.ClusterName,
+		crcBundleMetadata.ClusterInfo.BaseDomain, crcBundleMetadata.ClusterInfo.AppsDomain); err != nil {
+		result.Error = err.Error()
+		return *result, errors.Newf("Failed to query DNS from host: %v", err)
+	}
+
 	// Additional steps to perform after newly created VM is up
 	if !exists {
 		if err := updateSSHKeyPair(sshRunner); err != nil {


### PR DESCRIPTION
This check will make sure that host can able to resolve the dns
for api and app domain of crc using dnsmasq which is running
inside the VM.

This patch is heavily based on a patch from Praveen Kumar
<kumarpraveen.nitdgp@gmail.com>, with the addition of the code excluding macos
from the apps domain check.

This fixes https://github.com/code-ready/crc/issues/854