### PR TITLE
Issue #947 use GetNoProxyString() to set no proxy for proxy resource

### DIFF
--- a/cmd/crc/cmd/root.go
+++ b/cmd/crc/cmd/root.go
@@ -100,8 +100,8 @@ func setProxyDefaults() {
 	}
 
 	if proxyConfig.IsEnabled() {
-		logging.Debugf("HTTP-PROXY: %s, HTTPS-PROXY: %s, NO-PROXY: %v", proxyConfig.HttpProxyForDisplay(),
-			proxyConfig.HttpsProxyForDisplay(), proxyConfig.NoProxy)
+		logging.Debugf("HTTP-PROXY: %s, HTTPS-PROXY: %s, NO-PROXY: %s", proxyConfig.HttpProxyForDisplay(),
+			proxyConfig.HttpsProxyForDisplay(), proxyConfig.GetNoProxyString())
 		proxyConfig.ApplyToEnvironment()
 	}
 }

--- a/pkg/crc/cluster/cluster.go
+++ b/pkg/crc/cluster/cluster.go
@@ -163,7 +163,7 @@ func AddProxyToKubeletAndCriO(sshRunner *ssh.SSHRunner, proxy *network.ProxyConf
 Environment=HTTP_PROXY=%s
 Environment=HTTPS_PROXY=%s
 Environment=NO_PROXY=.cluster.local,.svc,10.128.0.0/14,172.30.0.0/16,%s`
-	p := fmt.Sprintf(proxyTemplate, proxy.HttpProxy, proxy.HttpsProxy, strings.Join(proxy.NoProxy, ","))
+	p := fmt.Sprintf(proxyTemplate, proxy.HttpProxy, proxy.HttpsProxy, proxy.GetNoProxyString())
 	// This will create a systemd drop-in configuration for proxy (both for kubelet and crio services) on the VM.
 	_, err := sshRunner.RunPrivate(fmt.Sprintf("cat <<EOF | sudo tee /etc/systemd/system/crio.service.d/10-default-env.conf\n%s\nEOF", p))
 	if err != nil {

--- a/pkg/crc/cluster/cluster.go
+++ b/pkg/crc/cluster/cluster.go
@@ -141,7 +141,7 @@ func StopAndRemovePodsInVM(sshRunner *ssh.SSHRunner) error {
 
 func AddProxyConfigToCluster(oc oc.OcConfig, proxy *network.ProxyConfig) error {
 	cmdArgs := []string{"patch", "proxy", "cluster", "-p",
-		fmt.Sprintf(`{"spec":{"httpProxy":"%s", "httpsProxy":"%s", "noProxy":"%s"}}`, proxy.HttpProxy, proxy.HttpsProxy, proxy.NoProxy),
+		fmt.Sprintf(`{"spec":{"httpProxy":"%s", "httpsProxy":"%s", "noProxy":"%s"}}`, proxy.HttpProxy, proxy.HttpsProxy, proxy.GetNoProxyString()),
 		"-n", "openshift-config", "--type", "merge"}
 
 	if err := oc.WaitForOpenshiftResource("proxy"); err != nil {

--- a/pkg/crc/network/proxy.go
+++ b/pkg/crc/network/proxy.go
@@ -17,7 +17,7 @@ var (
 type ProxyConfig struct {
 	HttpProxy  string
 	HttpsProxy string
-	NoProxy    []string
+	noProxy    []string
 }
 
 func NewProxyDefaults(httpProxy, httpsProxy, noProxy string) (*ProxyConfig, error) {
@@ -48,9 +48,9 @@ func NewProxyConfig() (*ProxyConfig, error) {
 		HttpsProxy: DefaultProxy.HttpsProxy,
 	}
 
-	config.NoProxy = defaultNoProxies
-	if len(DefaultProxy.NoProxy) != 0 {
-		config.AddNoProxy(DefaultProxy.NoProxy...)
+	config.noProxy = defaultNoProxies
+	if len(DefaultProxy.noProxy) != 0 {
+		config.AddNoProxy(DefaultProxy.noProxy...)
 	}
 
 	err := ValidateProxyURL(config.HttpProxy)
@@ -88,18 +88,18 @@ func (p *ProxyConfig) HttpsProxyForDisplay() string {
 
 // AddNoProxy appends the specified host to the list of no proxied hosts.
 func (p *ProxyConfig) AddNoProxy(host ...string) {
-	p.NoProxy = append(p.NoProxy, host...)
+	p.noProxy = append(p.noProxy, host...)
 }
 
 func (p *ProxyConfig) setNoProxyString(noProxies string) {
 	if noProxies == "" {
 		return
 	}
-	p.NoProxy = strings.Split(noProxies, ",")
+	p.noProxy = strings.Split(noProxies, ",")
 }
 
 func (p *ProxyConfig) GetNoProxyString() string {
-	return strings.Join(p.NoProxy, ",")
+	return strings.Join(p.noProxy, ",")
 }
 
 // Sets the current config as environment variables in the current process.
@@ -116,7 +116,7 @@ func (p *ProxyConfig) ApplyToEnvironment() {
 		os.Setenv("HTTPS_PROXY", p.HttpsProxy)
 		os.Setenv("https_proxy", p.HttpsProxy)
 	}
-	if len(p.NoProxy) != 0 {
+	if len(p.noProxy) != 0 {
 		os.Setenv("NO_PROXY", p.GetNoProxyString())
 		os.Setenv("no_proxy", p.GetNoProxyString())
 	}


### PR DESCRIPTION
NoProxy is `[]string` type for ProxyConfig struct and we are directly using it with `%s` for proxy resource which need a `string` type.