### PR TITLE
Issue #1015: Set /var/lib/kubelet/config.json permissions to 0600

### DIFF
--- a/pkg/crc/cluster/cluster.go
+++ b/pkg/crc/cluster/cluster.go
@@ -196,10 +196,11 @@ func AddProxyConfigToMarketplaceOperator(oc oc.OcConfig, proxy *network.ProxyCon
 }
 
 func addPullSecretToInstanceDisk(sshRunner *ssh.SSHRunner, pullSec string) error {
-	err := sshRunner.SetTextContentAsRoot("/var/lib/kubelet/config.json", pullSec, 0644)
+	err := sshRunner.SetTextContentAsRoot("/var/lib/kubelet/config.json", pullSec, 0600)
 	if err != nil {
 		return err
 	}
+
 	return nil
 }
 

--- a/pkg/crc/cluster/cluster.go
+++ b/pkg/crc/cluster/cluster.go
@@ -167,11 +167,11 @@ Environment=HTTPS_PROXY=%s
 Environment=NO_PROXY=%s,%s`
 	p := fmt.Sprintf(proxyTemplate, proxy.HttpProxy, proxy.HttpsProxy, internalNoProxy, proxy.GetNoProxyString())
 	// This will create a systemd drop-in configuration for proxy (both for kubelet and crio services) on the VM.
-	_, err := sshRunner.RunPrivate(fmt.Sprintf("cat <<EOF | sudo tee /etc/systemd/system/crio.service.d/10-default-env.conf\n%s\nEOF", p))
+	err := sshRunner.SetTextContentAsRoot("/etc/systemd/system/crio.service.d/10-default-env.conf", p, 0644)
 	if err != nil {
 		return err
 	}
-	_, err = sshRunner.RunPrivate(fmt.Sprintf("cat <<EOF | sudo tee /etc/systemd/system/kubelet.service.d/10-default-env.conf\n%s\nEOF", p))
+	err = sshRunner.SetTextContentAsRoot("/etc/systemd/system/kubelet.service.d/10-default-env.conf", p, 0644)
 	if err != nil {
 		return err
 	}
@@ -196,7 +196,7 @@ func AddProxyConfigToMarketplaceOperator(oc oc.OcConfig, proxy *network.ProxyCon
 }
 
 func addPullSecretToInstanceDisk(sshRunner *ssh.SSHRunner, pullSec string) error {
-	_, err := sshRunner.RunPrivate(fmt.Sprintf("cat <<EOF | sudo tee /var/lib/kubelet/config.json\n%s\nEOF", pullSec))
+	err := sshRunner.SetTextContentAsRoot("/var/lib/kubelet/config.json", pullSec, 0644)
 	if err != nil {
 		return err
 	}

--- a/pkg/crc/machine/cert-renewal.go
+++ b/pkg/crc/machine/cert-renewal.go
@@ -180,7 +180,7 @@ func RegenerateCertificates(sshRunner *ssh.SSHRunner, machineName string) error 
 		return err
 	}
 	/* Copy the ca-bundle data we just read to etc/kubernetes/kubelet-ca.crt */
-	_, err = sshRunner.Run(fmt.Sprintf("cat <<EOF | sudo tee /etc/kubernetes/kubelet-ca.crt\n%s\nEOF", output))
+	err = sshRunner.SetTextContentAsRoot("/etc/kubernetes/kubelet-ca.crt", output, 0644)
 	if err != nil {
 		logging.Debugf("Error writing kubelet client CA to /etc/kubernetes/kubelet-ca.crt: %v", err)
 		return err

--- a/pkg/crc/ssh/ssh.go
+++ b/pkg/crc/ssh/ssh.go
@@ -2,6 +2,8 @@ package ssh
 
 import (
 	"fmt"
+	"os"
+
 	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/code-ready/crc/pkg/crc/logging"
 	"github.com/code-ready/machine/libmachine/drivers"
@@ -23,6 +25,14 @@ func CreateRunnerWithPrivateKey(driver drivers.Driver, privateKey string) *SSHRu
 // Create a host using the driver's config
 func (runner *SSHRunner) Run(command string) (string, error) {
 	return runner.runSSHCommandFromDriver(command, false)
+}
+
+func (runner *SSHRunner) SetTextContentAsRoot(destFilename string, content string, mode os.FileMode) error {
+	logging.Debugf("Creating %s with permissions 0%o in the CRC VM", destFilename, mode)
+	command := fmt.Sprintf("sudo install -m 0%o /dev/null %s && cat <<EOF | sudo tee %s\n%s\nEOF", mode, destFilename, destFilename, content)
+	_, err := runner.RunPrivate(command)
+
+	return err
 }
 
 func (runner *SSHRunner) RunPrivate(command string) (string, error) {


### PR DESCRIPTION
oc logs  -n openshift-machine-config-operator
machine-config-daemon-5t5sj -c machine-config-daemon

E0217 20:22:13.809612    4901 daemon.go:1341] mode mismatch for file:
"/var/lib/kubelet/config.json"; expected: -rw-------; received:
-rw-r--r--

This fixes https://github.com/code-ready/crc/issues/1015