### PR TITLE
preflight: macos: reset /etc/hosts permissions to 0644

### DIFF
--- a/pkg/crc/preflight/preflight_checks_darwin.go
+++ b/pkg/crc/preflight/preflight_checks_darwin.go
@@ -20,6 +20,7 @@ import (
 const (
 	resolverDir  = "/etc/resolver"
 	resolverFile = "/etc/resolver/testing"
+	hostsFile    = "/etc/hosts"
 )
 
 func basenameFromUrl(url string) (string, error) {
@@ -128,6 +129,35 @@ func checkMachineDriverHyperKitInstalled() error {
 
 func fixMachineDriverHyperKitInstalled() error {
 	return extractOrDownloadBinary(hyperkit.MachineDriverDownloadUrl)
+}
+
+func checkEtcHostsFilePermissions() error {
+	logging.Debugf("Checking if /etc/hosts ownership/permissions need to be adjusted after crc upgrade")
+	fileinfo, err := os.Stat(hostsFile)
+	if err != nil {
+		return err
+	}
+	// Older crc releases were setting /etc/hosts permissions to 0600 and ownership to the current user
+	// This will cause issues if ownership is reset to root:wheel with permissions
+	// issue if other tools
+	if fileinfo.Mode().Perm() == 0600 {
+		return fmt.Errorf("%s permissions are not 0644", hostsFile)
+	}
+	return nil
+}
+
+func fixEtcHostsFilePermissions() error {
+	stdOut, stdErr, err := crcos.RunWithPrivilege(fmt.Sprintf("change ownership of %s", hostsFile), "chown", "root:wheel", hostsFile)
+	if err != nil {
+		return fmt.Errorf("Unable to change ownership of %s: %s %v: %s", hostsFile, stdOut, err, stdErr)
+	}
+
+	stdOut, stdErr, err = crcos.RunWithPrivilege(fmt.Sprintf("change permissions of %s", hostsFile), "chmod", "644", hostsFile)
+	if err != nil {
+		return fmt.Errorf("Unable to change permissions of %s to 0644: %s %v: %s", hostsFile, stdOut, err, stdErr)
+	}
+
+	return nil
 }
 
 func checkResolverFilePermissions() error {

--- a/pkg/crc/preflight/preflight_darwin.go
+++ b/pkg/crc/preflight/preflight_darwin.go
@@ -24,6 +24,13 @@ var hyperkitPreflightChecks = [...]PreflightCheck{
 
 var dnsPreflightChecks = [...]PreflightCheck{
 	{
+		configKeySuffix:  "check-hosts-file-permissions",
+		checkDescription: fmt.Sprintf("Checking file permissions for %s", hostsFile),
+		check:            checkEtcHostsFilePermissions,
+		fixDescription:   fmt.Sprintf("Setting file permissions for %s", hostsFile),
+		fix:              fixEtcHostsFilePermissions,
+	},
+	{
 		configKeySuffix:    "check-resolver-file-permissions",
 		checkDescription:   fmt.Sprintf("Checking file permissions for %s", resolverFile),
 		check:              checkResolverFilePermissions,


### PR DESCRIPTION
Up to crc 1.10, we were mistakenly setting /etc/hosts permissions to
0600. Since it was owned by the user running crc, this was not causing
noticeable issue. Now we no longer rely on the /etc/hosts file being
owned by the user, but it seems it's possible for some tool to reset
/etc/hosts ownership back to root:wheel without changing its
permissions.
When this happens, crc fails to start because of DNS problems. This
probably has an impact on other tools as well.
This commit readds a preflight check to reset permissions/ownership of
/etc/hosts to avoid this problematic 0600 / root:wheel situation.

## Solution/Idea

To prevent having a /etc/hosts file with 0600 permissions forever, this commit (re) adds a preflight check to reset the permissions and ownership back to some acceptable default values (0644 and root:wheel)

## Testing

What is the _bottom-line_ functionality that needs testing? Describe in pseudo-code or in English. Use verifiable statements that tie your changes to existing functionality.

1. run setup from an older (1.10 I believe, or before that) crc release on macos
2. check /etc/hosts permissions are 0600
3. run setup with these changes
4. check /etc/hosts permissions/ownership