### PR TITLE
Issue #1152 Add file mode as argument for file creation

### DIFF
--- a/pkg/crc/preflight/preflight_checks_linux.go
+++ b/pkg/crc/preflight/preflight_checks_linux.go
@@ -507,6 +507,7 @@ func fixCrcDnsmasqConfigFile() error {
 		fmt.Sprintf("write dnsmasq configuration in %s", crcDnsmasqConfigPath),
 		crcDnsmasqConfig,
 		crcDnsmasqConfigPath,
+		0644,
 	)
 	if err != nil {
 		return fmt.Errorf("Failed to write dnsmasq config file: %s: %v", crcDnsmasqConfigPath, err)
@@ -572,6 +573,7 @@ func fixCrcNetworkManagerConfig() error {
 		fmt.Sprintf("write NetworkManager config in %s", crcNetworkManagerConfigPath),
 		crcNetworkManagerConfig,
 		crcNetworkManagerConfigPath,
+		0644,
 	)
 	if err != nil {
 		return fmt.Errorf("Failed to write NetworkManager config file: %s: %v", crcNetworkManagerConfigPath, err)


### PR DESCRIPTION
As of now if a user uses umask as `0077` which is serve security
level then any file created by default not readable by any different
user. With this setup if that user run `crc setup` it will pass without
any issue but then `crc start` fails with following error.

```
FATA Error opening file: /etc/NetworkManager/conf.d/crc-nm-dnsmasq.conf: open /etc/NetworkManager/conf.d/crc-nm-dnsmasq.conf: permission denied
```

This is happen since we create those file using `sudo` and don't provide
any file-mode which makes those file only readable by root user and thus this failure.


**Fixes:** Issue #1152 

