### PR TITLE
Fix oc-env command error in windows

### DIFF
--- a/pkg/os/shell/shell.go
+++ b/pkg/os/shell/shell.go
@@ -50,7 +50,7 @@ func GenerateUsageHint(userShell, cmdLine string) string {
 		cmd = fmt.Sprintf("eval $(%s)", cmdLine)
 	}
 
-	return fmt.Sprintf("%s Run this command to configure your shell:\n%s %s\n", comment, comment, cmd)
+	return fmt.Sprintf("%s Run this command to configure your shell:\n%s %s", comment, comment, cmd)
 }
 
 func GetEnvString(userShell string, envName string, envValue string) string {


### PR DESCRIPTION
A newline after the usage message was causing error
in powershell from Invoke-Expression, removing the new line
at the end of the usage message fixes the issue


**Fixes:** Issue #1364 

```

PS C:\Users\Anjan\github.com\code-ready\crc> crc oc-env
$Env:PATH = "C:\Users\Anjan\.crc\bin\oc;$Env:PATH"
# Run this command to configure your shell:
# & crc oc-env | Invoke-Expression

PS C:\Users\Anjan\github.com\code-ready\crc> & crc oc-env | Invoke-Expression
Invoke-Expression : Cannot bind argument to parameter 'Command' because it is an empty string.
At line:1 char:16
+ & crc oc-env | Invoke-Expression
+                ~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidData: (:PSObject) [Invoke-Expression], ParameterBindingValidationException
    + FullyQualifiedErrorId : ParameterArgumentValidationErrorEmptyStringNotAllowed,Microsoft.PowerShell.Commands.InvokeExpressionCommand

Invoke-Expression : Cannot bind argument to parameter 'Command' because it is an empty string.
At line:1 char:16
+ & crc oc-env | Invoke-Expression
+                ~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidData: (:PSObject) [Invoke-Expression], ParameterBindingValidationException
    + FullyQualifiedErrorId : ParameterArgumentValidationErrorEmptyStringNotAllowed,Microsoft.PowerShell.Commands.InvokeExpressionCommand

-------------------------------------------------------------------------------------------------------------------------------------------------------------

PS C:\Users\Anjan\github.com\code-ready\crc> crc oc-env
$Env:PATH = "C:\Users\Anjan\.crc\bin\oc;$Env:PATH"
# Run this command to configure your shell:
# & crc oc-env | Invoke-Expression
PS C:\Users\Anjan\github.com\code-ready\crc> & crc oc-env | Invoke-Expression
PS C:\Users\Anjan\github.com\code-ready\crc> oc
OpenShift ClientThis client helps you develop, build, deploy, and run your applications on any

```
