### PR TITLE
Update the oc binary cache path

### DIFF
--- a/cmd/crc/cmd/oc_env.go
+++ b/cmd/crc/cmd/oc_env.go
@@ -27,7 +27,7 @@ var ocEnvCmd = &cobra.Command{
 		if err != nil {
 			errors.Exit(1)
 		}
-		output.Outln(shell.GetPathEnvString(userShell, constants.CrcBinDir))
+		output.Outln(shell.GetPathEnvString(userShell, constants.CrcOcBinDir))
 		if proxyConfig.IsEnabled() {
 			output.Outln(shell.GetEnvString(userShell, "HTTP_PROXY", proxyConfig.HttpProxy))
 			output.Outln(shell.GetEnvString(userShell, "HTTPS_PROXY", proxyConfig.HttpsProxy))

--- a/pkg/crc/constants/constants.go
+++ b/pkg/crc/constants/constants.go
@@ -97,6 +97,7 @@ func GetDefaultBundle() string {
 var (
 	CrcBaseDir         = filepath.Join(GetHomeDir(), ".crc")
 	CrcBinDir          = filepath.Join(CrcBaseDir, "bin")
+	CrcOcBinDir        = filepath.Join(CrcBinDir, "oc")
 	ConfigPath         = filepath.Join(CrcBaseDir, ConfigFile)
 	LogFilePath        = filepath.Join(CrcBaseDir, LogFile)
 	DaemonLogFilePath  = filepath.Join(CrcBaseDir, DaemonLogFile)

--- a/pkg/crc/oc/oc.go
+++ b/pkg/crc/oc/oc.go
@@ -44,7 +44,7 @@ func (oc OcLocalRunner) GetKubeconfigPath() string {
 // UseOcWithConfig return the oc binary along with valid kubeconfig
 func UseOCWithConfig(machineName string) OcConfig {
 	localRunner := OcLocalRunner{
-		OcBinaryPath:   filepath.Join(constants.CrcBinDir, constants.OcBinaryName),
+		OcBinaryPath:   filepath.Join(constants.CrcOcBinDir, constants.OcBinaryName),
 		KubeconfigPath: filepath.Join(constants.MachineInstanceDir, machineName, "kubeconfig"),
 	}
 	return NewOcConfig(localRunner, constants.DefaultContext, constants.DefaultName)

--- a/pkg/crc/preflight/preflight_checks_common.go
+++ b/pkg/crc/preflight/preflight_checks_common.go
@@ -67,7 +67,11 @@ func fixBundleCached() error {
 
 // Check if oc binary is cached or not
 func checkOcBinaryCached() error {
-	oc := cache.NewOcCache(constants.CrcBinDir)
+	// Remove oc binary from older location and ignore the error
+	// We should remove this code after 3-4 releases. (after 2020-07-10)
+	os.Remove(filepath.Join(constants.CrcBinDir, "oc"))
+
+	oc := cache.NewOcCache(constants.CrcOcBinDir)
 	if !oc.IsCached() {
 		return errors.New("oc binary is not cached")
 	}
@@ -76,7 +80,7 @@ func checkOcBinaryCached() error {
 }
 
 func fixOcBinaryCached() error {
-	oc := cache.NewOcCache(constants.CrcBinDir)
+	oc := cache.NewOcCache(constants.CrcOcBinDir)
 	if err := oc.EnsureIsCached(); err != nil {
 		return fmt.Errorf("Unable to download oc %v", err)
 	}


### PR DESCRIPTION
Right now we are storing all the binaries which are part of CRC
to `~/.crc/bin` and it causing the issue with env commands where
we set the path to `~/.crc/bin:$PATH` and all the binaries available
in the `~/.crc/bin` also available to user path and create confusion
for some of system specific binaries.