### PR TITLE
Add unzip pacakge to openshift-ci image

### DIFF
--- a/images/openshift-ci/Dockerfile
+++ b/images/openshift-ci/Dockerfile
@@ -20,6 +20,7 @@ RUN yum update -y && \
     libvirt-client \
     libvirt-libs \
     nss_wrapper \
+    unzip \
     openssh-clients && \
     yum clean all && rm -rf /var/cache/yum/*
 RUN mkdir /output && chown 1000:1000 /output


### PR DESCRIPTION
This is required to unzip the downloaded bundle.


