### PR TITLE
Add OWNERS file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file just uses aliases defined in OWNERS_ALIASES.
+
+approvers:
+  - crc-approvers
+reviewers:
+  - crc-reviewers
+component: crc

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,22 @@
+# See the OWNERS_ALIASES docs: https://git.k8s.io/community/contributors/guide/owners.md#OWNERS_ALIASES
+
+aliases:
+  crc-approvers:
+    - cfergeau
+    - praveenkumar
+    - anjannath
+    - jsliacan
+    - guillaumerose
+    - robin-owen
+    - gbraad
+  crc-reviewers:
+    - cfergeau
+    - praveenkumar
+    - anjannath
+    - guillaumerose
+    - gbraad
+  doc-reviewers:
+    - robin-owen
+  test-reviewers:
+    - jsliacan
+

--- a/docs/OWNERS
+++ b/docs/OWNERS
@@ -1,0 +1,7 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file just uses aliases defined in OWNERS_ALIASES.
+
+approvers:
+  - crc-approvers
+reviewers:
+  - doc-reviewers

--- a/test/OWNERS
+++ b/test/OWNERS
@@ -1,0 +1,7 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file just uses aliases defined in OWNERS_ALIASES.
+
+approvers:
+  - crc-approvers
+reviewers:
+  - test-reviewers


### PR DESCRIPTION
This file is used by openshift ci bot to assign a reviewer and also
provide permission to specific member to approve it.

