### PR TITLE
Issue #1283 Update troubleshooting docs for certificate expiration

### DIFF
--- a/docs/source/topics/proc_troubleshooting-expired-certificates.adoc
+++ b/docs/source/topics/proc_troubleshooting-expired-certificates.adoc
@@ -1,9 +1,15 @@
 [id="troubleshooting-expired-certificates_{context}"]
 = Troubleshooting expired certificates
 
-Before {rh-prod} 1.2.0, the system bundle in each released [command]`{bin}` binary expired 30 days after the release.
-This expiration was due to certificates embedded in the OpenShift cluster.
-As a result, using an older [command]`{bin}` binary or system bundle results in an expired certificates error.
+[NOTE]
+====
+As of the {prod} 1.10.0 release, the certificate renewal process is not working as intended.
+Follow this procedure to avoid potential errors due to certificate expiration.
+====
+
+The system bundle in each released [command]`{bin}` binary expires 30 days after the release.
+This expiration is due to certificates embedded in the OpenShift cluster.
+As a result, using an older [command]`{bin}` binary or system bundle can result in an expired certificates error.
 
 Starting from {prod} 1.2.0, the embedded certificates can be automatically renewed by [command]`{bin}`.
 The [command]`{bin} start` command triggers the certificate renewal process when needed.
@@ -11,7 +17,7 @@ Certificate renewal can add up to five minutes to the start time of the cluster.
 
 .Procedure
 
-With {prod} releases older than 1.2.0, to resolve expired certificate errors:
+To resolve expired certificate errors that cannot be automatically renewed:
 
 . link:{crc-download-url}[Download the latest {prod} release] and place the [command]`{bin}` binary in your `$PATH`.
 


### PR DESCRIPTION
**Fixes:** Issue #1283

## Solution/Idea

Update the troubleshooting information for expired certificate errors which occur in recent versions of CodeReady Containers. Advocate for upgrading to the latest available version to prevent these errors.
