### PR TITLE
Issue #1006 Use ubi instead of centos as base image

### DIFF
--- a/images/dnsmasq/Dockerfile
+++ b/images/dnsmasq/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:8
+FROM registry.redhat.io/ubi8/ubi
 MAINTAINER CodeReady Container <devtools-cdk@redhat.com>
 
 RUN yum -y install dnsmasq && \


### PR DESCRIPTION
dnsmasq rpm now available on ubi-8-appstream repo, so better to use
ubi then centos base image.

- BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1766581