### PR TITLE
Add podman-env command

### DIFF
--- a/cmd/crc-embedder/cmd/embed.go
+++ b/cmd/crc-embedder/cmd/embed.go
@@ -91,6 +91,7 @@ var (
 			hyperkit.HyperkitDownloadUrl,
 			constants.GetOcUrlForOs("darwin"),
 			constants.GetCrcTrayDownloadURL(),
+			constants.GetPodmanUrl(),
 		},
 		"linux": []string{
 			libvirt.MachineDriverDownloadUrl,

--- a/cmd/crc/cmd/podman_env.go
+++ b/cmd/crc/cmd/podman_env.go
@@ -1,0 +1,46 @@
+package cmd
+
+import (
+	"github.com/code-ready/crc/pkg/crc/constants"
+	"github.com/code-ready/crc/pkg/crc/errors"
+	"github.com/code-ready/crc/pkg/crc/machine"
+	"github.com/code-ready/crc/pkg/crc/output"
+	"github.com/code-ready/crc/pkg/os/shell"
+	"github.com/spf13/cobra"
+)
+
+var podmanEnvCmd = &cobra.Command{
+	Use:   "podman-env",
+	Short: "Setup podman environment",
+	Long:  `Setup environment for 'podman' binary to access podman on CRC VM`,
+	Run: func(cmd *cobra.Command, args []string) {
+		userShell, err := shell.GetShell(forceShell)
+		if err != nil {
+			errors.ExitWithMessage(1, "Error running the podman-env command: %s", err.Error())
+		}
+
+		ipConfig := machine.IpConfig{
+			Name:  constants.DefaultName,
+			Debug: isDebugLog(),
+		}
+
+		exitIfMachineMissing(ipConfig.Name)
+
+		result, err := machine.Ip(ipConfig)
+		if err != nil {
+			errors.Exit(1)
+		}
+
+		output.Outln(shell.GetPathEnvString(userShell, constants.CrcBinDir))
+		output.Outln(shell.GetEnvString(userShell, "PODMAN_USER", constants.DefaultSSHUser))
+		output.Outln(shell.GetEnvString(userShell, "PODMAN_HOST", result.IP))
+		output.Outln(shell.GetEnvString(userShell, "PODMAN_IDENTITY_FILE", constants.GetPrivateKeyPath()))
+		output.Outln(shell.GetEnvString(userShell, "PODMAN_IGNORE_HOSTS", "1"))
+		output.Outln(shell.GenerateUsageHint(userShell, "crc podman-env"))
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(podmanEnvCmd)
+	podmanEnvCmd.Flags().StringVar(&forceShell, "shell", "", "Set the environment for the specified shell: [fish, cmd, powershell, tcsh, bash, zsh]. Default is auto-detect.")
+}

--- a/pkg/crc/constants/constants.go
+++ b/pkg/crc/constants/constants.go
@@ -30,8 +30,9 @@ const (
 	CrcLandingPageURL    = "https://cloud.redhat.com/openshift/install/crc/installer-provisioned" // #nosec G101
 	PullSecretFile       = "pullsecret.json"
 
-	DefaultOcUrlBase   = "https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest"
-	CrcTrayDownloadURL = "https://github.com/code-ready/tray-macos/releases/download/v%s/crc-tray-macos.tar.gz"
+	DefaultOcUrlBase     = "https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest"
+	DefaultPodmanUrlBase = "https://storage.googleapis.com/libpod-master-releases"
+	CrcTrayDownloadURL   = "https://github.com/code-ready/tray-macos/releases/download/v%s/crc-tray-macos.tar.gz"
 )
 
 var ocUrlForOs = map[string]string{
@@ -46,6 +47,16 @@ func GetOcUrlForOs(os string) string {
 
 func GetOcUrl() string {
 	return GetOcUrlForOs(runtime.GOOS)
+}
+
+var PodmanUrlForOs = map[string]string{
+	"darwin":  fmt.Sprintf("%s/%s", DefaultPodmanUrlBase, "podman-remote-latest-master-darwin-amd64.zip"),
+	"linux":   fmt.Sprintf("%s/%s", DefaultPodmanUrlBase, "podman-remote-latest-master-linux---amd64.zip"),
+	"windows": fmt.Sprintf("%s/%s", DefaultPodmanUrlBase, "podman-remote-latest-master-windows-amd64.zip"),
+}
+
+func GetPodmanUrl() string {
+	return PodmanUrlForOs[runtime.GOOS]
 }
 
 var defaultBundleForOs = map[string]string{

--- a/pkg/crc/constants/constants_darwin.go
+++ b/pkg/crc/constants/constants_darwin.go
@@ -3,8 +3,9 @@ package constants
 import "path/filepath"
 
 const (
-	OcBinaryName   = "oc"
-	TrayBinaryName = "CodeReady Containers.app"
+	OcBinaryName     = "oc"
+	PodmanBinaryName = "podman"
+	TrayBinaryName   = "CodeReady Containers.app"
 )
 
 var (

--- a/pkg/crc/constants/constants_linux.go
+++ b/pkg/crc/constants/constants_linux.go
@@ -1,5 +1,6 @@
 package constants
 
 const (
-	OcBinaryName = "oc"
+	OcBinaryName     = "oc"
+	PodmanBinaryName = "podman"
 )

--- a/pkg/crc/constants/constants_windows.go
+++ b/pkg/crc/constants/constants_windows.go
@@ -1,5 +1,6 @@
 package constants
 
 const (
-	OcBinaryName = "oc.exe"
+	OcBinaryName     = "oc.exe"
+	PodmanBinaryName = "podman.exe"
 )

--- a/pkg/crc/oc/oc_cache.go
+++ b/pkg/crc/oc/oc_cache.go
@@ -14,12 +14,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-const (
-	OC_CACHE_DIR = "oc"
-	TARGZ        = "tar.gz"
-	ZIP          = "zip"
-)
-
 // Oc is a struct with methods designed for dealing with the oc binary
 type OcCached struct{}
 

--- a/pkg/crc/podman/podman_cache.go
+++ b/pkg/crc/podman/podman_cache.go
@@ -1,0 +1,118 @@
+package podman
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/code-ready/crc/pkg/crc/constants"
+	"github.com/code-ready/crc/pkg/crc/logging"
+	"github.com/code-ready/crc/pkg/download"
+	"github.com/code-ready/crc/pkg/embed"
+	"github.com/code-ready/crc/pkg/extract"
+	crcos "github.com/code-ready/crc/pkg/os"
+	"github.com/pkg/errors"
+)
+
+// Podman is a struct with methods designed for dealing with the podman binary
+type PodmanCached struct{}
+
+func (podman *PodmanCached) EnsureIsCached() error {
+	if !podman.IsCached() {
+		err := podman.cachePodman()
+		if err != nil {
+			return err
+		}
+
+	}
+	return nil
+}
+
+func (podman *PodmanCached) IsCached() bool {
+	if _, err := os.Stat(filepath.Join(constants.CrcBinDir, constants.PodmanBinaryName)); os.IsNotExist(err) {
+		return false
+	}
+	return true
+}
+
+func (podman *PodmanCached) getPodman(destDir string) (string, error) {
+	logging.Debug("Trying to extract podman from crc binary")
+	archiveName := filepath.Base(constants.GetPodmanUrl())
+	destPath := filepath.Join(destDir, archiveName)
+	err := embed.Extract(archiveName, destPath)
+	if err != nil {
+		logging.Debug("Downloading podman")
+		return download.Download(constants.GetPodmanUrl(), destDir, 0600)
+	}
+
+	return destPath, err
+}
+
+// cachePodman downloads and caches the podman binary into the CRC directory
+func (podman *PodmanCached) cachePodman() error {
+	if podman.IsCached() {
+		return nil
+	}
+
+	// Create tmp dir to download the podman tarball
+	tmpDir, err := ioutil.TempDir("", "crc")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(tmpDir)
+	assetTmpFile, err := podman.getPodman(tmpDir)
+	if err != nil {
+		return err
+	}
+
+	// Extract the tarball and put it the cache directory.
+	err = extract.Uncompress(assetTmpFile, tmpDir)
+	if err != nil {
+		return errors.Wrapf(err, "Cannot uncompress '%s'", assetTmpFile)
+	}
+
+	binaryName := constants.PodmanBinaryName
+	binaryPath, err := findBinary(tmpDir, binaryName)
+	if err != nil {
+		return err
+	}
+
+	// Copy the requested asset into its final destination
+	outputPath := constants.CrcBinDir
+	err = os.MkdirAll(outputPath, 0750)
+	if err != nil && !os.IsExist(err) {
+		return errors.Wrap(err, "Cannot create the target directory.")
+	}
+
+	finalBinaryPath := filepath.Join(outputPath, binaryName)
+	err = crcos.CopyFileContents(binaryPath, finalBinaryPath, 0500)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func findBinary(dirPath string, binaryName string) (string, error) {
+	var binaryPath string
+
+	err := filepath.Walk(dirPath, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if filepath.Base(path) == binaryName {
+			binaryPath = path
+
+			return filepath.SkipDir
+		}
+
+		return nil
+	})
+	if binaryPath == "" && err == nil {
+		err = fmt.Errorf("Failed to find `%s` binary in `%s`.", binaryName, dirPath)
+	}
+
+	return binaryPath, err
+}

--- a/pkg/crc/preflight/preflight_checks_common.go
+++ b/pkg/crc/preflight/preflight_checks_common.go
@@ -9,6 +9,7 @@ import (
 	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/code-ready/crc/pkg/crc/logging"
 	"github.com/code-ready/crc/pkg/crc/oc"
+	"github.com/code-ready/crc/pkg/crc/podman"
 	"github.com/code-ready/crc/pkg/embed"
 )
 
@@ -18,6 +19,12 @@ var genericPreflightChecks = [...]PreflightCheck{
 		check:            checkOcBinaryCached,
 		fixDescription:   "Caching oc binary",
 		fix:              fixOcBinaryCached,
+	},
+	{
+		checkDescription: "Checking if podman remote binary is cached",
+		check:            checkPodmanBinaryCached,
+		fixDescription:   "Caching podman remote binary",
+		fix:              fixPodmanBinaryCached,
 	},
 	{
 		configKeySuffix:  "check-bundle-cached",
@@ -68,5 +75,24 @@ func fixOcBinaryCached() error {
 		return fmt.Errorf("Unable to download oc %v", err)
 	}
 	logging.Debug("oc binary cached")
+	return nil
+}
+
+// Check if podman binary is cached or not
+func checkPodmanBinaryCached() error {
+	podman := podman.PodmanCached{}
+	if !podman.IsCached() {
+		return errors.New("podman remote binary is not cached")
+	}
+	logging.Debug("podman remote binary already cached")
+	return nil
+}
+
+func fixPodmanBinaryCached() error {
+	podman := podman.PodmanCached{}
+	if err := podman.EnsureIsCached(); err != nil {
+		return fmt.Errorf("Unable to download podman remote binary %v", err)
+	}
+	logging.Debug("podman remote binary cached")
 	return nil
 }


### PR DESCRIPTION
Fixes #961 

Add subcommand to setup environment variables to use `podman-remote` with the CRC VM.

This handles:

- [x]  the environment setup
- [x] Binary bundling/installation for all 3 OSs.