### PR TITLE
Issue #1143 Add docs for using `odo` with CRC

### DIFF
--- a/docs/source/meta/product-attributes.adoc
+++ b/docs/source/meta/product-attributes.adoc
@@ -26,4 +26,6 @@
 
 // URLs
 :crc-download-url: https://cloud.redhat.com/openshift/install/crc/installer-provisioned
-:odo-docs-url: https://docs.openshift.com/container-platform/latest/cli_reference/openshift_developer_cli/creating-a-single-component-application-with-odo.html
+:odo-docs-url: https://docs.openshift.com/container-platform/latest/cli_reference/openshift_developer_cli/understanding-odo.html
+:odo-docs-url-installing: https://docs.openshift.com/container-platform/latest/cli_reference/openshift_developer_cli/installing-odo.html
+:odo-docs-url-single-component: https://docs.openshift.com/container-platform/latest/cli_reference/openshift_developer_cli/creating-a-single-component-application-with-odo.html

--- a/docs/source/topics/assembly_using-codeready-containers.adoc
+++ b/docs/source/topics/assembly_using-codeready-containers.adoc
@@ -7,6 +7,8 @@ include::proc_starting-the-virtual-machine.adoc[leveloffset=+1]
 
 include::assembly_accessing-the-openshift-cluster.adoc[leveloffset=+1]
 
+include::proc_deploying-sample-application-with-odo.adoc[leveloffset=+1]
+
 include::proc_stopping-the-virtual-machine.adoc[leveloffset=+1]
 
 include::proc_deleting-the-virtual-machine.adoc[leveloffset=+1]

--- a/docs/source/topics/proc_accessing-the-openshift-cluster-with-oc.adoc
+++ b/docs/source/topics/proc_accessing-the-openshift-cluster-with-oc.adoc
@@ -50,4 +50,3 @@ See <<troubleshooting-codeready-containers_{context}>> if you cannot access the 
 .Additional resources
 
 * The link:https://docs.openshift.com/container-platform/latest/applications/projects/working-with-projects.html[OpenShift documentation] covers the creation of projects and applications.
-* You can also use link:{odo-docs-url}[OpenShift Do] (`odo`) to create OpenShift projects and applications from the command line.

--- a/docs/source/topics/proc_deploying-sample-application-with-odo.adoc
+++ b/docs/source/topics/proc_deploying-sample-application-with-odo.adoc
@@ -1,0 +1,80 @@
+[id="deploying-sample-application-with-odo_{context}"]
+= Deploying a sample application with `odo`
+
+You can use OpenShift Do ([command]`odo`) to create OpenShift projects and applications from the command line.
+This procedure deploys a sample application to the OpenShift cluster running in the {prod} virtual machine.
+
+.Prerequisites
+
+* You have installed [command]`odo`.
+For more information, see link:{odo-docs-url-installing}[Installing `odo`] in the [command]`odo` documentation.
+* The {prod} virtual machine is running.
+For more information, see <<starting-the-virtual-machine_{context}>>.
+
+.Procedure
+
+To deploy a sample application through [command]`odo`, follow these steps:
+
+. Log in to the running {prod} OpenShift cluster as the `developer` user:
++
+[subs="+quotes,attributes"]
+----
+$ odo login -u developer -p developer
+----
+
+. Create a project for your application:
++
+[subs="+quotes,attributes"]
+----
+$ odo project create sample-app
+----
+
+. Create a directory for your components:
++
+[subs="+quotes,attributes"]
+----
+$ mkdir sample-app
+$ cd sample-app
+----
+
+. Create a component from a sample application on GitHub:
++
+[subs="+quotes,attributes"]
+----
+$ odo create nodejs --git https://github.com/openshift/nodejs-ex
+----
++
+[NOTE]
+====
+Creating a component from a remote Git repository will rebuild the application each time you run the [command]`odo push` command.
+To create a component from a local Git repository, see link:{odo-docs-url-single-component}[Creating a single-component application with `odo`] in the [command]`odo` documentation.
+====
+
+. Create a URL and add an entry to the local configuration file:
++
+[subs="+quotes,attributes"]
+----
+$ odo url create --port 8080
+----
+
+. Push the changes:
++
+[subs="+quotes,attributes"]
+----
+$ odo push
+----
++
+Your component is now deployed to the cluster with an accessible URL.
+
+. List the URLs and check the desired URL for the component:
++
+[subs="+quotes,attributes"]
+----
+$ odo url list
+----
+
+. View the deployed application using the generated URL.
+
+.Additional resources
+
+* For more information about using [command]`odo`, see the link:{odo-docs-url}[`odo` documentation].


### PR DESCRIPTION
**Fixes:** Issue #1143

## Solution/Idea

We want to encourage the use of `odo` with the OpenShift cluster running in the CodeReady Containers VM for development purposes. This PR introduces a short guide for using `odo` to deploy a sample Java application with links to the `odo` documentation for more information.

## Proposed changes

1. Add the "Deploying a sample application with `odo`" procedure.
2. Add additional attributes for `odo` documentation.
3. Remove the mention of `odo` in "Accessing the OpenShift cluster with `oc`". We now include a procedure which goes over this process and includes links to `odo` documentation.