### PR TITLE
Issue #1066 Remove call to logging.Fatal from machine.Start

### DIFF
--- a/pkg/crc/machine/machine.go
+++ b/pkg/crc/machine/machine.go
@@ -185,8 +185,11 @@ func Start(startConfig StartConfig) (StartResult, error) {
 			return *result, errors.Newf("Error loading bundle metadata: %v", err)
 		}
 		if bundleName != filepath.Base(startConfig.BundlePath) {
-			logging.Fatalf("Bundle '%s' was requested, but the existing VM is using '%s'",
+			logging.Debugf("Bundle '%s' was requested, but the existing VM is using '%s'",
 				filepath.Base(startConfig.BundlePath), bundleName)
+			result.Error = fmt.Sprintf("Bundle '%s' was requested, but the existing VM is using '%s'",
+				filepath.Base(startConfig.BundlePath), bundleName)
+			return *result, errors.New(result.Error)
 		}
 		vmState, err := host.Driver.GetState()
 		if err != nil {


### PR DESCRIPTION
In case of the daemon, we don't want an error in machine.Start()
to exit the daemon process, logging.Fatal calls os.Exit which
kills the process