### PR TITLE
Ensure the host has at least 9GB of RAM

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/docker/go-units v0.4.0
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/mattn/go-colorable v0.1.2
+	github.com/pbnjay/memory v0.0.0-20190104145345-974d429e7ae4
 	github.com/pborman/uuid v1.2.0
 	github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4
 	github.com/pkg/errors v0.8.1

--- a/go.sum
+++ b/go.sum
@@ -77,6 +77,8 @@ github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b h1:j7+1HpAFS1zy5+Q4qx1f
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
 github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
+github.com/pbnjay/memory v0.0.0-20190104145345-974d429e7ae4 h1:MfIUBZ1bz7TgvQLVa/yPJZOGeKEgs6eTKUjz3zB4B+U=
+github.com/pbnjay/memory v0.0.0-20190104145345-974d429e7ae4/go.mod h1:RMU2gJXhratVxBDTFeOdNhd540tG57lt9FIUV0YLvIQ=
 github.com/pborman/uuid v1.2.0 h1:J7Q5mO4ysT1dv8hyrUGHb9+ooztCXu1D8MY8DZYsu3g=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181zc=

--- a/pkg/crc/preflight/preflight_checks_common.go
+++ b/pkg/crc/preflight/preflight_checks_common.go
@@ -10,9 +10,11 @@ import (
 	"github.com/code-ready/crc/pkg/crc/cache"
 	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/code-ready/crc/pkg/crc/logging"
+	"github.com/code-ready/crc/pkg/crc/validation"
 	"github.com/code-ready/crc/pkg/crc/version"
 	"github.com/code-ready/crc/pkg/embed"
 	crcos "github.com/code-ready/crc/pkg/os"
+	"github.com/docker/go-units"
 )
 
 var genericPreflightChecks = [...]PreflightCheck{
@@ -42,6 +44,15 @@ var genericPreflightChecks = [...]PreflightCheck{
 		fixDescription:   "Unpacking bundle from the CRC binary",
 		fix:              fixBundleCached,
 		flags:            SetupOnly,
+	},
+	{
+		configKeySuffix:  "check-ram",
+		checkDescription: "Checking minimum RAM requirements",
+		check: func() error {
+			return validation.ValidateEnoughMemory(constants.DefaultMemory)
+		},
+		fixDescription: fmt.Sprintf("crc requires at least %s to run", units.HumanSize(float64(constants.DefaultMemory*1024*1024))),
+		flags:          NoFix,
 	},
 }
 

--- a/pkg/crc/validation/validation.go
+++ b/pkg/crc/validation/validation.go
@@ -10,7 +10,10 @@ import (
 
 	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/code-ready/crc/pkg/crc/errors"
+	"github.com/code-ready/crc/pkg/crc/logging"
 	"github.com/code-ready/crc/pkg/crc/version"
+	"github.com/docker/go-units"
+	"github.com/pbnjay/memory"
 )
 
 // ValidateCPUs checks if provided cpus count is valid
