### PR TITLE
Issue #966 Remove driver option from setup

### DIFF
--- a/cmd/crc/cmd/config/config.go
+++ b/cmd/crc/cmd/config/config.go
@@ -6,13 +6,11 @@ import (
 
 	cfg "github.com/code-ready/crc/pkg/crc/config"
 	"github.com/code-ready/crc/pkg/crc/constants"
-	"github.com/code-ready/crc/pkg/crc/machine"
 	"github.com/spf13/cobra"
 )
 
 var (
 	// Start command settings in config
-	VMDriver       = cfg.AddSetting("vm-driver", machine.DefaultDriver.Driver, []cfg.ValidationFnType{cfg.ValidateDriver}, []cfg.SetFn{cfg.SuccessfullyApplied})
 	Bundle         = cfg.AddSetting("bundle", nil, []cfg.ValidationFnType{cfg.ValidateBundle}, []cfg.SetFn{cfg.SuccessfullyApplied})
 	CPUs           = cfg.AddSetting("cpus", constants.DefaultCPUs, []cfg.ValidationFnType{cfg.ValidateCPUs}, []cfg.SetFn{cfg.RequiresRestartMsg})
 	Memory         = cfg.AddSetting("memory", constants.DefaultMemory, []cfg.ValidationFnType{cfg.ValidateMemory}, []cfg.SetFn{cfg.RequiresRestartMsg})

--- a/cmd/crc/cmd/setup.go
+++ b/cmd/crc/cmd/setup.go
@@ -1,22 +1,16 @@
 package cmd
 
 import (
-	"fmt"
 	"github.com/spf13/cobra"
 
 	"github.com/code-ready/crc/cmd/crc/cmd/config"
 	crcConfig "github.com/code-ready/crc/pkg/crc/config"
 	"github.com/code-ready/crc/pkg/crc/constants"
-	"github.com/code-ready/crc/pkg/crc/errors"
-	"github.com/code-ready/crc/pkg/crc/machine"
 	"github.com/code-ready/crc/pkg/crc/output"
 	"github.com/code-ready/crc/pkg/crc/preflight"
-	"github.com/code-ready/crc/pkg/crc/validation"
 )
 
 func init() {
-	setupCmd.Flags().StringVarP(&vmDriver, config.VMDriver.Name, "d",
-		machine.DefaultDriver.Driver, fmt.Sprintf("The driver to use for the OpenShift cluster. Possible values: %v", machine.SupportedDriverValues()))
 	setupCmd.Flags().Bool(config.ExperimentalFeatures.Name, false, "Allow the use of experimental features")
 	_ = crcConfig.BindFlagSet(setupCmd.Flags())
 	rootCmd.AddCommand(setupCmd)
@@ -32,10 +26,6 @@ var setupCmd = &cobra.Command{
 }
 
 func runSetup(arguments []string) {
-	if err := validateSetupFlags(); err != nil {
-		errors.Exit(1)
-	}
-
 	if crcConfig.GetBool(config.ExperimentalFeatures.Name) {
 		preflight.EnableExperimentalFeatures = true
 	}
@@ -45,13 +35,4 @@ func runSetup(arguments []string) {
 		bundle = " -b $bundlename"
 	}
 	output.Outf("Setup is complete, you can now run 'crc start%s' to start the OpenShift cluster\n", bundle)
-}
-
-var vmDriver string
-
-func validateSetupFlags() error {
-	if err := validation.ValidateDriver(vmDriver); err != nil {
-		return err
-	}
-	return nil
 }

--- a/cmd/crc/cmd/start.go
+++ b/cmd/crc/cmd/start.go
@@ -52,7 +52,6 @@ func runStart(arguments []string) {
 	startConfig := machine.StartConfig{
 		Name:          constants.DefaultName,
 		BundlePath:    crcConfig.GetString(config.Bundle.Name),
-		VMDriver:      crcConfig.GetString(config.VMDriver.Name),
 		Memory:        crcConfig.GetInt(config.Memory.Name),
 		CPUs:          crcConfig.GetInt(config.CPUs.Name),
 		NameServer:    crcConfig.GetString(config.NameServer.Name),
@@ -76,7 +75,6 @@ func runStart(arguments []string) {
 func initStartCmdFlagSet() *pflag.FlagSet {
 	flagSet := pflag.NewFlagSet("start", pflag.ExitOnError)
 	flagSet.StringP(config.Bundle.Name, "b", constants.DefaultBundlePath, "The system bundle used for deployment of the OpenShift cluster")
-	flagSet.StringP(config.VMDriver.Name, "d", machine.DefaultDriver.Driver, fmt.Sprintf("The driver to use for the OpenShift cluster. Possible values: %v", machine.SupportedDriverValues()))
 	flagSet.StringP(config.PullSecretFile.Name, "p", "", fmt.Sprintf("File path of image pull secret (download from %s)", constants.CrcLandingPageURL))
 	flagSet.IntP(config.CPUs.Name, "c", constants.DefaultCPUs, "Number of CPU cores to allocate to the OpenShift cluster")
 	flagSet.IntP(config.Memory.Name, "m", constants.DefaultMemory, "MiB of memory to allocate to the OpenShift cluster")
@@ -91,9 +89,6 @@ func isDebugLog() bool {
 }
 
 func validateStartFlags() error {
-	if err := validation.ValidateDriver(crcConfig.GetString(config.VMDriver.Name)); err != nil {
-		return err
-	}
 	if err := validation.ValidateMemory(crcConfig.GetInt(config.Memory.Name)); err != nil {
 		return err
 	}

--- a/pkg/crc/api/handlers.go
+++ b/pkg/crc/api/handlers.go
@@ -32,7 +32,6 @@ func startHandler(_ ArgsType) string {
 	startConfig := machine.StartConfig{
 		Name:          constants.DefaultName,
 		BundlePath:    crcConfig.GetString(config.Bundle.Name),
-		VMDriver:      crcConfig.GetString(config.VMDriver.Name),
 		Memory:        crcConfig.GetInt(config.Memory.Name),
 		CPUs:          crcConfig.GetInt(config.CPUs.Name),
 		NameServer:    crcConfig.GetString(config.NameServer.Name),

--- a/pkg/crc/config/validations.go
+++ b/pkg/crc/config/validations.go
@@ -22,14 +22,6 @@ func ValidateBool(value interface{}) (bool, string) {
 	return false, "must be true or false"
 }
 
-// ValidateDriver checks if driver is valid in the config
-func ValidateDriver(value interface{}) (bool, string) {
-	if err := validation.ValidateDriver(value.(string)); err != nil {
-		return false, err.Error()
-	}
-	return true, ""
-}
-
 // ValidateCPUs checks if provided cpus count is valid in the config
 func ValidateCPUs(value interface{}) (bool, string) {
 	v, err := strconv.Atoi(value.(string))

--- a/pkg/crc/machine/driver.go
+++ b/pkg/crc/machine/driver.go
@@ -1,8 +1,6 @@
 package machine
 
 import (
-	"github.com/code-ready/crc/pkg/crc/errors"
-
 	crcos "github.com/code-ready/crc/pkg/os"
 )
 
@@ -24,13 +22,4 @@ func SupportedDriverValues() []string {
 		supportedDrivers = append(supportedDrivers, d.Driver)
 	}
 	return supportedDrivers
-}
-
-func getDriverInfo(driver string) (*MachineDriver, error) {
-	for _, d := range SupportedDrivers {
-		if driver == d.Driver {
-			return &d, nil
-		}
-	}
-	return nil, errors.Newf("No info about unknown driver: %s", driver)
 }

--- a/pkg/crc/machine/machine.go
+++ b/pkg/crc/machine/machine.go
@@ -113,13 +113,13 @@ func Start(startConfig StartConfig) (StartResult, error) {
 	// Pre-VM start
 	var privateKeyPath string
 	var pullSecret string
-	driverInfo, _ := getDriverInfo(startConfig.VMDriver)
+	driverInfo := DefaultDriver
 	exists, err := MachineExists(startConfig.Name)
 	if !exists {
 		machineConfig := config.MachineConfig{
 			Name:       startConfig.Name,
 			BundleName: filepath.Base(startConfig.BundlePath),
-			VMDriver:   startConfig.VMDriver,
+			VMDriver:   driverInfo.Driver,
 			CPUs:       startConfig.CPUs,
 			Memory:     startConfig.Memory,
 		}
@@ -181,12 +181,6 @@ func Start(startConfig StartConfig) (StartResult, error) {
 		if bundleName != filepath.Base(startConfig.BundlePath) {
 			logging.Fatalf("Bundle '%s' was requested, but the existing VM is using '%s'",
 				filepath.Base(startConfig.BundlePath), bundleName)
-		}
-		if host.Driver.DriverName() != startConfig.VMDriver {
-			err := errors.Newf("VM driver '%s' was requested, but the existing VM is using '%s' instead",
-				startConfig.VMDriver, host.Driver.DriverName())
-			result.Error = err.Error()
-			return *result, err
 		}
 		vmState, err := host.Driver.GetState()
 		if err != nil {

--- a/pkg/crc/machine/types.go
+++ b/pkg/crc/machine/types.go
@@ -14,9 +14,8 @@ type StartConfig struct {
 	BundlePath string
 
 	// Hypervisor
-	VMDriver string
-	Memory   int
-	CPUs     int
+	Memory int
+	CPUs   int
 
 	// Nameserver
 	NameServer string

--- a/pkg/crc/validation/validation.go
+++ b/pkg/crc/validation/validation.go
@@ -11,18 +11,7 @@ import (
 
 	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/code-ready/crc/pkg/crc/errors"
-	"github.com/code-ready/crc/pkg/crc/machine"
 )
-
-// Validate the given driver is supported or not
-func ValidateDriver(driver string) error {
-	for _, d := range machine.SupportedDriverValues() {
-		if driver == d {
-			return nil
-		}
-	}
-	return errors.Newf("Unsupported driver: %s, use '--vm-driver' option to provide a supported driver %s\n", driver, machine.SupportedDriverValues())
-}
 
 // ValidateCPUs checks if provided cpus count is valid
 func ValidateCPUs(value int) error {

--- a/test/integration/crcsuite/crcsuite.go
+++ b/test/integration/crcsuite/crcsuite.go
@@ -52,10 +52,8 @@ func FeatureContext(s *godog.Suite) {
 	// CRC related steps
 	s.Step(`^removing CRC home directory succeeds$`,
 		RemoveCRCHome)
-	s.Step(`^starting CRC with default bundle and default hypervisor (succeeds|fails)$`,
-		StartCRCWithDefaultBundleAndDefaultHypervisorSucceedsOrFails)
-	s.Step(`^starting CRC with default bundle and hypervisor "(.*)" (succeeds|fails)$`,
-		StartCRCWithDefaultBundleAndHypervisorSucceedsOrFails)
+	s.Step(`^starting CRC with default bundle (succeeds|fails)$`,
+		StartCRCWithDefaultBundleSucceedsOrFails)
 	s.Step(`^starting CRC with default bundle and nameserver "(.*)" (succeeds|fails)$`,
 		StartCRCWithDefaultBundleAndNameServerSucceedsOrFails)
 	s.Step(`^setting config property "(.*)" to value "(.*)" (succeeds|fails)$`,
@@ -347,7 +345,7 @@ func LoginToOcClusterSucceedsOrFails(expected string) error {
 	return err
 }
 
-func StartCRCWithDefaultBundleAndDefaultHypervisorSucceedsOrFails(expected string) error {
+func StartCRCWithDefaultBundleSucceedsOrFails(expected string) error {
 
 	var cmd string
 	var extraBundleArgs string
@@ -356,20 +354,6 @@ func StartCRCWithDefaultBundleAndDefaultHypervisorSucceedsOrFails(expected strin
 		extraBundleArgs = fmt.Sprintf("-b %s", bundleName)
 	}
 	cmd = fmt.Sprintf("crc start -p '%s' %s --log-level debug", pullSecretFile, extraBundleArgs)
-	err := clicumber.ExecuteCommandSucceedsOrFails(cmd, expected)
-
-	return err
-}
-
-func StartCRCWithDefaultBundleAndHypervisorSucceedsOrFails(hypervisor string, expected string) error {
-
-	var cmd string
-	var extraBundleArgs string
-
-	if bundleEmbedded == false {
-		extraBundleArgs = fmt.Sprintf("-b %s", bundleName)
-	}
-	cmd = fmt.Sprintf("crc start -d %s -p '%s' %s --log-level debug", hypervisor, pullSecretFile, extraBundleArgs)
 	err := clicumber.ExecuteCommandSucceedsOrFails(cmd, expected)
 
 	return err

--- a/test/integration/features/basic.feature
+++ b/test/integration/features/basic.feature
@@ -87,22 +87,14 @@ Feature: Basic test
         Then stdout should contain "Checking if user is a member of the Hyper-V Administrators group"
         Then stdout should contain "Checking if the Hyper-V virtual switch exist"
 
-    @linux @windows
+    @darwin @linux @windows
     Scenario: CRC start
-        When starting CRC with default bundle and default hypervisor succeeds
+        When starting CRC with default bundle succeeds
         Then stdout should contain "Started the OpenShift cluster"
         # Check if user can copy-paste login details for developer and kubeadmin users
         And stdout should match "(?s)(.*)oc login -u developer -p developer https:\/\/api\.crc\.testing:6443(.*)$"
         And stdout should match "(?s)(.*)oc login -u kubeadmin -p ([a-zA-Z0-9]{5}-){3}[a-zA-Z0-9]{5} https:\/\/api\.crc\.testing:6443(.*)$"
 
-    @darwin
-    Scenario: CRC start on Mac
-        When starting CRC with default bundle and hypervisor "hyperkit" succeeds
-        Then stdout should contain "Started the OpenShift cluster"
-        # Check if user can copy-paste login details for developer and kubeadmin users
-        And stdout should match "(?s)(.*)oc login -u developer -p developer https:\/\/api\.crc\.testing:6443(.*)$"
-        And stdout should match "(?s)(.*)oc login -u kubeadmin -p ([a-zA-Z0-9]{5}-){3}[a-zA-Z0-9]{5} https:\/\/api\.crc\.testing:6443(.*)$"
-    
     @darwin @linux @windows
     Scenario: CRC status and disk space check
         When with up to "15" retries with wait period of "1m" command "crc status" output should not contain "Stopped"

--- a/test/integration/features/config.feature
+++ b/test/integration/features/config.feature
@@ -192,7 +192,7 @@ Checks whether CRC `config set` command works as expected in conjunction with `c
        When executing "crc config set skip-check-crc-network true" succeeds
        And executing "crc config set skip-check-crc-network-active true" succeeds
        # Start CRC
-       Then starting CRC with default bundle and default hypervisor fails
+       Then starting CRC with default bundle fails
        And stderr contains "Network not found: no network with matching name 'crc'"
 
    @linux

--- a/test/integration/features/story_health.feature
+++ b/test/integration/features/story_health.feature
@@ -4,23 +4,14 @@ Feature:
     project and deploy an app. Check on the app and delete the
     project. Stop and delete CRC.
 
-    Scenario Outline: Start CRC
+    @linux @darwin
+    Scenario: Start CRC
         Given executing "crc setup" succeeds
-        When starting CRC with default bundle and hypervisor "<vm-driver>" succeeds
+        When starting CRC with default bundle succeeds
         Then stdout should contain "Started the OpenShift cluster"
         And executing "eval $(crc oc-env)" succeeds
         When with up to "4" retries with wait period of "2m" command "crc status" output matches ".*Running \(v\d+\.\d+\.\d+.*\).*"
         Then login to the oc cluster succeeds
-
-    @darwin
-        Examples:
-            | vm-driver  |
-            | hyperkit   |
-
-    @linux
-        Examples:
-            | vm-driver |
-            | libvirt   |
 
     @windows
     Scenario: Start CRC on Windows
@@ -68,7 +59,7 @@ Feature:
         Given with up to "2" retries with wait period of "60s" http response from "http://httpd-ex-testproj.apps-crc.testing" has status code "200"
         When executing "crc stop -f" succeeds
         Then with up to "4" retries with wait period of "2m" command "crc status" output should contain "Stopped"
-        When starting CRC with default bundle and default hypervisor succeeds
+        When starting CRC with default bundle succeeds
         Then with up to "4" retries with wait period of "2m" command "crc status" output should match ".*Running \(v\d+\.\d+\.\d+.*\).*"
         And with up to "2" retries with wait period of "60s" http response from "http://httpd-ex-testproj.apps-crc.testing" has status code "200"
 

--- a/test/integration/features/story_marketplace.feature
+++ b/test/integration/features/story_marketplace.feature
@@ -3,23 +3,14 @@ Feature:
     Install OpenShift operator from OperatorHub and use it to manage
     admin tasks.
 
-    Scenario Outline: Start CRC and login to cluster
+    @linux @darwin
+    Scenario: Start CRC and login to cluster
         Given executing "crc setup" succeeds
-        When starting CRC with default bundle and hypervisor "<vm-driver>" succeeds
+        When starting CRC with default bundle succeeds
         Then stdout should contain "Started the OpenShift cluster"
         When with up to "8" retries with wait period of "2m" command "crc status" output matches ".*Running \(v\d+\.\d+\.\d+.*\).*"
         Then executing "eval $(crc oc-env)" succeeds
         And login to the oc cluster succeeds
-
-    @darwin
-        Examples:
-            | vm-driver  |
-            | hyperkit   |
-
-    @linux
-        Examples:
-            | vm-driver |
-            | libvirt   |
 
     @windows
     Scenario: Start CRC on Windows

--- a/test/integration/features/story_registry.feature
+++ b/test/integration/features/story_registry.feature
@@ -6,17 +6,13 @@ Feature: Local image to image-registry to deployment
     project/namespace. They deploy and expose the app and check its
     accessibility.
 
-    Scenario Outline: Start CRC
+    Scenario: Start CRC
         Given executing "crc setup" succeeds
-        When starting CRC with default bundle and hypervisor "<vm-driver>" succeeds
+        When starting CRC with default bundle succeeds
         Then stdout should contain "Started the OpenShift cluster"
         And executing "eval $(crc oc-env)" succeeds
         When with up to "4" retries with wait period of "2m" command "crc status" output matches ".*Running \(v\d+\.\d+\.\d+.*\).*"
         Then login to the oc cluster succeeds
-
-        Examples:
-            | vm-driver |
-            | libvirt   |
 
     Scenario: Create local image
         Given executing "cd ../../../testdata" succeeds


### PR DESCRIPTION
CRC only support the native hypervisor for each platform and doesn't
provide any different driver to connect a non-native hypervisor. This
PR will remove unused `driver` option from setup.

Fix #966