### PR TITLE
Tray setup for windows

### DIFF
--- a/cmd/crc/cmd/daemon.go
+++ b/cmd/crc/cmd/daemon.go
@@ -1,11 +1,6 @@
 package cmd
 
 import (
-	"os"
-
-	"github.com/code-ready/crc/pkg/crc/api"
-	"github.com/code-ready/crc/pkg/crc/constants"
-	"github.com/code-ready/crc/pkg/crc/logging"
 	"github.com/spf13/cobra"
 )
 
@@ -21,19 +16,4 @@ var daemonCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		runDaemon()
 	},
-}
-
-func runDaemon() {
-	//setup separate logfile for daemon
-	logging.CloseLogging()
-	logging.InitLogrus(logging.LogLevel)
-	logging.SetupFileHook(constants.DaemonLogFilePath)
-
-	// Remove if an old socket is present
-	os.Remove(constants.DaemonSocketPath)
-	crcApiServer, err := api.CreateApiServer(constants.DaemonSocketPath)
-	if err != nil {
-		logging.Fatal("Failed to launch daemon", err)
-	}
-	crcApiServer.Serve()
 }

--- a/cmd/crc/cmd/daemon_nonwin.go
+++ b/cmd/crc/cmd/daemon_nonwin.go
@@ -1,0 +1,26 @@
+// +build !windows
+
+package cmd
+
+import (
+	"os"
+
+	"github.com/code-ready/crc/pkg/crc/api"
+	"github.com/code-ready/crc/pkg/crc/constants"
+	"github.com/code-ready/crc/pkg/crc/logging"
+)
+
+func runDaemon() {
+	//setup separate logfile for daemon
+	logging.CloseLogging()
+	logging.InitLogrus(logging.LogLevel)
+	logging.SetupFileHook(constants.DaemonLogFilePath)
+
+	// Remove if an old socket is present
+	os.Remove(constants.DaemonSocketPath)
+	crcApiServer, err := api.CreateApiServer(constants.DaemonSocketPath)
+	if err != nil {
+		logging.Fatal("Failed to launch daemon", err)
+	}
+	crcApiServer.Serve()
+}

--- a/cmd/crc/cmd/daemon_windows.go
+++ b/cmd/crc/cmd/daemon_windows.go
@@ -1,0 +1,20 @@
+package cmd
+
+import (
+	"os"
+
+	"github.com/code-ready/crc/pkg/crc/api"
+	"github.com/code-ready/crc/pkg/crc/constants"
+	"github.com/code-ready/crc/pkg/crc/logging"
+)
+
+func runDaemon() {
+	//setup separate logfile for daemon
+	logging.CloseLogging()
+	logging.InitLogrus(logging.LogLevel)
+	logging.SetupFileHook(constants.DaemonLogFilePath)
+
+	// Remove if an old socket is present
+	os.Remove(constants.DaemonSocketPath)
+	api.RunCrcDaemonService("CodeReady Containers", false)
+}

