### PR TITLE
Issue #1387 Add stop-chronyd hidden bool flag to start

### DIFF
--- a/developing.adoc
+++ b/developing.adoc
@@ -81,6 +81,24 @@ make integration GODOG_OPTS="--godog.tags='@basic && @windows'" BUNDLE_LOCATION=
 
 Please notice `@basic && @windows`, where `@basic` tag stands for `basic.feature` file and `@windows` tag for integration tests designed for Windows.
 
+[[how-to-test-cert-rotation]]
+=== How to test cert rotation
+
+On linux platform first stop the network time sync using:
+```
+$ sudo timedatectl set-ntp off
+```
+
+Set the time 2 month ahead:
+```
+$ sudo date -s '2 month'
+```
+
+Start the crc with `CRC_DEBUG_ENABLE_STOP_NTP=true` set:
+```
+$ CRC_DEBUG_ENABLE_STOP_NTP=true crc start
+```
+
 
 [[integration-test-logs]]
 === Logs

--- a/test/integration/crcsuite/crcsuite.go
+++ b/test/integration/crcsuite/crcsuite.go
@@ -41,6 +41,8 @@ func FeatureContext(s *godog.Suite) {
 		RemoveCRCHome)
 	s.Step(`^starting CRC with default bundle (succeeds|fails)$`,
 		StartCRCWithDefaultBundleSucceedsOrFails)
+	s.Step(`^starting CRC with default bundle along with stopped network time synchronization (succeeds|fails)$`,
+		StartCRCWithDefaultBundleWithStopNetworkTimeSynchronizationSucceedsOrFails)
 	s.Step(`^starting CRC with default bundle and nameserver "(.*)" (succeeds|fails)$`,
 		StartCRCWithDefaultBundleAndNameServerSucceedsOrFails)
 	s.Step(`^setting config property "(.*)" to value "(.*)" (succeeds|fails)$`,
@@ -341,6 +343,20 @@ func StartCRCWithDefaultBundleSucceedsOrFails(expected string) error {
 		extraBundleArgs = fmt.Sprintf("-b %s", bundleName)
 	}
 	cmd = fmt.Sprintf("crc start -p '%s' %s --log-level debug", pullSecretFile, extraBundleArgs)
+	err := clicumber.ExecuteCommandSucceedsOrFails(cmd, expected)
+
+	return err
+}
+
+func StartCRCWithDefaultBundleWithStopNetworkTimeSynchronizationSucceedsOrFails(expected string) error {
+
+	var cmd string
+	var extraBundleArgs string
+
+	if bundleEmbedded == false {
+		extraBundleArgs = fmt.Sprintf("-b %s", bundleName)
+	}
+	cmd = fmt.Sprintf("CRC_DEBUG_ENABLE_STOP_NTP=true crc start -p '%s' %s --log-level debug", pullSecretFile, extraBundleArgs)
 	err := clicumber.ExecuteCommandSucceedsOrFails(cmd, expected)
 
 	return err

--- a/test/integration/features/cert_rotation.feature
+++ b/test/integration/features/cert_rotation.feature
@@ -1,0 +1,25 @@
+@cert_rotation @linux
+Feature: Check the cert is rotation happen after it expire
+
+    The user try to use crc after one month. he/she expect the
+    cert rotation happen successfully and able to deploy the app and check its
+    accessibility.
+
+    Scenario: Set clock to 3 month ahead on the host
+      Given executing "sudo timedatectl set-ntp off" succeeds
+      Then executing "sudo date -s '3 month'" succeeds
+
+    Scenario: Start CRC
+      Given executing "crc setup" succeeds
+      When starting CRC with default bundle along with stopped network time synchronization succeeds
+      Then stdout should contain "Started the OpenShift cluster"
+      And executing "eval $(crc oc-env)" succeeds
+      When with up to "4" retries with wait period of "2m" command "crc status --log-level debug" output matches ".*Running \(v\d+\.\d+\.\d+.*\).*"
+      Then login to the oc cluster succeeds
+
+    Scenario: Set clock back to original time
+      Given executing "sudo timedatectl set-ntp on" succeeds
+
+    Scenario: CRC delete
+      When executing "crc delete -f" succeeds
+      Then stdout should contain "Deleted the OpenShift cluster"

--- a/test/integration/features/story_registry.feature
+++ b/test/integration/features/story_registry.feature
@@ -6,20 +6,18 @@ Feature: Local image to image-registry to deployment
     project/namespace. They deploy and expose the app and check its
     accessibility.
 
-    Scenario: Start CRC
+    Scenario: Start CRC and login to cluster
         Given executing "crc setup" succeeds
         When starting CRC with default bundle succeeds
         Then stdout should contain "Started the OpenShift cluster"
-        And executing "eval $(crc oc-env)" succeeds
-        When with up to "4" retries with wait period of "2m" command "crc status --log-level debug" output matches ".*Running \(v\d+\.\d+\.\d+.*\).*"
-        Then login to the oc cluster succeeds
+        When with up to "8" retries with wait period of "2m" command "crc status" output matches ".*Running \(v\d+\.\d+\.\d+.*\).*"
+        Then executing "eval $(crc oc-env)" succeeds
+        And login to the oc cluster succeeds
 
     Scenario: Create local image
-        Given executing "cd ../../../testdata" succeeds
-        When executing "sudo podman build -t hello:test ." succeeds
-        And executing "cd ../integration" succeeds
-        Then executing "sudo podman images" succeeds
-        And stdout should contain "localhost/hello"
+        Given executing "sudo podman build -t hello:test -f Dockerfile" succeeds
+        When executing "sudo podman images" succeeds
+        Then stdout should contain "localhost/hello"
         
     Scenario: Push local image to OpenShift image registry
         Given executing "oc new-project testproj-img" succeeds


### PR DESCRIPTION
To test the cert rotation we need to stop the chronyd service
in the VM so it will not sync with ntp server. On the host side
it is platform specific, like on linux host you do need to stop
the chronyd service and set the time in future (around 2 month)
`sudo date -s "2 month"` and then start crc with `--stop-chronyd`
flag to test out cert rotation.


**Fixes:** Issue #1387 

**Relates to:** Issue #N, PR #N, ...

## Solution/Idea

Test out cert rotation in the CI

## Proposed changes
Add a hidden option `stop-chronyd` as part of start flag

## Testing
On the linux host 

```
$ sudo systemctl stop chronyd.service
$ sudo date -s "2 month"
$ ./crc start -b ~/Downloads/crc_libvirt_4.5.1.crcbundle --log-level debug --stop-chronyd
```
