### PR TITLE
#1102 Make clear-cache work when there is no existing crc vm

### DIFF
--- a/cmd/crc/cmd/delete.go
+++ b/cmd/crc/cmd/delete.go
@@ -35,11 +35,12 @@ func runDelete(arguments []string) {
 		Name: constants.DefaultName,
 	}
 
-	exitIfMachineMissing(deleteConfig.Name)
-
 	if clearCache {
 		deleteCache()
 	}
+
+	exitIfMachineMissing(deleteConfig.Name)
+
 	yes := input.PromptUserForYesOrNo("Do you want to delete the OpenShift cluster", globalForce)
 	if yes {
 		_, err := machine.Delete(deleteConfig)


### PR DESCRIPTION
`crc delete --clear cache` did not work when there was no existing
vm, moved the vm exists check to after we check and perform if cache
needs to be cleared.

Fixes #1102 