--- a/pkg/crc/api/api_windows.go
+++ b/pkg/crc/api/api_windows.go
@@ -1,0 +1,76 @@
+package api
+
+import (
+	"fmt"
+
+	"github.com/code-ready/crc/pkg/crc/constants"
+	"golang.org/x/sys/windows/svc"
+	"golang.org/x/sys/windows/svc/debug"
+	"golang.org/x/sys/windows/svc/eventlog"
+)
+
+var elog debug.Log
+
+type crcDaemonService struct {
+	socketPath string
+}
+
+func (m *crcDaemonService) Execute(args []string, r <-chan svc.ChangeRequest, changes chan<- svc.Status) (ssec bool, errno uint32) {
+	const cmdsAccepted = svc.AcceptStop | svc.AcceptShutdown
+	crcApiServer, err := CreateApiServer(m.socketPath)
+	if err != nil {
+		elog.Error(1, fmt.Sprintf("Failed to start CRC daemon service: %v", err)) // nolint
+		return
+	}
+	// Windows servivce manager calls OnStart when starting the service
+	// and it calls this method, which the service manager expects to handle
+	// commands like stop, shutdown. crcApiServer.Serve is being called as a go routine
+	// since we don't want it block
+	go crcApiServer.Serve()
+	changes <- svc.Status{State: svc.Running, Accepts: cmdsAccepted}
+
+	MainLoop(r, changes)
+
+	// Above MainLoop will return when the daemon service is stopped
+	changes <- svc.Status{State: svc.Stopped}
+	return
+}
+
+func MainLoop(r <-chan svc.ChangeRequest, changes chan<- svc.Status) {
+	for c := range r {
+		switch c.Cmd {
+		case svc.Interrogate:
+			changes <- c.CurrentStatus
+		case svc.Stop, svc.Shutdown:
+			_ = elog.Info(1, "Shutting down CRC daemon service")
+			return
+		default:
+			_ = elog.Error(1, fmt.Sprintf("unexpected control request #%d", c))
+		}
+	}
+}
+
+func RunCrcDaemonService(name string, isDebug bool) {
+	var err error
+	if isDebug {
+		elog = debug.New(name)
+	} else {
+		elog, err = eventlog.Open(name)
+		if err != nil {
+			return
+		}
+	}
+	defer elog.Close()
+
+	elog.Info(1, fmt.Sprintf("starting %s service", name)) // nolint
+	run := svc.Run
+	if isDebug {
+		run = debug.Run
+	}
+	err = run(name, &crcDaemonService{socketPath: constants.DaemonSocketPath})
+	if err != nil {
+		elog.Error(1, fmt.Sprintf("%s service failed: %v", name, err)) // nolint
+		return
+	}
+	elog.Info(1, fmt.Sprintf("%s service stopped", name)) // nolint
+}

