### PR TITLE
Issue #507 Implement cleanup feature for macos

### DIFF
--- a/pkg/crc/preflight/preflight_check_tray_darwin.go
+++ b/pkg/crc/preflight/preflight_check_tray_darwin.go
@@ -62,6 +62,10 @@ func fixDaemonPlistFileExists() error {
 	return fixPlistFileExists(daemonConfig)
 }
 
+func removeDaemonPlistFile() error {
+	return launchd.RemovePlist(daemonAgentLabel)
+}
+
 func checkIfTrayPlistFileExists() error {
 	if !launchd.PlistExists(trayAgentLabel) {
 		return fmt.Errorf("Tray plist file does not exist")
@@ -76,6 +80,10 @@ func fixTrayPlistFileExists() error {
 		StdOutFilePath: stdOutFilePathTray,
 	}
 	return fixPlistFileExists(trayConfig)
+}
+
+func removeTrayPlistFile() error {
+	return launchd.RemovePlist(trayAgentLabel)
 }
 
 func checkIfDaemonAgentRunning() error {
@@ -93,6 +101,10 @@ func fixDaemonAgentRunning() error {
 	return launchd.StartAgent(daemonAgentLabel)
 }
 
+func unLoadDaemonAgent() error {
+	return launchd.UnloadPlist(daemonAgentLabel)
+}
+
 func checkIfTrayAgentRunning() error {
 	if !launchd.AgentRunning(trayAgentLabel) {
 		return fmt.Errorf("Tray is not running")
@@ -106,6 +118,10 @@ func fixTrayAgentRunning() error {
 		return err
 	}
 	return launchd.StartAgent(trayAgentLabel)
+}
+
+func unLoadTrayAgent() error {
+	return launchd.UnloadPlist(trayAgentLabel)
 }
 
 func checkTrayVersion() error {

--- a/pkg/crc/preflight/preflight_checks_darwin.go
+++ b/pkg/crc/preflight/preflight_checks_darwin.go
@@ -186,12 +186,32 @@ func fixResolverFilePermissions() error {
 	return addFileWritePermissionToUser(resolverFile)
 }
 
+func removeResolverFile() error {
+	// Check if the resolver file exist or not
+	if _, err := os.Stat(resolverFile); !os.IsNotExist(err) {
+		logging.Debugf("Removing %s file", resolverFile)
+		_, stdErr, err := crcos.RunWithPrivilege(fmt.Sprintf("Remove file %s", resolverFile), "rm", "-f", resolverFile)
+		if err != nil {
+			return fmt.Errorf("Unable to delete the resolver File: %s %v: %s", resolverFile, err, stdErr)
+		}
+	}
+	return nil
+}
+
 func checkHostsFilePermissions() error {
 	return isUserHaveFileWritePermission(hostFile)
 }
 
 func fixHostsFilePermissions() error {
 	return addFileWritePermissionToUser(hostFile)
+}
+
+func removeUserPermissionForHostsFile() error {
+	_, stdErr, err := crcos.RunWithPrivilege(fmt.Sprintf("change ownership of %s", hostFile), "chown", "root", hostFile)
+	if err != nil {
+		return fmt.Errorf("Unable to change ownership of the filename: %s %v: %s", hostFile, err, stdErr)
+	}
+	return nil
 }
 
 func isUserHaveFileWritePermission(filename string) error {

--- a/pkg/os/launchd/launchd_darwin.go
+++ b/pkg/os/launchd/launchd_darwin.go
@@ -92,6 +92,19 @@ func LoadPlist(label string) error {
 	return exec.Command("launchctl", "load", getPlistPath(label)).Run() // #nosec G204
 }
 
+// UnloadPlist Unloads a launchd agent's service
+func UnloadPlist(label string) error {
+	return exec.Command("launchctl", "unload", getPlistPath(label)).Run() // #nosec G204
+}
+
+// RemovePlist removes a launchd agent plist config file
+func RemovePlist(label string) error {
+	if _, err := goos.Stat(getPlistPath(label)); !goos.IsNotExist(err) {
+		return goos.Remove(getPlistPath(label))
+	}
+	return nil
+}
+
 // StartAgent starts a launchd agent
 func StartAgent(label string) error {
 	return exec.Command("launchctl", "start", label).Run() // #nosec G204


### PR DESCRIPTION
**Fixes:** Issue #507 

## Solution/Idea

Implement the cleanup for macos so user can run `crc cleanup` and it removes the file which created by setup command including the tray.

## Proposed changes

List main as well as consequential changes you introduced or had to introduce.

1. Add `cleanup` command.

## Testing

Run `crc cleanup` command and it should remove the files and change the file permission back to original user which created by `crc setup` command.