### PR TITLE
Issue #1060 Add admin context to oc runner

### DIFF
--- a/pkg/crc/constants/constants.go
+++ b/pkg/crc/constants/constants.go
@@ -33,6 +33,7 @@ const (
 	DefaultOcUrlBase     = "https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest"
 	DefaultPodmanUrlBase = "https://storage.googleapis.com/libpod-master-releases"
 	CrcTrayDownloadURL   = "https://github.com/code-ready/tray-macos/releases/download/v%s/crc-tray-macos.tar.gz"
+	DefaultContext       = "admin"
 )
 
 var ocUrlForOs = map[string]string{

--- a/pkg/crc/machine/cert-renewal.go
+++ b/pkg/crc/machine/cert-renewal.go
@@ -147,7 +147,7 @@ func RegenerateCertificates(sshRunner *ssh.SSHRunner, machineName string) error 
 	}
 	defer recoveryPod.runPodCommand("recovery-apiserver destroy") //nolint:errcheck
 
-	oc := oc.NewOcConfig(recoveryPod)
+	oc := oc.NewOcConfig(recoveryPod, "admin", "recovery")
 	err = waitForRecoveryPod(oc)
 	if err != nil {
 		logging.Debugf("Error waiting for recovery apiserver to come up: %v", err)

--- a/pkg/crc/oc/oc.go
+++ b/pkg/crc/oc/oc.go
@@ -19,7 +19,9 @@ type OcRunner interface {
 }
 
 type OcConfig struct {
-	runner OcRunner
+	runner  OcRunner
+	Context string
+	Cluster string
 }
 
 type OcLocalRunner struct {
@@ -45,21 +47,25 @@ func UseOCWithConfig(machineName string) OcConfig {
 		OcBinaryPath:   filepath.Join(constants.CrcBinDir, constants.OcBinaryName),
 		KubeconfigPath: filepath.Join(constants.MachineInstanceDir, machineName, "kubeconfig"),
 	}
-	return NewOcConfig(localRunner)
+	return NewOcConfig(localRunner, constants.DefaultContext, constants.DefaultName)
 }
 
 func (oc OcConfig) RunOcCommand(args ...string) (string, string, error) {
-	args = append(args, "--kubeconfig", oc.runner.GetKubeconfigPath())
+	args = append(args, "--kubeconfig", oc.runner.GetKubeconfigPath(), "--context", oc.Context, "--cluster", oc.Cluster)
 	return oc.runner.Run(args...)
 }
 
 func (oc OcConfig) RunOcCommandPrivate(args ...string) (string, string, error) {
-	args = append(args, "--kubeconfig", oc.runner.GetKubeconfigPath())
+	args = append(args, "--kubeconfig", oc.runner.GetKubeconfigPath(), "--context", oc.Context, "--cluster", oc.Cluster)
 	return oc.runner.RunPrivate(args...)
 }
 
-func NewOcConfig(runner OcRunner) OcConfig {
-	return OcConfig{runner: runner}
+func NewOcConfig(runner OcRunner, context string, clusterName string) OcConfig {
+	return OcConfig{
+		runner:  runner,
+		Context: context,
+		Cluster: clusterName,
+	}
 }
 
 func (oc OcConfig) WaitForOpenshiftResource(resource string) error {


### PR DESCRIPTION
If a user by mistake do following then the kubeconfig file which is part
of the bundle gets another entry for context and also current context
sets to a different cluster.

```
$ export KUBECONFIG=~/.crc/cache/<bundle>/kubeconfig
$ run kind <= way to deploy a single cluster
-- Check the contexts of the kubeconfig file --
$ oc config get-contexts  --kubeconfig ~/.crc/cache/<bundle>/kubeconfig
CURRENT   NAME                                      CLUSTER                AUTHINFO                          NAMESPACE
          admin                                     crc                    admin
          default/api-crc-testing:6443/kube:admin   api-crc-testing:6443   kube:admin/api-crc-testing:6443   default
*         kind-kind                                 kind-kind              kind-kind
```

With this kubeconfig file, if a user tries to run the crc cluster then
he might get something following.
```
Unable to connect to the server: x509: certificate signed by unknown authority (possibly because
of \"crypto/rsa: verification error\" while trying to verify candidate authority certificate \"kubernetes\")"
```

This patch make sure each oc command run use `admin` context which is default for crc cluster.