### PR TITLE
Improve libvirt preflight checks

### DIFF
--- a/pkg/crc/preflight/preflight_checks_linux.go
+++ b/pkg/crc/preflight/preflight_checks_linux.go
@@ -113,39 +113,6 @@ func fixLibvirtInstalled() error {
 	return nil
 }
 
-func checkLibvirtEnabled() error {
-	logging.Debug("Checking if libvirtd.service is enabled")
-	// check if libvirt service is enabled
-	path, err := exec.LookPath("systemctl")
-	if err != nil {
-		return fmt.Errorf("systemctl not found on path: %s", err.Error())
-	}
-	stdOut, _, err := crcos.RunWithDefaultLocale(path, "is-enabled", "libvirtd")
-	if err != nil {
-		return fmt.Errorf("Error checking if libvirtd service is enabled")
-	}
-	if strings.TrimSpace(stdOut) != "enabled" {
-		return fmt.Errorf("libvirtd.service is not enabled")
-	}
-	logging.Debug("libvirtd.service is already enabled")
-	return nil
-}
-
-func fixLibvirtEnabled() error {
-	logging.Debug("Enabling libvirtd.service")
-	// Start libvirt service
-	path, err := exec.LookPath("systemctl")
-	if err != nil {
-		return err
-	}
-	_, _, err = crcos.RunWithPrivilege("enable libvirtd service", path, "enable", "libvirtd")
-	if err != nil {
-		return fmt.Errorf("Failed to enable libvirtd service")
-	}
-	logging.Debug("libvirtd.service is enabled")
-	return nil
-}
-
 func fixLibvirtVersion() error {
 	return fmt.Errorf("libvirt v%s or newer is required and must be updated manually", minSupportedLibvirtVersion)
 }

--- a/pkg/crc/preflight/preflight_checks_linux.go
+++ b/pkg/crc/preflight/preflight_checks_linux.go
@@ -185,9 +185,11 @@ func checkLibvirtServiceRunning() error {
 	}
 	stdOut, _, err := crcos.RunWithDefaultLocale(path, "is-active", "libvirtd")
 	if err != nil {
+		logging.Warnf("No active (running) libvirtd systemd unit could be found - make sure one of libvirt systemd unit could be found - make sure one of libvirt systemd units is enabled so that it's autostarted at boot time.")
 		return fmt.Errorf("Failed to check if libvirtd service is active")
 	}
 	if strings.TrimSpace(stdOut) != "active" {
+		logging.Warnf("No active (running) libvirtd systemd unit could be found - make sure one of libvirt systemd unit could be found - make sure one of libvirt systemd units is enabled so that it's autostarted at boot time.")
 		return fmt.Errorf("libvirtd.service is not running")
 	}
 	logging.Debug("libvirtd.service is already running")

--- a/pkg/crc/preflight/preflight_linux.go
+++ b/pkg/crc/preflight/preflight_linux.go
@@ -30,13 +30,6 @@ var libvirtPreflightChecks = [...]PreflightCheck{
 		fix:              fixUserPartOfLibvirtGroup,
 	},
 	{
-		configKeySuffix:  "check-libvirt-enabled",
-		checkDescription: "Checking if libvirt is enabled",
-		check:            checkLibvirtEnabled,
-		fixDescription:   "Enabling libvirt",
-		fix:              fixLibvirtEnabled,
-	},
-	{
 		configKeySuffix:  "check-libvirt-running",
 		checkDescription: "Checking if libvirt daemon is running",
 		check:            checkLibvirtServiceRunning,


### PR DESCRIPTION
**Fixes:** Issue #1090 

## Solution/Idea

With recent libvirtd releases, checking if libvirtd.service is running is not enough to know whether libvirtd is running or not. This series fixes this.

## Testing

What is the _bottom-line_ functionality that needs testing? Describe in pseudo-code or in English. Use verifiable statements that tie your changes to existing functionality.

1. systemctl stop libvirtd.service libvirtd.socket
2. check that libvirtd is properly started by crc

1. systemctl stop libvirtd.service
2. systemctl start libvirtd.socket
3. check that crc does not attempt to start libvirtd as having the socket unit running should be enough

1. how to enable 'split daemon mode' is described in https://libvirt.org/daemons.html if you also want to test this scenario