### PR TITLE
Issue 1260 Add execute permission for users which are not wheel group

### DIFF
--- a/pkg/crc/network/utils.go
+++ b/pkg/crc/network/utils.go
@@ -10,6 +10,7 @@ import (
 	"github.com/code-ready/crc/pkg/crc/logging"
 	"github.com/code-ready/crc/pkg/crc/machine/bundle"
 	"github.com/code-ready/crc/pkg/crc/ssh"
+	crcos "github.com/code-ready/crc/pkg/os"
 )
 
 func executeCommandOrExit(sshRunner *ssh.SSHRunner, command string, errorMessage string) string {
@@ -125,6 +126,11 @@ func CheckCRCLocalDNSReachableFromHost(bundle *bundle.CrcBundleInfo, expectedIP 
 		appsHostname := bundle.GetAppHostname("foo")
 		ip, err = net.LookupIP(appsHostname)
 		if err != nil {
+			// Right now goodhosts fallback is not implemented in windows so
+			// this checks should still return the error.
+			if crcos.CurrentOS() == crcos.WINDOWS {
+				return err
+			}
 			logging.Warnf("Wildcard DNS resolution for %s does not appear to be working", bundle.ClusterInfo.AppsDomain)
 			return nil
 		}

--- a/pkg/crc/preflight/preflight_checks_nonwin.go
+++ b/pkg/crc/preflight/preflight_checks_nonwin.go
@@ -58,7 +58,7 @@ func setSuid(path string) error {
 	}
 
 	/* Can't do this before the chown as the chown will reset the suid bit */
-	stdOut, stdErr, err = crcos.RunWithPrivilege(fmt.Sprintf("set suid for %s", path), "chmod", "u+s,g+x", path)
+	stdOut, stdErr, err = crcos.RunWithPrivilege(fmt.Sprintf("set suid for %s", path), "chmod", "u+s,g+x,o+x", path)
 	if err != nil {
 		return fmt.Errorf("Unable to set suid bit on %s: %s %v: %s", path, stdOut, err, stdErr)
 	}


### PR DESCRIPTION
**Fixes:** Issue #1260 


## Solution/Idea

`chmod g+x` only set execute permission for the users which are part of currently set group for the file. Looks like by default the normal user in mac or linux is not part of wheel group and file execution permission is not set for the user which leads to permission denied error.

## Testing

What is the _bottom-line_ functionality that needs testing? Describe in pseudo-code or in English. Use verifiable statements that tie your changes to existing functionality.

1. `start` succeeds first time after `setup` succeeded 
