### PR TITLE
Add source code to openshift-ci image

### DIFF
--- a/images/openshift-ci/Dockerfile
+++ b/images/openshift-ci/Dockerfile
@@ -7,6 +7,7 @@ COPY . .
 RUN make cross
 
 FROM centos:7
+COPY --from=builder /go/src/github.com/code-ready/crc /opt/crc
 COPY --from=builder /go/src/github.com/code-ready/crc/out/linux-amd64/crc /bin/crc
 COPY --from=builder /go/src/github.com/code-ready/crc/images/openshift-ci/mock-nss.sh /bin/mock-nss.sh
 COPY --from=builder /go/src/github.com/code-ready/crc/images/openshift-ci/google-cloud-sdk.repo /etc/yum.repos.d/google-cloud-sdk.repo


### PR DESCRIPTION
Since our integration test depend on the source code we need to
put that in the image creation so during the test step we can
able to scp to the VM and run the integration test.


