### PR TITLE
Issue #878 [Integration] Small changes to tests

### DIFF
--- a/test/integration/features/basic.feature
+++ b/test/integration/features/basic.feature
@@ -91,11 +91,17 @@ Feature: Basic test
     Scenario: CRC start
         When starting CRC with default bundle and default hypervisor succeeds
         Then stdout should contain "Started the OpenShift cluster"
+        # Check if user can copy-paste login details for developer and kubeadmin users
+        And stdout should match "(?s)(.*)oc login -u developer -p developer https:\/\/api\.crc\.testing:6443(.*)$"
+        And stdout should match "(?s)(.*)oc login -u kubeadmin -p ([a-zA-Z0-9]{5}-){3}[a-zA-Z0-9]{5} https:\/\/api\.crc\.testing:6443(.*)$"
 
     @darwin
     Scenario: CRC start on Mac
         When starting CRC with default bundle and hypervisor "hyperkit" succeeds
         Then stdout should contain "Started the OpenShift cluster"
+        # Check if user can copy-paste login details for developer and kubeadmin users
+        And stdout should match "(?s)(.*)oc login -u developer -p developer https:\/\/api\.crc\.testing:6443(.*)$"
+        And stdout should match "(?s)(.*)oc login -u kubeadmin -p ([a-zA-Z0-9]{5}-){3}[a-zA-Z0-9]{5} https:\/\/api\.crc\.testing:6443(.*)$"
     
     @darwin @linux @windows
     Scenario: CRC status and disk space check

--- a/test/integration/features/basic.feature
+++ b/test/integration/features/basic.feature
@@ -81,7 +81,7 @@ Feature: Basic test
     Scenario: CRC setup on Windows
         When executing "crc setup" succeeds
         Then stdout should contain "Caching oc binary"
-        Then stdout should contain "Unpacking bundle from the CRC binary"
+        Then stdout should contain "Unpacking bundle from the CRC binary" if bundle is embedded
         Then stdout should contain "Checking Windows 10 release"
         Then stdout should contain "Checking if Hyper-V is installed"
         Then stdout should contain "Checking if user is a member of the Hyper-V Administrators group"

--- a/test/integration/features/story_marketplace.feature
+++ b/test/integration/features/story_marketplace.feature
@@ -7,9 +7,9 @@ Feature:
         Given executing "crc setup" succeeds
         When starting CRC with default bundle and hypervisor "<vm-driver>" succeeds
         Then stdout should contain "Started the OpenShift cluster"
-        And executing "eval $(crc oc-env)" succeeds
-        When with up to "4" retries with wait period of "2m" command "crc status" output matches ".*Running \(v\d+\.\d+\.\d+.*\).*"
-        Then login to the oc cluster succeeds
+        When with up to "8" retries with wait period of "2m" command "crc status" output matches ".*Running \(v\d+\.\d+\.\d+.*\).*"
+        Then executing "eval $(crc oc-env)" succeeds
+        And login to the oc cluster succeeds
 
     @darwin
         Examples:

--- a/test/integration/features/story_marketplace.feature
+++ b/test/integration/features/story_marketplace.feature
@@ -46,7 +46,7 @@ Feature:
         When executing "oc apply -f etcd-cluster5.yaml" succeeds
         Then with up to "10" retries with wait period of "30s" command "oc get pods" output matches "(?s)(.*example-[a-z0-9]* *1/1 *Running.*){5}"
     
-    @darwin @linux @windows
+    @darwin @linux
     Scenario: Failover
         # simulate failure of 1 pod, check that it was replaced
         When executing "POD=$(oc get pod -o jsonpath="{.items[0].metadata.name}")" succeeds
@@ -57,6 +57,19 @@ Feature:
         And with up to "10" retries with wait period of "30s" command "oc get pods" output matches "(?s)(.*example-[a-z0-9]* *1/1 *Running.*){5}"
         # but the deleted pod should not be up, it was replaced
         But executing "oc get pods $POD" fails
+        And stderr matches "(.*)pods (.*) not found$"
+
+    @windows
+    Scenario: Failover
+        # simulate failure of 1 pod, check that it was replaced
+        When executing "$Env:POD = $(oc get pod -o jsonpath="{.items[0].metadata.name}")" succeeds
+        And executing "echo $Env:POD" succeeds
+        And executing "oc delete pod $Env:POD --now" succeeds
+        Then stdout should match "^pod(.*)deleted$"
+        # after a while 5 pods should be up & running again
+        And with up to "10" retries with wait period of "30s" command "oc get pods" output matches "(?s)(.*example-[a-z0-9]* *1/1 *Running.*){5}"
+        # but the deleted pod should not be up, it was replaced
+        But executing "oc get pods $Env:POD" fails
         And stderr matches "(.*)pods (.*) not found$"
 
     @darwin @linux @windows


### PR DESCRIPTION
1. Up the wait for a status check (there was a failed PR check due to this)
2. Use env vars correctly in Powershell on Win. This is tested on Win, see [before-after test](https://drive.google.com/open?id=1vbhQ_L8_o9ZeZwPAAONxsxsLofwnEHW2) and [logs of the same](https://drive.google.com/open?id=1pWFWaRK7OkkbJlFkVH4KQC0WNvkduZrR).
3. Add a check to basic tests verifying that there is a copy-paste string for `oc login` as developer and as kubeadmin.

