### PR TITLE
Fix cache.Executable() check

### DIFF
--- a/pkg/crc/cache/cache.go
+++ b/pkg/crc/cache/cache.go
@@ -155,12 +155,3 @@ func IsTarball(filename string) bool {
 	}
 	return false
 }
-
-func (c *Cache) Executable() bool {
-	f := filepath.Join(c.destDir, c.binaryName)
-	fInfo, err := os.Stat(f)
-	if err != nil {
-		return false
-	}
-	return fInfo.Mode()&0100 != 0
-}

--- a/pkg/crc/preflight/preflight_checks_darwin.go
+++ b/pkg/crc/preflight/preflight_checks_darwin.go
@@ -27,7 +27,8 @@ func checkHyperKitInstalled() error {
 		return fmt.Errorf("%s binary is not cached", hyperkit.HyperkitCommand)
 	}
 	hyperkitPath := filepath.Join(constants.CrcBinDir, hyperkit.HyperkitCommand)
-	if !h.Executable() {
+	err := unix.Access(hyperkitPath, unix.X_OK)
+	if err != nil {
 		return fmt.Errorf("%s not executable", hyperkitPath)
 	}
 	return checkSuid(hyperkitPath)
@@ -48,9 +49,7 @@ func checkMachineDriverHyperKitInstalled() error {
 	if !hyperkitDriver.IsCached() {
 		return fmt.Errorf("%s binary is not cached", hyperkit.MachineDriverCommand)
 	}
-	if !hyperkitDriver.Executable() {
-		return fmt.Errorf("%s is not executable", filepath.Join(constants.CrcBinDir, hyperkit.MachineDriverCommand))
-	}
+
 	if err := hyperkitDriver.CheckVersion(); err != nil {
 		return err
 	}

--- a/pkg/crc/preflight/preflight_checks_linux.go
+++ b/pkg/crc/preflight/preflight_checks_linux.go
@@ -224,9 +224,6 @@ func checkMachineDriverLibvirtInstalled() error {
 	if !machineDriverLibvirt.IsCached() {
 		return fmt.Errorf("%s binary is not cached", libvirt.MachineDriverCommand)
 	}
-	if !machineDriverLibvirt.Executable() {
-		return fmt.Errorf("%s is not executable", filepath.Join(constants.CrcBinDir, libvirt.MachineDriverCommand))
-	}
 	if err := machineDriverLibvirt.CheckVersion(); err != nil {
 		return err
 	}


### PR DESCRIPTION
This check is incorrect as it will return true for a file with
permissions 744 which is not owned by the current user. This switches
back to using unix.Access, which reverts parts of b8aba44ea and
b59dcf96f
unix.Access is not available on Windows, which is why the generic cache
implementation cannot be switched to it. An alternative to calling
unix.Access directly from the preflight files would be to use
unix.Access in cache_nonwin.go, and have a different implementation in
cache_windows.go, but I was not sure how to implement this on Windows.



**Fixes:** Issue #N

**Relates to:** Issue #N, PR #N, ...

## Solution/Idea

Describe in plain English what you solved and how. For instance, _Added `start` command to CRC so the user can create a VM and set-up a single-node OpenShift cluster on it with one command. It requires blablabla..._

## Proposed changes

List main as well as consequential changes you introduced or had to introduce.

1. Add `start` command.
2. Add `setup` as prerequisite to `start`.
3. ...

## Testing

What is the _bottom-line_ functionality that needs testing? Describe in pseudo-code or in English. Use verifiable statements that tie your changes to existing functionality.

1. `start` succeeds first time after `setup` succeeded
2. stdout contains ... if `start` succeeded
3. stderr contains ... after `start` failed
4. `status` returns ... if `start` succeeded
5. `status` returns ... if `start` failed
6. `start` fails after `start` succeeded or after `status` says CRC is `Running`
7. ...