### PR TITLE
sshRunner API cleanups and fix small error in NTP logs

### DIFF
--- a/pkg/crc/cluster/cluster.go
+++ b/pkg/crc/cluster/cluster.go
@@ -145,11 +145,11 @@ Environment=HTTPS_PROXY=%s
 Environment=NO_PROXY=.cluster.local,.svc,10.128.0.0/14,172.30.0.0/16,%s`
 	p := fmt.Sprintf(proxyTemplate, proxy.HTTPProxy, proxy.HTTPSProxy, proxy.GetNoProxyString())
 	// This will create a systemd drop-in configuration for proxy (both for kubelet and crio services) on the VM.
-	err := sshRunner.SetTextContentAsRoot("/etc/systemd/system/crio.service.d/10-default-env.conf", p, 0644)
+	err := sshRunner.CopyData([]byte(p), "/etc/systemd/system/crio.service.d/10-default-env.conf", 0644)
 	if err != nil {
 		return err
 	}
-	err = sshRunner.SetTextContentAsRoot("/etc/systemd/system/kubelet.service.d/10-default-env.conf", p, 0644)
+	err = sshRunner.CopyData([]byte(p), "/etc/systemd/system/kubelet.service.d/10-default-env.conf", 0644)
 	if err != nil {
 		return err
 	}
@@ -157,7 +157,7 @@ Environment=NO_PROXY=.cluster.local,.svc,10.128.0.0/14,172.30.0.0/16,%s`
 }
 
 func addPullSecretToInstanceDisk(sshRunner *ssh.Runner, pullSec string) error {
-	err := sshRunner.SetTextContentAsRoot("/var/lib/kubelet/config.json", pullSec, 0600)
+	err := sshRunner.CopyData([]byte(pullSec), "/var/lib/kubelet/config.json", 0600)
 	if err != nil {
 		return err
 	}

--- a/pkg/crc/machine/machine.go
+++ b/pkg/crc/machine/machine.go
@@ -346,9 +346,9 @@ func Start(startConfig StartConfig) (StartResult, error) {
 		if err != nil {
 			return startError(startConfig.Name, "Error copying kubeconfig file", err)
 		}
-		// Copy kubeconfig file inside the VM
-		kubeconfigContent, _ := ioutil.ReadFile(kubeConfigFilePath)
-		_, err = sshRunner.RunPrivate(fmt.Sprintf("cat <<EOF | sudo tee /opt/kubeconfig\n%s\nEOF", string(kubeconfigContent)))
+
+		logging.Info("Copying kubeconfig file to CRC VM ...")
+		err = sshRunner.CopyFile(kubeConfigFilePath, "/opt/kubeconfig", 0644)
 		if err != nil {
 			return startError(startConfig.Name, "Error copying kubeconfig file in VM", err)
 		}

--- a/pkg/crc/machine/machine.go
+++ b/pkg/crc/machine/machine.go
@@ -247,9 +247,9 @@ func Start(startConfig StartConfig) (StartResult, error) {
 
 	// Start network time synchronization if `CRC_DEBUG_ENABLE_STOP_NTP` is not set
 	if stopNtp, _ := strconv.ParseBool(os.Getenv("CRC_DEBUG_ENABLE_STOP_NTP")); !stopNtp {
-		logging.Info("Stopping network time synchronization in CodeReady Containers VM")
+		logging.Info("Starting network time synchronization in CodeReady Containers VM")
 		if _, err := sshRunner.Run("sudo timedatectl set-ntp on"); err != nil {
-			return startError(startConfig.Name, "Failed to stop network time synchronization", err)
+			return startError(startConfig.Name, "Failed to start network time synchronization", err)
 		}
 	}
 

--- a/pkg/crc/machine/machine.go
+++ b/pkg/crc/machine/machine.go
@@ -245,8 +245,8 @@ func Start(startConfig StartConfig) (StartResult, error) {
 	}
 	logging.Info("CodeReady Containers VM is running")
 
-	// Start network time synchronization if `CRC_DEBUG_ENABLE_STOP_NTP` not set
-	if b, _ := strconv.ParseBool(os.Getenv("CRC_DEBUG_ENABLE_STOP_NTP")); !b {
+	// Start network time synchronization if `CRC_DEBUG_ENABLE_STOP_NTP` is not set
+	if stopNtp, _ := strconv.ParseBool(os.Getenv("CRC_DEBUG_ENABLE_STOP_NTP")); !stopNtp {
 		logging.Info("Stopping network time synchronization in CodeReady Containers VM")
 		if _, err := sshRunner.Run("sudo timedatectl set-ntp on"); err != nil {
 			return startError(startConfig.Name, "Failed to stop network time synchronization", err)

--- a/pkg/crc/network/nameservers.go
+++ b/pkg/crc/network/nameservers.go
@@ -34,7 +34,7 @@ func GetResolvValuesFromInstance(sshRunner *ssh.Runner) (*ResolvFileValues, erro
 func CreateResolvFileOnInstance(sshRunner *ssh.Runner, resolvFileValues ResolvFileValues) error {
 	resolvFile, _ := CreateResolvFile(resolvFileValues)
 
-	err := sshRunner.CopyData([]byte(resolvFile), "/etc/resolv.conf")
+	err := sshRunner.CopyData([]byte(resolvFile), "/etc/resolv.conf", 0644)
 	if err != nil {
 		return fmt.Errorf("Error creating /etc/resolv on instance: %s", err.Error())
 	}

--- a/pkg/crc/services/dns/template.go
+++ b/pkg/crc/services/dns/template.go
@@ -52,7 +52,7 @@ func createDnsmasqDNSConfig(serviceConfig services.ServicePostStartConfig) error
 		return err
 	}
 
-	return serviceConfig.SSHRunner.CopyData([]byte(dnsConfig), "/var/srv/dnsmasq.conf")
+	return serviceConfig.SSHRunner.CopyData([]byte(dnsConfig), "/var/srv/dnsmasq.conf", 0644)
 }
 
 func createDNSConfigFile(values dnsmasqConfFileValues, tmpl string) (string, error) {

--- a/pkg/crc/ssh/ssh.go
+++ b/pkg/crc/ssh/ssh.go
@@ -3,6 +3,7 @@ package ssh
 import (
 	"encoding/base64"
 	"fmt"
+	"io/ioutil"
 	"os"
 
 	"github.com/code-ready/crc/pkg/crc/constants"
@@ -43,6 +44,14 @@ func (runner *Runner) CopyData(data []byte, destFilename string, mode os.FileMod
 	_, err := runner.RunPrivate(command)
 
 	return err
+}
+
+func (runner *Runner) CopyFile(srcFilename string, destFilename string, mode os.FileMode) error {
+	data, err := ioutil.ReadFile(srcFilename)
+	if err != nil {
+		return err
+	}
+	return runner.CopyData(data, destFilename, mode)
 }
 
 func (runner *Runner) runSSHCommandFromDriver(command string, runPrivate bool) (string, error) {


### PR DESCRIPTION
The first 3 commits are merely minor code cleanups/improvements, the last commit fixes an erroneous log message, which says the NTP service is being stopped, when it's being started.

## Proposed changes

List main as well as consequential changes you introduced or had to introduce.

1. Add ssh.CopyFile
2. Merge ssh.CopyData and ssh.SetTextContentAsRoot
3. Improve variable name
4. Fix log message

## Testing

Check that during cluster startup (creation?), there's a `Starting network time synchronization in CodeReady Containers VM` log message, not a `Stopping network time synchronization in CodeReady Containers VM` log.