### PR TITLE
Make tray setup work when agents are removed and setup is ran from a different crc binary

### DIFF
--- a/pkg/crc/preflight/preflight_check_tray_darwin.go
+++ b/pkg/crc/preflight/preflight_check_tray_darwin.go
@@ -79,6 +79,9 @@ func checkIfDaemonAgentRunning() error {
 }
 
 func fixDaemonAgentRunning() error {
+	if err := launchd.LoadPlist(daemonAgentLabel); err != nil {
+		return err
+	}
 	return launchd.StartAgent(daemonAgentLabel)
 }
 
@@ -90,6 +93,9 @@ func checkIfTrayAgentRunning() error {
 }
 
 func fixTrayAgentRunning() error {
+	if err := launchd.LoadPlist(trayAgentLabel); err != nil {
+		return err
+	}
 	return launchd.StartAgent(trayAgentLabel)
 }
 

--- a/pkg/crc/preflight/preflight_check_tray_darwin.go
+++ b/pkg/crc/preflight/preflight_check_tray_darwin.go
@@ -86,6 +86,7 @@ func checkIfDaemonAgentRunning() error {
 }
 
 func fixDaemonAgentRunning() error {
+	logging.Debug("Starting daemon agent")
 	if err := launchd.LoadPlist(daemonAgentLabel); err != nil {
 		return err
 	}
@@ -100,6 +101,7 @@ func checkIfTrayAgentRunning() error {
 }
 
 func fixTrayAgentRunning() error {
+	logging.Debug("Starting tray agent")
 	if err := launchd.LoadPlist(trayAgentLabel); err != nil {
 		return err
 	}
@@ -130,6 +132,7 @@ func checkTrayVersion() error {
 }
 
 func fixTrayVersion() error {
+	logging.Debug("Downloading/extracting tray binary")
 	// get the tray app
 	err := downloadOrExtractTrayApp()
 	if err != nil {
@@ -146,6 +149,7 @@ func checkTrayBinaryPresent() error {
 }
 
 func fixTrayBinaryPresent() error {
+	logging.Debug("Downloading/extracting tray binary")
 	return downloadOrExtractTrayApp()
 }
 

--- a/pkg/crc/preflight/preflight_check_tray_darwin.go
+++ b/pkg/crc/preflight/preflight_check_tray_darwin.go
@@ -35,13 +35,20 @@ type TrayVersion struct {
 }
 
 func checkIfDaemonPlistFileExists() error {
-	if !launchd.PlistExists(daemonAgentLabel) {
-		return fmt.Errorf("Daemon plist file does not exist")
-	}
-	return nil
+	// crc setup can be ran from any location in the
+	// users computer, and we need to update the plist
+	// file with the path of the crc binary which was
+	// used to run setup, to force it this check needs
+	// to always fail so the fix routine is triggered
+
+	return fmt.Errorf("Ignoring this check and triggering creation of daemon plist")
 }
 
 func fixDaemonPlistFileExists() error {
+	// Try to remove the daemon agent from launchd
+	// and recreate its plist
+	_ = launchd.Remove(daemonAgentLabel)
+
 	currentExecutablePath, err := goos.Executable()
 	if err != nil {
 		return err

--- a/pkg/os/launchd/launchd_darwin.go
+++ b/pkg/os/launchd/launchd_darwin.go
@@ -128,3 +128,8 @@ func AgentRunning(label string) bool {
 	}
 	return false
 }
+
+// Remove removes the agent from launchd
+func Remove(label string) error {
+	return exec.Command("launchctl", "remove", label).Run() // #nosec G204
+}


### PR DESCRIPTION
**Fixes:** Issue #1140 #1141 

## Solution/Idea

1. When daemon/tray agent is removed using the `launchctl remove` command, `crc setup` was unable to restart it, since the plist file was removed and running `launchctl start` requires the agent to be loaded, therefore we load the agent plist before trying to start it as part of preflight check.
2. When the plist file already exists `crc setup` wouldn't recreate the daemon plist file with the current crc binary's path, so we make the `DaemonPlistFileExists` check to always fail and trigger the recreation of the plist file whenever setup is ran.

## Proposed changes
1. Load plist before starting it
2. Improve `launchd.AgentRunning` function to handle when an agent is removed from launchd
3. Force creation of daemon plist every time `crc setup` is ran

## Testing

1. run `launchctl remove crc.tray; launchctl remove crc.daemon`
2. Now when `crc setup --enable-experimental-fetures` is ran you should have a working tray
3. Download an older version of crc (1.6.0) and enable the tray using `crc setup --enable-experimental-features`
4. Check the crc version from the tray by clicking on _About_
5. Now run `crc setup --enable-experimetal-features` from the crc binary built from this PR.
6. Again check the version like in step 4, and the commit sha from the crc version should match the commit id from HEAD of this patch set. or just check inside `~/Library/LaunchAgents/crc.daemon.plist` that the first string in the `ProgramArguments` key is the path to the crc binary used in step 5.
