### PR TITLE
Enable size check for disk image

### DIFF
--- a/pkg/crc/machine/machine.go
+++ b/pkg/crc/machine/machine.go
@@ -136,6 +136,12 @@ func Start(startConfig StartConfig) (StartResult, error) {
 			return *result, errors.Newf("Error getting bundle metadata: %v", err)
 		}
 
+		logging.Infof("Checking size of the disk image %s ...", crcBundleMetadata.GetDiskImagePath())
+		if err := crcBundleMetadata.CheckDiskImageSize(); err != nil {
+			result.Error = err.Error()
+			return *result, errors.Newf("Invalid bundle disk image '%s', %v", crcBundleMetadata.GetDiskImagePath(), err)
+		}
+
 		openshiftVersion := crcBundleMetadata.GetOpenshiftVersion()
 		if openshiftVersion == "" {
 			logging.Infof("Creating VM...")


### PR DESCRIPTION
As of now there is no way to verify if the extracted disk image
is in sane condition or corupted. Using this patch now we can
match the size which is part of our bundle metadata to actual
disk image size and let user know if there is mismatch.