### PR TITLE
Issue #1099 Separate error message for instance and config removal

### DIFF
--- a/pkg/crc/machine/machine.go
+++ b/pkg/crc/machine/machine.go
@@ -501,15 +501,18 @@ func Delete(deleteConfig DeleteConfig) (DeleteResult, error) {
 	}
 	defer libMachineAPIClient.Close()
 
-	m := errors.MultiError{}
-	m.Collect(host.Driver.Remove())
-	m.Collect(libMachineAPIClient.Remove(deleteConfig.Name))
-
-	if len(m.Errors) != 0 {
+	if err := host.Driver.Remove(); err != nil {
 		result.Success = false
-		result.Error = m.ToError().Error()
-		return *result, errors.New(m.ToError().Error())
+		result.Error = err.Error()
+		return *result, errors.New(err.Error())
 	}
+
+	if err := libMachineAPIClient.Remove(deleteConfig.Name); err != nil {
+		result.Success = false
+		result.Error = err.Error()
+		return *result, errors.New(err.Error())
+	}
+
 	return *result, nil
 }
 


### PR DESCRIPTION
Error from `host.Driver.Remove()` and `libMachineAPIClient.Remove(deleteConfig.Name)`
shouldn't be collected together because if there is an deleting the instance then error
is just passed to error collector and config files are removed.

```
$ ./crc delete
Do you want to delete the OpenShift cluster? [y/N]: y
ERRO Driver "libvirt" not found. Do you have the plugin binary accessible in your PATH?

$ ./crc delete
Machine 'crc' does not exist. Use 'crc start' to create it.

$ sudo virsh list
 Id   Name   State
----------------------
 3    crc    running
```