### PR TITLE
[HOLD] Provide a way to run podman service only

### DIFF
--- a/cmd/crc/cmd/config/config.go
+++ b/cmd/crc/cmd/config/config.go
@@ -16,6 +16,7 @@ var (
 	Memory         = cfg.AddSetting("memory", constants.DefaultMemory, []cfg.ValidationFnType{cfg.ValidateMemory}, []cfg.SetFn{cfg.RequiresRestartMsg})
 	NameServer     = cfg.AddSetting("nameserver", nil, []cfg.ValidationFnType{cfg.ValidateIpAddress}, []cfg.SetFn{cfg.SuccessfullyApplied})
 	PullSecretFile = cfg.AddSetting("pull-secret-file", nil, []cfg.ValidationFnType{cfg.ValidatePath}, []cfg.SetFn{cfg.SuccessfullyApplied})
+	DisableCluster = cfg.AddSetting("disable-cluster", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})
 
 	DisableUpdateCheck   = cfg.AddSetting("disable-update-check", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})
 	ExperimentalFeatures = cfg.AddSetting("enable-experimental-features", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})

--- a/cmd/crc/cmd/status.go
+++ b/cmd/crc/cmd/status.go
@@ -28,6 +28,7 @@ var statusCmd = &cobra.Command{
 
 var statusFormat = `CRC VM:          {{.CrcStatus}}
 OpenShift:       {{.OpenShiftStatus}}
+Podman:          {{.PodmanStatus}}
 Disk Usage:      {{.DiskUsage}}
 Cache Usage:     {{.CacheUsage}}
 Cache Directory: {{.CacheDir}}
@@ -36,6 +37,7 @@ Cache Directory: {{.CacheDir}}
 type Status struct {
 	CrcStatus       string
 	OpenShiftStatus string
+	PodmanStatus    string
 	DiskUsage       string
 	CacheUsage      string
 	CacheDir        string
@@ -65,7 +67,7 @@ func runStatus() {
 	diskUse := units.HumanSize(float64(clusterStatus.DiskUse))
 	diskSize := units.HumanSize(float64(clusterStatus.DiskSize))
 	diskUsage := fmt.Sprintf("%s of %s (Inside the CRC VM)", diskUse, diskSize)
-	status := Status{clusterStatus.CrcStatus, clusterStatus.OpenshiftStatus, diskUsage, cacheUsage, cacheDir}
+	status := Status{clusterStatus.CrcStatus, clusterStatus.OpenshiftStatus, clusterStatus.PodmanStatus, diskUsage, cacheUsage, cacheDir}
 	printStatus(status, statusFormat)
 }
 

--- a/pkg/crc/machine/types.go
+++ b/pkg/crc/machine/types.go
@@ -25,6 +25,9 @@ type StartConfig struct {
 
 	// User Pull secret
 	GetPullSecret GetPullSecretFunc
+
+	// To disable launching of the cluster, or not
+	DisableCluster bool
 }
 
 type ClusterConfig struct {
@@ -94,6 +97,7 @@ type ClusterStatusConfig struct {
 type ClusterStatusResult struct {
 	Name            string
 	CrcStatus       string
+	PodmanStatus    string
 	OpenshiftStatus string
 	DiskUse         int64
 	DiskSize        int64


### PR DESCRIPTION
Without the Openshift cluster.

Fixes #1097.

Still WIP but creating PR already to get early feedback.

## Testing

1. `crc start --disable-cluster -b PATH_TO_BUNDLE`
2. `crc status`

The start command should say `Podman service now available` and status command should have this line:

```
Podman:       	 Service available
```