### PR TITLE
Trim new line from the output of virsh domstate

### DIFF
--- a/pkg/crc/preflight/preflight_checks_linux.go
+++ b/pkg/crc/preflight/preflight_checks_linux.go
@@ -393,7 +393,7 @@ func removeCrcVM() error {
 		//  in that case there is no crc vm so return early.
 		return nil
 	}
-	if stdout == "running" {
+	if strings.TrimSpace(stdout) == "running" {
 		_, stderr, err := crcos.RunWithDefaultLocale("virsh", "--connect", "qemu:///system", "destroy", constants.DefaultName)
 		if err != nil {
 			logging.Debugf("%v : %s", err, stderr)


### PR DESCRIPTION
`virsh--connect qemu:///system domstate crc` have new line as part of
output and we don't trim it so as a result our check around `running`
domain fails and the `crc` VM is undefined without destroy. If you run
`crc cleanup` again it fails.
```
$ ./crc cleanup --log-level debug
INFO Removing the crc VM if exists
DEBU Removing 'crc' VM
DEBU Running 'virsh --connect qemu:///system domstate crc'
DEBU Running 'virsh --connect qemu:///system undefine crc'
DEBU 'crc' VM is removed

$ virsh--connect qemu:///system domstate crc
running

$ ./crc cleanup --log-level debug
INFO Removing the crc VM if exists
DEBU Removing 'crc' VM
DEBU Running 'virsh --connect qemu:///system domstate crc'
DEBU Running 'virsh --connect qemu:///system destroy crc'
DEBU Running 'virsh --connect qemu:///system undefine crc'
DEBU Command failed: exit status 1
DEBU stdout:
DEBU stderr: error: failed to get domain 'crc'
DEBU exit status 1 : error: failed to get domain 'crc'
FATA Failed to undefine 'crc' VM
```
