### PR TITLE
Issue #1127 Remove Windows 10 Home docs as supported edition

### DIFF
--- a/docs/source/getting_started/content/ref_minimum-system-requirements.adoc
+++ b/docs/source/getting_started/content/ref_minimum-system-requirements.adoc
@@ -25,7 +25,7 @@ Some workloads may require more resources.
 
 === {msw}
 
-* On {msw}, {prod} requires the Windows 10 (Pro or Home) Fall Creators Update (version 1709).
+* On {msw}, {prod} requires the Windows 10 Pro Fall Creators Update (version 1709).
 {prod} does not work on earlier versions or editions of {msw}.
 
 === {mac}


### PR DESCRIPTION
Hyper-V is not available on this edition of Windows.


**Fixes:** Issue #1127