### PR TITLE
Issue #1156 Apply IBM style guide to documentation

### DIFF
--- a/docs/source/topics/assembly_accessing-the-openshift-cluster.adoc
+++ b/docs/source/topics/assembly_accessing-the-openshift-cluster.adoc
@@ -1,7 +1,7 @@
 [id="accessing-the-openshift-cluster_{context}"]
 = Accessing the OpenShift cluster
 
-Access the OpenShift cluster running in the {prod} virtual machine via the OpenShift web console or client binary ([command]`oc`).
+Access the OpenShift cluster running in the {prod} virtual machine through the OpenShift web console or client binary ([command]`oc`).
 
 include::proc_accessing-the-openshift-web-console.adoc[leveloffset=+1]
 

--- a/docs/source/topics/proc_accessing-the-openshift-cluster-with-oc.adoc
+++ b/docs/source/topics/proc_accessing-the-openshift-cluster-with-oc.adoc
@@ -8,7 +8,7 @@ For more information, see <<starting-the-virtual-machine_{context}>>.
 
 .Procedure
 
-To access the OpenShift cluster via the [command]`oc` command, follow these steps:
+To access the OpenShift cluster through the [command]`oc` command, follow these steps:
 
 . Run the [command]`{bin} oc-env` command to print the command needed to add the cached [command]`oc` binary to your `_PATH_`:
 +

--- a/docs/source/topics/proc_basic-troubleshooting.adoc
+++ b/docs/source/topics/proc_basic-troubleshooting.adoc
@@ -5,9 +5,9 @@ Resolve most issues by stopping the {prod} virtual machine, deleting it, and sta
 
 .Prerequisites
 
-* You set up the host machine via the [command]`{bin} setup` command.
+* You set up the host machine through the [command]`{bin} setup` command.
 For more information, see <<setting-up-codeready-containers_{context}>>.
-* You started {prod} via the [command]`{bin} start` command.
+* You started {prod} through the [command]`{bin} start` command.
 For more information, see <<starting-the-virtual-machine_{context}>>.
 * You are using the latest {prod} release.
 Using a version earlier than {prod} 1.2.0 may result in errors related to expired x509 certificates.

--- a/docs/source/topics/proc_starting-codeready-containers-behind-proxy.adoc
+++ b/docs/source/topics/proc_starting-codeready-containers-behind-proxy.adoc
@@ -6,7 +6,7 @@
 * To use an existing [command]`oc` binary on your host machine, export the `.testing` domain as part of the `no_proxy` environment variable.
 
 * The embedded [command]`oc` binary does not require manual settings.
-For more information on using the embedded [command]`oc` binary, see <<accessing-the-openshift-cluster-with-oc_{context}>>.
+For more information about using the embedded [command]`oc` binary, see <<accessing-the-openshift-cluster-with-oc_{context}>>.
 
 
 .Procedure
@@ -22,10 +22,10 @@ $ {bin} config set https-proxy http://example.proxy.com:__<port>__
 $ {bin} config set no-proxy __<comma-separated-no-proxy-entries>__
 ----
 +
-The [command]`{bin}` binary will be able to use the defined proxy once set via environment variables or {prod} configuration.
+The [command]`{bin}` binary will be able to use the defined proxy once set through environment variables or {prod} configuration.
 
 [NOTE]
 ====
-* Proxy-related values set in the configuration for {prod} have priority over values set via environment variables.
+* Proxy-related values set in the configuration for {prod} have priority over values set through environment variables.
 * SOCKS proxies are not supported by OpenShift Container Platform.
 ====

--- a/docs/source/topics/proc_starting-monitoring-alerting-telemetry.adoc
+++ b/docs/source/topics/proc_starting-monitoring-alerting-telemetry.adoc
@@ -9,7 +9,7 @@ Telemetry functionality is responsible for listing your cluster in the link:http
 
 * A running {prod} virtual machine and a working [command]`oc` command.
 For more information, see <<accessing-the-openshift-cluster-with-oc_{context}>>.
-* You must log in via [command]`oc` as the `kubeadmin` user.
+* You must log in through [command]`oc` as the `kubeadmin` user.
 * You must assign additional memory to the {prod} virtual machine.
 At least 12 GiB of memory (a value of `12288`) is recommended.
 For more information, see <<configuring-the-virtual-machine_{context}>>.

--- a/docs/source/topics/proc_starting-the-virtual-machine.adoc
+++ b/docs/source/topics/proc_starting-the-virtual-machine.adoc
@@ -5,7 +5,7 @@ The [command]`{bin} start` command starts the {prod} virtual machine and OpenShi
 
 .Prerequisites
 
-* You set up the host machine via the [command]`{bin} setup` command.
+* You set up the host machine through the [command]`{bin} setup` command.
 For more information, see <<setting-up-codeready-containers_{context}>>.
 * You have a valid OpenShift user pull secret.
 Copy or download the pull secret from the Pull Secret section of the link:https://cloud.redhat.com/openshift/install/crc/installer-provisioned[Install on Laptop: {rh-prod}] page on cloud.redhat.com.

--- a/docs/source/topics/ref_dns-configuration.adoc
+++ b/docs/source/topics/ref_dns-configuration.adoc
@@ -20,7 +20,7 @@ Additional checks are done to verify DNS is properly configured when running [co
 On Linux, {prod} expects the following DNS configuration:
 
 * {prod} expects NetworkManager to manage networking.
-* NetworkManager uses `dnsmasq` via the [filename]`/etc/NetworkManager/conf.d/crc-nm-dnsmasq.conf` configuration file.
+* NetworkManager uses `dnsmasq` through the [filename]`/etc/NetworkManager/conf.d/crc-nm-dnsmasq.conf` configuration file.
 * The configuration file for this `dnsmasq` instance is [filename]`/etc/NetworkManager/dnsmasq.d/crc.conf`:
 +
 ----


### PR DESCRIPTION
**Fixes:** Issue #1156

Note that the IBM style guide advocates the use of "notebook" rather than "laptop" when describing hardware. I've fixed the one time we use "laptop" in the documentation, but we do not directly control the page on cloud.redhat.com which is named "Install on Laptop" and includes wording such as "Red Hat CodeReady Containers brings a minimal OpenShift 4.2 or newer cluster to your local laptop or desktop computer."