### PR TITLE
Limit the use of os.Exit(). Push up errors

### DIFF
--- a/cmd/crc/cmd/config/get.go
+++ b/cmd/crc/cmd/config/get.go
@@ -4,7 +4,7 @@ import (
 	"os"
 
 	"github.com/code-ready/crc/pkg/crc/config"
-	"github.com/code-ready/crc/pkg/crc/errors"
+	"github.com/code-ready/crc/pkg/crc/exit"
 	"github.com/code-ready/crc/pkg/crc/output"
 	"github.com/spf13/cobra"
 )
@@ -29,7 +29,7 @@ var configGetCmd = &cobra.Command{
 func runConfigGet(key string) {
 	v, err := config.Get(key)
 	if err != nil {
-		errors.ExitWithMessage(1, err.Error())
+		exit.WithMessage(1, err.Error())
 	}
 	output.Outln(key, ":", v)
 }

--- a/cmd/crc/cmd/config/get.go
+++ b/cmd/crc/cmd/config/get.go
@@ -1,8 +1,6 @@
 package config
 
 import (
-	"os"
-
 	"github.com/code-ready/crc/pkg/crc/config"
 	"github.com/code-ready/crc/pkg/crc/exit"
 	"github.com/code-ready/crc/pkg/crc/output"
@@ -19,8 +17,7 @@ var configGetCmd = &cobra.Command{
 	Long:  `Gets a crc configuration property.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) < 1 {
-			output.Outln("Please provide a configuration property to get")
-			os.Exit(1)
+			exit.WithMessage(1, "Please provide a configuration property to get")
 		}
 		runConfigGet(args[0])
 	},

--- a/cmd/crc/cmd/config/set.go
+++ b/cmd/crc/cmd/config/set.go
@@ -3,7 +3,7 @@ package config
 import (
 	"github.com/code-ready/crc/pkg/crc/config"
 	"github.com/code-ready/crc/pkg/crc/constants"
-	"github.com/code-ready/crc/pkg/crc/errors"
+	"github.com/code-ready/crc/pkg/crc/exit"
 	"github.com/code-ready/crc/pkg/crc/output"
 	"github.com/spf13/cobra"
 )
@@ -18,7 +18,7 @@ var configSetCmd = &cobra.Command{
 	Long:  `Sets a crc configuration property.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) < 2 {
-			errors.ExitWithMessage(1, "Please provide a configuration property and its value as in 'crc config set KEY VALUE'")
+			exit.WithMessage(1, "Please provide a configuration property and its value as in 'crc config set KEY VALUE'")
 		}
 		runConfigSet(args[0], args[1])
 	},
@@ -27,11 +27,11 @@ var configSetCmd = &cobra.Command{
 func runConfigSet(key string, value interface{}) {
 	setMessage, err := config.Set(key, value)
 	if err != nil {
-		errors.ExitWithMessage(1, err.Error())
+		exit.WithMessage(1, err.Error())
 	}
 
 	if err := config.WriteConfig(); err != nil {
-		errors.ExitWithMessage(1, "Error writing configuration to file '%s': %s", constants.ConfigPath, err.Error())
+		exit.WithMessage(1, "Error writing configuration to file '%s': %s", constants.ConfigPath, err.Error())
 	}
 
 	if setMessage != "" {

--- a/cmd/crc/cmd/config/unset.go
+++ b/cmd/crc/cmd/config/unset.go
@@ -3,7 +3,7 @@ package config
 import (
 	"github.com/code-ready/crc/pkg/crc/config"
 	"github.com/code-ready/crc/pkg/crc/constants"
-	"github.com/code-ready/crc/pkg/crc/errors"
+	"github.com/code-ready/crc/pkg/crc/exit"
 	"github.com/code-ready/crc/pkg/crc/output"
 	"github.com/spf13/cobra"
 )
@@ -18,7 +18,7 @@ var configUnsetCmd = &cobra.Command{
 	Long:  `Unsets a crc configuration property.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) != 1 {
-			errors.ExitWithMessage(1, "Please provide a configuration property to unset")
+			exit.WithMessage(1, "Please provide a configuration property to unset")
 		}
 		runConfigUnset(args[0])
 	},
@@ -27,10 +27,10 @@ var configUnsetCmd = &cobra.Command{
 func runConfigUnset(key string) {
 	unsetMessage, err := config.Unset(key)
 	if err != nil {
-		errors.ExitWithMessage(1, err.Error())
+		exit.WithMessage(1, err.Error())
 	}
 	if err := config.WriteConfig(); err != nil {
-		errors.ExitWithMessage(1, "Error writing configuration to file '%s': %s", constants.ConfigPath, err.Error())
+		exit.WithMessage(1, "Error writing configuration to file '%s': %s", constants.ConfigPath, err.Error())
 	}
 
 	if unsetMessage != "" {

--- a/cmd/crc/cmd/console.go
+++ b/cmd/crc/cmd/console.go
@@ -2,7 +2,7 @@ package cmd
 
 import (
 	"github.com/code-ready/crc/pkg/crc/constants"
-	"github.com/code-ready/crc/pkg/crc/errors"
+	"github.com/code-ready/crc/pkg/crc/exit"
 	"github.com/code-ready/crc/pkg/crc/machine"
 	"github.com/code-ready/crc/pkg/crc/output"
 	"github.com/pkg/browser"
@@ -40,7 +40,7 @@ func runConsole(arguments []string) {
 
 	result, err := machine.GetConsoleURL(consoleConfig)
 	if err != nil {
-		errors.Exit(1)
+		exit.WithoutMessage(1)
 	}
 
 	if consolePrintURL {
@@ -55,11 +55,11 @@ func runConsole(arguments []string) {
 	}
 
 	if !machine.IsRunning(result.State) {
-		errors.ExitWithMessage(1, "The OpenShift cluster is not running, cannot open the OpenShift Web Console.")
+		exit.WithMessage(1, "The OpenShift cluster is not running, cannot open the OpenShift Web Console.")
 	}
 	output.Outln("Opening the OpenShift Web Console in the default browser...")
 	err = browser.OpenURL(result.ClusterConfig.WebConsoleURL)
 	if err != nil {
-		errors.ExitWithMessage(1, "Failed to open the OpenShift Web Console, you can access it by opening %s in your web browser.", result.ClusterConfig.WebConsoleURL)
+		exit.WithMessage(1, "Failed to open the OpenShift Web Console, you can access it by opening %s in your web browser.", result.ClusterConfig.WebConsoleURL)
 	}
 }

--- a/cmd/crc/cmd/delete.go
+++ b/cmd/crc/cmd/delete.go
@@ -4,13 +4,12 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/spf13/cobra"
-
 	"github.com/code-ready/crc/pkg/crc/constants"
-	"github.com/code-ready/crc/pkg/crc/errors"
+	"github.com/code-ready/crc/pkg/crc/exit"
 	"github.com/code-ready/crc/pkg/crc/input"
 	"github.com/code-ready/crc/pkg/crc/machine"
 	"github.com/code-ready/crc/pkg/crc/output"
+	"github.com/spf13/cobra"
 )
 
 func init() {
@@ -45,7 +44,7 @@ func runDelete(arguments []string) {
 	if yes {
 		_, err := machine.Delete(deleteConfig)
 		if err != nil {
-			errors.Exit(1)
+			exit.WithoutMessage(1)
 		}
 		output.Outln("Deleted the OpenShift cluster")
 	}

--- a/cmd/crc/cmd/ip.go
+++ b/cmd/crc/cmd/ip.go
@@ -1,12 +1,11 @@
 package cmd
 
 import (
-	"github.com/spf13/cobra"
-
 	"github.com/code-ready/crc/pkg/crc/constants"
-	"github.com/code-ready/crc/pkg/crc/errors"
+	"github.com/code-ready/crc/pkg/crc/exit"
 	"github.com/code-ready/crc/pkg/crc/machine"
 	"github.com/code-ready/crc/pkg/crc/output"
+	"github.com/spf13/cobra"
 )
 
 func init() {
@@ -32,7 +31,7 @@ func runIP(arguments []string) {
 
 	result, err := machine.IP(ipConfig)
 	if err != nil {
-		errors.Exit(1)
+		exit.WithoutMessage(1)
 	}
 	output.Outln(result.IP)
 }

--- a/cmd/crc/cmd/ip.go
+++ b/cmd/crc/cmd/ip.go
@@ -17,21 +17,26 @@ var ipCmd = &cobra.Command{
 	Short: "Get IP address of the running OpenShift cluster",
 	Long:  "Get IP address of the running OpenShift cluster",
 	Run: func(cmd *cobra.Command, args []string) {
-		runIP(args)
+		if err := runIP(args); err != nil {
+			exit.WithMessage(1, err.Error())
+		}
 	},
 }
 
-func runIP(arguments []string) {
+func runIP(arguments []string) error {
 	ipConfig := machine.IPConfig{
 		Name:  constants.DefaultName,
 		Debug: isDebugLog(),
 	}
 
-	exitIfMachineMissing(ipConfig.Name)
+	if err := checkIfMachineMissing(ipConfig.Name); err != nil {
+		return err
+	}
 
 	result, err := machine.IP(ipConfig)
 	if err != nil {
-		exit.WithoutMessage(1)
+		return err
 	}
 	output.Outln(result.IP)
+	return nil
 }

--- a/cmd/crc/cmd/oc_env.go
+++ b/cmd/crc/cmd/oc_env.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/code-ready/crc/pkg/crc/exit"
 	"github.com/code-ready/crc/pkg/crc/machine"
@@ -18,23 +20,30 @@ var ocEnvCmd = &cobra.Command{
 	Short: "Add the 'oc' binary to PATH",
 	Long:  `Add the OpenShift client binary 'oc' to PATH`,
 	Run: func(cmd *cobra.Command, args []string) {
-		userShell, err := shell.GetShell(forceShell)
-		if err != nil {
-			exit.WithMessage(1, "Error running the oc-env command: %s", err.Error())
+		if err := runOcEnv(args); err != nil {
+			exit.WithMessage(1, err.Error())
 		}
-
-		proxyConfig, err := machine.GetProxyConfig(constants.DefaultName)
-		if err != nil {
-			exit.WithoutMessage(1)
-		}
-		output.Outln(shell.GetPathEnvString(userShell, constants.CrcOcBinDir))
-		if proxyConfig.IsEnabled() {
-			output.Outln(shell.GetEnvString(userShell, "HTTP_PROXY", proxyConfig.HTTPProxy))
-			output.Outln(shell.GetEnvString(userShell, "HTTPS_PROXY", proxyConfig.HTTPSProxy))
-			output.Outln(shell.GetEnvString(userShell, "NO_PROXY", proxyConfig.GetNoProxyString()))
-		}
-		output.Outln(shell.GenerateUsageHint(userShell, "crc oc-env"))
 	},
+}
+
+func runOcEnv(args []string) error {
+	userShell, err := shell.GetShell(forceShell)
+	if err != nil {
+		return fmt.Errorf("Error running the oc-env command: %s", err.Error())
+	}
+
+	proxyConfig, err := machine.GetProxyConfig(constants.DefaultName)
+	if err != nil {
+		return err
+	}
+	output.Outln(shell.GetPathEnvString(userShell, constants.CrcOcBinDir))
+	if proxyConfig.IsEnabled() {
+		output.Outln(shell.GetEnvString(userShell, "HTTP_PROXY", proxyConfig.HTTPProxy))
+		output.Outln(shell.GetEnvString(userShell, "HTTPS_PROXY", proxyConfig.HTTPSProxy))
+		output.Outln(shell.GetEnvString(userShell, "NO_PROXY", proxyConfig.GetNoProxyString()))
+	}
+	output.Outln(shell.GenerateUsageHint(userShell, "crc oc-env"))
+	return nil
 }
 
 func init() {

--- a/cmd/crc/cmd/oc_env.go
+++ b/cmd/crc/cmd/oc_env.go
@@ -2,7 +2,7 @@ package cmd
 
 import (
 	"github.com/code-ready/crc/pkg/crc/constants"
-	"github.com/code-ready/crc/pkg/crc/errors"
+	"github.com/code-ready/crc/pkg/crc/exit"
 	"github.com/code-ready/crc/pkg/crc/machine"
 	"github.com/code-ready/crc/pkg/crc/output"
 	"github.com/code-ready/crc/pkg/os/shell"
@@ -20,12 +20,12 @@ var ocEnvCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		userShell, err := shell.GetShell(forceShell)
 		if err != nil {
-			errors.ExitWithMessage(1, "Error running the oc-env command: %s", err.Error())
+			exit.WithMessage(1, "Error running the oc-env command: %s", err.Error())
 		}
 
 		proxyConfig, err := machine.GetProxyConfig(constants.DefaultName)
 		if err != nil {
-			errors.Exit(1)
+			exit.WithoutMessage(1)
 		}
 		output.Outln(shell.GetPathEnvString(userShell, constants.CrcOcBinDir))
 		if proxyConfig.IsEnabled() {

--- a/cmd/crc/cmd/podman_env.go
+++ b/cmd/crc/cmd/podman_env.go
@@ -2,7 +2,7 @@ package cmd
 
 import (
 	"github.com/code-ready/crc/pkg/crc/constants"
-	"github.com/code-ready/crc/pkg/crc/errors"
+	"github.com/code-ready/crc/pkg/crc/exit"
 	"github.com/code-ready/crc/pkg/crc/machine"
 	"github.com/code-ready/crc/pkg/crc/output"
 	"github.com/code-ready/crc/pkg/os/shell"
@@ -16,11 +16,11 @@ var podmanEnvCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 
 		// See issue #961; Currently does not work on Windows in combination with the CRC vm.
-		errors.ExitWithMessage(1, "Currently not supported.")
+		exit.WithMessage(1, "Currently not supported.")
 
 		userShell, err := shell.GetShell(forceShell)
 		if err != nil {
-			errors.ExitWithMessage(1, "Error running the podman-env command: %s", err.Error())
+			exit.WithMessage(1, "Error running the podman-env command: %s", err.Error())
 		}
 
 		ipConfig := machine.IPConfig{
@@ -32,7 +32,7 @@ var podmanEnvCmd = &cobra.Command{
 
 		result, err := machine.IP(ipConfig)
 		if err != nil {
-			errors.Exit(1)
+			exit.WithoutMessage(1)
 		}
 
 		output.Outln(shell.GetPathEnvString(userShell, constants.CrcBinDir))

--- a/cmd/crc/cmd/podman_env.go
+++ b/cmd/crc/cmd/podman_env.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/code-ready/crc/pkg/crc/exit"
 	"github.com/code-ready/crc/pkg/crc/machine"
@@ -14,34 +16,42 @@ var podmanEnvCmd = &cobra.Command{
 	Short: "Setup podman environment",
 	Long:  `Setup environment for 'podman' binary to access podman on CRC VM`,
 	Run: func(cmd *cobra.Command, args []string) {
-
-		// See issue #961; Currently does not work on Windows in combination with the CRC vm.
-		exit.WithMessage(1, "Currently not supported.")
-
-		userShell, err := shell.GetShell(forceShell)
-		if err != nil {
-			exit.WithMessage(1, "Error running the podman-env command: %s", err.Error())
+		if err := runPodmanEnv(args); err != nil {
+			exit.WithMessage(1, err.Error())
 		}
-
-		ipConfig := machine.IPConfig{
-			Name:  constants.DefaultName,
-			Debug: isDebugLog(),
-		}
-
-		exitIfMachineMissing(ipConfig.Name)
-
-		result, err := machine.IP(ipConfig)
-		if err != nil {
-			exit.WithoutMessage(1)
-		}
-
-		output.Outln(shell.GetPathEnvString(userShell, constants.CrcBinDir))
-		output.Outln(shell.GetEnvString(userShell, "PODMAN_USER", constants.DefaultSSHUser))
-		output.Outln(shell.GetEnvString(userShell, "PODMAN_HOST", result.IP))
-		output.Outln(shell.GetEnvString(userShell, "PODMAN_IDENTITY_FILE", constants.GetPrivateKeyPath()))
-		output.Outln(shell.GetEnvString(userShell, "PODMAN_IGNORE_HOSTS", "1"))
-		output.Outln(shell.GenerateUsageHint(userShell, "crc podman-env"))
 	},
+}
+
+func runPodmanEnv(args []string) error {
+	// See issue #961; Currently does not work on Windows in combination with the CRC vm.
+	exit.WithMessage(1, "Currently not supported.")
+
+	userShell, err := shell.GetShell(forceShell)
+	if err != nil {
+		return fmt.Errorf("Error running the podman-env command: %s", err.Error())
+	}
+
+	ipConfig := machine.IPConfig{
+		Name:  constants.DefaultName,
+		Debug: isDebugLog(),
+	}
+
+	if err := checkIfMachineMissing(ipConfig.Name); err != nil {
+		return err
+	}
+
+	result, err := machine.IP(ipConfig)
+	if err != nil {
+		return err
+	}
+
+	output.Outln(shell.GetPathEnvString(userShell, constants.CrcBinDir))
+	output.Outln(shell.GetEnvString(userShell, "PODMAN_USER", constants.DefaultSSHUser))
+	output.Outln(shell.GetEnvString(userShell, "PODMAN_HOST", result.IP))
+	output.Outln(shell.GetEnvString(userShell, "PODMAN_IDENTITY_FILE", constants.GetPrivateKeyPath()))
+	output.Outln(shell.GetEnvString(userShell, "PODMAN_IGNORE_HOSTS", "1"))
+	output.Outln(shell.GenerateUsageHint(userShell, "crc podman-env"))
+	return nil
 }
 
 func init() {

--- a/cmd/crc/cmd/root.go
+++ b/cmd/crc/cmd/root.go
@@ -1,7 +1,7 @@
 package cmd
 
 import (
-	"github.com/code-ready/crc/pkg/crc/errors"
+	"github.com/code-ready/crc/pkg/crc/exit"
 	"github.com/code-ready/crc/pkg/crc/machine"
 	"github.com/code-ready/crc/pkg/crc/network"
 	"github.com/code-ready/crc/pkg/crc/output"
@@ -84,10 +84,10 @@ func setConfigDefaults() {
 func exitIfMachineMissing(name string) {
 	exists, err := machine.Exists(name)
 	if err != nil {
-		errors.ExitWithMessage(1, err.Error())
+		exit.WithMessage(1, err.Error())
 	}
 	if !exists {
-		errors.ExitWithMessage(1, "Machine '%s' does not exist. Use 'crc start' to create it.", name)
+		exit.WithMessage(1, "Machine '%s' does not exist. Use 'crc start' to create it.", name)
 	}
 }
 
@@ -98,7 +98,7 @@ func setProxyDefaults() {
 
 	proxyConfig, err := network.NewProxyDefaults(httpProxy, httpsProxy, noProxy)
 	if err != nil {
-		errors.ExitWithMessage(1, err.Error())
+		exit.WithMessage(1, err.Error())
 	}
 
 	if proxyConfig.IsEnabled() {

--- a/cmd/crc/cmd/root.go
+++ b/cmd/crc/cmd/root.go
@@ -1,18 +1,18 @@
 package cmd
 
 import (
+	"fmt"
+
+	cmdConfig "github.com/code-ready/crc/cmd/crc/cmd/config"
+	"github.com/code-ready/crc/pkg/crc/config"
+	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/code-ready/crc/pkg/crc/exit"
+	"github.com/code-ready/crc/pkg/crc/logging"
 	"github.com/code-ready/crc/pkg/crc/machine"
 	"github.com/code-ready/crc/pkg/crc/network"
 	"github.com/code-ready/crc/pkg/crc/output"
-	"github.com/spf13/cobra"
-
-	cmdConfig "github.com/code-ready/crc/cmd/crc/cmd/config"
-
-	"github.com/code-ready/crc/pkg/crc/config"
-	"github.com/code-ready/crc/pkg/crc/constants"
-	"github.com/code-ready/crc/pkg/crc/logging"
 	"github.com/code-ready/crc/pkg/crc/preflight"
+	"github.com/spf13/cobra"
 )
 
 var rootCmd = &cobra.Command{
@@ -81,14 +81,15 @@ func setConfigDefaults() {
 	config.SetDefaults()
 }
 
-func exitIfMachineMissing(name string) {
+func checkIfMachineMissing(name string) error {
 	exists, err := machine.Exists(name)
 	if err != nil {
-		exit.WithMessage(1, err.Error())
+		return err
 	}
 	if !exists {
-		exit.WithMessage(1, "Machine '%s' does not exist. Use 'crc start' to create it.", name)
+		return fmt.Errorf("Machine '%s' does not exist. Use 'crc start' to create it", constants.DefaultName)
 	}
+	return nil
 }
 
 func setProxyDefaults() {

--- a/cmd/crc/cmd/setup.go
+++ b/cmd/crc/cmd/setup.go
@@ -1,13 +1,13 @@
 package cmd
 
 import (
-	"github.com/spf13/cobra"
-
 	"github.com/code-ready/crc/cmd/crc/cmd/config"
 	crcConfig "github.com/code-ready/crc/pkg/crc/config"
 	"github.com/code-ready/crc/pkg/crc/constants"
+	"github.com/code-ready/crc/pkg/crc/exit"
 	"github.com/code-ready/crc/pkg/crc/output"
 	"github.com/code-ready/crc/pkg/crc/preflight"
+	"github.com/spf13/cobra"
 )
 
 func init() {
@@ -21,11 +21,13 @@ var setupCmd = &cobra.Command{
 	Short: "Set up prerequisites for the OpenShift cluster",
 	Long:  "Set up local virtualization and networking infrastructure for the OpenShift cluster",
 	Run: func(cmd *cobra.Command, args []string) {
-		runSetup(args)
+		if err := runSetup(args); err != nil {
+			exit.WithMessage(1, err.Error())
+		}
 	},
 }
 
-func runSetup(arguments []string) {
+func runSetup(arguments []string) error {
 	if crcConfig.GetBool(config.ExperimentalFeatures.Name) {
 		preflight.EnableExperimentalFeatures = true
 	}
@@ -35,4 +37,5 @@ func runSetup(arguments []string) {
 		bundle = " -b $bundlename"
 	}
 	output.Outf("Setup is complete, you can now run 'crc start%s' to start the OpenShift cluster\n", bundle)
+	return nil
 }

--- a/cmd/crc/cmd/start.go
+++ b/cmd/crc/cmd/start.go
@@ -4,13 +4,11 @@ import (
 	"fmt"
 	"io/ioutil"
 
-	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
-
 	"github.com/code-ready/crc/cmd/crc/cmd/config"
 	crcConfig "github.com/code-ready/crc/pkg/crc/config"
 	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/code-ready/crc/pkg/crc/errors"
+	"github.com/code-ready/crc/pkg/crc/exit"
 	"github.com/code-ready/crc/pkg/crc/input"
 	"github.com/code-ready/crc/pkg/crc/logging"
 	"github.com/code-ready/crc/pkg/crc/machine"
@@ -18,6 +16,8 @@ import (
 	"github.com/code-ready/crc/pkg/crc/preflight"
 	"github.com/code-ready/crc/pkg/crc/validation"
 	"github.com/code-ready/crc/pkg/crc/version"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 func init() {
@@ -42,7 +42,7 @@ var (
 
 func runStart(arguments []string) {
 	if err := validateStartFlags(); err != nil {
-		errors.Exit(1)
+		exit.WithoutMessage(1)
 	}
 
 	checkIfNewVersionAvailable(crcConfig.GetBool(config.DisableUpdateCheck.Name))
@@ -61,7 +61,7 @@ func runStart(arguments []string) {
 
 	commandResult, err := machine.Start(startConfig)
 	if err != nil {
-		errors.Exit(1)
+		exit.WithoutMessage(1)
 	}
 	if commandResult.Status == "Running" {
 		output.Outln("Started the OpenShift cluster")

--- a/cmd/crc/cmd/status.go
+++ b/cmd/crc/cmd/status.go
@@ -7,7 +7,7 @@ import (
 	"text/template"
 
 	"github.com/code-ready/crc/pkg/crc/constants"
-	"github.com/code-ready/crc/pkg/crc/errors"
+	"github.com/code-ready/crc/pkg/crc/exit"
 	"github.com/code-ready/crc/pkg/crc/machine"
 	"github.com/docker/go-units"
 	"github.com/spf13/cobra"
@@ -48,7 +48,7 @@ func runStatus() {
 
 	clusterStatus, err := machine.Status(statusConfig)
 	if err != nil {
-		errors.Exit(1)
+		exit.WithoutMessage(1)
 	}
 	cacheDir := constants.MachineCacheDir
 	var size int64
@@ -59,7 +59,7 @@ func runStatus() {
 		return err
 	})
 	if err != nil {
-		errors.ExitWithMessage(1, "Error finding size of cache: %s", err.Error())
+		exit.WithMessage(1, "Error finding size of cache: %s", err.Error())
 	}
 	cacheUsage := units.HumanSize(float64(size))
 	diskUse := units.HumanSize(float64(clusterStatus.DiskUse))
@@ -72,10 +72,10 @@ func runStatus() {
 func printStatus(status interface{}, statusFormat string) {
 	tmpl, err := template.New("status").Parse(statusFormat)
 	if err != nil {
-		errors.ExitWithMessage(1, "Error creating status template: %s", err.Error())
+		exit.WithMessage(1, "Error creating status template: %s", err.Error())
 	}
 	err = tmpl.Execute(os.Stdout, status)
 	if err != nil {
-		errors.ExitWithMessage(1, "Error executing status template: %s", err.Error())
+		exit.WithMessage(1, "Error executing status template: %s", err.Error())
 	}
 }

--- a/cmd/crc/cmd/stop.go
+++ b/cmd/crc/cmd/stop.go
@@ -2,7 +2,7 @@ package cmd
 
 import (
 	"github.com/code-ready/crc/pkg/crc/constants"
-	"github.com/code-ready/crc/pkg/crc/errors"
+	"github.com/code-ready/crc/pkg/crc/exit"
 	"github.com/code-ready/crc/pkg/crc/input"
 	"github.com/code-ready/crc/pkg/crc/logging"
 	"github.com/code-ready/crc/pkg/crc/machine"
@@ -49,10 +49,10 @@ func runStop(arguments []string) {
 			yes := input.PromptUserForYesOrNo("Do you want to force power off", globalForce)
 			if yes {
 				killVM(killConfig)
-				errors.Exit(0)
+				exit.WithoutMessage(0)
 			}
 		}
-		errors.Exit(1)
+		exit.WithoutMessage(1)
 	}
 	if commandResult.Success {
 		output.Outln("Stopped the OpenShift cluster")
@@ -65,7 +65,7 @@ func runStop(arguments []string) {
 func killVM(killConfig machine.PowerOffConfig) {
 	_, err := machine.PowerOff(killConfig)
 	if err != nil {
-		errors.Exit(1)
+		exit.WithoutMessage(1)
 	}
 	output.Outln("Forcibly stopped the OpenShift cluster")
 }

--- a/pkg/crc/cluster/clusteroperator_test.go
+++ b/pkg/crc/cluster/clusteroperator_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/code-ready/crc/pkg/crc/oc"
-
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/crc/config/viper_config.go
+++ b/pkg/crc/config/viper_config.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/code-ready/crc/pkg/crc/constants"
-	"github.com/code-ready/crc/pkg/crc/errors"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 )
@@ -49,11 +48,11 @@ func set(key string, value interface{}) {
 func syncViperState(viper *viper.Viper) error {
 	encodedConfig, err := json.MarshalIndent(changedConfigs, "", " ")
 	if err != nil {
-		return errors.Newf("Error encoding configuration to JSON: %v", err)
+		return fmt.Errorf("Error encoding configuration to JSON: %v", err)
 	}
 	err = viper.ReadConfig(bytes.NewBuffer(encodedConfig))
 	if err != nil {
-		return errors.Newf("Error reading configuration file '%s': %v", constants.ConfigFile, err)
+		return fmt.Errorf("Error reading configuration file '%s': %v", constants.ConfigFile, err)
 	}
 	return nil
 }

--- a/pkg/crc/exit/atexit.go
+++ b/pkg/crc/exit/atexit.go
@@ -1,4 +1,4 @@
-package errors
+package exit
 
 import (
 	"fmt"
@@ -15,8 +15,8 @@ type exitHandlerFunc func(int) bool
 // exitHandlers keeps track of the list of registered exit handlers. Handlers are applied in the order defined in this list.
 var exitHandlers = []exitHandlerFunc{}
 
-// Exit runs all registered exit handlers and then exits the program with the specified exit code using os.Exit.
-func Exit(code int) {
+// WithoutMessage runs all registered exit handlers and then exits the program with the specified exit code using os.Exit.
+func WithoutMessage(code int) {
 	veto := runHandlers(code)
 	if veto {
 		panic(ExitHandlerPanicMessage)
@@ -24,18 +24,18 @@ func Exit(code int) {
 	os.Exit(code)
 }
 
-// ExitWithMessage runs all registered exit handlers, prints the specified message and then exits the program with the specified exit code.
+// WithMessage runs all registered exit handlers, prints the specified message and then exits the program with the specified exit code.
 // If the exit code is 0, the message is prints to stdout, otherwise to stderr.
-func ExitWithMessage(code int, text string, args ...interface{}) {
+func WithMessage(code int, text string, args ...interface{}) {
 	if code == 0 {
 		_, _ = output.Fout(os.Stdout, fmt.Sprintf(text, args...))
 	} else {
 		_, _ = output.Fout(os.Stderr, fmt.Sprintf(text, args...))
 	}
-	Exit(code)
+	WithoutMessage(code)
 }
 
-// Register registers an exit handler function which is run when Exit is called
+// Register registers an exit handler function which is run when WithoutMessage is called
 func RegisterExitHandler(exitHandler exitHandlerFunc) {
 	exitHandlers = append(exitHandlers, exitHandler)
 }

--- a/pkg/crc/machine/client/client_darwin.go
+++ b/pkg/crc/machine/client/client_darwin.go
@@ -3,14 +3,14 @@ package client
 import (
 	"os"
 
-	"github.com/code-ready/crc/pkg/crc/errors"
+	"github.com/code-ready/crc/pkg/crc/exit"
 	"github.com/code-ready/machine/libmachine/drivers/plugin/localbinary"
 )
 
 // StartDriver starts the desired machine driver if necessary.
 func StartDriver() {
 	if os.Getenv(localbinary.PluginEnvKey) == localbinary.PluginEnvVal {
-		errors.ExitWithMessage(1, "Unregistered driver: %s\n", os.Getenv(localbinary.PluginEnvDriverName))
+		exit.WithMessage(1, "Unregistered driver: %s\n", os.Getenv(localbinary.PluginEnvDriverName))
 		return
 	}
 	localbinary.CurrentBinaryIsCRCMachine = true

--- a/pkg/crc/machine/client/client_linux.go
+++ b/pkg/crc/machine/client/client_linux.go
@@ -3,14 +3,14 @@ package client
 import (
 	"os"
 
-	"github.com/code-ready/crc/pkg/crc/errors"
+	"github.com/code-ready/crc/pkg/crc/exit"
 	"github.com/code-ready/machine/libmachine/drivers/plugin/localbinary"
 )
 
 // StartDriver starts the desired machine driver if necessary.
 func StartDriver() {
 	if os.Getenv(localbinary.PluginEnvKey) == localbinary.PluginEnvVal {
-		errors.ExitWithMessage(1, "Unregistered driver: %s\n", os.Getenv(localbinary.PluginEnvDriverName))
+		exit.WithMessage(1, "Unregistered driver: %s\n", os.Getenv(localbinary.PluginEnvDriverName))
 		return
 	}
 	localbinary.CurrentBinaryIsCRCMachine = true

--- a/pkg/crc/machine/client/client_windows.go
+++ b/pkg/crc/machine/client/client_windows.go
@@ -3,7 +3,7 @@ package client
 import (
 	"os"
 
-	"github.com/code-ready/crc/pkg/crc/errors"
+	"github.com/code-ready/crc/pkg/crc/exit"
 	"github.com/code-ready/machine/drivers/hyperv"
 	"github.com/code-ready/machine/libmachine/drivers/plugin"
 	"github.com/code-ready/machine/libmachine/drivers/plugin/localbinary"
@@ -17,7 +17,7 @@ func StartDriver() {
 		case "hyperv":
 			plugin.RegisterDriver(hyperv.NewDriver("", ""))
 		default:
-			errors.ExitWithMessage(1, "Unregistered driver: %s\n", driverName)
+			exit.WithMessage(1, "Unregistered driver: %s\n", driverName)
 		}
 		return
 	}

--- a/pkg/crc/machine/driver_darwin.go
+++ b/pkg/crc/machine/driver_darwin.go
@@ -2,11 +2,10 @@ package machine
 
 import (
 	"github.com/code-ready/crc/pkg/crc/constants"
-	"github.com/code-ready/crc/pkg/crc/errors"
-	crcos "github.com/code-ready/crc/pkg/os"
-
+	"github.com/code-ready/crc/pkg/crc/exit"
 	"github.com/code-ready/crc/pkg/crc/machine/config"
 	"github.com/code-ready/crc/pkg/crc/machine/hyperkit"
+	crcos "github.com/code-ready/crc/pkg/os"
 )
 
 func init() {
@@ -34,7 +33,7 @@ func getDriverOptions(machineConfig config.MachineConfig) interface{} {
 		driver = hyperkit.CreateHost(machineConfig)
 
 	default:
-		errors.ExitWithMessage(1, "Unsupported driver: %s", machineConfig.VMDriver)
+		exit.WithMessage(1, "Unsupported driver: %s", machineConfig.VMDriver)
 	}
 
 	return driver

--- a/pkg/crc/machine/driver_linux.go
+++ b/pkg/crc/machine/driver_linux.go
@@ -2,11 +2,10 @@ package machine
 
 import (
 	"github.com/code-ready/crc/pkg/crc/constants"
-	"github.com/code-ready/crc/pkg/crc/errors"
-	crcos "github.com/code-ready/crc/pkg/os"
-
+	"github.com/code-ready/crc/pkg/crc/exit"
 	"github.com/code-ready/crc/pkg/crc/machine/config"
 	"github.com/code-ready/crc/pkg/crc/machine/libvirt"
+	crcos "github.com/code-ready/crc/pkg/os"
 )
 
 func init() {
@@ -34,7 +33,7 @@ func getDriverOptions(machineConfig config.MachineConfig) interface{} {
 		driver = libvirt.CreateHost(machineConfig)
 
 	default:
-		errors.ExitWithMessage(1, "Unsupported driver: %s", machineConfig.VMDriver)
+		exit.WithMessage(1, "Unsupported driver: %s", machineConfig.VMDriver)
 	}
 
 	return driver

--- a/pkg/crc/machine/driver_windows.go
+++ b/pkg/crc/machine/driver_windows.go
@@ -1,11 +1,10 @@
 package machine
 
 import (
-	"github.com/code-ready/crc/pkg/crc/errors"
-	crcos "github.com/code-ready/crc/pkg/os"
-
+	"github.com/code-ready/crc/pkg/crc/exit"
 	"github.com/code-ready/crc/pkg/crc/machine/config"
 	"github.com/code-ready/crc/pkg/crc/machine/hyperv"
+	crcos "github.com/code-ready/crc/pkg/os"
 )
 
 func init() {
@@ -32,7 +31,7 @@ func getDriverOptions(machineConfig config.MachineConfig) interface{} {
 		driver = hyperv.CreateHost(machineConfig)
 
 	default:
-		errors.ExitWithMessage(1, "Unsupported driver: %s", machineConfig.VMDriver)
+		exit.WithMessage(1, "Unsupported driver: %s", machineConfig.VMDriver)
 	}
 
 	return driver

--- a/pkg/crc/machine/machine.go
+++ b/pkg/crc/machine/machine.go
@@ -672,7 +672,7 @@ func addNameServerToInstance(sshRunner *crcssh.Runner, ns string) error {
 	}
 	if !exist {
 		logging.Infof("Adding %s as nameserver to the instance ...", nameserver.IPAddress)
-		network.AddNameserversToInstance(sshRunner, nameservers)
+		return network.AddNameserversToInstance(sshRunner, nameservers)
 	}
 	return nil
 }

--- a/pkg/crc/network/nameservers.go
+++ b/pkg/crc/network/nameservers.go
@@ -5,7 +5,7 @@ import (
 	"io/ioutil"
 	"strings"
 
-	"github.com/code-ready/crc/pkg/crc/errors"
+	"github.com/code-ready/crc/pkg/crc/exit"
 	"github.com/code-ready/crc/pkg/crc/ssh"
 )
 
@@ -37,7 +37,7 @@ func CreateResolvFileOnInstance(sshRunner *ssh.Runner, resolvFileValues ResolvFi
 
 	err := sshRunner.CopyData([]byte(resolvFile), "/etc/resolv.conf")
 	if err != nil {
-		errors.ExitWithMessage(1, "Error creating /etc/resolv on instance: %s", err.Error())
+		exit.WithMessage(1, "Error creating /etc/resolv on instance: %s", err.Error())
 	}
 }
 

--- a/pkg/crc/network/utils.go
+++ b/pkg/crc/network/utils.go
@@ -7,6 +7,7 @@ import (
 	"runtime"
 
 	"github.com/code-ready/crc/pkg/crc/errors"
+	"github.com/code-ready/crc/pkg/crc/exit"
 	"github.com/code-ready/crc/pkg/crc/logging"
 	"github.com/code-ready/crc/pkg/crc/machine/bundle"
 	"github.com/code-ready/crc/pkg/crc/ssh"
@@ -17,7 +18,7 @@ func executeCommandOrExit(sshRunner *ssh.Runner, command string, errorMessage st
 	result, err := sshRunner.Run(command)
 
 	if err != nil {
-		errors.ExitWithMessage(1, "%s: %s", errorMessage, err.Error())
+		exit.WithMessage(1, "%s: %s", errorMessage, err.Error())
 	}
 	return result
 }

--- a/pkg/crc/network/utils.go
+++ b/pkg/crc/network/utils.go
@@ -1,27 +1,16 @@
 package network
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"net/url"
 	"runtime"
 
-	"github.com/code-ready/crc/pkg/crc/errors"
-	"github.com/code-ready/crc/pkg/crc/exit"
 	"github.com/code-ready/crc/pkg/crc/logging"
 	"github.com/code-ready/crc/pkg/crc/machine/bundle"
-	"github.com/code-ready/crc/pkg/crc/ssh"
 	crcos "github.com/code-ready/crc/pkg/os"
 )
-
-func executeCommandOrExit(sshRunner *ssh.Runner, command string, errorMessage string) string {
-	result, err := sshRunner.Run(command)
-
-	if err != nil {
-		exit.WithMessage(1, "%s: %s", errorMessage, err.Error())
-	}
-	return result
-}
 
 // Contains returns true if the IP address belongs to the network given
 func Contains(network string, ip string) bool {

--- a/pkg/crc/preflight/preflight.go
+++ b/pkg/crc/preflight/preflight.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	cfg "github.com/code-ready/crc/pkg/crc/config"
-	"github.com/code-ready/crc/pkg/crc/errors"
 	"github.com/code-ready/crc/pkg/crc/logging"
 )
 
@@ -88,7 +87,7 @@ func (check *Check) doFix() error {
 		panic(fmt.Sprintf("Should not happen, empty description for fix '%s'", check.configKeySuffix))
 	}
 	if check.flags&NoFix == NoFix {
-		return errors.Newf(check.fixDescription)
+		return fmt.Errorf(check.fixDescription)
 	}
 
 	logging.Infof("%s", check.fixDescription)

--- a/pkg/crc/services/dns/dns.go
+++ b/pkg/crc/services/dns/dns.go
@@ -80,7 +80,11 @@ func RunPostStart(serviceConfig services.ServicePostStartConfig) (services.Servi
 		SearchDomains: []network.SearchDomain{searchdomain},
 		NameServers:   nameservers}
 
-	network.CreateResolvFileOnInstance(serviceConfig.SSHRunner, resolvFileValues)
+	if err := network.CreateResolvFileOnInstance(serviceConfig.SSHRunner, resolvFileValues); err != nil {
+		result.Success = false
+		result.Error = err.Error()
+		return *result, err
+	}
 
 	result.Success = true
 	return *result, nil

--- a/pkg/crc/services/dns/dns_windows.go
+++ b/pkg/crc/services/dns/dns_windows.go
@@ -2,13 +2,12 @@ package dns
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
 
-	"github.com/code-ready/crc/pkg/crc/errors"
 	"github.com/code-ready/crc/pkg/crc/services"
-
 	winnet "github.com/code-ready/crc/pkg/os/windows/network"
 	"github.com/code-ready/crc/pkg/os/windows/powershell"
 	"github.com/code-ready/crc/pkg/os/windows/win32"

--- a/pkg/crc/validation/validation.go
+++ b/pkg/crc/validation/validation.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/code-ready/crc/pkg/crc/constants"
-	"github.com/code-ready/crc/pkg/crc/errors"
 	"github.com/code-ready/crc/pkg/crc/logging"
 	"github.com/code-ready/crc/pkg/crc/version"
 	"github.com/docker/go-units"
@@ -19,7 +18,7 @@ import (
 // ValidateCPUs checks if provided cpus count is valid
 func ValidateCPUs(value int) error {
 	if value < constants.DefaultCPUs {
-		return errors.Newf("requires CPUs >= %d", constants.DefaultCPUs)
+		return fmt.Errorf("requires CPUs >= %d", constants.DefaultCPUs)
 	}
 	return nil
 }
@@ -27,7 +26,7 @@ func ValidateCPUs(value int) error {
 // ValidateMemory checks if provided Memory count is valid
 func ValidateMemory(value int) error {
 	if value < constants.DefaultMemory {
-		return errors.Newf("requires memory in MiB >= %d", constants.DefaultMemory)
+		return fmt.Errorf("requires memory in MiB >= %d", constants.DefaultMemory)
 	}
 	return ValidateEnoughMemory(value)
 }
@@ -49,15 +48,15 @@ func ValidateEnoughMemory(value int) error {
 func ValidateBundle(bundle string) error {
 	if err := ValidatePath(bundle); err != nil {
 		if constants.BundleEmbedded() {
-			return errors.Newf("Run 'crc setup' to unpack the bundle to disk")
+			return fmt.Errorf("Run 'crc setup' to unpack the bundle to disk")
 		}
-		return errors.Newf("Please provide the path to a valid bundle using the -b option")
+		return fmt.Errorf("Please provide the path to a valid bundle using the -b option")
 	}
 	// Check if the version of the bundle provided by user is same as what is released with crc.
 	releaseBundleVersion := version.GetBundleVersion()
 	userProvidedBundleVersion := filepath.Base(bundle)
 	if !strings.Contains(userProvidedBundleVersion, fmt.Sprintf("%s.crcbundle", releaseBundleVersion)) {
-		return errors.Newf("%s bundle is not supported by this binary, please use %s", userProvidedBundleVersion, constants.GetDefaultBundle())
+		return fmt.Errorf("%s bundle is not supported by this binary, please use %s", userProvidedBundleVersion, constants.GetDefaultBundle())
 	}
 	return nil
 }
@@ -66,7 +65,7 @@ func ValidateBundle(bundle string) error {
 func ValidateIPAddress(ipAddress string) error {
 	ip := net.ParseIP(ipAddress).To4()
 	if ip == nil {
-		return errors.Newf("'%s' is not a valid IPv4 address", ipAddress)
+		return fmt.Errorf("'%s' is not a valid IPv4 address", ipAddress)
 	}
 	return nil
 }
@@ -74,7 +73,7 @@ func ValidateIPAddress(ipAddress string) error {
 // ValidatePath check if provide path is exist
 func ValidatePath(path string) error {
 	if _, err := os.Stat(path); os.IsNotExist(err) {
-		return errors.Newf("file '%s' does not exist", path)
+		return fmt.Errorf("file '%s' does not exist", path)
 	}
 	return nil
 }

--- a/pkg/download/download.go
+++ b/pkg/download/download.go
@@ -1,12 +1,11 @@
 package download
 
 import (
+	"fmt"
 	"os"
 
-	"github.com/code-ready/crc/pkg/crc/errors"
-	"github.com/code-ready/crc/pkg/crc/logging"
-
 	"github.com/cavaliercoder/grab"
+	"github.com/code-ready/crc/pkg/crc/logging"
 )
 
 func Download(uri, destination string, mode os.FileMode) (string, error) {
@@ -15,7 +14,7 @@ func Download(uri, destination string, mode os.FileMode) (string, error) {
 	client := grab.NewClient()
 	req, err := grab.NewRequest(destination, uri)
 	if err != nil {
-		return "", errors.Newf("Unable to get response from %s: %v", uri, err)
+		return "", fmt.Errorf("Unable to get response from %s: %v", uri, err)
 	}
 	defer func() {
 		if err != nil {
@@ -25,7 +24,7 @@ func Download(uri, destination string, mode os.FileMode) (string, error) {
 	resp := client.Do(req)
 	// check for errors
 	if err := resp.Err(); err != nil {
-		return "", errors.Newf("Download failed: %v", err)
+		return "", fmt.Errorf("Download failed: %v", err)
 	}
 
 	err = os.Chmod(resp.Filename, mode)

--- a/pkg/os/shell/shell.go
+++ b/pkg/os/shell/shell.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/code-ready/crc/pkg/crc/errors"
 	"github.com/code-ready/machine/libmachine/shell"
 )
 
@@ -18,7 +17,7 @@ type Config struct {
 func GetShell(userShell string) (string, error) {
 	if userShell != "" {
 		if !isSupportedShell(userShell) {
-			return "", errors.Newf("'%s' is not a supported shell.\nSupported shells are %s.", userShell, strings.Join(supportedShell, ", "))
+			return "", fmt.Errorf("'%s' is not a supported shell.\nSupported shells are %s", userShell, strings.Join(supportedShell, ", "))
 		}
 		return userShell, nil
 	}

--- a/test/integration/features/basic.feature
+++ b/test/integration/features/basic.feature
@@ -31,7 +31,7 @@ Feature: Basic test
         When executing "crc status" fails
         Then stderr should contain 
         """
-        Machine 'crc' does not exist. Use 'crc start' to create it.
+        Machine 'crc' does not exist. Use 'crc start' to create it
         """
 
     @linux
@@ -131,7 +131,7 @@ Feature: Basic test
         Given executing "crc status" succeeds
         And stdout contains "Stopped"
         When executing "crc console"
-        Then stderr should contain "The OpenShift cluster is not running, cannot open the OpenShift Web Console."
+        Then stderr should contain "The OpenShift cluster is not running, cannot open the OpenShift Web Console"
 
     @darwin @linux @windows
     Scenario: CRC delete


### PR DESCRIPTION
Reduce the number of os.Exit() and use return err instead (esp. in non cmd/ code). This is required for the daemon: we don't want it to crash in the middle of a call. In the cmd package, it gives us a better understanding of the flow.