### PR TITLE
Issue #1024 Integration: Add basic daemon test

### DIFF
--- a/test/integration/features/story_daemon.feature
+++ b/test/integration/features/story_daemon.feature
@@ -1,14 +1,14 @@
 @story_daemon @darwin @linux @windows
 Feature: CRC daemon
 
-    User starts the CRC daemon and performs basic operations: start, stop, delete, and status.
+    User starts the CRC daemon and performs basic operations: start,
+    stop, delete, and status.
 
     Scenario: Prepare
         When setting config property "pull-secret-file" to value "default pull secret" succeeds
         Then "JSON" config file "crc.json" in CRC home folder contains key "pull-secret-file"
-        When executing "crc setup" succeeds
+        When executing "crc setup --enable-environmental-features" succeeds
         Then stdout should contain "Setup is complete"
-        And executing "crc daemon &" succeeds
 
     Scenario: 'Version' command
         Then sending "version" command to daemon succeeds

--- a/test/integration/features/story_daemon.feature
+++ b/test/integration/features/story_daemon.feature
@@ -1,0 +1,101 @@
+@story_daemon @darwin @linux @windows
+Feature: CRC daemon
+
+    User starts the CRC daemon and performs basic operations: start, stop, delete, and status.
+
+    Scenario: Prepare
+        When setting config property "pull-secret-file" to value "default pull secret" succeeds
+        Then "JSON" config file "crc.json" in CRC home folder contains key "pull-secret-file"
+        When executing "crc setup" succeeds
+        Then stdout should contain "Setup is complete"
+        And executing "crc daemon &" succeeds
+
+    Scenario: 'Version' command
+        Then sending "version" command to daemon succeeds
+
+    Scenario Outline: Answer to 'version' command
+        Then "JSON" config file "answer.json" in CRC home folder contains key "<key>" with value matching "<value>"
+
+        Examples:
+
+            | key              | value           |
+            | Success          | true            |
+            | CrcVersion       | \d+\.\d+\.\d+.* |
+            | OpenshiftVersion | \d+\.\d+\.\d+.* |
+            | CommitSha        | [A-Za-z0-9]{7}  |
+
+
+    Scenario: 'Start' command via daemon
+        Given sending "start" command to daemon succeeds
+
+    Scenario Outline: Answer to 'start' command
+        Then "JSON" config file "answer.json" in CRC home folder contains key "<key>" with value matching "<value>"
+
+        Examples:
+
+            | key            | value   |
+            | Name           | crc     |
+            | KubeletStarted | true    |
+
+    Scenario: 'Status' command via daemon with CRC running
+        Given sending "status" command to daemon succeeds
+
+    Scenario Outline: Answer to 'status' command with CRC running
+        Then "JSON" config file "answer.json" in CRC home folder contains key "<key>" with value matching "<value>"
+
+        Examples:  
+
+            | key             | value                       |
+            | Name            | crc                         |
+            | CrcStatus       | Running                     |
+            | OpenshiftStatus | Running\ \(v\d+\.\d+\.\d+\) |
+            | DiskUse         | \d+                         |
+            | DiskSize        | \d+                         |
+            | Success         | true                        |
+
+    Scenario: 'Stop' via daemon
+        Given sending "stop" command to daemon succeeds
+
+    Scenario Outline: Answer to 'stop' command
+       Then "JSON" config file "answer.json" in CRC home folder contains key "<key>" with value matching "<value>"
+
+        Examples:  
+
+            | key     | value |
+            | Name    | crc   |
+            | Success | true  |
+            | State   | 1     |
+
+    Scenario: 'Status' via daemon with CRC stopped
+        Given sending "status" command to daemon succeeds
+
+    Scenario Outline: Answer to 'status' command with CRC stopped
+       Then "JSON" config file "answer.json" in CRC home folder contains key "<key>" with value matching "<value>"
+
+        Examples:  
+
+            | key             | value   |
+            | Name            | crc     |
+            | CrcStatus       | Stopped |
+            | OpenshiftStatus | Stopped |
+            | DiskSize        | 0       |
+            | DiskUse         | 0       |
+            | Success         | true    |
+
+    Scenario: 'Delete' via daemon
+        Given sending "delete" command to daemon succeeds
+
+    Scenario Outline: Answer to 'delete' command
+       Then "JSON" config file "answer.json" in CRC home folder contains key "<key>" with value matching "<value>"
+
+        Examples:  
+
+            | key             | value   |
+            | Name            | crc     |
+            | Success         | true    |
+
+
+    Scenario: Kill daemon
+        When executing "killall crc" succeeds
+
+# NOTE: answer.json remains in ~/.crc after this feature, delete? no need? 

--- a/test/integration/features/story_marketplace.feature
+++ b/test/integration/features/story_marketplace.feature
@@ -8,7 +8,7 @@ Feature:
         Given executing "crc setup" succeeds
         When starting CRC with default bundle succeeds
         Then stdout should contain "Started the OpenShift cluster"
-        When with up to "8" retries with wait period of "2m" command "crc status" output matches ".*Running \(v\d+\.\d+\.\d+.*\).*"
+        When with up to "8" retries with wait period of "2m" command "crc status --log-level debug" output matches ".*Running \(v\d+\.\d+\.\d+.*\).*"
         Then executing "eval $(crc oc-env)" succeeds
         And login to the oc cluster succeeds
 


### PR DESCRIPTION
Add test feature to verify basic crc daemon functionality. This is a prerequisite to a functioning system tray on MacOS and Windows. 

Fixes: #1024 

## Solution/Idea
1. Feature file will specify which CRC command to use.
2. `SendingCommandToDaemonSucceeds` function opens a connection to the socket and calls a `SockReader` go routine. It then sends commands to the daemon via `connection.Write` and waits for the `SockReader` routine to finish. Success/failure of `SendingCommandToDaemonSucceeds` says nothing about the success/failure of the CRC command itself.
3. `SockReader` routine decodes the message from the daemon and stores it in `~/.crc/answer.json` file (location arbitrary, no reason for it).
4. Next step in the feature then checks the content of the JSON answer file according to examples in `Scenario Outline`. 

## Proposed changes
1. Add `story_daemon.feature`.
2. Add `SendingCommandToDaemonSucceeds` function.
3. Add `SockReader` helper function.
4. Add JSON answer structs.

## Testing
1. Only works with CRC binary with embedded bundle (or place bundle into `~/.crc/cache/`and run with unembedded binary - not actually tried!). 
2. Modify L126-134 to contain `--bundle-location=embedded` and `--godog.tags='@daemon'`, with the correct location of your pull-secret file.
3. Run `make integration` (it should only run `story_daemon.feature` file).

## Disclaimer
Does not work on Windows as of now. Other platforms OK.