### PR TITLE
Create release tarball without preserving current user

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,11 +176,11 @@ release: fmtcheck embed_bundle build_docs_pdf gen_release_info
 	
 	@mkdir -p $(BUILD_DIR)/crc-macos-$(CRC_VERSION)-amd64
 	@cp LICENSE $(DOCS_BUILD_DIR)/doc.pdf $(BUILD_DIR)/macos-amd64/crc $(BUILD_DIR)/crc-macos-$(CRC_VERSION)-amd64
-	tar cJSf $(RELEASE_DIR)/crc-macos-amd64.tar.xz -C $(BUILD_DIR) crc-macos-$(CRC_VERSION)-amd64
+	tar cJSf $(RELEASE_DIR)/crc-macos-amd64.tar.xz -C $(BUILD_DIR) crc-macos-$(CRC_VERSION)-amd64 --owner=0 --group=0
 
 	@mkdir -p $(BUILD_DIR)/crc-linux-$(CRC_VERSION)-amd64
 	@cp LICENSE $(DOCS_BUILD_DIR)/doc.pdf $(BUILD_DIR)/linux-amd64/crc $(BUILD_DIR)/crc-linux-$(CRC_VERSION)-amd64
-	tar cJSf $(RELEASE_DIR)/crc-linux-amd64.tar.xz -C $(BUILD_DIR) crc-linux-$(CRC_VERSION)-amd64
+	tar cJSf $(RELEASE_DIR)/crc-linux-amd64.tar.xz -C $(BUILD_DIR) crc-linux-$(CRC_VERSION)-amd64 --owner=0 --group=0
 	
 	@mkdir -p $(BUILD_DIR)/crc-windows-$(CRC_VERSION)-amd64
 	@cp LICENSE $(DOCS_BUILD_DIR)/doc.pdf $(BUILD_DIR)/windows-amd64/crc.exe $(BUILD_DIR)/crc-windows-$(CRC_VERSION)-amd64


### PR DESCRIPTION
As of now the tarball we produce from the CI to distribute,
have user/group info associated with current jenkins user, with
this commit we remove this user:group info.

```
$ tar -tvf crc-linux-amd64.tar.xz
drwxrwxr-x prkumar/prkumar   0 2020-06-01 03:54 crc-linux-1.11.0-amd64/
-rw-rw-r-- prkumar/prkumar 11325 2020-06-01 03:54 crc-linux-1.11.0-amd64/LICENSE
-rw-r--r-- prkumar/prkumar 319164 2020-06-01 03:54 crc-linux-1.11.0-amd64/doc.pdf
-rwxrwxr-x prkumar/prkumar 2195573725 2020-06-01 03:55 crc-linux-1.11.0-amd64/crc
```

- https://www.gnu.org/software/tar/manual/html_section/tar_33.html#SEC69

