### PR TITLE
Issue #1423 Add VPN note to `crc start` documentation

### DIFF
--- a/docs/source/topics/proc_starting-the-virtual-machine.adoc
+++ b/docs/source/topics/proc_starting-the-virtual-machine.adoc
@@ -5,6 +5,11 @@ The [command]`{bin} start` command starts the {prod} virtual machine and OpenShi
 
 .Prerequisites
 
+[NOTE]
+====
+To avoid networking-related issues, ensure that you are not connected to a VPN and that your network connection is reliable.
+====
+
 * You set up the host machine through the [command]`{bin} setup` command.
 For more information, see link:{crc-gsg-url}#setting-up-codeready-containers_gsg[Setting up {prod}].
 * You have a valid OpenShift user pull secret.


### PR DESCRIPTION
**Fixes:** Issue #1423

I used an admonition here to make the information stand out more than the rest of the prerequisites. Normally, this would be listed as another bullet item.