### PR TITLE
Use deployment instead deploymentconfigs (dc) for rollout status

### DIFF
--- a/test/integration/features/story_health.feature
+++ b/test/integration/features/story_health.feature
@@ -49,7 +49,7 @@ Feature:
             """
             service "httpd-ex" created
             """
-        When executing "oc rollout status dc/httpd-ex" succeeds
+        When executing "oc rollout status deployment httpd-ex" succeeds
         Then stdout should contain "successfully rolled out"
         And executing "oc expose svc/httpd-ex" succeeds
         And with up to "2" retries with wait period of "60s" http response from "http://httpd-ex-testproj.apps-crc.testing" has status code "200"

--- a/test/integration/features/story_registry.feature
+++ b/test/integration/features/story_registry.feature
@@ -29,7 +29,7 @@ Feature: Local image to image-registry to deployment
 
     Scenario: Deploy the image
         Given executing "oc new-app testproj-img/hello:test" succeeds
-        When executing "oc rollout status dc/hello" succeeds
+        When executing "oc rollout status deployment hello" succeeds
         Then stdout should contain "successfully rolled out"
         When executing "oc get pods" succeeds
         Then stdout should contain "Running"


### PR DESCRIPTION
With newer version of oc binary when you use a mapping github repo
for your app deployment which have deploymentconfig as template
then it uses deployment instead dc.

```
$ ~/.crc/bin/oc/oc version
Client Version: 4.5.0-202005291417-9933eb9
$ ~/.crc/bin/oc/oc new-app centos/httpd-24-centos7~https://github.com/sclorg/httpd-ex
[...]
    deployment.apps "httpd-ex" created
$ oc version
Client Version: 4.5.0-20200326-010450
$ oc new-app centos/httpd-24-centos7~https://github.com/sclorg/httpd-ex && oc rollout status dc/httpd-ex
[...]
    deploymentconfig.apps.openshift.io "httpd-ex" created
```


