### PR TITLE
Add mock bundle logic in makefile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,4 @@ script:
 - make cross-lint
 - make cross
 - make test
-- alias podman=docker
+- make BUNDLE_DIR=/tmp MOCK_BUNDLE=true release

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,5 @@ script:
 - make cross-lint
 - make cross
 - make test
+- alias podman=docker
+- make BUNDLE_DIR=/tmp MOCK_BUNDLE=true release

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,12 @@ language: go
 go:
 - 1.13.4
 
+before_script:
+  - echo "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_18.04 /" | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
+  - curl -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_18.04/Release.key | sudo apt-key add -
+  - sudo apt-get update -qq
+  - sudo apt-get -qq -y install podman slirp4netns
+
 script:
 - make
 - make vendorcheck

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: bionic
+
 language: go
 
 go:
@@ -10,4 +12,3 @@ script:
 - make cross
 - make test
 - alias podman=docker
-- make BUNDLE_DIR=/tmp MOCK_BUNDLE=true release

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,8 @@ SOURCES := $(shell git ls-files  *.go ":^vendor")
 
 RELEASE_INFO := release-info.json
 
+MOCK_BUNDLE ?= false
+
 # Check that given variables are set and all have non-empty values,
 # die with an error otherwise.
 #
@@ -195,6 +197,9 @@ LIBVIRT_BUNDLENAME = $(BUNDLE_DIR)/crc_libvirt_$(BUNDLE_VERSION).$(BUNDLE_EXTENS
 
 .PHONY: embed_bundle check_bundledir
 check_bundledir:
+ifeq ($(MOCK_BUNDLE),true)
+	touch $(HYPERKIT_BUNDLENAME) $(HYPERV_BUNDLENAME) $(LIBVIRT_BUNDLENAME)
+endif
 	@$(call check_defined, BUNDLE_DIR, "Embedding bundle requires BUNDLE_DIR set to a directory containing CRC bundles for all hypervisors")
 
 embed_bundle: LDFLAGS += $(BUNDLE_EMBEDDED)

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+SHELL := /bin/bash
+
 BUNDLE_VERSION = 4.5.1
 # OC_VERSION and BUNDLE_VERSION are going to same for release artifacts but
 # different for nightly and CI bits where bundle version would be any random


### PR DESCRIPTION
In the CI we can run the release target using mock
bundles which will help us to detect any issue due to changes
in release target.