### PR TITLE
Mention total # of retries in RetryAfter

### DIFF
--- a/pkg/crc/errors/multierror.go
+++ b/pkg/crc/errors/multierror.go
@@ -44,7 +44,7 @@ func RetryAfter(attempts int, callback func() error, d time.Duration) (err error
 	m := MultiError{}
 	for i := 0; i < attempts; i++ {
 		if i > 0 {
-			logging.Debugf("retry loop %d", i)
+			logging.Debugf("retry loop: attempt %d out of %d", i, attempts)
 		}
 		err = callback()
 		if err == nil {


### PR DESCRIPTION
Some users have been thinking RetryAfter loops keep going forever. This
commit adds the maximum number of retries to RetryAfter debug logs to
try to avoid this misperception.

## Proposed changes

List main as well as consequential changes you introduced or had to introduce.

1. Add `start` command.
2. Add `setup` as prerequisite to `start`.
3. ...

## Testing

The RetryAfter debug log changes should be visible with `crc start --log-level debug`,
`retry loop xx` is now `retry loop: attempt xx out of NN"