### PR TITLE
Add GetPodmanUrlForOs to get OS specific tarball for embedder

### DIFF
--- a/cmd/crc-embedder/cmd/embed.go
+++ b/cmd/crc-embedder/cmd/embed.go
@@ -91,7 +91,7 @@ var (
 			hyperkit.HyperkitDownloadUrl,
 			constants.GetOcUrlForOs("darwin"),
 			constants.GetCrcTrayDownloadURL(),
-			constants.GetPodmanUrl(),
+			constants.GetPodmanUrlForOs("darwin"),
 		},
 		"linux": []string{
 			libvirt.MachineDriverDownloadUrl,

--- a/pkg/crc/constants/constants.go
+++ b/pkg/crc/constants/constants.go
@@ -55,6 +55,10 @@ var PodmanUrlForOs = map[string]string{
 	"windows": fmt.Sprintf("%s/%s", DefaultPodmanUrlBase, "podman-remote-latest-master-windows-amd64.zip"),
 }
 
+func GetPodmanUrlForOs(os string) string {
+	return PodmanUrlForOs[os]
+}
+
 func GetPodmanUrl() string {
 	return PodmanUrlForOs[runtime.GOOS]
 }

--- a/pkg/crc/constants/constants.go
+++ b/pkg/crc/constants/constants.go
@@ -49,18 +49,18 @@ func GetOcUrl() string {
 	return GetOcUrlForOs(runtime.GOOS)
 }
 
-var PodmanUrlForOs = map[string]string{
+var podmanUrlForOs = map[string]string{
 	"darwin":  fmt.Sprintf("%s/%s", DefaultPodmanUrlBase, "podman-remote-latest-master-darwin-amd64.zip"),
 	"linux":   fmt.Sprintf("%s/%s", DefaultPodmanUrlBase, "podman-remote-latest-master-linux---amd64.zip"),
 	"windows": fmt.Sprintf("%s/%s", DefaultPodmanUrlBase, "podman-remote-latest-master-windows-amd64.zip"),
 }
 
 func GetPodmanUrlForOs(os string) string {
-	return PodmanUrlForOs[os]
+	return podmanUrlForOs[os]
 }
 
 func GetPodmanUrl() string {
-	return PodmanUrlForOs[runtime.GOOS]
+	return podmanUrlForOs[runtime.GOOS]
 }
 
 var defaultBundleForOs = map[string]string{


### PR DESCRIPTION
Currently `GetPodmanUrl()` return the url of running OS since we are
building embedded bits on linux so it always taking linux podman tarball
instead OS specific.

```
$ make release
[...]
out/linux-amd64/crc-dddembedder embed --log-level debug --goos=darwin --bundle-dir=bundle out/macos-amd64/crc
level=debug msg="Downloading https://github.com/code-ready/tray-macos/releases/download/v1.0.0-alpha.3/crc-tray-macos.tar.gz to /tmp/crc-embedder258918553"
level=debug msg="Download saved to /tmp/crc-embedder258918553/crc-tray-macos.tar.gz"
level=debug msg="Downloading https://storage.googleapis.com/libpod-master-releases/podman-remote-latest-master-linux---amd64.zip to /tmp/crc-embedder258918553"
level=debug msg="Download saved to /tmp/crc-embedder258918553/podman-remote-latest-master-linux---amd64.zip"
```