### PR TITLE
Issue #1360 Explicitly mention Windows 10 Home is not supported

### DIFF
--- a/docs/source/topics/ref_minimum-system-requirements.adoc
+++ b/docs/source/topics/ref_minimum-system-requirements.adoc
@@ -28,6 +28,7 @@ To assign more resources to the {prod} virtual machine, see <<configuring-the-vi
 
 * On {msw}, {prod} requires the Windows 10 Pro Fall Creators Update (version 1709) or newer.
 {prod} does not work on earlier versions or editions of {msw}.
+{msw} 10 Home Edition is not supported.
 
 === {mac}
 


### PR DESCRIPTION
The required hypervisor is not available in this edition.

**Fixes:** Issue #1360