### PR TITLE
Experimental embed tray

### DIFF
--- a/cmd/crc-embedder/cmd/embed.go
+++ b/cmd/crc-embedder/cmd/embed.go
@@ -90,6 +90,7 @@ var (
 			hyperkit.MachineDriverDownloadUrl,
 			hyperkit.HyperkitDownloadUrl,
 			constants.GetOcUrlForOs("darwin"),
+			constants.GetCrcTrayDownloadURL(),
 		},
 		"linux": []string{
 			libvirt.MachineDriverDownloadUrl,

--- a/cmd/crc/cmd/config/config.go
+++ b/cmd/crc/cmd/config/config.go
@@ -19,7 +19,8 @@ var (
 	NameServer     = cfg.AddSetting("nameserver", nil, []cfg.ValidationFnType{cfg.ValidateIpAddress}, []cfg.SetFn{cfg.SuccessfullyApplied})
 	PullSecretFile = cfg.AddSetting("pull-secret-file", nil, []cfg.ValidationFnType{cfg.ValidatePath}, []cfg.SetFn{cfg.SuccessfullyApplied})
 
-	DisableUpdateCheck = cfg.AddSetting("disable-update-check", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})
+	DisableUpdateCheck   = cfg.AddSetting("disable-update-check", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})
+	ExperimentalFeatures = cfg.AddSetting("enable-experimental-features", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})
 
 	// Proxy Configuration
 	HttpProxy  = cfg.AddSetting("http-proxy", nil, []cfg.ValidationFnType{cfg.ValidateURI}, []cfg.SetFn{cfg.SuccessfullyApplied})

