### PR TITLE
Update bundle from 4.3.0 to 4.2.16

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-BUNDLE_VERSION = 4.3.0
+BUNDLE_VERSION = 4.2.16
 BUNDLE_EXTENSION = crcbundle
 CRC_VERSION = 1.6.0-dev
 COMMIT_SHA=$(shell git rev-parse --short HEAD)

--- a/centos_ci.sh
+++ b/centos_ci.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # bundle location
-BUNDLE_VERSION=4.3.0
+BUNDLE_VERSION=4.2.16
 BUNDLE=crc_libvirt_$BUNDLE_VERSION.crcbundle
 GO_VERSION=1.12.13
 


### PR DESCRIPTION
Since we are facing issues with 4.3.0 bundles[0], we need to revert
back to 4.2.x to make CI stable again.

- https://bugzilla.redhat.com/show_bug.cgi?id=1795163