### PR TITLE
Issue #1041 Add intermediate `Starting` status for the cluster

### DIFF
--- a/pkg/crc/machine/machine.go
+++ b/pkg/crc/machine/machine.go
@@ -582,6 +582,10 @@ func Status(statusConfig ClusterStatusConfig) (ClusterStatusResult, error) {
 				openshiftVersion = crcBundleMetadata.GetOpenshiftVersion()
 			}
 			openshiftStatus = fmt.Sprintf("Running (v%s)", openshiftVersion)
+		} else if operatorsStatus.Degraded {
+			openshiftStatus = fmt.Sprintf("Degraded")
+		} else if operatorsStatus.Progressing {
+			openshiftStatus = fmt.Sprintf("Starting")
 		}
 		sshRunner := crcssh.CreateRunner(host.Driver)
 		diskSize, diskUse, err = cluster.GetRootPartitionUsage(sshRunner)

--- a/pkg/crc/machine/machine.go
+++ b/pkg/crc/machine/machine.go
@@ -567,13 +567,13 @@ func Status(statusConfig ClusterStatusConfig) (ClusterStatusResult, error) {
 
 		// check if all the clusteroperators are running
 		ocConfig := oc.UseOCWithConfig(statusConfig.Name)
-		operatorsRunning, err := oc.GetClusterOperatorStatus(ocConfig)
+		operatorsStatus, err := oc.GetClusterOperatorStatus(ocConfig)
 		if err != nil {
 			result.Success = false
 			result.Error = err.Error()
 			return *result, errors.New(err.Error())
 		}
-		if operatorsRunning {
+		if operatorsStatus.Available {
 			openshiftVersion := "4.x"
 			_, crcBundleMetadata, err := getBundleMetadataFromDriver(host.Driver)
 			if err != nil {

--- a/test/integration/crcsuite/crcsuite.go
+++ b/test/integration/crcsuite/crcsuite.go
@@ -186,7 +186,7 @@ func CheckClusterOperatorsWithRetry(retryCount int, retryWait string) error {
 		if err != nil {
 			return err
 		}
-		if s == true {
+		if s.Available == true {
 			return nil
 		}
 		time.Sleep(retryDuration)


### PR DESCRIPTION
When starting CRC, some of the operators don't available even
after 3 min wait. A user who execute `crc status` sees openshift status
as stopped which is confusing since cluster is not completely stopped
but waiting for some of operators to be available. After this change, user
can see `Starting` as status.

```
$crc status
CRC VM:          Running
OpenShift:       Starting
Disk Usage:      10.11GB of 32.2GB (Inside the CRC VM)
Cache Usage:     22.99GB
Cache Directory: /home/prkumar/.crc/cache
```