--- a/cmd/crc/cmd/setup.go
+++ b/cmd/crc/cmd/setup.go
@@ -16,6 +16,8 @@ import (
 func init() {
 	setupCmd.Flags().StringVarP(&vmDriver, config.VMDriver.Name, "d",
 		machine.DefaultDriver.Driver, fmt.Sprintf("The driver to use for the OpenShift cluster. Possible values: %v", machine.SupportedDriverValues()))
+	setupCmd.Flags().Bool(config.ExperimentalFeatures.Name, false, "Allow the use of experimental features")
+
 	rootCmd.AddCommand(setupCmd)
 }
 

--- a/cmd/crc/cmd/setup.go
+++ b/cmd/crc/cmd/setup.go
@@ -5,6 +5,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/code-ready/crc/cmd/crc/cmd/config"
+	crcConfig "github.com/code-ready/crc/pkg/crc/config"
 	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/code-ready/crc/pkg/crc/errors"
 	"github.com/code-ready/crc/pkg/crc/machine"
@@ -33,6 +34,10 @@ var setupCmd = &cobra.Command{
 func runSetup(arguments []string) {
 	if err := validateSetupFlags(); err != nil {
 		errors.Exit(1)
+	}
+
+	if crcConfig.GetBool(config.ExperimentalFeatures.Name) {
+		preflight.EnableExperimentalFeatures = true
 	}
 	preflight.SetupHost()
 	var bundle string

--- a/pkg/crc/constants/constants.go
+++ b/pkg/crc/constants/constants.go
@@ -30,7 +30,8 @@ const (
 	CrcLandingPageURL    = "https://cloud.redhat.com/openshift/install/crc/installer-provisioned" // #nosec G101
 	PullSecretFile       = "pullsecret.json"
 
-	DefaultOcUrlBase = "https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest"
+	DefaultOcUrlBase   = "https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest"
+	CrcTrayDownloadURL = "https://github.com/code-ready/tray-macos/releases/download/v%s/crc-tray-macos.tar.gz"
 )
 
 var ocUrlForOs = map[string]string{
@@ -115,4 +116,8 @@ func GetPublicKeyPath() string {
 
 func GetPrivateKeyPath() string {
 	return filepath.Join(MachineInstanceDir, DefaultName, "id_rsa")
+}
+
+func GetCrcTrayDownloadURL() string {
+	return fmt.Sprintf(CrcTrayDownloadURL, version.GetCRCTrayVersion())
 }

--- a/pkg/crc/constants/constants_darwin.go
+++ b/pkg/crc/constants/constants_darwin.go
@@ -1,5 +1,12 @@
 package constants
 
+import "path/filepath"
+
 const (
-	OcBinaryName = "oc"
+	OcBinaryName   = "oc"
+	TrayBinaryName = "CodeReady Containers.app"
+)
+
+var (
+	TrayBinaryPath = filepath.Join(CrcBinDir, TrayBinaryName)
 )

--- a/pkg/crc/preflight/preflight.go
+++ b/pkg/crc/preflight/preflight.go
@@ -10,6 +10,9 @@ import (
 
 type PreflightCheckFlags uint32
 
+// Enables the use of experimental features
+var EnableExperimentalFeatures bool
+
 const (
 	// Indicates a PreflightCheck should only be run as part of "crc setup"
 	SetupOnly PreflightCheckFlags = 1 << iota

--- a/pkg/crc/preflight/preflight_check_tray_darwin.go
+++ b/pkg/crc/preflight/preflight_check_tray_darwin.go
@@ -1,0 +1,244 @@
+package preflight
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	goos "os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	goTemplate "text/template"
+
+	"github.com/code-ready/crc/pkg/crc/constants"
+	"github.com/code-ready/crc/pkg/crc/logging"
+	dl "github.com/code-ready/crc/pkg/download"
+	"github.com/code-ready/crc/pkg/embed"
+	"github.com/code-ready/crc/pkg/extract"
+	"github.com/code-ready/crc/pkg/os"
+	"github.com/pkg/errors"
+)
+
+const (
+	trayPlistTemplate = `<?xml version='1.0' encoding='UTF-8'?>
+	<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+	<plist version='1.0'>
+		<dict>
+			<key>Label</key>
+			<string>crc.tray</string>
+			<key>ProgramArguments</key>
+			<array>
+				<string>{{ .BinaryPath }}</string>
+			</array>
+			<key>StandardOutPath</key>
+			<string>{{ .StdOutFilePath }}</string>
+			<key>Disabled</key>
+			<false/>
+			<key>RunAtLoad</key>
+			<true/>
+		</dict>
+	</plist>`
+
+	daemonPlistTemplate = `<?xml version='1.0' encoding='UTF-8'?>
+	<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+	<plist version='1.0'>
+		<dict>
+			<key>Label</key>
+			<string>crc.daemon</string>
+			<key>ProgramArguments</key>
+			<array>
+				<string>{{ .BinaryPath }}</string>
+				<string>daemon</string>
+				<string>--log-level</string>
+				<string>debug</string>
+			</array>
+			<key>StandardOutPath</key>
+			<string>{{ .StdOutFilePath }}</string>
+			<key>KeepAlive</key>
+			<true/>
+			<key>Disabled</key>
+			<false/>
+		</dict>
+	</plist>`
+
+	daemonAgentLabel = "crc.daemon"
+	trayAgentLabel   = "crc.tray"
+)
+
+var (
+	launchAgentDir       = filepath.Join(constants.GetHomeDir(), "Library", "LaunchAgents")
+	daemonPlistFilePath  = filepath.Join(launchAgentDir, "crc.daemon.plist")
+	trayPlistFilePath    = filepath.Join(launchAgentDir, "crc.tray.plist")
+	stdOutFilePathDaemon = filepath.Join(constants.CrcBaseDir, ".crcd-agent.log")
+	stdOutFilePathTray   = filepath.Join(constants.CrcBaseDir, ".crct-agent.log")
+)
+
+type AgentConfig struct {
+	BinaryPath     string
+	StdOutFilePath string
+}
+
+func checkTrayExistsAndRunning() error {
+	logging.Debug("Checking if daemon plist file exists")
+	if !os.FileExists(daemonPlistFilePath) {
+		return errors.New("Daemon plist file does not exist")
+	}
+	logging.Debug("Checking if crc agent running")
+	if !agentRunning(daemonAgentLabel) {
+		return errors.New("crc daemon is not running")
+	}
+	logging.Debug("Checking if tray plist file exists")
+	if !os.FileExists(trayPlistFilePath) {
+		return errors.New("Tray plist file does not exist")
+	}
+	logging.Debug("Checking if tray agent running")
+	if !agentRunning(trayAgentLabel) {
+		return errors.New("Tray is not running")
+	}
+	return nil
+}
+
+func fixTrayExistsAndRunning() error {
+	// get the tray app
+	if !trayAppCached() {
+		err := downloadOrExtractTrayApp()
+		if err != nil {
+			return err
+		}
+	}
+	currentExecutablePath, err := goos.Executable()
+	if err != nil {
+		return err
+	}
+	daemonConfig := AgentConfig{
+		BinaryPath:     currentExecutablePath,
+		StdOutFilePath: stdOutFilePathDaemon,
+	}
+
+	trayConfig := AgentConfig{
+		BinaryPath:     filepath.Join(constants.CrcBinDir, constants.TrayBinaryName, "Contents", "MacOS", "CodeReady Containers"),
+		StdOutFilePath: stdOutFilePathTray,
+	}
+	logging.Debug("Creating daemon plist")
+	err = createPlist(daemonPlistTemplate, daemonConfig, daemonPlistFilePath)
+	if err != nil {
+		return err
+	}
+	logging.Debug("Creating tray plist")
+	err = createPlist(trayPlistTemplate, trayConfig, trayPlistFilePath)
+	if err != nil {
+		return err
+	}
+
+	// load crc daemon
+	err = launchctlLoadPlist(daemonPlistFilePath)
+	if err != nil {
+		return err
+	}
+	if !agentRunning(daemonAgentLabel) {
+		if err = startAgent(daemonAgentLabel); err != nil {
+			return err
+		}
+	}
+	// load tray
+	err = launchctlLoadPlist(trayPlistFilePath)
+	if err != nil {
+		return err
+	}
+	if !agentRunning(trayAgentLabel) {
+		if err = startAgent(trayAgentLabel); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func createPlist(template string, config AgentConfig, plistPath string) error {
+	var plistContent bytes.Buffer
+	t, err := goTemplate.New("plist").Parse(template)
+	if err != nil {
+		return err
+	}
+	err = t.Execute(&plistContent, config)
+	if err != nil {
+		return err
+	}
+	err = ioutil.WriteFile(plistPath, plistContent.Bytes(), 0644)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func launchctlLoadPlist(plistFilePath string) error {
+	_, err := exec.Command("launchctl", "load", plistFilePath).Output() // #nosec G204
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func startAgent(label string) error {
+	_, err := exec.Command("launchctl", "start", label).Output() // #nosec G204
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// check if a service (daemon,tray) is running
+func agentRunning(label string) bool {
+	// This command return a PID if the process
+	// is running, otherwise returns "-"
+	launchctlListCommand := `launchctl list | grep %s | awk '{print $1}'`
+	cmd := fmt.Sprintf(launchctlListCommand, label)
+	out, err := exec.Command("bash", "-c", cmd).Output() // #nosec G204
+	if err != nil {
+		return false
+	}
+	if strings.TrimSpace(string(out)) == "-" {
+		return false
+	}
+	return true
+}
+
+func trayAppCached() bool {
+	return os.FileExists(constants.TrayBinaryPath)
+}
+
+func downloadOrExtractTrayApp() error {
+	if trayAppCached() {
+		return nil
+	}
+
+	// Extract the tray and put it in the bin directory.
+	tmpArchivePath, err := ioutil.TempDir("", "crc")
+	if err != nil {
+		logging.Error("Failed creating temporary directory for extracting tray")
+		return err
+	}
+	defer func() {
+		_ = goos.RemoveAll(tmpArchivePath)
+	}()
+
+	logging.Debug("Trying to extract tray from crc binary")
+	err = embed.Extract(filepath.Base(constants.GetCrcTrayDownloadURL()), tmpArchivePath)
+	if err != nil {
+		logging.Debug("Downloading crc tray")
+		_, err = dl.Download(constants.GetCrcTrayDownloadURL(), tmpArchivePath, 0600)
+		if err != nil {
+			return err
+		}
+	}
+	archivePath := filepath.Join(tmpArchivePath, filepath.Base(constants.GetCrcTrayDownloadURL()))
+	outputPath := constants.CrcBinDir
+	err = goos.MkdirAll(outputPath, 0750)
+	if err != nil && !goos.IsExist(err) {
+		return errors.Wrap(err, "Cannot create the target directory.")
+	}
+	err = extract.Uncompress(archivePath, outputPath)
+	if err != nil {
+		return errors.Wrapf(err, "Cannot uncompress '%s'", archivePath)
+	}
+	return nil
+}

--- a/pkg/crc/preflight/preflight_darwin.go
+++ b/pkg/crc/preflight/preflight_darwin.go
@@ -39,6 +39,15 @@ var dnsPreflightChecks = [...]PreflightCheck{
 	},
 }
 
+var traySetupCheck = PreflightCheck{
+	configKeySuffix:  "check-tray-setup",
+	checkDescription: "Checking if the tray is installed and running",
+	check:            checkTrayExistsAndRunning,
+	fixDescription:   "Installing and setting up tray app",
+	fix:              fixTrayExistsAndRunning,
+	flags:            SetupOnly,
+}
+
 func getPreflightChecks() []PreflightCheck {
 	checks := []PreflightCheck{}
 
@@ -46,6 +55,7 @@ func getPreflightChecks() []PreflightCheck {
 	checks = append(checks, nonWinPreflightChecks[:]...)
 	checks = append(checks, hyperkitPreflightChecks[:]...)
 	checks = append(checks, dnsPreflightChecks[:]...)
+	checks = append(checks, traySetupCheck)
 
 	return checks
 }

--- a/pkg/crc/preflight/preflight_darwin.go
+++ b/pkg/crc/preflight/preflight_darwin.go
@@ -55,7 +55,11 @@ func getPreflightChecks() []PreflightCheck {
 	checks = append(checks, nonWinPreflightChecks[:]...)
 	checks = append(checks, hyperkitPreflightChecks[:]...)
 	checks = append(checks, dnsPreflightChecks[:]...)
-	checks = append(checks, traySetupCheck)
+
+	// Experimental feature
+	if EnableExperimentalFeatures {
+		checks = append(checks, traySetupCheck)
+	}
 
 	return checks
 }

--- a/pkg/crc/version/version.go
+++ b/pkg/crc/version/version.go
@@ -39,6 +39,8 @@ var (
 
 const (
 	releaseInfoLink = "https://mirror.openshift.com/pub/openshift-v4/clients/crc/latest/release-info.json"
+	// Tray version to be embedded in binary
+	crcTrayVersion = "1.0.0-alpha"
 )
 
 type CrcReleaseInfo struct {
@@ -57,6 +59,10 @@ func GetCommitSha() string {
 
 func GetBundleVersion() string {
 	return bundleVersion
+}
+
+func GetCRCTrayVersion() string {
+	return crcTrayVersion
 }
 
 func getCRCLatestVersionFromMirror() (*semver.Version, error) {

--- a/pkg/os/util.go
+++ b/pkg/os/util.go
@@ -93,3 +93,11 @@ func WriteFileIfContentChanged(path string, new_content []byte, perm os.FileMode
 	}
 	return true, nil
 }
+
+func FileExists(path string) bool {
+	_, err := os.Stat(path)
+	if err != nil && os.IsNotExist(err) {
+		return false
+	}
+	return true
+}


### PR DESCRIPTION
Combines #931 and #962 to prevent the tray from installing by default

This should expose a flag for `setup` named `enable-experimental-features` to select additional tech-preview features to be enabled. This should be used as:

```
$ crc setup --enable-experimental-features
```
