### PR TITLE
Use os.Args[0] instead of crc in usage hints

### DIFF
--- a/cmd/crc/cmd/oc_env.go
+++ b/cmd/crc/cmd/oc_env.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"os"
+
 	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/code-ready/crc/pkg/crc/errors"
 	"github.com/code-ready/crc/pkg/crc/machine"
@@ -33,7 +35,7 @@ var ocEnvCmd = &cobra.Command{
 			output.Outln(shell.GetEnvString(userShell, "HTTPS_PROXY", proxyConfig.HttpsProxy))
 			output.Outln(shell.GetEnvString(userShell, "NO_PROXY", proxyConfig.GetNoProxyString()))
 		}
-		output.Outln(shell.GenerateUsageHint(userShell, "crc oc-env"))
+		output.Outln(shell.GenerateUsageHint(userShell, os.Args[0]+" oc-env"))
 	},
 }
 

--- a/cmd/crc/cmd/podman_env.go
+++ b/cmd/crc/cmd/podman_env.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"os"
+
 	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/code-ready/crc/pkg/crc/errors"
 	"github.com/code-ready/crc/pkg/crc/machine"
@@ -40,7 +42,7 @@ var podmanEnvCmd = &cobra.Command{
 		output.Outln(shell.GetEnvString(userShell, "PODMAN_HOST", result.IP))
 		output.Outln(shell.GetEnvString(userShell, "PODMAN_IDENTITY_FILE", constants.GetPrivateKeyPath()))
 		output.Outln(shell.GetEnvString(userShell, "PODMAN_IGNORE_HOSTS", "1"))
-		output.Outln(shell.GenerateUsageHint(userShell, "crc podman-env"))
+		output.Outln(shell.GenerateUsageHint(userShell, os.Args[0]+" podman-env"))
 	},
 }
 


### PR DESCRIPTION
As a developer, I often run a custom version of `crc`. This PR helps to have the correct eval string.

``` 
$ crc oc-env
export PATH="/home/guillaumerose/.crc/bin/oc:$PATH"
# Run this command to configure your shell:
# eval $(crc oc-env)

$ ./out/linux-amd64/crc oc-env
export PATH="/home/guillaumerose/.crc/bin/oc:$PATH"
# Run this command to configure your shell:
# eval $(./out/linux-amd64/crc oc-env)

$ cd out/linux-amd64 
$ ./crc oc-env
export PATH="/home/guillaumerose/.crc/bin/oc:$PATH"
# Run this command to configure your shell:
# eval $(./crc oc-env)

```