### PR TITLE
set no proxy environment variable properly in kubelet and crio

### DIFF
--- a/pkg/crc/cluster/cluster.go
+++ b/pkg/crc/cluster/cluster.go
@@ -163,8 +163,7 @@ func AddProxyToKubeletAndCriO(sshRunner *ssh.SSHRunner, proxy *network.ProxyConf
 Environment=HTTP_PROXY=%s
 Environment=HTTPS_PROXY=%s
 Environment=NO_PROXY=.cluster.local,.svc,10.128.0.0/14,172.30.0.0/16,%s`
-
-	p := fmt.Sprintf(proxyTemplate, proxy.HttpProxy, proxy.HttpsProxy, proxy.NoProxy)
+	p := fmt.Sprintf(proxyTemplate, proxy.HttpProxy, proxy.HttpsProxy, strings.Join(proxy.NoProxy, ","))
 	// This will create a systemd drop-in configuration for proxy (both for kubelet and crio services) on the VM.
 	_, err := sshRunner.RunPrivate(fmt.Sprintf("cat <<EOF | sudo tee /etc/systemd/system/crio.service.d/10-default-env.conf\n%s\nEOF", p))
 	if err != nil {


### PR DESCRIPTION
the NO_PROXY variable was incorrectly set, this should fix this

```
$ cat /etc/systemd/system/crio.service.d/10-default-env.conf
[Service]
Environment=HTTP_PROXY=http://10.3.0.2:8118
Environment=HTTPS_PROXY=http://10.3.0.2:8118
Environment=NO_PROXY=.cluster.local,.svc,10.128.0.0/14,172.30.0.0/16,[127.0.0.1 localhost .testing 192.168.64.2]
```