### PR TITLE
Fix 'crc cleanup' failure when VM is stopped

### DIFF
--- a/pkg/crc/preflight/preflight_checks_linux.go
+++ b/pkg/crc/preflight/preflight_checks_linux.go
@@ -387,18 +387,20 @@ func removeLibvirtCrcNetwork() error {
 
 func removeCrcVM() error {
 	logging.Debug("Removing 'crc' VM")
-	_, _, err := crcos.RunWithDefaultLocale("virsh", "--connect", "qemu:///system", "dominfo", constants.DefaultName)
+	stdout, _, err := crcos.RunWithDefaultLocale("virsh", "--connect", "qemu:///system", "domstate", constants.DefaultName)
 	if err != nil {
 		//  User may have run `crc delete` before `crc cleanup`
 		//  in that case there is no crc vm so return early.
 		return nil
 	}
-	_, stderr, err := crcos.RunWithDefaultLocale("virsh", "--connect", "qemu:///system", "destroy", constants.DefaultName)
-	if err != nil {
-		logging.Debugf("%v : %s", err, stderr)
-		return fmt.Errorf("Failed to destroy 'crc' VM")
+	if stdout == "running" {
+		_, stderr, err := crcos.RunWithDefaultLocale("virsh", "--connect", "qemu:///system", "destroy", constants.DefaultName)
+		if err != nil {
+			logging.Debugf("%v : %s", err, stderr)
+			return fmt.Errorf("Failed to destroy 'crc' VM")
+		}
 	}
-	_, stderr, err = crcos.RunWithDefaultLocale("virsh", "--connect", "qemu:///system", "undefine", constants.DefaultName)
+	_, stderr, err := crcos.RunWithDefaultLocale("virsh", "--connect", "qemu:///system", "undefine", constants.DefaultName)
 	if err != nil {
 		logging.Debugf("%v : %s", err, stderr)
 		return fmt.Errorf("Failed to undefine 'crc' VM")


### PR DESCRIPTION
At the moment, if the crc VM is stopped, `crc cleanup` will error out
when trying to run `virsh destroy` rather than not trying to stop it,
and keep going.
This commit switches to `domstate` instead of `dominfo` in order to check
if the VM is running or not before invoking `virsh destroy`

## Testing

What is the _bottom-line_ functionality that needs testing? Describe in pseudo-code or in English. Use verifiable statements that tie your changes to existing functionality.

1. run `crc start`
2. run `crc stop`
3. run `crc cleanup`
before this change, it fails when trying to remove the CRC VM and stops there
after this change it keeps going.
