### PR TITLE
Issue #1278: Don't use 'wheel' group in setSuid 

### DIFF
--- a/pkg/crc/preflight/preflight_checks_nonwin.go
+++ b/pkg/crc/preflight/preflight_checks_nonwin.go
@@ -58,7 +58,7 @@ func setSuid(path string) error {
 	}
 
 	/* Can't do this before the chown as the chown will reset the suid bit */
-	stdOut, stdErr, err = crcos.RunWithPrivilege(fmt.Sprintf("set suid for %s", path), "chmod", "u+s,g+x,o+x", path)
+	stdOut, stdErr, err = crcos.RunWithPrivilege(fmt.Sprintf("set suid for %s", path), "chmod", "u+s,g+x", path)
 	if err != nil {
 		return fmt.Errorf("Unable to set suid bit on %s: %s %v: %s", path, stdOut, err, stdErr)
 	}

--- a/pkg/crc/preflight/preflight_checks_nonwin.go
+++ b/pkg/crc/preflight/preflight_checks_nonwin.go
@@ -51,9 +51,9 @@ func extractBinary(binaryName string, mode os.FileMode) (string, error) {
 func setSuid(path string) error {
 	logging.Debugf("Making %s suid", path)
 
-	stdOut, stdErr, err := crcos.RunWithPrivilege(fmt.Sprintf("change ownership of %s", path), "chown", "root:wheel", path)
+	stdOut, stdErr, err := crcos.RunWithPrivilege(fmt.Sprintf("change ownership of %s", path), "chown", "root", path)
 	if err != nil {
-		return fmt.Errorf("Unable to set ownership of %s to root:wheel: %s %v: %s",
+		return fmt.Errorf("Unable to set ownership of %s to root: %s %v: %s",
 			path, stdOut, err, stdErr)
 	}
 


### PR DESCRIPTION
This group does not exist on ubuntu, and the user does not need to be
part of any specific group since commit 70800d0 'Add execute
permission for users which are not wheel group'.

Best way to test would be to run `crc setup` on Ubuntu and make sure `~/.crc/bin/goodhosts` can be run, an alternative is to `rm -rf ~/.crc/bin && crc setup` and then check with `ls -al ~/.crc/bin/goodhosts` that the binary is not part of the wheel group.