### PR TITLE
Rename log-level param to loglevel

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -21,7 +21,7 @@ assignees: ''
   
 ## CRC status
 ```bash
-# Put `crc status --log-level debug` output here
+# Put `crc status --loglevel debug` output here
 ```
 
 ## CRC config
@@ -56,7 +56,7 @@ Before gather the logs try following if that fix your issue
 $ crc delete -f
 $ crc cleanup
 $ crc setup
-$ crc start --log-level debug
+$ crc start --loglevel debug
 ```
 
-Please consider posting the output of `crc start --log-level debug`  on http://gist.github.com/ and post the link in the issue.
+Please consider posting the output of `crc start --loglevel debug`  on http://gist.github.com/ and post the link in the issue.

--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -50,5 +50,5 @@ assignees: ''
 
 ### Logs
 
-You can start crc with `crc start --log-level debug` to collect logs.
+You can start crc with `crc start --loglevel debug` to collect logs.
 Please consider posting this on http://gist.github.com/ and post the link in the issue.

--- a/Makefile
+++ b/Makefile
@@ -206,6 +206,6 @@ endif
 
 embed_bundle: LDFLAGS += $(BUNDLE_EMBEDDED)
 embed_bundle: clean cross $(HOST_BUILD_DIR)/crc-embedder check_bundledir $(HYPERKIT_BUNDLENAME) $(HYPERV_BUNDLENAME) $(LIBVIRT_BUNDLENAME)
-	$(HOST_BUILD_DIR)/crc-embedder embed --log-level debug --goos=darwin --bundle-dir=$(BUNDLE_DIR) $(BUILD_DIR)/macos-amd64/crc
-	$(HOST_BUILD_DIR)/crc-embedder embed --log-level debug --goos=linux --bundle-dir=$(BUNDLE_DIR) $(BUILD_DIR)/linux-amd64/crc
-	$(HOST_BUILD_DIR)/crc-embedder embed --log-level debug --goos=windows --bundle-dir=$(BUNDLE_DIR) $(BUILD_DIR)/windows-amd64/crc.exe
+	$(HOST_BUILD_DIR)/crc-embedder embed --loglevel debug --goos=darwin --bundle-dir=$(BUNDLE_DIR) $(BUILD_DIR)/macos-amd64/crc
+	$(HOST_BUILD_DIR)/crc-embedder embed --loglevel debug --goos=linux --bundle-dir=$(BUNDLE_DIR) $(BUILD_DIR)/linux-amd64/crc
+	$(HOST_BUILD_DIR)/crc-embedder embed --loglevel debug --goos=windows --bundle-dir=$(BUNDLE_DIR) $(BUILD_DIR)/windows-amd64/crc.exe

--- a/cmd/crc-embedder/cmd/root.go
+++ b/cmd/crc-embedder/cmd/root.go
@@ -26,7 +26,7 @@ when building the crc binary for release`,
 }
 
 func init() {
-	rootCmd.PersistentFlags().StringVar(&logging.LogLevel, "log-level", constants.DefaultLogLevel, "log level (e.g. \"debug | info | warn | error\")")
+	rootCmd.PersistentFlags().StringVar(&logging.LogLevel, "loglevel", constants.DefaultLogLevel, "log level (e.g. \"debug | info | warn | error\")")
 }
 
 func Execute() {

--- a/cmd/crc/cmd/root.go
+++ b/cmd/crc/cmd/root.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"strconv"
+
 	"github.com/code-ready/crc/pkg/crc/errors"
 	"github.com/code-ready/crc/pkg/crc/machine"
 	"github.com/code-ready/crc/pkg/crc/network"
@@ -50,16 +52,28 @@ func init() {
 	// subcommands
 	rootCmd.AddCommand(cmdConfig.GetConfigCmd())
 
-	rootCmd.PersistentFlags().StringVar(&logging.LogLevel, "log-level", constants.DefaultLogLevel, "log level (e.g. \"debug | info | warn | error\")")
+	rootCmd.PersistentFlags().StringVar(&logging.LogLevel, "loglevel", constants.DefaultLogLevel, "log level (e.g. \"debug | info | warn | error\")")
 	rootCmd.PersistentFlags().BoolVarP(&globalForce, "force", "f", false, "Forcefully perform an action")
 }
 
 func runPrerun() {
+	convertNumericLogLevelToStringLevel()
 	// Setting up logrus
 	logging.InitLogrus(logging.LogLevel, constants.LogFilePath)
 	setProxyDefaults()
 	for _, str := range GetVersionStrings() {
 		logging.Debugf(str)
+	}
+}
+
+func convertNumericLogLevelToStringLevel() {
+	n, err := strconv.Atoi(logging.LogLevel)
+	if err == nil {
+		if n > 0 {
+			logging.LogLevel = "debug"
+		} else {
+			logging.LogLevel = "info"
+		}
 	}
 }
 

--- a/pkg/crc/preflight/preflight_check_tray_darwin.go
+++ b/pkg/crc/preflight/preflight_check_tray_darwin.go
@@ -57,7 +57,7 @@ func fixDaemonPlistFileExists() error {
 		Label:          daemonAgentLabel,
 		BinaryPath:     currentExecutablePath,
 		StdOutFilePath: stdOutFilePathDaemon,
-		Args:           []string{"daemon", "--log-level", "debug"},
+		Args:           []string{"daemon", "--loglevel", "debug"},
 	}
 	return fixPlistFileExists(daemonConfig)
 }

