### PR TITLE
Remove the crc machine directory before removing the VM

### DIFF
--- a/pkg/crc/preflight/preflight_checks_linux.go
+++ b/pkg/crc/preflight/preflight_checks_linux.go
@@ -366,6 +366,12 @@ func removeLibvirtCrcNetwork() error {
 
 func removeCrcVM() error {
 	logging.Debug("Removing 'crc' VM")
+
+	if err := os.RemoveAll(constants.MachineInstanceDir); err != nil {
+		logging.Debugf("Error removing %s dir: %v", constants.MachineInstanceDir, err)
+		return fmt.Errorf("Error removing %s dir", constants.MachineInstanceDir)
+	}
+
 	stdout, _, err := crcos.RunWithDefaultLocale("virsh", "--connect", "qemu:///system", "domstate", constants.DefaultName)
 	if err != nil {
 		//  User may have run `crc delete` before `crc cleanup`
@@ -384,12 +390,7 @@ func removeCrcVM() error {
 		logging.Debugf("%v : %s", err, stderr)
 		return fmt.Errorf("Failed to undefine 'crc' VM")
 	}
-	if err := os.RemoveAll(constants.MachineInstanceDir); err != nil {
-		logging.Debugf("Error removing %s dir: %v", constants.MachineInstanceDir, err)
-		return fmt.Errorf("Error removing %s dir", constants.MachineInstanceDir)
-	}
 	logging.Debug("'crc' VM is removed")
-
 	return nil
 }
 


### PR DESCRIPTION
Right now removeCRCVM() function return as soon as it sees there
is no crc domain which might give false positive for cleanup scenario
consider following.

- crc start
- sudo virsh --connect qemu:///system destroy crc
- sudo virsh --connect qemu:///system undefine crc
- crc delete
Do you want to delete the OpenShift cluster? [y/N]: y
(crc) Failed to fetch machine
ERRO Failed to fetch machine 'crc'
- crc cleanup --log-level debug
[...]
DEBU Running 'virsh --connect qemu:///system domstate crc'
DEBU Command failed: exit status 1
DEBU stdout:
DEBU stderr: error: failed to get domain 'crc'
INFO Removing /etc/NetworkManager/dnsmasq.d/crc.conf file
- ls ~/.crc/machines/crc/
config.json  crc  id_rsa  id_rsa.pub  kubeconfig

Above you can see we just check about crc domain status and return
and step not reached to delete the machine dir.
