### PR TITLE
Remove fmtcheck from release target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -165,7 +165,7 @@ gen_release_info:
 	@sed -i s/@OPENSHIFT_VERSION@/\"$(BUNDLE_VERSION)\"/ $(RELEASE_INFO)
 
 .PHONY: release
-release: fmtcheck embed_bundle build_docs_pdf gen_release_info
+release: cross-lint embed_bundle build_docs_pdf gen_release_info
 	mkdir $(RELEASE_DIR)
 	
 	@mkdir -p $(BUILD_DIR)/crc-macos-$(CRC_VERSION)-amd64


### PR DESCRIPTION
b374b3f remove the fmtcheck target from makefile but not
removed from release target.
