### PR TITLE
doc: Update Odo doc link to 4.3

### DIFF
--- a/docs/source/getting_started/content/proc_accessing-the-openshift-cluster-with-oc.adoc
+++ b/docs/source/getting_started/content/proc_accessing-the-openshift-cluster-with-oc.adoc
@@ -50,4 +50,4 @@ See <<troubleshooting-codeready-containers_{context}>> if you cannot access the 
 .Additional resources
 
 * The link:https://docs.openshift.com/container-platform/latest/applications/projects/working-with-projects.html[OpenShift documentation] covers the creation of projects and applications.
-* You can also use link:https://docs.openshift.com/container-platform/4.2/cli_reference/openshift_developer_cli/understanding-odo.html[OpenShift Do] (`odo`) to create OpenShift projects and applications from the command line.
+* You can also use link:{odo-docs-url}[OpenShift Do] (`odo`) to create OpenShift projects and applications from the command line.

--- a/docs/source/meta/product-attributes.adoc
+++ b/docs/source/meta/product-attributes.adoc
@@ -26,3 +26,4 @@
 
 // URLs
 :crc-download-url: https://cloud.redhat.com/openshift/install/crc/installer-provisioned
+:odo-docs-url: https://docs.openshift.com/container-platform/latest/cli_reference/openshift_developer_cli/creating-a-single-component-application-with-odo.html


### PR DESCRIPTION
This was still pointing to 4.2 documentation. I don't think much changed
for basic Odo use between these 2 releases, but better to point to the
latest one.


## Testing

Check the link at the bottom of https://code-ready.github.io/crc/#accessing-the-openshift-cluster-with-oc_gsg (or local documentation)