### PR TITLE
Issue #1386 Run all oc commands from the VM

### DIFF
--- a/pkg/crc/cluster/cluster.go
+++ b/pkg/crc/cluster/cluster.go
@@ -90,7 +90,7 @@ func AddPullSecret(sshRunner *ssh.Runner, ocConfig oc.Config, pullSec string) er
 
 	base64OfPullSec := base64.StdEncoding.EncodeToString([]byte(pullSec))
 	cmdArgs := []string{"patch", "secret", "pull-secret", "-p",
-		fmt.Sprintf(`{"data":{".dockerconfigjson":"%s"}}`, base64OfPullSec),
+		fmt.Sprintf(`'{"data":{".dockerconfigjson":"%s"}}'`, base64OfPullSec),
 		"-n", "openshift-config", "--type", "merge"}
 
 	if err := WaitForOpenshiftResource(ocConfig, "secret"); err != nil {
@@ -106,7 +106,7 @@ func AddPullSecret(sshRunner *ssh.Runner, ocConfig oc.Config, pullSec string) er
 func UpdateClusterID(ocConfig oc.Config) error {
 	clusterID := uuid.New()
 	cmdArgs := []string{"patch", "clusterversion", "version", "-p",
-		fmt.Sprintf(`{"spec":{"clusterID":"%s"}}`, clusterID), "--type", "merge"}
+		fmt.Sprintf(`'{"spec":{"clusterID":"%s"}}'`, clusterID), "--type", "merge"}
 
 	if err := WaitForOpenshiftResource(ocConfig, "clusterversion"); err != nil {
 		return err
@@ -121,7 +121,7 @@ func UpdateClusterID(ocConfig oc.Config) error {
 
 func AddProxyConfigToCluster(ocConfig oc.Config, proxy *network.ProxyConfig) error {
 	cmdArgs := []string{"patch", "proxy", "cluster", "-p",
-		fmt.Sprintf(`{"spec":{"httpProxy":"%s", "httpsProxy":"%s", "noProxy":"%s"}}`, proxy.HTTPProxy, proxy.HTTPSProxy, proxy.GetNoProxyString()),
+		fmt.Sprintf(`'{"spec":{"httpProxy":"%s", "httpsProxy":"%s", "noProxy":"%s"}}'`, proxy.HTTPProxy, proxy.HTTPSProxy, proxy.GetNoProxyString()),
 		"-n", "openshift-config", "--type", "merge"}
 
 	if err := WaitForOpenshiftResource(ocConfig, "proxy"); err != nil {

--- a/pkg/crc/cluster/clusteroperator.go
+++ b/pkg/crc/cluster/clusteroperator.go
@@ -49,7 +49,7 @@ func getStatus(ocConfig oc.Config, selector []string) (*Status, error) {
 		Available: true,
 	}
 
-	data, stderr, err := ocConfig.RunOcCommand("get", "co", "-ojson")
+	data, stderr, err := ocConfig.RunOcCommandPrivate("get", "co", "-ojson")
 	if err != nil {
 		return cs, fmt.Errorf("%s", stderr)
 	}

--- a/pkg/crc/cluster/clusteroperator_test.go
+++ b/pkg/crc/cluster/clusteroperator_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/code-ready/crc/pkg/crc/oc"
 
-	"github.com/code-ready/crc/pkg/crc/errors"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -68,7 +67,8 @@ func (r *mockRunner) Run(args ...string) (string, string, error) {
 }
 
 func (r *mockRunner) RunPrivate(args ...string) (string, string, error) {
-	return "", "", errors.New("not implemented")
+	bin, err := ioutil.ReadFile(r.file)
+	return string(bin), "", err
 }
 
 func (r *mockRunner) GetKubeconfigPath() string {

--- a/pkg/crc/cluster/csr.go
+++ b/pkg/crc/cluster/csr.go
@@ -33,7 +33,7 @@ func ApproveNodeCSR(ocConfig oc.Config) error {
 
 	logging.Debug("Approving pending CSRs")
 	// Execute 'oc get csr -oname' and store the output
-	csrsJSON, stderr, err := ocConfig.RunOcCommand("get", "csr", "-ojson")
+	csrsJSON, stderr, err := ocConfig.RunOcCommandPrivate("get", "csr", "-ojson")
 	if err != nil {
 		return fmt.Errorf("Not able to get csr names (%v : %s)", err, stderr)
 	}

--- a/pkg/crc/oc/oc.go
+++ b/pkg/crc/oc/oc.go
@@ -1,9 +1,12 @@
 package oc
 
 import (
+	"fmt"
 	"path/filepath"
+	"strings"
 
 	"github.com/code-ready/crc/pkg/crc/constants"
+	"github.com/code-ready/crc/pkg/crc/ssh"
 	crcos "github.com/code-ready/crc/pkg/os"
 )
 
@@ -81,4 +84,30 @@ func (oc Config) RunOcCommandPrivate(args ...string) (string, string, error) {
 		args = append(args, "--cluster", oc.Cluster)
 	}
 	return oc.Runner.RunPrivate(args...)
+}
+
+type SSHRunner struct {
+	Runner *ssh.Runner
+}
+
+func UseOCWithSSH(sshRunner *ssh.Runner) Config {
+	return Config{
+		Runner: SSHRunner{
+			Runner: sshRunner,
+		},
+		Context: constants.DefaultContext,
+		Cluster: constants.DefaultName,
+	}
+}
+
+func (oc SSHRunner) Run(args ...string) (string, string, error) {
+	command := fmt.Sprintf("oc --kubeconfig /opt/kubeconfig %s", strings.Join(args, " "))
+	stdout, err := oc.Runner.Run(command)
+	return stdout, "", err
+}
+
+func (oc SSHRunner) RunPrivate(args ...string) (string, string, error) {
+	command := fmt.Sprintf("oc --kubeconfig /opt/kubeconfig %s", strings.Join(args, " "))
+	stdout, err := oc.Runner.RunPrivate(command)
+	return stdout, "", err
 }


### PR DESCRIPTION
Currently running oc commands from the host need dns to be working,
and something it doesn't work as expected, running all oc commands
from the VM to make sure that atleast initial startup doesn't depend
on the host side.
