### PR TITLE
Issue #149 Document configuration

### DIFF
--- a/docs/source/getting_started/content/assembly_configuring-codeready-containers.adoc
+++ b/docs/source/getting_started/content/assembly_configuring-codeready-containers.adoc
@@ -1,0 +1,8 @@
+[id="configuring-codeready-containers_{context}"]
+= Configuring {prod}
+
+include::con_about-codeready-containers-configuration.adoc[leveloffset=+1]
+
+include::proc_viewing-codeready-containers-configuration.adoc[leveloffset=+1]
+
+include::proc_configuring-the-virtual-machine.adoc[leveloffset=+1]

--- a/docs/source/getting_started/content/con_about-codeready-containers-configuration.adoc
+++ b/docs/source/getting_started/content/con_about-codeready-containers-configuration.adoc
@@ -1,0 +1,12 @@
+[id="about-codeready-containers-configuration_{context}"]
+= About {prod} configuration
+
+You can use the [command]`{bin} config` command to configure both the [command]`{bin}` binary and the {prod} virtual machine.
+The [command]`{bin} config` command requires a subcommand to act on the configuration.
+The available subcommands are `get`, `set,` `unset`, and `view`.
+The `get`, `set`, and `unset` subcommands operate on named configurable properties.
+Run the [command]`{bin} config --help` command to list the available properties.
+
+You can also use the [command]`{bin} config` command to configure the behavior of the startup checks for the [command]`{bin} start` and [command]`{bin} setup` commands.
+By default, startup checks report an error and stop execution when their conditions are not met.
+To change this behavior, set the value of a property starting with `skip-check` or `warn-check` to `true` to skip the check or report a warning rather than an error, respectively.

--- a/docs/source/getting_started/content/proc_configuring-the-virtual-machine.adoc
+++ b/docs/source/getting_started/content/proc_configuring-the-virtual-machine.adoc
@@ -1,0 +1,52 @@
+[id="configuring-the-virtual-machine_{context}"]
+= Configuring the virtual machine
+
+Use the `cpus` and `memory` properties to configure the default number of vCPUs and amount of memory available to the {prod} virtual machine, respectively.
+
+[IMPORTANT]
+====
+You cannot modify the configuration of an existing {prod} virtual machine.
+To enable configuration changes, you must delete the existing virtual machine and create a new one.
+
+To create the new virtual machine, first delete the existing {prod} virtual machine, then start a new virtual machine with the configuration changes:
+
+[subs="+quotes,attributes"]
+----
+$ {bin} delete
+$ {bin} start
+----
+====
+
+[WARNING]
+====
+The [command]`{bin} delete` command results in the loss of data stored in the {prod} virtual machine.
+Save any desired information stored in the virtual machine before running this command.
+====
+
+.Procedure
+
+* To increase the number of vCPUs available to the virtual machine:
++
+[subs="+quotes,attributes"]
+----
+$ {bin} config set cpus _<number>_
+----
++
+The default value for the `cpus` property is `4`.
+The number of vCPUs to allocate must be greater than or equal to the default.
+
+* To increase the memory available to the virtual machine:
++
+[subs="+quotes,attributes"]
+----
+$ {bin} config set memory _<number-in-mib>_
+----
++
+[NOTE]
+====
+Values for available memory must be supplied in mebibytes (MiB).
+One gibibyte (GiB) of memory is equal to 1024 MiB.
+====
++
+The default value for the `memory` property is `8192`.
+The amount of memory to allocate must be greater than or equal to the default.

--- a/docs/source/getting_started/content/proc_viewing-codeready-containers-configuration.adoc
+++ b/docs/source/getting_started/content/proc_viewing-codeready-containers-configuration.adoc
@@ -1,0 +1,32 @@
+[id="viewing-codeready-containers-configuration_{context}"]
+= Viewing {prod} configuration
+
+The {prod} binary provides commands to view configurable properties and the current {prod} configuration.
+
+.Procedure
+
+* To view the available configurable properties:
++
+[subs="+quotes,attributes"]
+----
+$ {bin} config --help
+----
+
+* To view the values for a configurable property:
++
+[subs="+quotes,attributes"]
+----
+$ {bin} config get _<property>_
+----
+
+* To view the complete current configuration:
++
+[subs="+quotes,attributes"]
+----
+$ {bin} config view
+----
++
+[NOTE]
+====
+The [command]`{bin} config view` command does not return any information if the configuration consists of default values.
+====

--- a/docs/source/getting_started/content/snip_crc-delete.adoc
+++ b/docs/source/getting_started/content/snip_crc-delete.adoc
@@ -5,6 +5,6 @@ $ {bin} delete
 +
 [WARNING]
 ====
-The [command]`{bin} delete` command will result in the loss of data stored in the {prod} virtual machine.
-Save any desired instance information before running this command.
+The [command]`{bin} delete` command results in the loss of data stored in the {prod} virtual machine.
+Save any desired information stored in the virtual machine before running this command.
 ====

--- a/docs/source/getting_started/master.adoc
+++ b/docs/source/getting_started/master.adoc
@@ -10,6 +10,8 @@ include::content/assembly_installation.adoc[leveloffset=+1]
 
 include::content/assembly_using-codeready-containers.adoc[leveloffset=+1]
 
+include::content/assembly_configuring-codeready-containers.adoc[leveloffset=+1]
+
 include::content/assembly_networking.adoc[leveloffset=+1]
 
 include::content/assembly_administrative-tasks.adoc[leveloffset=+1]


### PR DESCRIPTION
This PR primarily documents configuring the virtual machine, as that procedure requires more steps than general configuration (which is simply `crc config set <property>`).

The documentation for configuration in general is intentionally non-specific. We guide the reader as to how to view the current configuration and modify it, but do not list the configurable properties. These can be discovered via `crc config --help`, and not listing them explicitly removes a potential maintenance concern.

Configuration of preflight checks for the `crc start` command are also briefly mentioned.