### PR TITLE
Improve crc status

### DIFF
--- a/pkg/crc/machine/machine.go
+++ b/pkg/crc/machine/machine.go
@@ -594,9 +594,8 @@ func Status(statusConfig ClusterStatusConfig) (ClusterStatusResult, error) {
 		ocConfig := oc.UseOCWithConfig(statusConfig.Name)
 		operatorsStatus, err := oc.GetClusterOperatorStatus(ocConfig)
 		if err != nil {
-			result.Success = false
-			result.Error = err.Error()
-			return *result, errors.New(err.Error())
+			openshiftStatus = "Not Reachable"
+			logging.Debug(err.Error())
 		}
 		if operatorsStatus.Available {
 			openshiftVersion := "4.x"

--- a/pkg/crc/oc/clusteroperator.go
+++ b/pkg/crc/oc/clusteroperator.go
@@ -38,7 +38,7 @@ func GetClusterOperatorStatus(oc OcConfig) (*ClusterStatus, error) {
 	cs := &ClusterStatus{}
 	data, stderr, err := oc.RunOcCommand("get", "co", "-ojson")
 	if err != nil {
-		return cs, fmt.Errorf("%s - %v", stderr, err)
+		return cs, fmt.Errorf("%s", stderr)
 	}
 
 	var co K8sResource


### PR DESCRIPTION
## Solution/Idea

Right now, if the `crc start` fails before copy the kubeconfig file to respective directory or if any reason the apiserver is not up then the `crc status` will fail without providing additional part of status command.

```
$ ./crc status
error: stat /home/prkumar/.crc/machines/crc/kubeconfig: no such file or directory
 - exit status 1

or 

$ ./crc status
Error: The connection to the server api.crc.testing:6443 was refused - did you specify the right host or port?
  - exit status 1
```

## Proposed changes

With this patch now `crc status` is not blocked with intermediate issues (these will go with warn message).

```
 $ ./crc status
WARN error: stat /home/prkumar/.crc/machines/crc/kubeconfig: no such file or directory 
CRC VM:          Running
OpenShift:       Not Reachable
Disk Usage:      10.16GB of 32.72GB (Inside the CRC VM)
Cache Usage:     19.73GB
Cache Directory: /home/prkumar/.crc/cache

or 

$ ./crc status
WARN The connection to the server api.crc.testing:6443 was refused - did you specify the right host or port? 
CRC VM:          Running
OpenShift:       Not Reachable
Disk Usage:      10.16GB of 32.72GB (Inside the CRC VM)
Cache Usage:     19.73GB
Cache Directory: /home/prkumar/.crc/cache

or

$ ./crc status
WARN error: the server doesn't have a resource type "co" 
CRC VM:          Running
OpenShift:       Not Reachable
Disk Usage:      10.26GB of 32.72GB (Inside the CRC VM)
Cache Usage:     19.73GB
Cache Directory: /home/prkumar/.crc/cache

```

## Testing

Start the crc and wait till cluster provision. Try to remove/backup the `~/.crc/machine/crc/kubeconfig` and try to execute `crc status` and same with you can ssh to VM and try stop the kubelet and kill all the pods and check again `crc status`.
