### PR TITLE
Issue #1301 Clarify wording based on DDF feedback

### DIFF
--- a/docs/source/topics/proc_starting-monitoring-alerting-telemetry.adoc
+++ b/docs/source/topics/proc_starting-monitoring-alerting-telemetry.adoc
@@ -25,7 +25,6 @@ For more information, see <<configuring-the-virtual-machine_{context}>>.
 $ oc get clusterversion version -ojsonpath='{range .spec.overrides[*]}{.name}{"\n"}{end}' | nl -v 0
 ----
 
-// TODO: Revise the command for PowerShell in the future.
 ** On {msw} using PowerShell:
 +
 [subs="+quotes"]
@@ -33,7 +32,7 @@ $ oc get clusterversion version -ojsonpath='{range .spec.overrides[*]}{.name}{"\
 PS> oc get clusterversion version -ojsonpath='{range .spec.overrides[*]}{.name}{"\n"}{end}' | % {$nl++;"`t$($nl-1) `t $_"};$nl=0
 ----
 
-. Start monitoring, alerting, and telemetry services using the identified numeric index:
+. Start monitoring, alerting, and telemetry services using the identified numeric index for `cluster-monitoring-operator`:
 +
 [subs="+quotes"]
 ----

--- a/docs/source/topics/ref_required-software-packages.adoc
+++ b/docs/source/topics/ref_required-software-packages.adoc
@@ -1,7 +1,7 @@
 [id="required-software-packages_{context}"]
-= Required software packages
+= Required software packages for Linux
 
-{prod} requires the `libvirt` and `NetworkManager` packages.
+{prod} requires the `libvirt` and `NetworkManager` packages to run on Linux.
 Consult the following table to find the command used to install these packages for your Linux distribution:
 
 .Package installation commands by distribution


### PR DESCRIPTION
Also remove the TODO note in the "Starting monitoring" procedure for rendering purposes. The comment was causing this content to be improperly rendered (the numbered list restarted at "1." following the comment).

**Fixes:** Issue #1301