### PR TITLE
Remove openshift-marketplace operator proxy settings

### DIFF
--- a/pkg/crc/machine/machine.go
+++ b/pkg/crc/machine/machine.go
@@ -820,11 +820,6 @@ func configProxyForCluster(ocConfig oc.OcConfig, sshRunner *crcssh.SSHRunner, sd
 		return err
 	}
 
-	logging.Info("Adding proxy configuration to marketplace operator ...")
-	if err := cluster.AddProxyConfigToMarketplaceOperator(ocConfig, proxy); err != nil {
-		return err
-	}
-
 	logging.Info("Adding proxy configuration to kubelet and crio service ...")
 	if err := cluster.AddProxyToKubeletAndCriO(sshRunner, proxy); err != nil {
 		return err


### PR DESCRIPTION
Since we are now using a bundle with the cluster-version-operator (CVO)
enabled, crc no longer needs to propagate the proxy settings itself as
CVO does it for the deployments with the `inject-proxy` annotation.

This reverts commits 8674e3, 75414b and f8441b