### PR TITLE
Add proxy setting to ingress and image registry operators

### DIFF
--- a/pkg/crc/machine/machine.go
+++ b/pkg/crc/machine/machine.go
@@ -815,11 +815,6 @@ func configProxyForCluster(ocConfig oc.OcConfig, sshRunner *crcssh.SSHRunner, sd
 		return err
 	}
 
-	logging.Info("Adding proxy configuration to operators ...")
-	if err := cluster.AddProxyConfigToDeployments(ocConfig, proxy); err != nil {
-		return err
-	}
-
 	logging.Info("Adding proxy configuration to kubelet and crio service ...")
 	if err := cluster.AddProxyToKubeletAndCriO(sshRunner, proxy); err != nil {
 		return err

--- a/pkg/crc/machine/machine.go
+++ b/pkg/crc/machine/machine.go
@@ -815,8 +815,8 @@ func configProxyForCluster(ocConfig oc.OcConfig, sshRunner *crcssh.SSHRunner, sd
 		return err
 	}
 
-	logging.Info("Adding proxy configuration to marketplace operator ...")
-	if err := cluster.AddProxyConfigToMarketplaceOperator(ocConfig, proxy); err != nil {
+	logging.Info("Adding proxy configuration to operators ...")
+	if err := cluster.AddProxyConfigToDeployments(ocConfig, proxy); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
After some investigations with tcpconnect, I noticed these operators/pods have an inject-proxy annotation and are not using the proxy setting in crc