### PR TITLE
Host might be unreachable

### DIFF
--- a/pkg/crc/machine/machine.go
+++ b/pkg/crc/machine/machine.go
@@ -240,7 +240,7 @@ func Start(startConfig StartConfig) (StartResult, error) {
 	logging.Debug("Waiting until ssh is available")
 	if err := cluster.WaitForSsh(sshRunner); err != nil {
 		result.Error = err.Error()
-		return *result, errors.New("Failed to connect to the CRC VM with SSH")
+		return *result, errors.New("Failed to connect to the CRC VM with SSH -- host might be unreachable")
 	}
 
 	// Check the certs validity inside the vm


### PR DESCRIPTION
In case SSH fails this might also be caused due to a booting
problem of the VM (see #1016 - kernel panic - not syncing: VFS)