### PR TITLE
Disable the podman remote

### DIFF
--- a/cmd/crc-embedder/cmd/embed.go
+++ b/cmd/crc-embedder/cmd/embed.go
@@ -91,12 +91,10 @@ var (
 			hyperkit.HyperkitDownloadUrl,
 			constants.GetOcUrlForOs("darwin"),
 			constants.GetCrcTrayDownloadURL(),
-			constants.GetPodmanUrlForOs("darwin"),
 		},
 		"linux": []string{
 			libvirt.MachineDriverDownloadUrl,
 			constants.GetOcUrlForOs("linux"),
-			constants.GetPodmanUrlForOs("linux"),
 		},
 		"windows": []string{
 			constants.GetOcUrlForOs("windows"),

--- a/cmd/crc/cmd/podman_env.go
+++ b/cmd/crc/cmd/podman_env.go
@@ -5,7 +5,6 @@ import (
 	"github.com/code-ready/crc/pkg/crc/errors"
 	"github.com/code-ready/crc/pkg/crc/machine"
 	"github.com/code-ready/crc/pkg/crc/output"
-	crcos "github.com/code-ready/crc/pkg/os"
 	"github.com/code-ready/crc/pkg/os/shell"
 	"github.com/spf13/cobra"
 )
@@ -17,9 +16,7 @@ var podmanEnvCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 
 		// See issue #961; Currently does not work on Windows in combination with the CRC vm.
-		if crcos.CurrentOS() == crcos.WINDOWS {
-			errors.ExitWithMessage(1, "Currently not supported on this platform.")
-		}
+		errors.ExitWithMessage(1, "Currently not supported.")
 
 		userShell, err := shell.GetShell(forceShell)
 		if err != nil {

--- a/pkg/crc/preflight/preflight_checks_common.go
+++ b/pkg/crc/preflight/preflight_checks_common.go
@@ -11,7 +11,6 @@ import (
 	"github.com/code-ready/crc/pkg/crc/oc"
 	"github.com/code-ready/crc/pkg/crc/podman"
 	"github.com/code-ready/crc/pkg/embed"
-	crcos "github.com/code-ready/crc/pkg/os"
 )
 
 var genericPreflightChecks = [...]PreflightCheck{
@@ -82,18 +81,8 @@ func fixOcBinaryCached() error {
 
 // Check if podman binary is cached or not
 func checkPodmanBinaryCached() error {
-
-	// See issue #961; Currently does not work on Windows in combination with the CRC vm.
-	if crcos.CurrentOS() == crcos.WINDOWS {
-		logging.Debug("podman remote currently not supported on this platform")
-		return nil
-	}
-
-	podman := podman.PodmanCached{}
-	if !podman.IsCached() {
-		return errors.New("podman remote binary is not cached")
-	}
-	logging.Debug("podman remote binary already cached")
+	// Disable the podman cache until further notice
+	logging.Debug("Currently podman remote is not supported")
 	return nil
 }
 


### PR DESCRIPTION
## Solution/Idea

Disable the podman remote support.

## Proposed changes

List main as well as consequential changes you introduced or had to introduce.
- No podman remote binary download for any platform
- No podman remote binary embedded for any platform
- `podman-env` will error out for each platform.

## Testing

```
$ ./crc setup --log-level debug
INFO Checking if oc binary is cached              
DEBU oc binary already cached                     
INFO Checking if podman remote binary is cached   
DEBU Currently podman remote is not supported     
[...]

$ ./crc podman-env
Currently not supported.
```