### PR TITLE
Issue #983 Integration: Increase freq and num of reps for status check wait

### DIFF
--- a/test/integration/features/basic.feature
+++ b/test/integration/features/basic.feature
@@ -99,6 +99,7 @@ Feature: Basic test
     Scenario: CRC status and disk space check
         When with up to "15" retries with wait period of "1m" command "crc status --log-level debug" output should not contain "Stopped"
         And stdout should contain "Running"
+        And stdout should match ".*Running \(v\d+\.\d+\.\d+.*\).*"
         And stdout should match ".*Disk Usage: *\d+\.\d+GB of 32.\d+GB.*"
 
     @darwin @linux @windows

--- a/test/integration/features/basic.feature
+++ b/test/integration/features/basic.feature
@@ -130,8 +130,6 @@ Feature: Basic test
 
     @darwin @linux @windows
     Scenario: CRC console check
-        Given executing "crc status" succeeds
-        And stdout contains "Stopped"
         When executing "crc console"
         Then stderr should contain "The OpenShift cluster is not running, cannot open the OpenShift Web Console."
 

--- a/test/integration/features/story_health.feature
+++ b/test/integration/features/story_health.feature
@@ -9,8 +9,8 @@ Feature:
         Given executing "crc setup" succeeds
         When starting CRC with default bundle succeeds
         Then stdout should contain "Started the OpenShift cluster"
+        When with up to "15" retries with wait period of "1m" command "crc status --log-level debug" output matches ".*Running \(v\d+\.\d+\.\d+.*\).*"
         And executing "eval $(crc oc-env)" succeeds
-        When with up to "4" retries with wait period of "2m" command "crc status --log-level debug" output matches ".*Running \(v\d+\.\d+\.\d+.*\).*"
         Then login to the oc cluster succeeds
 
     @windows
@@ -18,8 +18,8 @@ Feature:
         Given executing "crc setup" succeeds
         When starting CRC with default bundle and nameserver "10.75.5.25" succeeds
         Then stdout should contain "Started the OpenShift cluster"
+        When with up to "15" retries with wait period of "1m" command "crc status --log-level debug" output matches ".*Running \(v\d+\.\d+\.\d+.*\).*"
         And executing "crc oc-env | Invoke-Expression" succeeds
-        When with up to "4" retries with wait period of "2m" command "crc status --log-level debug" output matches ".*Running \(v\d+\.\d+\.\d+.*\).*"
         Then login to the oc cluster succeeds
 
     @linux @darwin @windows    
@@ -60,7 +60,7 @@ Feature:
         When executing "crc stop -f" succeeds
         Then with up to "4" retries with wait period of "2m" command "crc status" output should contain "Stopped"
         When starting CRC with default bundle succeeds
-        Then with up to "4" retries with wait period of "2m" command "crc status" output should match ".*Running \(v\d+\.\d+\.\d+.*\).*"
+        Then with up to "15" retries with wait period of "1m" command "crc status" output should match ".*Running \(v\d+\.\d+\.\d+.*\).*"
         And with up to "2" retries with wait period of "60s" http response from "http://httpd-ex-testproj.apps-crc.testing" has status code "200"
 
     @darwin @linux @windows

--- a/test/integration/features/story_marketplace.feature
+++ b/test/integration/features/story_marketplace.feature
@@ -8,9 +8,9 @@ Feature:
         Given executing "crc setup" succeeds
         When starting CRC with default bundle succeeds
         Then stdout should contain "Started the OpenShift cluster"
-        When with up to "8" retries with wait period of "2m" command "crc status" output matches ".*Running \(v\d+\.\d+\.\d+.*\).*"
-        Then executing "eval $(crc oc-env)" succeeds
-        And login to the oc cluster succeeds
+        When with up to "15" retries with wait period of "1m" command "crc status" output matches ".*Running \(v\d+\.\d+\.\d+.*\).*"
+        And executing "eval $(crc oc-env)" succeeds
+        Then login to the oc cluster succeeds
 
     @windows
     Scenario: Start CRC on Windows
@@ -18,7 +18,7 @@ Feature:
         When starting CRC with default bundle and nameserver "10.75.5.25" succeeds
         Then stdout should contain "Started the OpenShift cluster"
         And executing "crc oc-env | Invoke-Expression" succeeds
-        When with up to "4" retries with wait period of "2m" command "crc status --log-level debug" output matches ".*Running \(v\d+\.\d+\.\d+.*\).*"
+        When with up to "15" retries with wait period of "1m" command "crc status --log-level debug" output matches ".*Running \(v\d+\.\d+\.\d+.*\).*"
         Then login to the oc cluster succeeds
 
     @darwin @linux @windows

--- a/test/integration/features/story_registry.feature
+++ b/test/integration/features/story_registry.feature
@@ -10,8 +10,8 @@ Feature: Local image to image-registry to deployment
         Given executing "crc setup" succeeds
         When starting CRC with default bundle succeeds
         Then stdout should contain "Started the OpenShift cluster"
+        When with up to "15" retries with wait period of "1m" command "crc status --log-level debug" output matches ".*Running \(v\d+\.\d+\.\d+.*\).*"
         And executing "eval $(crc oc-env)" succeeds
-        When with up to "4" retries with wait period of "2m" command "crc status --log-level debug" output matches ".*Running \(v\d+\.\d+\.\d+.*\).*"
         Then login to the oc cluster succeeds
 
     Scenario: Create local image


### PR DESCRIPTION
Addresses Issue #983: 
- changed wait time from 4x2min to 15x1min (also rearranged lines: first check status, then `crc oc-env`, then `oc login`)
- removed redundant lines (`crc status` was checked in Scenario immediately above)