### PR TITLE
Issue #747 Enable sha256sum check for disk image

### DIFF
--- a/pkg/crc/machine/bundle/metadata.go
+++ b/pkg/crc/machine/bundle/metadata.go
@@ -42,8 +42,10 @@ type CrcBundleInfo struct {
 	} `json:"nodes"`
 	Storage struct {
 		DiskImages []struct {
-			Name   string `json:"name"`
-			Format string `json:"format"`
+			Name      string `json:"name"`
+			Format    string `json:"format"`
+			Size      string `json:"size"`
+			Sha256sum string `json:"sha256sum"`
 		} `json:"diskImages"`
 	} `json:"storage"`
 	cachedPath string
@@ -145,4 +147,8 @@ func (bundle *CrcBundleInfo) GetBundleBuildTime() (time.Time, error) {
 
 func (bundle *CrcBundleInfo) GetOpenshiftVersion() string {
 	return bundle.ClusterInfo.OpenShiftVersion
+}
+
+func (bundle *CrcBundleInfo) GetSha256sumOfDisk() string {
+	return bundle.Storage.DiskImages[0].Sha256sum
 }


### PR DESCRIPTION
As of now there is no way to verify if the extracted disk image
is in sane condition or corupted. Using this patch now we can
match the sha256sum which is part of our bundle metadata to actual
disk image sha256sum and let user know if there is mismatch.