### PR TITLE
Issue #1022 Split tray setup logic into smaller checks

### DIFF
--- a/pkg/crc/constants/constants_darwin.go
+++ b/pkg/crc/constants/constants_darwin.go
@@ -8,5 +8,6 @@ const (
 )
 
 var (
-	TrayBinaryPath = filepath.Join(CrcBinDir, TrayBinaryName)
+	TrayAppBundlePath = filepath.Join(CrcBinDir, TrayBinaryName)
+	TrayBinaryPath    = filepath.Join(TrayAppBundlePath, "Contents", "MacOS", "CodeReady Containers")
 )

--- a/pkg/crc/preflight/preflight_darwin.go
+++ b/pkg/crc/preflight/preflight_darwin.go
@@ -39,12 +39,49 @@ var dnsPreflightChecks = [...]PreflightCheck{
 	},
 }
 
-var traySetupCheck = PreflightCheck{
-	checkDescription: "Checking if the tray is installed and running",
-	check:            checkTrayExistsAndRunning,
-	fixDescription:   "Installing and setting up tray app",
-	fix:              fixTrayExistsAndRunning,
-	flags:            SetupOnly,
+var traySetupChecks = [...]PreflightCheck{
+	{
+		checkDescription: "Checking if tray binary is installed",
+		check:            checkTrayBinaryPresent,
+		fixDescription:   "Installing and setting up tray",
+		fix:              fixTrayBinaryPresent,
+		flags:            SetupOnly,
+	},
+	{
+		checkDescription: "Checking if launchd configuration for daemon exists",
+		check:            checkIfDaemonPlistFileExists,
+		fixDescription:   "Creating launchd configuration for daemon",
+		fix:              fixDaemonPlistFileExists,
+		flags:            SetupOnly,
+	},
+	{
+		checkDescription: "Checking if launchd configuration for tray exists",
+		check:            checkIfTrayPlistFileExists,
+		fixDescription:   "Creating launchd configuration for tray",
+		fix:              fixTrayPlistFileExists,
+		flags:            SetupOnly,
+	},
+	{
+		checkDescription: "Checking installed tray version",
+		check:            checkTrayVersion,
+		fixDescription:   "Installing and setting up tray app",
+		fix:              fixTrayVersion,
+		flags:            SetupOnly,
+	},
+	{
+		checkDescription: "Checking if CodeReady Containers daemon is running",
+		check:            checkIfDaemonAgentRunning,
+		fixDescription:   "Starting CodeReady Containers daemon",
+		fix:              fixDaemonAgentRunning,
+		flags:            SetupOnly,
+	},
+	{
+		checkDescription: "Check if CodeReady Containers tray is running",
+		check:            checkIfTrayAgentRunning,
+		fixDescription:   "Starting CodeReady Containers tray",
+		fix:              fixTrayAgentRunning,
+		flags:            SetupOnly,
+	},
 }
 
 func getPreflightChecks() []PreflightCheck {
@@ -57,7 +94,7 @@ func getPreflightChecks() []PreflightCheck {
 
 	// Experimental feature
 	if EnableExperimentalFeatures {
-		checks = append(checks, traySetupCheck)
+		checks = append(checks, traySetupChecks[:]...)
 	}
 
 	return checks

--- a/pkg/launchd/launchd.go
+++ b/pkg/launchd/launchd.go
@@ -1,0 +1,97 @@
+package launchd
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os/exec"
+	"strings"
+	"text/template"
+)
+
+const (
+	plistTemplate = `<?xml version='1.0' encoding='UTF-8'?>
+	<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+	<plist version='1.0'>
+		<dict>
+			<key>Label</key>
+			<string>{{ .Label }}</string>
+			<key>ProgramArguments</key>
+			<array>
+				<string>{{ .BinaryPath }}</string>
+			{{ range .Args }}
+				<string>{{ . }}</string>
+			{{ end }}
+			</array>
+			<key>StandardOutPath</key>
+			<string>{{ .StdOutFilePath }}</string>
+			<key>Disabled</key>
+			<false/>
+			<key>RunAtLoad</key>
+			<true/>
+		</dict>
+	</plist>`
+)
+
+// AgentConfig is struct to contain configuration for agent plist file
+type AgentConfig struct {
+	Label          string
+	BinaryPath     string
+	StdOutFilePath string
+	Args           []string
+}
+
+// CreatePlist creates a launchd agent plist config file
+func CreatePlist(config AgentConfig, plistPath string) error {
+	var plistContent bytes.Buffer
+	t, err := template.New("plist").Parse(plistTemplate)
+	if err != nil {
+		return err
+	}
+	err = t.Execute(&plistContent, config)
+	if err != nil {
+		return err
+	}
+	err = ioutil.WriteFile(plistPath, plistContent.Bytes(), 0644)
+	return err
+}
+
+// LoadPlist loads a launchd agents' plist file
+func LoadPlist(plistFilePath string) error {
+	return exec.Command("launchctl", "load", plistFilePath).Run() // #nosec G204
+}
+
+// StartAgent starts a launchd agent
+func StartAgent(label string) error {
+	return exec.Command("launchctl", "start", label).Run() // #nosec G204
+}
+
+// StopAgent stops a launchd agent
+func StopAgent(label string) error {
+	return exec.Command("launchctl", "stop", label).Run() // #nosec G204
+}
+
+// RestartAgent restarts a launchd agent
+func RestartAgent(label string) error {
+	err := StopAgent(label)
+	if err != nil {
+		return err
+	}
+	return StartAgent(label)
+}
+
+// AgentRunning checks if a launchd service is running
+func AgentRunning(label string) bool {
+	// This command return a PID if the process
+	// is running, otherwise returns "-"
+	launchctlListCommand := `launchctl list | grep %s | awk '{print $1}'`
+	cmd := fmt.Sprintf(launchctlListCommand, label)
+	out, err := exec.Command("bash", "-c", cmd).Output() // #nosec G204
+	if err != nil {
+		return false
+	}
+	if strings.TrimSpace(string(out)) == "-" {
+		return false
+	}
+	return true
+}


### PR DESCRIPTION
Its mostly the existing code, just split into individual
functions, and accordingly Preflight structs are created
for each check function

The checks performed:
1. Check if tray binary is present
2. Check if tray/daemon plist is present (if not fix would create plist and load using `launchctl load`)
3. Check if tray version is matching (if not the fix would download/extract the tray and restart the tray)
4. Check if both tray/daemon running.