### PR TITLE
Windows preflight fixes

### DIFF
--- a/pkg/crc/machine/machine.go
+++ b/pkg/crc/machine/machine.go
@@ -721,7 +721,7 @@ func updateSSHKeyPair(sshRunner *crcssh.Runner) error {
 	if err != nil {
 		return err
 	}
-	cmd := fmt.Sprintf("echo '%s' > /home/core/.ssh/authorized_keys", publicKey)
+	cmd := fmt.Sprintf("echo '%s' > /home/core/.ssh/authorized_keys; chmod 644 /home/core/.ssh/authorized_keys", publicKey)
 	_, err = sshRunner.Run(cmd)
 	if err != nil {
 		return err

--- a/pkg/crc/machine/machine.go
+++ b/pkg/crc/machine/machine.go
@@ -246,6 +246,14 @@ func Start(startConfig StartConfig) (StartResult, error) {
 	}
 	logging.Info("CodeReady Containers VM is running")
 
+	// Post VM start immediately update SSH key and copy kubeconfig to instance
+	// dir and VM
+	if !exists {
+		if err := updateSSHKeyAndCopyKubeconfigToVM(sshRunner, startConfig, crcBundleMetadata); err != nil {
+			return startError(startConfig.Name, "Error updating public key", err)
+		}
+	}
+
 	// Start network time synchronization if `CRC_DEBUG_ENABLE_STOP_NTP` is not set
 	if stopNtp, _ := strconv.ParseBool(os.Getenv("CRC_DEBUG_ENABLE_STOP_NTP")); !stopNtp {
 		logging.Info("Starting network time synchronization in CodeReady Containers VM")
@@ -328,31 +336,6 @@ func Start(startConfig StartConfig) (StartResult, error) {
 	logging.Info("Check DNS query from host ...")
 	if err := network.CheckCRCLocalDNSReachableFromHost(crcBundleMetadata, instanceIP); err != nil {
 		return startError(startConfig.Name, "Failed to query DNS from host", err)
-	}
-
-	// Additional steps to perform after newly created VM is up
-	if !exists {
-		logging.Info("Generating new SSH key")
-		if err := updateSSHKeyPair(sshRunner); err != nil {
-
-			return startError(startConfig.Name, "Error updating public key", err)
-		}
-		// Copy Kubeconfig file from bundle extract path to machine directory.
-		// In our case it would be ~/.crc/machines/crc/
-		logging.Info("Copying kubeconfig file to instance dir ...")
-		kubeConfigFilePath := filepath.Join(constants.MachineInstanceDir, startConfig.Name, "kubeconfig")
-		err := crcos.CopyFileContents(crcBundleMetadata.GetKubeConfigPath(),
-			kubeConfigFilePath,
-			0644)
-		if err != nil {
-			return startError(startConfig.Name, "Error copying kubeconfig file", err)
-		}
-
-		logging.Info("Copying kubeconfig file to CRC VM ...")
-		err = sshRunner.CopyFile(kubeConfigFilePath, "/opt/kubeconfig", 0644)
-		if err != nil {
-			return startError(startConfig.Name, "Error copying kubeconfig file in VM", err)
-		}
 	}
 
 	ocConfig := oc.UseOCWithSSH(sshRunner)
@@ -746,6 +729,32 @@ func updateSSHKeyPair(sshRunner *crcssh.Runner) error {
 	sshRunner.SetPrivateKeyPath(constants.GetPrivateKeyPath())
 
 	return err
+}
+
+func updateSSHKeyAndCopyKubeconfigToVM(sshRunner *crcssh.Runner, startConfig StartConfig, crcBundleMetadata *bundle.CrcBundleInfo) error {
+	logging.Info("Generating new SSH Key pair ...")
+	if err := updateSSHKeyPair(sshRunner); err != nil {
+		return fmt.Errorf("Error updating SSH Keys: %v", err)
+	}
+
+	// Copy Kubeconfig file from bundle extract path to machine directory.
+	// In our case it would be ~/.crc/machines/crc/
+	logging.Info("Copying kubeconfig file to instance dir ...")
+	kubeConfigFilePath := filepath.Join(constants.MachineInstanceDir, startConfig.Name, "kubeconfig")
+	err := crcos.CopyFileContents(crcBundleMetadata.GetKubeConfigPath(),
+		kubeConfigFilePath,
+		0644)
+	if err != nil {
+		return fmt.Errorf("Error copying kubeconfig file to instance dir: %v", err)
+	}
+
+	logging.Info("Copying kubeconfig file to CRC VM ...")
+	err = sshRunner.CopyFile(kubeConfigFilePath, "/opt/kubeconfig", 0644)
+	if err != nil {
+		return fmt.Errorf("Error copying kubeconfig file to VM: %v", err)
+	}
+
+	return nil
 }
 
 func configureCluster(ocConfig oc.Config, sshRunner *crcssh.Runner, proxyConfig *network.ProxyConfig, pullSecret, instanceIP string) (rerr error) {

--- a/pkg/crc/preflight/preflight_checks_windows.go
+++ b/pkg/crc/preflight/preflight_checks_windows.go
@@ -41,6 +41,30 @@ func checkVersionOfWindowsUpdate() error {
 	return nil
 }
 
+func checkWindowsEdition() error {
+	windowsEditionCmd := `(Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion").EditionID`
+
+	stdOut, _, err := powershell.Execute(windowsEditionCmd)
+	if err != nil {
+		logging.Debug(err.Error())
+		return fmt.Errorf("Failed to get Windows edition")
+	}
+
+	windowsEdition := strings.TrimSpace(stdOut)
+	logging.Debugf("Running on Windows %s edition", windowsEdition)
+
+	if strings.HasPrefix(windowsEdition, "Professional") {
+		return nil
+	}
+
+	switch windowsEdition {
+	case "Enterprise":
+		return nil
+	default:
+		return fmt.Errorf("Supported Windows editions are Professional and Enterprise. Windows %s edition is not supported", windowsEdition)
+	}
+}
+
 func checkHyperVInstalled() error {
 	// check to see if a hypervisor is present. if hyper-v is installed and enabled,
 	checkHypervisorPresent := `@(Get-Wmiobject Win32_ComputerSystem).HypervisorPresent`

--- a/pkg/crc/preflight/preflight_windows.go
+++ b/pkg/crc/preflight/preflight_windows.go
@@ -16,6 +16,13 @@ var hypervPreflightChecks = [...]Check{
 		flags:            NoFix,
 	},
 	{
+		configKeySuffix:  "check-windows-edition",
+		checkDescription: "Checking Windows edition",
+		check:            checkWindowsEdition,
+		fixDescription:   "Your Windows edition is not supported. Consider using Professional or Enterprise editions of Windows",
+		flags:            NoFix,
+	},
+	{
 		configKeySuffix:  "check-hyperv-installed",
 		checkDescription: "Checking if Hyper-V is installed and operational",
 		check:            checkHyperVInstalled,

--- a/pkg/crc/preflight/preflight_windows.go
+++ b/pkg/crc/preflight/preflight_windows.go
@@ -40,7 +40,7 @@ var hypervPreflightChecks = [...]Check{
 		configKeySuffix:  "check-hyperv-switch",
 		checkDescription: "Checking if the Hyper-V virtual switch exist",
 		check:            checkIfHyperVVirtualSwitchExists,
-		fixDescription:   "Unable to perform Hyper-V administrative commands. Please make sure to re-login or reboot your system",
+		fixDescription:   "Unable to perform Hyper-V administrative commands. Please reboot your system and run 'crc setup' to complete the setup process",
 		flags:            NoFix,
 	},
 	{


### PR DESCRIPTION
- Add a preflight check for windows edition
- Clearly mention to reboot and re-run `crc setup` in windows when setup fails due to not being able to run hyperv commands.