--- a/pkg/crc/constants/constants.go
+++ b/pkg/crc/constants/constants.go
@@ -30,11 +30,12 @@ const (
 	CrcLandingPageURL    = "https://cloud.redhat.com/openshift/install/crc/installer-provisioned" // #nosec G101
 	PullSecretFile       = "pullsecret.json"
 
-	DefaultOcUrlBase        = "https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest"
-	DefaultPodmanUrlBase    = "https://storage.googleapis.com/libpod-master-releases"
-	DefaultGoodhostsCliBase = "https://github.com/code-ready/goodhosts-cli/releases/download/v1.0.0"
-	CrcTrayDownloadURL      = "https://github.com/code-ready/tray-macos/releases/download/v%s/crc-tray-macos.tar.gz"
-	DefaultContext          = "admin"
+	DefaultOcUrlBase          = "https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest"
+	DefaultPodmanUrlBase      = "https://storage.googleapis.com/libpod-master-releases"
+	DefaultGoodhostsCliBase   = "https://github.com/code-ready/goodhosts-cli/releases/download/v1.0.0"
+	CrcTrayDownloadURL        = "https://github.com/code-ready/tray-macos/releases/download/v%s/crc-tray-macos.tar.gz"
+	CRCWindowsTrayDownloadURL = "https://github.com/code-ready/tray-windows/releases/download/v%s/crc-tray-windows.zip"
+	DefaultContext            = "admin"
 )
 
 var ocUrlForOs = map[string]string{
@@ -149,6 +150,11 @@ func GetPrivateKeyPath() string {
 	return filepath.Join(MachineInstanceDir, DefaultName, "id_rsa")
 }
 
+// TODO: follow the same pattern as oc and podman above
 func GetCrcTrayDownloadURL() string {
 	return fmt.Sprintf(CrcTrayDownloadURL, version.GetCRCTrayVersion())
+}
+
+func GetCRCWindowsTrayDownloadURL() string {
+	return fmt.Sprintf(CRCWindowsTrayDownloadURL, version.GetCRCWindowsTrayVersion())
 }

--- a/pkg/crc/constants/constants_windows.go
+++ b/pkg/crc/constants/constants_windows.go
@@ -1,7 +1,14 @@
 package constants
 
+import "path/filepath"
+
 const (
 	OcBinaryName        = "oc.exe"
 	PodmanBinaryName    = "podman.exe"
 	GoodhostsBinaryName = "goodhosts.exe"
+	TrayBinaryName      = "tray-windows.exe"
+	DaemonServiceName   = "CodeReady Containers"
+	TrayShortcutName    = "tray-windows.lnk"
 )
+
+var TrayBinaryPath = filepath.Join(CrcBinDir, "tray-windows", TrayBinaryName)

--- a/pkg/crc/preflight/preflight_checks_tray_windows.go
+++ b/pkg/crc/preflight/preflight_checks_tray_windows.go
@@ -1,0 +1,187 @@
+package preflight
+
+import (
+	"fmt"
+	"io/ioutil"
+	goos "os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/code-ready/crc/pkg/crc/constants"
+	"github.com/code-ready/crc/pkg/crc/input"
+	"github.com/code-ready/crc/pkg/crc/logging"
+	"github.com/code-ready/crc/pkg/crc/version"
+	dl "github.com/code-ready/crc/pkg/download"
+	"github.com/code-ready/crc/pkg/embed"
+	"github.com/code-ready/crc/pkg/extract"
+	"github.com/code-ready/crc/pkg/os"
+	"github.com/code-ready/crc/pkg/os/windows/powershell"
+	"github.com/code-ready/crc/pkg/os/windows/service"
+)
+
+var startUpFolder = filepath.Join(constants.GetHomeDir(), "AppData", "Roaming", "Microsoft", "Windows", "Start Menu", "Programs", "Startup")
+
+func checkIfDaemonServiceInstalled() error {
+	// We want to force installation whenever setup is ran
+	// as we want the service config to point to the binary
+	// with which the setup command was issued
+	return fmt.Errorf("Ignoring check and forcing installation of daemon service")
+}
+
+func fixDaemonServiceInstalled() error {
+	// try to remove if a previous version exists
+	_ = service.Stop(constants.DaemonServiceName)
+	_ = service.Delete(constants.DaemonServiceName)
+	// get executables path
+	binPath, err := goos.Executable()
+	if err != nil {
+		return fmt.Errorf("Unable to find the current executables location: %v", err)
+	}
+	binPathWithArgs := fmt.Sprintf("%s daemon --log-level debug", strings.TrimSpace(binPath))
+
+	// get the account name
+	whoami, err := exec.LookPath("whoami.exe")
+	if err != nil {
+		return fmt.Errorf("Unable to find whoami.exe in path: %v", err)
+	}
+	stdOut, err := exec.Command(whoami).Output() // #nosec
+	if err != nil {
+		return fmt.Errorf("Unable to get the current account name: %v", err)
+	}
+	accountName := string(stdOut)
+	accountName = strings.TrimSpace(accountName)
+
+	// get the password from user
+	password, err := input.PromptUserForSecret("Enter account login password for service installation", "This is the login password of your current account, needed to install the daemon service")
+	if err != nil {
+		return fmt.Errorf("Unable to get login password: %v", err)
+	}
+	err = service.Create(constants.DaemonServiceName, binPathWithArgs, accountName, password)
+	if err != nil {
+		return fmt.Errorf("Failed to install CodeReady Containers daemon service: %v", err)
+	}
+	return nil
+}
+
+func checkIfDaemonServiceRunning() error {
+	if service.IsRunning(constants.DaemonServiceName) {
+		return nil
+	}
+	return fmt.Errorf("CodeReady Containers dameon service is not running")
+}
+
+func fixDaemonServiceRunning() error {
+	return service.Start(constants.DaemonServiceName)
+}
+
+func checkTrayBinaryExists() error {
+	if os.FileExists(constants.TrayBinaryPath) {
+		return nil
+	}
+	return fmt.Errorf("Tray binary does not exists")
+}
+
+func fixTrayBinaryExists() error {
+	tmpArchivePath, err := ioutil.TempDir("", "crc")
+	if err != nil {
+		logging.Error("Failed creating temporary directory for extracting tray")
+		return err
+	}
+	defer func() {
+		_ = goos.RemoveAll(tmpArchivePath)
+	}()
+
+	logging.Debug("Trying to extract tray from crc binary")
+	err = embed.Extract(filepath.Base(constants.GetCRCWindowsTrayDownloadURL()), tmpArchivePath)
+	if err != nil {
+		logging.Debug("Could not extract tray from crc binary", err)
+		logging.Debug("Downloading crc tray")
+		_, err = dl.Download(constants.GetCRCWindowsTrayDownloadURL(), tmpArchivePath, 0600)
+		if err != nil {
+			return err
+		}
+	}
+	archivePath := filepath.Join(tmpArchivePath, filepath.Base(constants.GetCRCWindowsTrayDownloadURL()))
+	outputPath := constants.CrcBinDir
+	//err = goos.MkdirAll(filepath.Join(outputPath, "tray-windows"), 0750)
+	if err != nil && !goos.IsExist(err) {
+		return fmt.Errorf("Cannot create the target directory: %v", err)
+	}
+	_, err = extract.Uncompress(archivePath, outputPath) //filepath.Join(outputPath, "tray-windows"))
+	if err != nil {
+		return fmt.Errorf("Cannot uncompress '%s': %v", archivePath, err)
+	}
+
+	// If a tray is already running kill it
+	if err := checkTrayRunning(); err == nil {
+		cmd := `Stop-Process -Name "tray-windows"`
+		if _, _, err := powershell.Execute(cmd); err != nil {
+			logging.Debugf("Failed to kill running tray: %v", err)
+		}
+	}
+	return nil
+}
+
+func checkTrayBinaryVersion() error {
+	versionCmd := `(Get-Item %s).VersionInfo.ProductVersion`
+	stdOut, stdErr, err := powershell.Execute(fmt.Sprintf(versionCmd, constants.TrayBinaryPath))
+	if err != nil {
+		return fmt.Errorf("Failed to get the version of tray: %v: %s", err, stdErr)
+	}
+	currentTrayVersion := strings.TrimSpace(stdOut)
+	if currentTrayVersion != version.GetCRCWindowsTrayVersion() {
+		return fmt.Errorf("Current tray version doesn't match with expected version")
+	}
+	return nil
+}
+
+func fixTrayBinaryVersion() error {
+	return fixTrayBinaryExists()
+}
+
+func checkTrayBinaryAddedToStartupFolder() error {
+	if os.FileExists(filepath.Join(startUpFolder, constants.TrayShortcutName)) {
+		return nil
+	}
+	return fmt.Errorf("Tray shortcut does not exists in startup folder")
+}
+
+func fixTrayBinaryAddedToStartupFolder() error {
+	cmd := fmt.Sprintf(
+		"New-Item -ItemType SymbolicLink -Path \"%s\" -Name \"%s\" -Value \"%s\"",
+		startUpFolder,
+		constants.TrayShortcutName,
+		constants.TrayBinaryPath,
+	)
+	_, _, err := powershell.ExecuteAsAdmin("Adding tray binary to startup applications", cmd)
+	if err != nil {
+		return fmt.Errorf("Failed to create shortcut of tray binary in startup folder: %v", err)
+	}
+	return nil
+}
+
+func removeTrayBinaryFromStartupFolder() error {
+	return goos.Remove(filepath.Join(startUpFolder, constants.TrayShortcutName))
+}
+
+func checkTrayRunning() error {
+	trayProcessName := constants.TrayBinaryName[:len(constants.TrayBinaryName)-4]
+	cmd := fmt.Sprintf("Get-Process -Name \"%s\"", trayProcessName)
+	_, stdErr, err := powershell.Execute(cmd)
+	if err != nil {
+		return fmt.Errorf("Failed to check if the tray is running: %v", err)
+	}
+	if strings.Contains(stdErr, constants.TrayBinaryName) {
+		return fmt.Errorf("Tray binary is not running")
+	}
+	return nil
+}
+
+func fixTrayRunning() error {
+	err := exec.Command(constants.TrayBinaryPath).Start()
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/crc/preflight/preflight_windows.go
+++ b/pkg/crc/preflight/preflight_windows.go
@@ -55,10 +55,60 @@ var hypervPreflightChecks = [...]PreflightCheck{
 	},
 }
 
+var traySetupChecks = [...]PreflightCheck{
+	{
+		checkDescription: "Checking if daemon service is installed",
+		check:            checkIfDaemonServiceInstalled,
+		fixDescription:   "Installing daemon service",
+		fix:              fixDaemonServiceInstalled,
+		flags:            SetupOnly,
+	},
+	{
+		checkDescription: "Checking if daemon service is running",
+		check:            checkIfDaemonServiceRunning,
+		fixDescription:   "Starting daemon service",
+		fix:              fixDaemonServiceRunning,
+		flags:            SetupOnly,
+	},
+	{
+		checkDescription: "Checking if tray binary is present",
+		check:            checkTrayBinaryExists,
+		fixDescription:   "Caching tray binary",
+		fix:              fixTrayBinaryExists,
+		flags:            SetupOnly,
+	},
+	{
+		checkDescription: "Checking if tray binary is added to startup applications",
+		check:            checkTrayBinaryAddedToStartupFolder,
+		fixDescription:   "Adding tray binary to startup applications",
+		fix:              fixTrayBinaryAddedToStartupFolder,
+		flags:            SetupOnly,
+	},
+	{
+		checkDescription: "Checking if tray version is correct",
+		check:            checkTrayBinaryVersion,
+		fixDescription:   "Caching correct tray version",
+		fix:              fixTrayBinaryVersion,
+		flags:            SetupOnly,
+	},
+	{
+		checkDescription: "Checking if tray is running",
+		check:            checkTrayRunning,
+		fixDescription:   "Starting CodeReady Containers tray",
+		fix:              fixTrayRunning,
+		flags:            SetupOnly,
+	},
+}
+
 func getPreflightChecks() []PreflightCheck {
 	checks := []PreflightCheck{}
 	checks = append(checks, genericPreflightChecks[:]...)
 	checks = append(checks, hypervPreflightChecks[:]...)
+
+	// Experimental feature
+	if EnableExperimentalFeatures {
+		checks = append(checks, traySetupChecks[:]...)
+	}
 
 	return checks
 }

--- a/pkg/crc/preflight/preflight_windows.go
+++ b/pkg/crc/preflight/preflight_windows.go
@@ -57,11 +57,13 @@ var hypervPreflightChecks = [...]PreflightCheck{
 
 var traySetupChecks = [...]PreflightCheck{
 	{
-		checkDescription: "Checking if daemon service is installed",
-		check:            checkIfDaemonServiceInstalled,
-		fixDescription:   "Installing daemon service",
-		fix:              fixDaemonServiceInstalled,
-		flags:            SetupOnly,
+		checkDescription:   "Checking if daemon service is installed",
+		check:              checkIfDaemonServiceInstalled,
+		fixDescription:     "Installing daemon service",
+		fix:                fixDaemonServiceInstalled,
+		cleanupDescription: "Removing daemon service if exists",
+		cleanup:            removeDaemonService,
+		flags:              SetupOnly,
 	},
 	{
 		checkDescription: "Checking if daemon service is running",
@@ -78,11 +80,13 @@ var traySetupChecks = [...]PreflightCheck{
 		flags:            SetupOnly,
 	},
 	{
-		checkDescription: "Checking if tray binary is added to startup applications",
-		check:            checkTrayBinaryAddedToStartupFolder,
-		fixDescription:   "Adding tray binary to startup applications",
-		fix:              fixTrayBinaryAddedToStartupFolder,
-		flags:            SetupOnly,
+		checkDescription:   "Checking if tray binary is added to startup applications",
+		check:              checkTrayBinaryAddedToStartupFolder,
+		fixDescription:     "Adding tray binary to startup applications",
+		fix:                fixTrayBinaryAddedToStartupFolder,
+		cleanupDescription: "Removing tray binary from startup folder if exists",
+		cleanup:            removeTrayBinaryFromStartupFolder,
+		flags:              SetupOnly,
 	},
 	{
 		checkDescription: "Checking if tray version is correct",
@@ -92,11 +96,13 @@ var traySetupChecks = [...]PreflightCheck{
 		flags:            SetupOnly,
 	},
 	{
-		checkDescription: "Checking if tray is running",
-		check:            checkTrayRunning,
-		fixDescription:   "Starting CodeReady Containers tray",
-		fix:              fixTrayRunning,
-		flags:            SetupOnly,
+		checkDescription:   "Checking if tray is running",
+		check:              checkTrayRunning,
+		fixDescription:     "Starting CodeReady Containers tray",
+		fix:                fixTrayRunning,
+		cleanupDescription: "Stopping tray process if running",
+		cleanup:            stopTray,
+		flags:              SetupOnly,
 	},
 }
 
@@ -128,5 +134,12 @@ func RegisterSettings() {
 }
 
 func CleanUpHost() {
-	doCleanUpPreflightChecks(getPreflightChecks())
+	// A user can use setup with experiment flag
+	// and not use cleanup with same flag, to avoid
+	// any extra step/confusion we are just adding the checks
+	// which are behind the experiment flag. This way cleanup
+	// perform action in a sane way.
+	checks := getPreflightChecks()
+	checks = append(checks, traySetupChecks[:]...)
+	doCleanUpPreflightChecks(checks)
 }

--- a/pkg/crc/version/version.go
+++ b/pkg/crc/version/version.go
@@ -42,6 +42,8 @@ const (
 	releaseInfoLink = "https://mirror.openshift.com/pub/openshift-v4/clients/crc/latest/release-info.json"
 	// Tray version to be embedded in binary
 	crcTrayVersion = "1.0.0-alpha.3"
+	// Windows forms application version type major.minor.buildnumber.revesion
+	crcWindowsTrayVersion = "0.1.0.0"
 )
 
 type CrcReleaseInfo struct {
@@ -64,6 +66,10 @@ func GetBundleVersion() string {
 
 func GetCRCTrayVersion() string {
 	return crcTrayVersion
+}
+
+func GetCRCWindowsTrayVersion() string {
+	return crcWindowsTrayVersion
 }
 
 func getCRCLatestVersionFromMirror() (*semver.Version, error) {

--- a/pkg/os/windows/service/service_windows.go
+++ b/pkg/os/windows/service/service_windows.go
@@ -1,0 +1,115 @@
+package service
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/code-ready/crc/pkg/crc/logging"
+	"github.com/code-ready/crc/pkg/os/windows/powershell"
+)
+
+func IsInstalled(serviceName string) bool {
+	cmd := fmt.Sprintf("Get-Service -Name \"%s\"", serviceName)
+	_, stdErr, err := powershell.Execute(cmd)
+	if err != nil {
+		logging.Debugf("Failed to execute powershell command: %v", err)
+		return false
+	}
+	if strings.Contains(stdErr, serviceName) {
+		return false
+	}
+	return true
+}
+
+func IsRunning(serviceName string) bool {
+	cmd := fmt.Sprintf("(Get-Service -Name \"%s\").Status", serviceName)
+	stdOut, _, err := powershell.Execute(cmd)
+	if err != nil {
+		logging.Debugf("Failed to execute powershell command: %v", err)
+		return false
+	}
+	if strings.TrimSpace(stdOut) == "Running" {
+		return true
+	}
+	return false
+}
+
+func Start(serviceName string) error {
+	cmd := fmt.Sprintf("%s start \"%s\"", getScExePath(), serviceName)
+	_, _, err := powershell.ExecuteAsAdmin(fmt.Sprintf("Starting service: %s", serviceName), cmd)
+	if err != nil {
+		logging.Debug("Failed to execute powershell command as admin")
+		return err
+	}
+	// Needs a bit of time to reflect the service status in svc manager
+	time.Sleep(2 * time.Second)
+
+	// Since ExecuteAsAdmin doesn't return useful stdOut or stdErr
+	// We independently check if the service was actually started
+	if IsRunning(serviceName) {
+		return nil
+	}
+	return fmt.Errorf("Could not start service: %s", serviceName)
+}
+
+func Stop(serviceName string) error {
+	cmd := fmt.Sprintf("%s stop \"%s\"", getScExePath(), serviceName)
+	_, _, err := powershell.ExecuteAsAdmin(fmt.Sprintf("Stopping service: %s", serviceName), cmd)
+	if err != nil {
+		logging.Debug("Failed to execute powershell command as admin")
+		return err
+	}
+	time.Sleep(2 * time.Second)
+	if IsRunning(serviceName) {
+		return fmt.Errorf("Could not stop service: %s", serviceName)
+	}
+	return nil
+}
+
+func Delete(serviceName string) error {
+	cmd := fmt.Sprintf("%s delete \"%s\"", getScExePath(), serviceName)
+	_, _, err := powershell.ExecuteAsAdmin(fmt.Sprintf("Uninstalling service: %s", serviceName), cmd)
+	if err != nil {
+		logging.Debug("Failed to execute powershell command as admin")
+		return err
+	}
+	time.Sleep(2 * time.Second)
+	if IsInstalled(serviceName) {
+		return fmt.Errorf("Could not uninstall service: %s", serviceName)
+	}
+	return nil
+}
+
+func Create(serviceName, binPath, accountName, password string) error {
+	var args = []string{
+		fmt.Sprintf("binPath= \"%s\"", binPath),
+		"type= own",
+		"start= auto",
+		fmt.Sprintf("DisplayName= \"%s\"", serviceName),
+		fmt.Sprintf("obj= \"%s\"", accountName),
+		fmt.Sprintf("password= %s", password),
+	}
+
+	cmd := fmt.Sprintf("%s create --%% \"%s\" %s", getScExePath(), serviceName, strings.Join(args, " "))
+	_, _, err := powershell.ExecuteAsAdmin("Install daemon service", cmd)
+	if err != nil {
+		logging.Debug("Failed to execute powershell command as admin")
+		return fmt.Errorf("Error installing service %s: %v", serviceName, err)
+	}
+	time.Sleep(2 * time.Second)
+	if !IsInstalled(serviceName) {
+		return fmt.Errorf("Failed to install service: %s", serviceName)
+	}
+	return nil
+}
+
+func getScExePath() string {
+	path, err := exec.LookPath("sc.exe")
+	if err != nil {
+		logging.Debug("Unable to find sc.exe on path")
+		return ""
+	}
+	return path
+}


### PR DESCRIPTION
**Fixes:** #795 

## Solution/Idea

Make the crc daemon run as a service in windows and automate tray installation process from `crc setup --enable-experimental-features`

## Proposed changes

Add preflight and clean up checks

## Testing

1. `crc setup --enable-experimental-features` succeeds
2. should have a working system tray
3. The tray and the daemon service should auto start after windows boots

For debugging we can check if the _CodeReady Containers_ service was created in the service manager (in run box `services.msc`