--- a/test/integration/crcsuite/crcsuite.go
+++ b/test/integration/crcsuite/crcsuite.go
@@ -355,7 +355,7 @@ func StartCRCWithDefaultBundleSucceedsOrFails(expected string) error {
 	if bundleEmbedded == false {
 		extraBundleArgs = fmt.Sprintf("-b %s", bundleName)
 	}
-	cmd = fmt.Sprintf("crc start -p '%s' %s --log-level debug", pullSecretFile, extraBundleArgs)
+	cmd = fmt.Sprintf("crc start -p '%s' %s --loglevel debug", pullSecretFile, extraBundleArgs)
 	err := clicumber.ExecuteCommandSucceedsOrFails(cmd, expected)
 
 	return err
@@ -370,7 +370,7 @@ func StartCRCWithDefaultBundleAndNameServerSucceedsOrFails(nameserver string, ex
 
 	var cmd string
 
-	cmd = fmt.Sprintf("crc start -n %s -p '%s' %s --log-level debug", nameserver, pullSecretFile, extraBundleArgs)
+	cmd = fmt.Sprintf("crc start -n %s -p '%s' %s --loglevel debug", nameserver, pullSecretFile, extraBundleArgs)
 	err := clicumber.ExecuteCommandSucceedsOrFails(cmd, expected)
 
 	return err

--- a/test/integration/features/basic.feature
+++ b/test/integration/features/basic.feature
@@ -96,7 +96,7 @@ Feature: Basic test
 
     @darwin @linux @windows
     Scenario: CRC status and disk space check
-        When with up to "15" retries with wait period of "1m" command "crc status --log-level debug" output should not contain "Stopped"
+        When with up to "15" retries with wait period of "1m" command "crc status --loglevel debug" output should not contain "Stopped"
         And stdout should contain "Running"
         And stdout should match ".*Disk Usage: *\d+\.\d+GB of 32.\d+GB.*"
 
@@ -123,7 +123,7 @@ Feature: Basic test
 
     @darwin @linux @windows
     Scenario: CRC status check
-        When with up to "2" retries with wait period of "1m" command "crc status --log-level debug" output should not contain "Running"
+        When with up to "2" retries with wait period of "1m" command "crc status --loglevel debug" output should not contain "Running"
         And stdout should contain "Stopped"
 
     @darwin @linux @windows

--- a/test/integration/features/story_health.feature
+++ b/test/integration/features/story_health.feature
@@ -10,7 +10,7 @@ Feature:
         When starting CRC with default bundle succeeds
         Then stdout should contain "Started the OpenShift cluster"
         And executing "eval $(crc oc-env)" succeeds
-        When with up to "4" retries with wait period of "2m" command "crc status --log-level debug" output matches ".*Running \(v\d+\.\d+\.\d+.*\).*"
+        When with up to "4" retries with wait period of "2m" command "crc status --loglevel debug" output matches ".*Running \(v\d+\.\d+\.\d+.*\).*"
         Then login to the oc cluster succeeds
 
     @windows
@@ -19,7 +19,7 @@ Feature:
         When starting CRC with default bundle and nameserver "10.75.5.25" succeeds
         Then stdout should contain "Started the OpenShift cluster"
         And executing "crc oc-env | Invoke-Expression" succeeds
-        When with up to "4" retries with wait period of "2m" command "crc status --log-level debug" output matches ".*Running \(v\d+\.\d+\.\d+.*\).*"
+        When with up to "4" retries with wait period of "2m" command "crc status --loglevel debug" output matches ".*Running \(v\d+\.\d+\.\d+.*\).*"
         Then login to the oc cluster succeeds
 
     @linux @darwin @windows    

--- a/test/integration/features/story_marketplace.feature
+++ b/test/integration/features/story_marketplace.feature
@@ -18,7 +18,7 @@ Feature:
         When starting CRC with default bundle and nameserver "10.75.5.25" succeeds
         Then stdout should contain "Started the OpenShift cluster"
         And executing "crc oc-env | Invoke-Expression" succeeds
-        When with up to "4" retries with wait period of "2m" command "crc status --log-level debug" output matches ".*Running \(v\d+\.\d+\.\d+.*\).*"
+        When with up to "4" retries with wait period of "2m" command "crc status --loglevel debug" output matches ".*Running \(v\d+\.\d+\.\d+.*\).*"
         Then login to the oc cluster succeeds
 
     @darwin @linux @windows

--- a/test/integration/features/story_registry.feature
+++ b/test/integration/features/story_registry.feature
@@ -11,7 +11,7 @@ Feature: Local image to image-registry to deployment
         When starting CRC with default bundle succeeds
         Then stdout should contain "Started the OpenShift cluster"
         And executing "eval $(crc oc-env)" succeeds
-        When with up to "4" retries with wait period of "2m" command "crc status --log-level debug" output matches ".*Running \(v\d+\.\d+\.\d+.*\).*"
+        When with up to "4" retries with wait period of "2m" command "crc status --loglevel debug" output matches ".*Running \(v\d+\.\d+\.\d+.*\).*"
         Then login to the oc cluster succeeds
 
     Scenario: Create local image


### PR DESCRIPTION
Automatically convert numerical level to string level so that `--loglevel=0` is equivalent to info and `--loglevel=1` and more to debug.

This PR makes `crc` command behave like `oc`.

There is a breaking change in the tray setup. The command line changed and I'm not sure if it will be migrated automatically. It's still an experimental feature so I guess it's ok.
