### PR TITLE
Add json output format for crc status

### DIFF
--- a/cmd/crc/cmd/client.go
+++ b/cmd/crc/cmd/client.go
@@ -1,0 +1,18 @@
+package cmd
+
+import "github.com/code-ready/crc/pkg/crc/machine"
+
+type client interface {
+	Status(statusConfig machine.ClusterStatusConfig) (machine.ClusterStatusResult, error)
+	Exists(name string) (bool, error)
+}
+
+type libmachineClient struct{}
+
+func (*libmachineClient) Status(statusConfig machine.ClusterStatusConfig) (machine.ClusterStatusResult, error) {
+	return machine.Status(statusConfig)
+}
+
+func (*libmachineClient) Exists(name string) (bool, error) {
+	return machine.Exists(name)
+}

--- a/cmd/crc/cmd/console.go
+++ b/cmd/crc/cmd/console.go
@@ -41,7 +41,7 @@ func runConsole(arguments []string) error {
 		Name: constants.DefaultName,
 	}
 
-	if err := checkIfMachineMissing(consoleConfig.Name); err != nil {
+	if err := checkIfMachineMissing(&libmachineClient{}, consoleConfig.Name); err != nil {
 		return err
 	}
 

--- a/cmd/crc/cmd/delete.go
+++ b/cmd/crc/cmd/delete.go
@@ -40,7 +40,7 @@ func runDelete(arguments []string) error {
 		deleteCache()
 	}
 
-	if err := checkIfMachineMissing(deleteConfig.Name); err != nil {
+	if err := checkIfMachineMissing(&libmachineClient{}, deleteConfig.Name); err != nil {
 		return err
 	}
 

--- a/cmd/crc/cmd/ip.go
+++ b/cmd/crc/cmd/ip.go
@@ -29,7 +29,7 @@ func runIP(arguments []string) error {
 		Debug: isDebugLog(),
 	}
 
-	if err := checkIfMachineMissing(ipConfig.Name); err != nil {
+	if err := checkIfMachineMissing(&libmachineClient{}, ipConfig.Name); err != nil {
 		return err
 	}
 

--- a/cmd/crc/cmd/podman_env.go
+++ b/cmd/crc/cmd/podman_env.go
@@ -36,7 +36,7 @@ func runPodmanEnv(args []string) error {
 		Debug: isDebugLog(),
 	}
 
-	if err := checkIfMachineMissing(ipConfig.Name); err != nil {
+	if err := checkIfMachineMissing(&libmachineClient{}, ipConfig.Name); err != nil {
 		return err
 	}
 

--- a/cmd/crc/cmd/root.go
+++ b/cmd/crc/cmd/root.go
@@ -8,7 +8,6 @@ import (
 	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/code-ready/crc/pkg/crc/exit"
 	"github.com/code-ready/crc/pkg/crc/logging"
-	"github.com/code-ready/crc/pkg/crc/machine"
 	"github.com/code-ready/crc/pkg/crc/network"
 	"github.com/code-ready/crc/pkg/crc/output"
 	"github.com/code-ready/crc/pkg/crc/preflight"
@@ -81,13 +80,13 @@ func setConfigDefaults() {
 	config.SetDefaults()
 }
 
-func checkIfMachineMissing(name string) error {
-	exists, err := machine.Exists(name)
+func checkIfMachineMissing(client client, name string) error {
+	exists, err := client.Exists(name)
 	if err != nil {
 		return err
 	}
 	if !exists {
-		return fmt.Errorf("Machine '%s' does not exist. Use 'crc start' to create it", constants.DefaultName)
+		return fmt.Errorf("Machine '%s' does not exist. Use 'crc start' to create it", name)
 	}
 	return nil
 }

--- a/cmd/crc/cmd/status.go
+++ b/cmd/crc/cmd/status.go
@@ -22,7 +22,7 @@ var statusCmd = &cobra.Command{
 	Short: "Display status of the OpenShift cluster",
 	Long:  "Show details about the OpenShift cluster",
 	Run: func(cmd *cobra.Command, args []string) {
-		if err := runStatus(args); err != nil {
+		if err := runStatus(); err != nil {
 			exit.WithMessage(1, err.Error())
 		}
 	},
@@ -43,7 +43,7 @@ type Status struct {
 	CacheDir        string
 }
 
-func runStatus(args []string) error {
+func runStatus() error {
 	statusConfig := machine.ClusterStatusConfig{Name: constants.DefaultName}
 
 	if err := checkIfMachineMissing(statusConfig.Name); err != nil {

--- a/cmd/crc/cmd/status.go
+++ b/cmd/crc/cmd/status.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -14,7 +15,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const jsonFormat = "json"
+
+var (
+	outputFormat string
+)
+
 func init() {
+	statusCmd.Flags().StringVarP(&outputFormat, "output", "o", "", "Output format. One of: json")
 	rootCmd.AddCommand(statusCmd)
 }
 
@@ -23,7 +31,7 @@ var statusCmd = &cobra.Command{
 	Short: "Display status of the OpenShift cluster",
 	Long:  "Show details about the OpenShift cluster",
 	Run: func(cmd *cobra.Command, args []string) {
-		if err := runStatus(os.Stdout, &libmachineClient{}, constants.MachineCacheDir); err != nil {
+		if err := runStatus(os.Stdout, &libmachineClient{}, constants.MachineCacheDir, outputFormat); err != nil {
 			exit.WithMessage(1, err.Error())
 		}
 	},
@@ -37,14 +45,14 @@ Cache Directory: {{.CacheDir}}
 `
 
 type Status struct {
-	CrcStatus       string
-	OpenShiftStatus string
-	DiskUsage       string
-	CacheUsage      string
-	CacheDir        string
+	CrcStatus       string `json:"crcStatus"`
+	OpenShiftStatus string `json:"openshiftStatus"`
+	DiskUsage       string `json:"diskUsage"`
+	CacheUsage      string `json:"cacheUsage"`
+	CacheDir        string `json:"cacheDir"`
 }
 
-func runStatus(writer io.Writer, client client, cacheDir string) error {
+func runStatus(writer io.Writer, client client, cacheDir, outputFormat string) error {
 	statusConfig := machine.ClusterStatusConfig{Name: constants.DefaultName}
 
 	if err := checkIfMachineMissing(client, statusConfig.Name); err != nil {
@@ -69,7 +77,19 @@ func runStatus(writer io.Writer, client client, cacheDir string) error {
 	diskUse := units.HumanSize(float64(clusterStatus.DiskUse))
 	diskSize := units.HumanSize(float64(clusterStatus.DiskSize))
 	diskUsage := fmt.Sprintf("%s of %s (Inside the CRC VM)", diskUse, diskSize)
-	status := Status{clusterStatus.CrcStatus, clusterStatus.OpenshiftStatus, diskUsage, cacheUsage, cacheDir}
+	status := Status{
+		CrcStatus:       clusterStatus.CrcStatus,
+		OpenShiftStatus: clusterStatus.OpenshiftStatus,
+		DiskUsage:       diskUsage,
+		CacheUsage:      cacheUsage,
+		CacheDir:        cacheDir,
+	}
+
+	if outputFormat == jsonFormat {
+		encoder := json.NewEncoder(writer)
+		encoder.SetIndent("", "  ")
+		return encoder.Encode(status)
+	}
 	return printStatus(writer, status, statusFormat)
 }
 

--- a/cmd/crc/cmd/status.go
+++ b/cmd/crc/cmd/status.go
@@ -38,12 +38,13 @@ var statusCmd = &cobra.Command{
 }
 
 type Status struct {
-	CrcStatus       string `json:"crcStatus"`
-	OpenShiftStatus string `json:"openshiftStatus"`
-	DiskUsage       int64  `json:"diskUsage"`
-	DiskSize        int64  `json:"diskSize"`
-	CacheUsage      int64  `json:"cacheUsage"`
-	CacheDir        string `json:"cacheDir"`
+	CrcStatus        string `json:"crcStatus"`
+	OpenShiftStatus  string `json:"openshiftStatus"`
+	OpenShiftVersion string `json:"openshiftVersion"`
+	DiskUsage        int64  `json:"diskUsage"`
+	DiskSize         int64  `json:"diskSize"`
+	CacheUsage       int64  `json:"cacheUsage"`
+	CacheDir         string `json:"cacheDir"`
 }
 
 func runStatus(writer io.Writer, client client, cacheDir, outputFormat string) error {
@@ -68,12 +69,13 @@ func runStatus(writer io.Writer, client client, cacheDir, outputFormat string) e
 		return fmt.Errorf("Error finding size of cache: %s", err.Error())
 	}
 	status := Status{
-		CrcStatus:       clusterStatus.CrcStatus,
-		OpenShiftStatus: clusterStatus.OpenshiftStatus,
-		DiskUsage:       clusterStatus.DiskUse,
-		DiskSize:        clusterStatus.DiskSize,
-		CacheUsage:      size,
-		CacheDir:        cacheDir,
+		CrcStatus:        clusterStatus.CrcStatus,
+		OpenShiftStatus:  clusterStatus.OpenshiftStatus,
+		OpenShiftVersion: clusterStatus.OpenshiftVersion,
+		DiskUsage:        clusterStatus.DiskUse,
+		DiskSize:         clusterStatus.DiskSize,
+		CacheUsage:       size,
+		CacheDir:         cacheDir,
 	}
 
 	if outputFormat == jsonFormat {
@@ -86,11 +88,12 @@ func runStatus(writer io.Writer, client client, cacheDir, outputFormat string) e
 
 func printStatus(writer io.Writer, status Status) error {
 	w := tabwriter.NewWriter(writer, 0, 0, 1, ' ', 0)
+
 	lines := []struct {
 		left, right string
 	}{
 		{"CRC VM", status.CrcStatus},
-		{"OpenShift", status.OpenShiftStatus},
+		{"OpenShift", openshiftStatus(status)},
 		{"Disk Usage", fmt.Sprintf(
 			"%s of %s (Inside the CRC VM)",
 			units.HumanSize(float64(status.DiskUsage)),
@@ -104,6 +107,13 @@ func printStatus(writer io.Writer, status Status) error {
 		}
 	}
 	return w.Flush()
+}
+
+func openshiftStatus(status Status) string {
+	if status.OpenShiftVersion != "" {
+		return fmt.Sprintf("%s (v%s)", status.OpenShiftStatus, status.OpenShiftVersion)
+	}
+	return status.OpenShiftStatus
 }
 
 func printLine(w *tabwriter.Writer, left string, right string) error {

--- a/cmd/crc/cmd/status_test.go
+++ b/cmd/crc/cmd/status_test.go
@@ -24,7 +24,7 @@ func TestPlainStatus(t *testing.T) {
 	assert.NoError(t, runStatus(out, &mockClient{}, cacheDir, ""))
 
 	expected := `CRC VM:          Running
-OpenShift:       Stopped
+OpenShift:       Running (v4.5.1)
 Disk Usage:      10GB of 20GB (Inside the CRC VM)
 Cache Usage:     10kB
 Cache Directory: %s
@@ -44,7 +44,8 @@ func TestJsonStatus(t *testing.T) {
 
 	expected := `{
   "crcStatus": "Running",
-  "openshiftStatus": "Stopped",
+  "openshiftStatus": "Running",
+  "openshiftVersion": "4.5.1",
   "diskUsage": 10000000000,
   "diskSize": 20000000000,
   "cacheUsage": 10000,
@@ -58,12 +59,13 @@ type mockClient struct{}
 
 func (mockClient) Status(statusConfig machine.ClusterStatusConfig) (machine.ClusterStatusResult, error) {
 	return machine.ClusterStatusResult{
-		Name:            "crc",
-		CrcStatus:       "Running",
-		OpenshiftStatus: "Stopped",
-		DiskUse:         10_000_000_000,
-		DiskSize:        20_000_000_000,
-		Success:         true,
+		Name:             "crc",
+		CrcStatus:        "Running",
+		OpenshiftStatus:  "Running",
+		OpenshiftVersion: "4.5.1",
+		DiskUse:          10_000_000_000,
+		DiskSize:         20_000_000_000,
+		Success:          true,
 	}, nil
 }
 

--- a/cmd/crc/cmd/status_test.go
+++ b/cmd/crc/cmd/status_test.go
@@ -45,8 +45,9 @@ func TestJsonStatus(t *testing.T) {
 	expected := `{
   "crcStatus": "Running",
   "openshiftStatus": "Stopped",
-  "diskUsage": "10GB of 20GB (Inside the CRC VM)",
-  "cacheUsage": "10kB",
+  "diskUsage": 10000000000,
+  "diskSize": 20000000000,
+  "cacheUsage": 10000,
   "cacheDir": "%s"
 }
 `

--- a/cmd/crc/cmd/status_test.go
+++ b/cmd/crc/cmd/status_test.go
@@ -21,13 +21,34 @@ func TestPlainStatus(t *testing.T) {
 	require.NoError(t, ioutil.WriteFile(filepath.Join(cacheDir, "crc.qcow2"), make([]byte, 10000), 0600))
 
 	out := new(bytes.Buffer)
-	assert.NoError(t, runStatus(out, &mockClient{}, cacheDir))
+	assert.NoError(t, runStatus(out, &mockClient{}, cacheDir, ""))
 
 	expected := `CRC VM:          Running
 OpenShift:       Stopped
 Disk Usage:      10GB of 20GB (Inside the CRC VM)
 Cache Usage:     10kB
 Cache Directory: %s
+`
+	assert.Equal(t, fmt.Sprintf(expected, cacheDir), out.String())
+}
+
+func TestJsonStatus(t *testing.T) {
+	cacheDir, err := ioutil.TempDir("", "cache")
+	require.NoError(t, err)
+	defer os.RemoveAll(cacheDir)
+
+	require.NoError(t, ioutil.WriteFile(filepath.Join(cacheDir, "crc.qcow2"), make([]byte, 10000), 0600))
+
+	out := new(bytes.Buffer)
+	assert.NoError(t, runStatus(out, &mockClient{}, cacheDir, jsonFormat))
+
+	expected := `{
+  "crcStatus": "Running",
+  "openshiftStatus": "Stopped",
+  "diskUsage": "10GB of 20GB (Inside the CRC VM)",
+  "cacheUsage": "10kB",
+  "cacheDir": "%s"
+}
 `
 	assert.Equal(t, fmt.Sprintf(expected, cacheDir), out.String())
 }

--- a/cmd/crc/cmd/status_test.go
+++ b/cmd/crc/cmd/status_test.go
@@ -1,0 +1,50 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/code-ready/crc/pkg/crc/machine"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPlainStatus(t *testing.T) {
+	cacheDir, err := ioutil.TempDir("", "cache")
+	require.NoError(t, err)
+	defer os.RemoveAll(cacheDir)
+
+	require.NoError(t, ioutil.WriteFile(filepath.Join(cacheDir, "crc.qcow2"), make([]byte, 10000), 0600))
+
+	out := new(bytes.Buffer)
+	assert.NoError(t, runStatus(out, &mockClient{}, cacheDir))
+
+	expected := `CRC VM:          Running
+OpenShift:       Stopped
+Disk Usage:      10GB of 20GB (Inside the CRC VM)
+Cache Usage:     10kB
+Cache Directory: %s
+`
+	assert.Equal(t, fmt.Sprintf(expected, cacheDir), out.String())
+}
+
+type mockClient struct{}
+
+func (mockClient) Status(statusConfig machine.ClusterStatusConfig) (machine.ClusterStatusResult, error) {
+	return machine.ClusterStatusResult{
+		Name:            "crc",
+		CrcStatus:       "Running",
+		OpenshiftStatus: "Stopped",
+		DiskUse:         10_000_000_000,
+		DiskSize:        20_000_000_000,
+		Success:         true,
+	}, nil
+}
+
+func (mockClient) Exists(name string) (bool, error) {
+	return true, nil
+}

--- a/cmd/crc/cmd/stop.go
+++ b/cmd/crc/cmd/stop.go
@@ -36,7 +36,7 @@ func runStop(arguments []string) error {
 		Name: constants.DefaultName,
 	}
 
-	if err := checkIfMachineMissing(stopConfig.Name); err != nil {
+	if err := checkIfMachineMissing(&libmachineClient{}, stopConfig.Name); err != nil {
 		return err
 	}
 

--- a/pkg/crc/machine/machine.go
+++ b/pkg/crc/machine/machine.go
@@ -553,6 +553,7 @@ func Status(statusConfig ClusterStatusConfig) (ClusterStatusResult, error) {
 	}
 
 	openshiftStatus := "Stopped"
+	openshiftVersion := ""
 	var diskUse int64
 	var diskSize int64
 
@@ -586,11 +587,11 @@ func Status(statusConfig ClusterStatusConfig) (ClusterStatusResult, error) {
 		}
 		switch {
 		case operatorsStatus.Available:
-			openshiftVersion := "4.x"
+			openshiftVersion = "4.x"
 			if crcBundleMetadata.GetOpenshiftVersion() != "" {
 				openshiftVersion = crcBundleMetadata.GetOpenshiftVersion()
 			}
-			openshiftStatus = fmt.Sprintf("Running (v%s)", openshiftVersion)
+			openshiftStatus = "Running"
 		case operatorsStatus.Degraded:
 			openshiftStatus = "Degraded"
 		case operatorsStatus.Progressing:
@@ -602,12 +603,13 @@ func Status(statusConfig ClusterStatusConfig) (ClusterStatusResult, error) {
 		}
 	}
 	return ClusterStatusResult{
-		Name:            statusConfig.Name,
-		CrcStatus:       vmStatus.String(),
-		OpenshiftStatus: openshiftStatus,
-		DiskUse:         diskUse,
-		DiskSize:        diskSize,
-		Success:         true,
+		Name:             statusConfig.Name,
+		CrcStatus:        vmStatus.String(),
+		OpenshiftStatus:  openshiftStatus,
+		OpenshiftVersion: openshiftVersion,
+		DiskUse:          diskUse,
+		DiskSize:         diskSize,
+		Success:          true,
 	}, nil
 }
 

--- a/pkg/crc/machine/types.go
+++ b/pkg/crc/machine/types.go
@@ -92,13 +92,14 @@ type ClusterStatusConfig struct {
 }
 
 type ClusterStatusResult struct {
-	Name            string
-	CrcStatus       string
-	OpenshiftStatus string
-	DiskUse         int64
-	DiskSize        int64
-	Error           string
-	Success         bool
+	Name             string
+	CrcStatus        string
+	OpenshiftStatus  string
+	OpenshiftVersion string
+	DiskUse          int64
+	DiskSize         int64
+	Error            string
+	Success          bool
 }
 
 type ConsoleConfig struct {


### PR DESCRIPTION
Partial fix for #1227

```
$ crc status -o json               
{
  "virtualMachineStatus": "Running",
  "openshiftStatus": "Running",
  "openshiftVersion": "4.5.1",
  "diskUsage": 12852875264,
  "diskSize": 32720793600,
  "cacheUsage": 9769732330,
  "cacheDir": "/home/guillaumerose/.crc/cache"
}

$ crc status        
CRC VM:          Running
OpenShift:       Running (v4.5.1)
Disk Usage:      12.86GB of 32.72GB (Inside the CRC VM)
Cache Usage:     9.77GB
Cache Directory: /home/guillaumerose/.crc/cache

$ crc status -o wide
CRC VM:          Running
OpenShift:       Running (v4.5.1)
Disk Usage:      12.86GB of 32.72GB (Inside the CRC VM)
Cache Usage:     9.77GB
Cache Directory: /home/guillaumerose/.crc/cache

```