### PR TITLE
Issue #1013: Check resolved IP in CheckCRCLocalDNSReachableFromHost

### DIFF
--- a/pkg/crc/machine/machine.go
+++ b/pkg/crc/machine/machine.go
@@ -322,8 +322,7 @@ func Start(startConfig StartConfig) (StartResult, error) {
 
 	// Check DNS lookup from host to VM
 	logging.Info("Check DNS query from host ...")
-	if err := network.CheckCRCLocalDNSReachableFromHost(crcBundleMetadata.ClusterInfo.ClusterName,
-		crcBundleMetadata.ClusterInfo.BaseDomain, crcBundleMetadata.ClusterInfo.AppsDomain); err != nil {
+	if err := network.CheckCRCLocalDNSReachableFromHost(crcBundleMetadata, instanceIP); err != nil {
 		result.Error = err.Error()
 		return *result, errors.Newf("Failed to query DNS from host: %v", err)
 	}


### PR DESCRIPTION
CheckCRCLocalDNSReachableFromHost checks that the api.crc.testing and
foo.apps-crc.testing hostnames can be resolved, but it does not check
this returns the IP of the VM. This commit adds an additional check
that the resolved IP matches the IP of the VM as this could help crc
detect some host misconfigurations early.

This resolves https://github.com/code-ready/crc/issues/1013

I've only tested this on linux.