### PR TITLE
Enable gocritic linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,3 +7,4 @@ linters:
     - goimports
     - gofmt
     - gosec
+    - gocritic

--- a/pkg/crc/machine/client/client_darwin.go
+++ b/pkg/crc/machine/client/client_darwin.go
@@ -11,11 +11,7 @@ import (
 // StartDriver starts the desired machine driver if necessary.
 func StartDriver() {
 	if os.Getenv(localbinary.PluginEnvKey) == localbinary.PluginEnvVal {
-		driverName := os.Getenv(localbinary.PluginEnvDriverName)
-		switch driverName {
-		default:
-			errors.ExitWithMessage(1, fmt.Sprintf("Unregistered driver: %s\n", driverName))
-		}
+		errors.ExitWithMessage(1, fmt.Sprintf("Unregistered driver: %s\n", os.Getenv(localbinary.PluginEnvDriverName)))
 		return
 	}
 	localbinary.CurrentBinaryIsCRCMachine = true

--- a/pkg/crc/machine/client/client_linux.go
+++ b/pkg/crc/machine/client/client_linux.go
@@ -11,11 +11,7 @@ import (
 // StartDriver starts the desired machine driver if necessary.
 func StartDriver() {
 	if os.Getenv(localbinary.PluginEnvKey) == localbinary.PluginEnvVal {
-		driverName := os.Getenv(localbinary.PluginEnvDriverName)
-		switch driverName {
-		default:
-			errors.ExitWithMessage(1, fmt.Sprintf("Unregistered driver: %s\n", driverName))
-		}
+		errors.ExitWithMessage(1, fmt.Sprintf("Unregistered driver: %s\n", os.Getenv(localbinary.PluginEnvDriverName)))
 		return
 	}
 	localbinary.CurrentBinaryIsCRCMachine = true

--- a/pkg/crc/machine/machine.go
+++ b/pkg/crc/machine/machine.go
@@ -473,11 +473,11 @@ func Stop(stopConfig StopConfig) (StopResult, error) {
 	return *result, nil
 }
 
-func PowerOff(PowerOff PowerOffConfig) (PowerOffResult, error) {
-	result := &PowerOffResult{Name: PowerOff.Name}
+func PowerOff(powerOff PowerOffConfig) (PowerOffResult, error) {
+	result := &PowerOffResult{Name: powerOff.Name}
 
 	libMachineAPIClient := libmachine.NewClient(constants.MachineBaseDir, constants.MachineCertsDir)
-	host, err := libMachineAPIClient.Load(PowerOff.Name)
+	host, err := libMachineAPIClient.Load(powerOff.Name)
 
 	if err != nil {
 		result.Success = false
@@ -597,7 +597,8 @@ func Status(statusConfig ClusterStatusConfig) (ClusterStatusResult, error) {
 			openshiftStatus = "Not Reachable"
 			logging.Debug(err.Error())
 		}
-		if operatorsStatus.Available {
+		switch {
+		case operatorsStatus.Available:
 			openshiftVersion := "4.x"
 			_, crcBundleMetadata, err := getBundleMetadataFromDriver(host.Driver)
 			if err != nil {
@@ -606,9 +607,9 @@ func Status(statusConfig ClusterStatusConfig) (ClusterStatusResult, error) {
 				openshiftVersion = crcBundleMetadata.GetOpenshiftVersion()
 			}
 			openshiftStatus = fmt.Sprintf("Running (v%s)", openshiftVersion)
-		} else if operatorsStatus.Degraded {
+		case operatorsStatus.Degraded:
 			openshiftStatus = "Degraded"
-		} else if operatorsStatus.Progressing {
+		case operatorsStatus.Progressing:
 			openshiftStatus = "Starting"
 		}
 		sshRunner := crcssh.CreateRunner(host.Driver)

--- a/pkg/crc/services/dns/dns_darwin.go
+++ b/pkg/crc/services/dns/dns_darwin.go
@@ -69,13 +69,13 @@ func runPostStartForOS(serviceConfig services.ServicePostStartConfig, result *se
 	return *result, nil
 }
 
-func createResolverFile(InstanceIP string, domain string, filename string) (bool, error) {
+func createResolverFile(instanceIP string, domain string, filename string) (bool, error) {
 	var resolverFile bytes.Buffer
 
 	values := resolverFileValues{
 		Port:        dnsServicePort,
 		Domain:      domain,
-		IP:          InstanceIP,
+		IP:          instanceIP,
 		SearchOrder: 1,
 	}
 

--- a/pkg/extract/extract.go
+++ b/pkg/extract/extract.go
@@ -36,21 +36,22 @@ func uncompress(tarball, targetDir string, fileFilter func(string) bool) ([]stri
 	}
 	defer file.Close()
 
-	if strings.HasSuffix(tarball, ".tar.xz") || strings.HasSuffix(tarball, ".crcbundle") {
+	switch {
+	case strings.HasSuffix(tarball, ".tar.xz"), strings.HasSuffix(tarball, ".crcbundle"):
 		filereader, err = xz.NewReader(file, 0)
 		if err != nil {
 			return nil, err
 		}
-	} else if strings.HasSuffix(tarball, ".tar.gz") {
+	case strings.HasSuffix(tarball, ".tar.gz"):
 		reader, err := gzip.NewReader(file)
 		if err != nil {
 			return nil, err
 		}
 		defer reader.Close()
 		filereader = io.Reader(reader)
-	} else if strings.HasSuffix(tarball, ".tar") {
+	case strings.HasSuffix(tarball, ".tar"):
 		filereader = file
-	} else {
+	default:
 		logging.Warnf("Unknown file format when trying to uncompress %s", tarball)
 	}
 


### PR DESCRIPTION
This is a proposition, not sure we should merge it.

It catches errors like capitalized variable name and switch with default case only.
On the other hand, it forces us to rewrite some if-else statements with switchs.