### PR TITLE
 Embed: make errors as fatal for logging

### DIFF
--- a/cmd/crc-embedder/cmd/embed.go
+++ b/cmd/crc-embedder/cmd/embed.go
@@ -45,19 +45,19 @@ func runEmbed(args []string) {
 	binaryPath := args[0]
 	destDir, err := ioutil.TempDir("", "crc-embedder")
 	if err != nil {
-		logging.Errorf(fmt.Sprintf("Failed to create temporary directory: %v", err))
+		logging.Fatalf("Failed to create temporary directory: %v", err)
 	}
 	defer os.RemoveAll(destDir)
 	downloadedFiles, err := downloadDataFiles(goos, destDir)
 	if err != nil {
-		logging.Errorf(fmt.Sprintf("Failed to download data files: %v", err))
+		logging.Fatalf("Failed to download data files: %v", err)
 	}
 
 	bundlePath := path.Join(bundleDir, constants.GetDefaultBundleForOs(goos))
 	downloadedFiles = append(downloadedFiles, bundlePath)
 	err = embedFiles(binaryPath, downloadedFiles)
 	if err != nil {
-		logging.Errorf(fmt.Sprintf("Failed to embed data files: %v", err))
+		logging.Fatalf("Failed to embed data files: %v", err)
 	}
 }
 

--- a/cmd/crc-embedder/cmd/embed.go
+++ b/cmd/crc-embedder/cmd/embed.go
@@ -40,7 +40,7 @@ var embedCmd = &cobra.Command{
 
 func runEmbed(args []string) {
 	if len(args) != 1 {
-		logging.Fatalf("embed takes exactly one argument")
+		logging.Fatal("embed takes exactly one argument")
 	}
 	binaryPath := args[0]
 	destDir, err := ioutil.TempDir("", "crc-embedder")


### PR DESCRIPTION
Without fatal, the errors are just printed on stderr and program doesn't
exit which caused a missing file in the tarball due to github outage.

```
level=debug msg="Embedding bundle/crc_hyperkit_4.5.1.crcbundle in out/macos-amd64/crc"
out/linux-amd64/crc-embedder embed --log-level debug --goos=linux --bundle-dir=bundle out/linux-amd64/crc
level=debug msg="Downloading https://github.com/code-ready/machine-driver-libvirt/releases/download/0.12.8/crc-driver-libvirt to /tmp/crc-embedder762990131"
level=error msg="Download failed: server returned 500 Internal Server Error"
level=error msg="Failed to download data files: Download failed: server returned 500 Internal Server Error"
level=debug msg="Embedding bundle/crc_libvirt_4.5.1.crcbundle in out/linux-amd64/crc"
out/linux-amd64/crc-embedder embed --log-level debug --goos=windows --bundle-dir=bundle out/windows-amd64/crc.exe
level=debug msg="Downloading https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.5.1/openshift-client-windows.zip to /tmp/crc-embedder747319307"