### PR TITLE
Mention that cert renewal takes a few minutes

### DIFF
--- a/pkg/crc/machine/machine.go
+++ b/pkg/crc/machine/machine.go
@@ -347,7 +347,7 @@ func Start(startConfig StartConfig) (StartResult, error) {
 	}
 
 	if needsCertsRenewal {
-		logging.Infof("Cluster TLS certificates have expired, renewing them...")
+		logging.Infof("Cluster TLS certificates have expired, renewing them... [will take up to 5 minutes]")
 		err = RegenerateCertificates(sshRunner, startConfig.Name)
 		if err != nil {
 			result.Error = err.Error()


### PR DESCRIPTION
As it can be unexpected that this process takes a while, this commit
improves the log message when cert renewal happens.

This is related to https://github.com/code-ready/crc/issues/930