### PR TITLE
Preflight checks improvements

### DIFF
--- a/pkg/crc/preflight/preflight_checks_darwin.go
+++ b/pkg/crc/preflight/preflight_checks_darwin.go
@@ -144,13 +144,13 @@ func checkMachineDriverHyperKitInstalled() error {
 	hyperkitPath := filepath.Join(constants.CrcBinDir, hyperkit.MachineDriverCommand)
 	err := unix.Access(hyperkitPath, unix.X_OK)
 	if err != nil {
-		return err
+		return fmt.Errorf("%s is not executable", hyperkitPath)
 	}
 
 	// Check the version of driver if it matches to supported one
 	stdOut, stdErr, err := crcos.RunWithDefaultLocale(hyperkitPath, "version")
 	if err != nil {
-		return err
+		return fmt.Errorf("Failed to check hyperkit machine driver's version")
 	}
 	if !strings.Contains(stdOut, hyperkit.MachineDriverVersion) {
 		return fmt.Errorf("%s does not have right version \n Required: %s \n Got: %s use 'crc setup' command.\n %v\n", hyperkit.MachineDriverCommand, hyperkit.MachineDriverVersion, stdOut, stdErr)
@@ -206,7 +206,8 @@ func addFileWritePermissionToUser(filename string) error {
 	logging.Debugf("Making %s readable/writable by the current user", filename)
 	currentUser, err := user.Current()
 	if err != nil {
-		return err
+		logging.Debugf("user.Current() failed: %v", err)
+		return fmt.Errorf("Failed to get current user id")
 	}
 
 	stdOut, stdErr, err := crcos.RunWithPrivilege(fmt.Sprintf("change ownership of %s", filename), "chown", currentUser.Username, filename)

--- a/pkg/crc/preflight/preflight_checks_linux.go
+++ b/pkg/crc/preflight/preflight_checks_linux.go
@@ -2,7 +2,6 @@ package preflight
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"golang.org/x/sys/unix"
 	"io/ioutil"
@@ -49,34 +48,34 @@ func checkVirtualizationEnabled() error {
 	out, err := ioutil.ReadFile("/proc/cpuinfo")
 	if err != nil {
 		logging.Debugf("Failed to read /proc/cpuinfo: %v", err)
-		return errors.New("Failed to read /proc/cpuinfo")
+		return fmt.Errorf("Failed to read /proc/cpuinfo")
 	}
 	re := regexp.MustCompile(`flags.*:.*`)
 
 	flags := re.FindString(string(out))
 	if flags == "" {
-		return errors.New("Could not find cpu flags from /proc/cpuinfo")
+		return fmt.Errorf("Could not find cpu flags from /proc/cpuinfo")
 	}
 
 	re = regexp.MustCompile(`(vmx|svm)`)
 
 	cputype := re.FindString(flags)
 	if cputype == "" {
-		return errors.New("Virtualization is not available for you CPU")
+		return fmt.Errorf("Virtualization is not available for you CPU")
 	}
 	logging.Debug("CPU virtualization flags are good")
 	return nil
 }
 
 func fixVirtualizationEnabled() error {
-	return errors.New("You need to enable virtualization in BIOS")
+	return fmt.Errorf("You need to enable virtualization in BIOS")
 }
 
 func checkKvmEnabled() error {
 	logging.Debug("Checking if /dev/kvm exists")
 	// Check if /dev/kvm exists
 	if _, err := os.Stat("/dev/kvm"); os.IsNotExist(err) {
-		return errors.New("kvm kernel module is not loaded")
+		return fmt.Errorf("kvm kernel module is not loaded")
 	}
 	logging.Debug("/dev/kvm was found")
 	return nil
@@ -100,7 +99,7 @@ func checkLibvirtInstalled() error {
 	logging.Debug("Checking if 'virsh' is available")
 	path, err := exec.LookPath("virsh")
 	if err != nil {
-		return errors.New("Libvirt cli virsh was not found in path")
+		return fmt.Errorf("Libvirt cli virsh was not found in path")
 	}
 	logging.Debug("'virsh' was found in ", path)
 	return nil
@@ -128,7 +127,7 @@ func checkLibvirtEnabled() error {
 		return fmt.Errorf("Error checking if libvirtd service is enabled")
 	}
 	if strings.TrimSpace(stdOut) != "enabled" {
-		return errors.New("libvirtd.service is not enabled")
+		return fmt.Errorf("libvirtd.service is not enabled")
 	}
 	logging.Debug("libvirtd.service is already enabled")
 	return nil
@@ -224,7 +223,7 @@ func checkLibvirtServiceRunning() error {
 		return fmt.Errorf("Failed to check if libvirtd service is active")
 	}
 	if strings.TrimSpace(stdOut) != "active" {
-		return errors.New("libvirtd.service is not running")
+		return fmt.Errorf("libvirtd.service is not running")
 	}
 	logging.Debug("libvirtd.service is already running")
 	return nil
@@ -311,7 +310,7 @@ func checkLibvirtCrcNetworkAvailable() error {
 	logging.Debug("Checking if libvirt 'crc' network exists")
 	_, _, err := crcos.RunWithDefaultLocale("virsh", "--connect", "qemu:///system", "net-info", "crc")
 	if err != nil {
-		return errors.New("Libvirt network crc not found")
+		return fmt.Errorf("Libvirt network crc not found")
 	}
 
 	return checkLibvirtCrcNetworkDefinition()
@@ -414,7 +413,7 @@ func checkLibvirtCrcNetworkActive() error {
 			return nil
 		}
 	}
-	return errors.New("Libvirt crc network is not active")
+	return fmt.Errorf("Libvirt crc network is not active")
 }
 
 func fixLibvirtCrcNetworkActive() error {
@@ -518,7 +517,7 @@ func checkNetworkManagerInstalled() error {
 	logging.Debug("Checking if 'nmcli' is available")
 	path, err := exec.LookPath("nmcli")
 	if err != nil {
-		return errors.New("NetworkManager cli nmcli was not found in path")
+		return fmt.Errorf("NetworkManager cli nmcli was not found in path")
 	}
 	logging.Debug("'nmcli' was found in ", path)
 	return nil
@@ -539,7 +538,7 @@ func checkNetworkManagerIsRunning() error {
 		return fmt.Errorf("%v : %s", err, stdErr)
 	}
 	if strings.TrimSpace(stdOut) != "active" {
-		return errors.New("NetworkManager.service is not running")
+		return fmt.Errorf("NetworkManager.service is not running")
 	}
 	logging.Debug("NetworkManager.service is already running")
 	return nil

--- a/pkg/crc/preflight/preflight_checks_linux.go
+++ b/pkg/crc/preflight/preflight_checks_linux.go
@@ -61,7 +61,7 @@ func checkVirtualizationEnabled() error {
 
 	cputype := re.FindString(flags)
 	if cputype == "" {
-		return fmt.Errorf("Virtualization is not available for you CPU")
+		return fmt.Errorf("Virtualization is not available for your CPU")
 	}
 	logging.Debug("CPU virtualization flags are good")
 	return nil

--- a/pkg/crc/preflight/preflight_checks_linux.go
+++ b/pkg/crc/preflight/preflight_checks_linux.go
@@ -305,19 +305,11 @@ func fixOldMachineDriverLibvirtInstalled() error {
 
 func checkLibvirtCrcNetworkAvailable() error {
 	logging.Debug("Checking if libvirt 'crc' network exists")
-	stdOut, stdErr, err := crcos.RunWithDefaultLocale("virsh", "--connect", "qemu:///system", "net-list")
+	_, stdErr, err := crcos.RunWithDefaultLocale("virsh", "--connect", "qemu:///system", "net-info", "crc")
 	if err != nil {
-		return fmt.Errorf("%+v: %s", err, stdErr)
+		return errors.New("Libvirt network crc not found")
 	}
-	outputSlice := strings.Split(stdOut, "\n")
-	for _, stdOut = range outputSlice {
-		stdOut = strings.TrimSpace(stdOut)
-		if strings.HasPrefix(stdOut, "crc") {
-			logging.Debug("libvirt 'crc' network exists")
-			return nil
-		}
-	}
-	return errors.New("Libvirt network crc not found")
+	return nil
 }
 
 func fixLibvirtCrcNetworkAvailable() error {
@@ -358,7 +350,7 @@ func fixLibvirtCrcNetworkAvailable() error {
 
 func checkLibvirtCrcNetworkActive() error {
 	logging.Debug("Checking if libvirt 'crc' network is active")
-	stdOut, stdErr, err := crcos.RunWithDefaultLocale("virsh", "--connect", "qemu:///system", "net-list")
+	stdOut, stdErr, err := crcos.RunWithDefaultLocale("virsh", "--connect", "qemu:///system", "net-info", "crc")
 	if err != nil {
 		return fmt.Errorf("%+v: %s", err, stdErr)
 	}
@@ -366,7 +358,7 @@ func checkLibvirtCrcNetworkActive() error {
 
 	for _, stdOut = range outputSlice {
 		stdOut = strings.TrimSpace(stdOut)
-		if strings.HasPrefix(stdOut, "crc") && strings.Contains(stdOut, "active") {
+		if strings.HasPrefix(stdOut, "Active") && strings.Contains(stdOut, "yes") {
 			logging.Debug("libvirt 'crc' network is already active")
 			return nil
 		}

--- a/pkg/crc/preflight/preflight_checks_linux.go
+++ b/pkg/crc/preflight/preflight_checks_linux.go
@@ -528,7 +528,7 @@ func fixNetworkManagerInstalled() error {
 	return fmt.Errorf("NetworkManager is required and must be installed manually")
 }
 
-func CheckNetworkManagerIsRunning() error {
+func checkNetworkManagerIsRunning() error {
 	logging.Debug("Checking if NetworkManager.service is running")
 	path, err := exec.LookPath("systemctl")
 	if err != nil {

--- a/pkg/crc/preflight/preflight_linux.go
+++ b/pkg/crc/preflight/preflight_linux.go
@@ -90,7 +90,7 @@ var libvirtPreflightChecks = [...]PreflightCheck{
 	{
 		configKeySuffix:  "check-network-manager-running",
 		checkDescription: "Checking if NetworkManager service is running",
-		check:            CheckNetworkManagerIsRunning,
+		check:            checkNetworkManagerIsRunning,
 		fixDescription:   "Checking if NetworkManager service is running",
 		fix:              fixNetworkManagerIsRunning,
 	},

--- a/pkg/os/exec.go
+++ b/pkg/os/exec.go
@@ -8,28 +8,14 @@ import (
 	"strings"
 )
 
-// RunWithPrivilege executes a command using sudo
-// provide a reason why root is needed as the first argument
-func RunWithPrivilege(reason string, cmdAndArgs ...string) (string, string, error) {
-	sudo, err := exec.LookPath("sudo")
-	if err != nil {
-		return "", "", err
-	}
-	cmd := exec.Command(sudo, cmdAndArgs...) // #nosec G204
-	stdOut := new(bytes.Buffer)
-	stdErr := new(bytes.Buffer)
-	cmd.Stdout = stdOut
-	cmd.Stderr = stdErr
-	logging.Infof("Will use root access: %s", reason)
-	logging.Debugf("Running %s with sudo", strings.Join(cmdAndArgs, " "))
-	err = cmd.Run()
-	return stdOut.String(), stdErr.String(), err
-}
-
-func RunWithDefaultLocale(command string, args ...string) (string, string, error) {
+func run(command string, args []string, env map[string]string) (string, string, error) {
 	cmd := exec.Command(command, args...) // #nosec G204
-	cmd.Env = ReplaceEnv(os.Environ(), "LC_ALL", "C")
-	cmd.Env = ReplaceEnv(cmd.Env, "LANG", "C")
+	if len(env) != 0 {
+		cmd.Env = os.Environ()
+		for key, value := range env {
+			cmd.Env = ReplaceEnv(cmd.Env, key, value)
+		}
+	}
 	stdOut := new(bytes.Buffer)
 	stdErr := new(bytes.Buffer)
 	cmd.Stdout = stdOut
@@ -37,4 +23,19 @@ func RunWithDefaultLocale(command string, args ...string) (string, string, error
 	logging.Debugf("Running %s %s", command, strings.Join(args, " "))
 	err := cmd.Run()
 	return stdOut.String(), stdErr.String(), err
+}
+
+// RunWithPrivilege executes a command using sudo
+// provide a reason why root is needed as the first argument
+func RunWithPrivilege(reason string, cmdAndArgs ...string) (string, string, error) {
+	sudo, err := exec.LookPath("sudo")
+	if err != nil {
+		return "", "", err
+	}
+	logging.Infof("Will use root access: %s", reason)
+	return run(sudo, cmdAndArgs, map[string]string{})
+}
+
+func RunWithDefaultLocale(command string, args ...string) (string, string, error) {
+	return run(command, args, map[string]string{"LC_ALL": "C", "LANG": "C"})
 }

--- a/pkg/os/exec.go
+++ b/pkg/os/exec.go
@@ -5,6 +5,7 @@ import (
 	"github.com/code-ready/crc/pkg/crc/logging"
 	"os"
 	"os/exec"
+	"strings"
 )
 
 // RunWithPrivilege executes a command using sudo
@@ -20,6 +21,7 @@ func RunWithPrivilege(reason string, cmdAndArgs ...string) (string, string, erro
 	cmd.Stdout = stdOut
 	cmd.Stderr = stdErr
 	logging.Infof("Will use root access: %s", reason)
+	logging.Debugf("Running %s with sudo", strings.Join(cmdAndArgs, " "))
 	err = cmd.Run()
 	return stdOut.String(), stdErr.String(), err
 }
@@ -32,6 +34,7 @@ func RunWithDefaultLocale(command string, args ...string) (string, string, error
 	stdErr := new(bytes.Buffer)
 	cmd.Stdout = stdOut
 	cmd.Stderr = stdErr
+	logging.Debugf("Running %s %s", command, strings.Join(args, " "))
 	err := cmd.Run()
 	return stdOut.String(), stdErr.String(), err
 }

--- a/pkg/os/exec.go
+++ b/pkg/os/exec.go
@@ -20,8 +20,13 @@ func run(command string, args []string, env map[string]string) (string, string, 
 	stdErr := new(bytes.Buffer)
 	cmd.Stdout = stdOut
 	cmd.Stderr = stdErr
-	logging.Debugf("Running %s %s", command, strings.Join(args, " "))
+	logging.Debugf("Running '%s %s'", command, strings.Join(args, " "))
 	err := cmd.Run()
+	if err != nil {
+		logging.Debugf("Command failed: %v", err)
+		logging.Debugf("stdout: %s", stdOut.String())
+		logging.Debugf("stderr: %s", stdErr.String())
+	}
 	return stdOut.String(), stdErr.String(), err
 }
 


### PR DESCRIPTION
This pull-request can be split in 2 different parts
- first one improves the preflight checks related to libvirt crc network
- second part improves the error messages which are shown to the user when preflight failures happen

It fixes #990 and #995.