### PR TITLE
Issue #929: logging: Ensure ~/.crc exists before creating log file

### DIFF
--- a/pkg/crc/logging/logging.go
+++ b/pkg/crc/logging/logging.go
@@ -18,6 +18,10 @@ var (
 )
 
 func OpenLogFile() (*os.File, error) {
+	err := constants.EnsureBaseDirExists()
+	if err != nil {
+		return nil, err
+	}
 	l, err := os.OpenFile(filepath.Join(constants.LogFilePath), os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0600)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
crc-embedder currently fails if ~/.crc does not exist. This is because
it tries to create a log file before ~/.crc is created. Adding a call to
EnsureBaseDirExists() before trying to create the log file fixes this
issue.

This fixes https://github.com/code-ready/crc/issues/929