### PR TITLE
Issue #999 Call WatchConfig in viper initialization

### DIFF
--- a/pkg/crc/config/viper_config.go
+++ b/pkg/crc/config/viper_config.go
@@ -101,6 +101,7 @@ func InitViper() error {
 	if err != nil {
 		return fmt.Errorf("Error reading configuration file '%s': %v", constants.ConfigFile, err)
 	}
+	v.WatchConfig()
 	globalViper = v
 	return v.Unmarshal(&changedConfigs)
 }


### PR DESCRIPTION
Since we initialize viper in root.go and the daemon runs that
only once, the new changes to the config is not reflected on the
daemon side, this should make daemon aware of changes made to the
config file, after it has been launched.

This needs to be tested specially on macOS and windows, since it depends on file system notifications to work as expected.