@@ -25,6 +28,19 @@ func ValidateCPUs(value int) error {
 func ValidateMemory(value int) error {
 	if value < constants.DefaultMemory {
 		return errors.Newf("requires memory in MiB >= %d", constants.DefaultMemory)
+	}
+	return ValidateEnoughMemory(value)
+}
+
+// ValidateEnoughMemory checks if enough memory is installed on the host
+func ValidateEnoughMemory(value int) error {
+	totalMemory := memory.TotalMemory()
+	logging.Debugf("Total memory of system is %d bytes", totalMemory)
+	valueBytes := value * 1024 * 1024
+	if totalMemory < uint64(valueBytes) {
+		return fmt.Errorf("only %s of memory found (%s required)",
+			units.HumanSize(float64(totalMemory)),
+			units.HumanSize(float64(valueBytes)))
 	}
 	return nil
 }

--- a/vendor/github.com/pbnjay/memory/LICENSE
+++ b/vendor/github.com/pbnjay/memory/LICENSE
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2017, Jeremy Jay
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/pbnjay/memory/README.md
+++ b/vendor/github.com/pbnjay/memory/README.md
@@ -1,0 +1,40 @@
+# memory
+
+Package `memory` provides a single method reporting total physical system memory
+accessible to the kernel. It does not account for memory used by other processes.
+
+This package has no external dependency beside the standard library.
+
+Documentation:
+[![GoDoc](https://godoc.org/github.com/pbnjay/memory?status.svg)](https://godoc.org/github.com/pbnjay/memory)
+
+This is useful for dynamic code to minimize thrashing and other contention, similar to the stdlib `runtime.NumCPU`
+See some history of the proposal at https://github.com/golang/go/issues/21816
+
+
+## Example
+
+```go
+fmt.Printf("Total system memory: %d\n", memory.TotalMemory())
+```
+
+
+## Testing
+
+Tested/working on:
+ - macOS 10.12.6 (16G29)
+ - Windows 10 1511 (10586.1045)
+ - Linux RHEL (3.10.0-327.3.1.el7.x86_64)
+ - Raspberry Pi 3 (ARMv8) on Raspbian, ODROID-C1+ (ARMv7) on Ubuntu, C.H.I.P
+   (ARMv7).
+
+Tested on virtual machines:
+ - Windows 7 SP1 386
+ - Debian stretch 386
+ - NetBSD 7.1 amd64 + 386
+ - OpenBSD 6.1 amd64 + 386
+ - FreeBSD 11.1 amd64 + 386
+ - DragonFly BSD 4.8.1 amd64
+
+If you have access to untested systems (notably arm) please
+test and file bugs if necessary.

--- a/vendor/github.com/pbnjay/memory/doc.go
+++ b/vendor/github.com/pbnjay/memory/doc.go
@@ -1,0 +1,14 @@
+// Package memory provides a single method reporting total system memory
+// accessible to the kernel.
+package memory
+
+// TotalMemory returns the total accessible system memory in bytes.
+//
+// The total accessible memory is installed physical memory size minus reserved
+// areas for the kernel and hardware, if such reservations are reported by
+// the operating system.
+//
+// If accessible memory size could not be determined, then 0 is returned.
+func TotalMemory() uint64 {
+	return sysTotalMemory()
+}

--- a/vendor/github.com/pbnjay/memory/memory_bsd.go
+++ b/vendor/github.com/pbnjay/memory/memory_bsd.go
@@ -1,0 +1,11 @@
+// +build freebsd openbsd dragonfly netbsd
+
+package memory
+
+func sysTotalMemory() uint64 {
+	s, err := sysctlUint64("hw.physmem")
+	if err != nil {
+		return 0
+	}
+	return s
+}

--- a/vendor/github.com/pbnjay/memory/memory_darwin.go
+++ b/vendor/github.com/pbnjay/memory/memory_darwin.go
@@ -1,0 +1,11 @@
+// +build darwin
+
+package memory
+
+func sysTotalMemory() uint64 {
+	s, err := sysctlUint64("hw.memsize")
+	if err != nil {
+		return 0
+	}
+	return s
+}

--- a/vendor/github.com/pbnjay/memory/memory_linux.go
+++ b/vendor/github.com/pbnjay/memory/memory_linux.go
@@ -1,0 +1,17 @@
+// +build linux
+
+package memory
+
+import "syscall"
+
+func sysTotalMemory() uint64 {
+	in := &syscall.Sysinfo_t{}
+	err := syscall.Sysinfo(in)
+	if err != nil {
+		return 0
+	}
+	// If this is a 32-bit system, then these fields are
+	// uint32 instead of uint64.
+	// So we always convert to uint64 to match signature.
+	return uint64(in.Totalram) * uint64(in.Unit)
+}

--- a/vendor/github.com/pbnjay/memory/memory_windows.go
+++ b/vendor/github.com/pbnjay/memory/memory_windows.go
@@ -1,0 +1,38 @@
+// +build windows
+
+package memory
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+// omitting a few fields for brevity...
+// https://msdn.microsoft.com/en-us/library/windows/desktop/aa366589(v=vs.85).aspx
+type memStatusEx struct {
+	dwLength     uint32
+	dwMemoryLoad uint32
+	ullTotalPhys uint64
+	unused       [6]uint64
+}
+
+func sysTotalMemory() uint64 {
+	kernel32, err := syscall.LoadDLL("kernel32.dll")
+	if err != nil {
+		return 0
+	}
+	// GetPhysicallyInstalledSystemMemory is simpler, but broken on
+	// older versions of windows (and uses this under the hood anyway).
+	globalMemoryStatusEx, err := kernel32.FindProc("GlobalMemoryStatusEx")
+	if err != nil {
+		return 0
+	}
+	msx := &memStatusEx{
+		dwLength: 64,
+	}
+	r, _, _ := globalMemoryStatusEx.Call(uintptr(unsafe.Pointer(msx)))
+	if r == 0 {
+		return 0
+	}
+	return msx.ullTotalPhys
+}

--- a/vendor/github.com/pbnjay/memory/memsysctl.go
+++ b/vendor/github.com/pbnjay/memory/memsysctl.go
@@ -1,0 +1,21 @@
+// +build darwin freebsd openbsd dragonfly netbsd
+
+package memory
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+func sysctlUint64(name string) (uint64, error) {
+	s, err := syscall.Sysctl(name)
+	if err != nil {
+		return 0, err
+	}
+	// hack because the string conversion above drops a \0
+	b := []byte(s)
+	if len(b) < 8 {
+		b = append(b, 0)
+	}
+	return *(*uint64)(unsafe.Pointer(&b[0])), nil
+}

--- a/vendor/github.com/pbnjay/memory/stub.go
+++ b/vendor/github.com/pbnjay/memory/stub.go
@@ -1,0 +1,7 @@
+// +build !linux,!darwin,!windows,!freebsd,!dragonfly,!netbsd,!openbsd
+
+package memory
+
+func sysTotalMemory() uint64 {
+	return 0
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -82,6 +82,8 @@ github.com/mattn/go-runewidth
 github.com/mgutz/ansi
 # github.com/mitchellh/mapstructure v1.1.2
 github.com/mitchellh/mapstructure
+# github.com/pbnjay/memory v0.0.0-20190104145345-974d429e7ae4
+github.com/pbnjay/memory
 # github.com/pborman/uuid v1.2.0
 github.com/pborman/uuid
 # github.com/pelletier/go-toml v1.2.0


### PR DESCRIPTION
Helpful for https://github.com/code-ready/crc/issues/1401

The implementation of `memory.TotalMemory()` seems good. It uses the same mechanism for Windows as Kubelet.

https://github.com/pbnjay/memory/blob/master/memory_windows.go#L26
https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/winstats/perfcounter_nodestats.go#L232