### PR TITLE
Move usage message in cmd package

### DIFF
--- a/cmd/crc/cmd/start.go
+++ b/cmd/crc/cmd/start.go
@@ -62,16 +62,23 @@ func runStart(arguments []string) error {
 	}
 
 	client := machine.NewClient()
-	commandResult, err := client.Start(startConfig)
+	result, err := client.Start(startConfig)
 	if err != nil {
 		return err
 	}
-	if commandResult.Status == "Running" {
-		output.Outln("Started the OpenShift cluster")
-		logging.Warn("The cluster might report a degraded or error state. This is expected since several operators have been disabled to lower the resource usage. For more information, please consult the documentation")
-	} else {
-		logging.Warnf("Unexpected status of the OpenShift cluster: %s", commandResult.Status)
+	if result.Status != "Running" {
+		return fmt.Errorf("Unexpected status of the OpenShift cluster: %s", result.Status)
 	}
+
+	logging.Warn("The cluster might report a degraded or error state. This is expected since several operators have been disabled to lower the resource usage. For more information, please consult the documentation")
+
+	output.Outln("Started the OpenShift cluster.")
+	output.Outln("")
+	output.Outln("To access the cluster, first set up your environment by following 'crc oc-env' instructions.")
+	output.Outf("Then you can access it by running 'oc login -u developer -p developer %s'.\n", result.ClusterConfig.ClusterAPI)
+	output.Outf("To login as an admin, run 'oc login -u kubeadmin -p %s %s'.\n", result.ClusterConfig.KubeAdminPass, result.ClusterConfig.ClusterAPI)
+	output.Outln("")
+	output.Outln("You can now run 'crc console' and use these credentials to access the OpenShift web console.")
 	return nil
 }
 

--- a/pkg/crc/machine/machine.go
+++ b/pkg/crc/machine/machine.go
@@ -411,14 +411,6 @@ func (client *client) Start(startConfig StartConfig) (StartResult, error) {
 		waitForProxyPropagation(ocConfig, proxyConfig)
 	}
 
-	// If no error, return usage message
-	logging.Info("")
-	logging.Info("To access the cluster, first set up your environment by following 'crc oc-env' instructions")
-	logging.Infof("Then you can access it by running 'oc login -u developer -p developer %s'", clusterConfig.ClusterAPI)
-	logging.Infof("To login as an admin, run 'oc login -u kubeadmin -p %s %s'", clusterConfig.KubeAdminPass, clusterConfig.ClusterAPI)
-	logging.Info("")
-	logging.Info("You can now run 'crc console' and use these credentials to access the OpenShift web console")
-
 	return StartResult{
 		Name:           startConfig.Name,
 		KubeletStarted: kubeletStarted,


### PR DESCRIPTION
This is a very subjective change.

Before:
```
INFO Starting OpenShift kubelet service           
INFO Starting OpenShift cluster ... [waiting 3m]  
INFO                                              
INFO To access the cluster, first set up your environment by following 'crc oc-env' instructions 
INFO Then you can access it by running 'oc login -u developer -p developer https://api.crc.testing:6443' 
INFO To login as an admin, run 'oc login -u kubeadmin -p DhjTx-8gIJC-2h2tK-eksGY https://api.crc.testing:6443' 
INFO                                              
INFO You can now run 'crc console' and use these credentials to access the OpenShift web console 
Started the OpenShift cluster
WARN The cluster might report a degraded or error state. This is expected since several operators have been disabled to lower the resource usage. For more information, please consult the documentation 
```

After:
``` 
INFO Starting OpenShift kubelet service           
INFO Starting OpenShift cluster ... [waiting 3m]  
WARN The cluster might report a degraded or error state. This is expected since several operators have been disabled to lower the resource usage. For more information, please consult the documentation 
Started the OpenShift cluster.

To access the cluster, first set up your environment by following 'crc oc-env' instructions.
Then you can access it by running 'oc login -u developer -p developer https://api.crc.testing:6443'.
To login as an admin, run 'oc login -u kubeadmin -p DhjTx-8gIJC-2h2tK-eksGY https://api.crc.testing:6443'.

You can now run 'crc console' and use these credentials to access the OpenShift web console.
```

Why?
* It ends more positively, the warning is the last log.
* It ends with an action.
* Instructions are not really logs.
* When starting the VM with the API (crc daemon), we don't really want the instructions in the log file.