### PR TITLE
Add cleanup command to tests

### DIFF
--- a/test/integration/features/basic.feature
+++ b/test/integration/features/basic.feature
@@ -137,3 +137,39 @@ Feature: Basic test
     Scenario: CRC delete
         When executing "crc delete -f" succeeds
         Then stdout should contain "Deleted the OpenShift cluster"
+
+    @darwin
+    Scenario Outline: CRC clean-up
+        When executing "crc cleanup" succeeds
+        Then stdout should contain "Unload CodeReady Containers tray"
+        And stdout should contain "Unload CodeReady Containers daemon"
+        And stdout should contain "Removing launchd configuration for tray"
+        And stdout should contain "Removing launchd configuration for daemon"
+        And stdout should contain "Removing /etc/resolver/testing file"
+        And stdout should contain "Will use root access: Remove file /etc/resolver/testing"
+        And stdout should contain "Cleanup finished"
+
+    @linux
+    Scenario Outline: CRC clean-up
+        When executing "crc cleanup" succeeds
+        Then stdout should contain "Removing the crc VM if exists"
+        And stdout should contain "Removing /etc/NetworkManager/dnsmasq.d/crc.conf file"
+        And stdout should contain "Will use root access: removing dnsmasq configuration in /etc/NetworkManager/dnsmasq.d/crc.conf"
+        And stdout should contain "Will use root access: execute systemctl daemon-reload command"
+        And stdout should contain "Will use root access: execute systemctl stop/start command"
+        And stdout should contain "Removing /etc/NetworkManager/conf.d/crc-nm-dnsmasq.conf file"
+        And stdout should contain "Will use root access: Removing NetworkManager config in /etc/NetworkManager/conf.d/crc-nm-dnsmasq.conf"
+        And stdout should contain "Will use root access: execute systemctl daemon-reload command"
+        And stdout should contain "Will use root access: execute systemctl stop/start command"
+        And stdout should contain "Removing 'crc' network from libvirt"
+        And stdout should contain "Cleanup finished"
+
+    @windows
+    Scenario Outline: CRC clean-up
+        When executing "crc cleanup" succeeds
+        Then stdout should contain "Uninstalling tray if installed"
+        And stdout should contain "Will run as admin: Uninstalling CodeReady Containers System Tray"
+        And stdout should contain "Removing the crc VM if exists"
+        And stdout should contain "Removing dns server from interface"
+        And stdout should contain "Will run as admin: Remove dns entry for default switch"
+        And stdout should contain "Cleanup finished"

--- a/test/integration/features/cert_rotation.feature
+++ b/test/integration/features/cert_rotation.feature
@@ -20,6 +20,7 @@ Feature: Check the cert is rotation happen after it expire
     Scenario: Set clock back to original time
       Given executing "sudo timedatectl set-ntp on" succeeds
 
-    Scenario: CRC delete
+    Scenario: CRC delete and cleanup
       When executing "crc delete -f" succeeds
       Then stdout should contain "Deleted the OpenShift cluster"
+      When executing "crc cleanup" succeeds

--- a/test/integration/features/proxy.feature
+++ b/test/integration/features/proxy.feature
@@ -28,4 +28,6 @@ Feature: Test the proxy
     When executing "crc delete -f" succeeds
     Then stdout should contain "Deleted the OpenShift cluster"
     And  executing "crc config unset http-proxy" succeeds
-    Then executing "crc config unset https-proxy" succeeds
+    And executing "crc config unset https-proxy" succeeds
+    And executing "crc cleanup" succeeds
+

--- a/test/integration/features/story_health.feature
+++ b/test/integration/features/story_health.feature
@@ -61,10 +61,10 @@ Feature:
         Then with up to "4" retries with wait period of "2m" command "crc status" output should match ".*Running \(v\d+\.\d+\.\d+.*\).*"
         And with up to "2" retries with wait period of "60s" http response from "http://httpd-example-testproj.apps-crc.testing" has status code "200"
 
+
     @darwin @linux @windows
-    Scenario: Clean up
-        Given executing "oc delete project testproj" succeeds
-        When executing "crc stop -f" succeeds
-        Then stdout should match "(.*)[Ss]topped the OpenShift cluster"
-        When executing "crc delete -f" succeeds
-        Then stdout should contain "Deleted the OpenShift cluster"
+    Scenario: Switch off CRC
+        When executing "oc delete project testproj" succeeds
+        Then executing "crc stop -f" succeeds
+        And executing "crc delete -f" succeeds
+        And executing "crc cleanup" succeeds

--- a/test/integration/features/story_marketplace.feature
+++ b/test/integration/features/story_marketplace.feature
@@ -75,3 +75,5 @@ Feature:
         Then stdout should match "(.*)[Ss]topped the OpenShift cluster"
         When executing "crc delete -f" succeeds
         Then stdout should contain "Deleted the OpenShift cluster"
+        When executing "crc cleanup" succeeds
+        Then stdout should contain "Cleanup finished"

--- a/test/integration/features/story_registry.feature
+++ b/test/integration/features/story_registry.feature
@@ -43,4 +43,5 @@ Feature: Local image to image-registry to deployment
         Then stdout should match "(.*)[Ss]topped the OpenShift cluster"
         And executing "crc delete -f" succeeds
         Then stdout should contain "Deleted the OpenShift cluster"
-
+        When executing "crc cleanup" succeeds
+        Then stdout should contain "Cleanup finished"


### PR DESCRIPTION
**Fixes:** Issue #1279 

**Relates to:** Issue # PR #

## Solution/Idea

Simply add the step to `basic.feature` file that uses `crc cleanup` to remove the relevant settings. Check the stdout against expected stdout. Then use `crc cleanup` through other feature files after the crux of the story is finished.

## Proposed changes

List main as well as consequential changes you introduced or had to introduce.

1. Modify `*.feature` files except for `config.feature`, where CRC is not started.

## Testing

What is the _bottom-line_ functionality that needs testing? Describe in pseudo-code or in English. Use verifiable statements that tie your changes to existing functionality.

1. Run `make integration` and all tests should pass, including the `crc cleanup` related steps.
