### PR TITLE
Add feature to automate proxy ca cert

### DIFF
--- a/cmd/crc/cmd/config/config.go
+++ b/cmd/crc/cmd/config/config.go
@@ -23,9 +23,10 @@ var (
 
 	// Proxy Configuration
 
-	HTTPProxy  = cfg.AddSetting("http-proxy", nil, []cfg.ValidationFnType{cfg.ValidateURI}, []cfg.SetFn{cfg.SuccessfullyApplied})
-	HTTPSProxy = cfg.AddSetting("https-proxy", nil, []cfg.ValidationFnType{cfg.ValidateURI}, []cfg.SetFn{cfg.SuccessfullyApplied})
-	NoProxy    = cfg.AddSetting("no-proxy", nil, []cfg.ValidationFnType{cfg.ValidateNoProxy}, []cfg.SetFn{cfg.SuccessfullyApplied})
+	HTTPProxy   = cfg.AddSetting("http-proxy", nil, []cfg.ValidationFnType{cfg.ValidateURI}, []cfg.SetFn{cfg.SuccessfullyApplied})
+	HTTPSProxy  = cfg.AddSetting("https-proxy", nil, []cfg.ValidationFnType{cfg.ValidateURI}, []cfg.SetFn{cfg.SuccessfullyApplied})
+	NoProxy     = cfg.AddSetting("no-proxy", nil, []cfg.ValidationFnType{cfg.ValidateNoProxy}, []cfg.SetFn{cfg.SuccessfullyApplied})
+	ProxyCAFile = cfg.AddSetting("proxy-ca-file", nil, []cfg.ValidationFnType{cfg.ValidatePath}, []cfg.SetFn{cfg.SuccessfullyApplied})
 )
 
 var (

--- a/docs/source/topics/proc_starting-codeready-containers-behind-proxy.adoc
+++ b/docs/source/topics/proc_starting-codeready-containers-behind-proxy.adoc
@@ -22,6 +22,16 @@ $ {bin} config set https-proxy http://example.proxy.com:__<port>__
 $ {bin} config set no-proxy __<comma-separated-no-proxy-entries>__
 ----
 +
+
+. If proxy uses custom CA then use the `{bin} config set` command as follows:
++
+[subs="+quotes,attributes"]
+----
+$ {bin} config set proxy-ca-file __<Path to custom CA file>__
+----
++
+
+
 The [command]`{bin}` binary will be able to use the defined proxy once set through environment variables or {prod} configuration.
 
 [NOTE]

--- a/pkg/crc/machine/machine.go
+++ b/pkg/crc/machine/machine.go
@@ -795,7 +795,7 @@ func configProxyForCluster(ocConfig oc.Config, sshRunner *crcssh.Runner, sd *sys
 
 	logging.Info("Adding proxy configuration to the cluster ...")
 	proxy.AddNoProxy(instanceIP)
-	if err := cluster.AddProxyConfigToCluster(ocConfig, proxy); err != nil {
+	if err := cluster.AddProxyConfigToCluster(sshRunner, ocConfig, proxy); err != nil {
 		return err
 	}
 

--- a/pkg/crc/network/proxy.go
+++ b/pkg/crc/network/proxy.go
@@ -15,15 +15,17 @@ var (
 
 // ProxyConfig keeps the proxy configuration for the current environment
 type ProxyConfig struct {
-	HTTPProxy  string
-	HTTPSProxy string
-	noProxy    []string
+	HTTPProxy   string
+	HTTPSProxy  string
+	noProxy     []string
+	ProxyCACert string
 }
 
-func NewProxyDefaults(httpProxy, httpsProxy, noProxy string) (*ProxyConfig, error) {
+func NewProxyDefaults(httpProxy, httpsProxy, noProxy, proxyCACert string) (*ProxyConfig, error) {
 	DefaultProxy = ProxyConfig{
-		HTTPProxy:  httpProxy,
-		HTTPSProxy: httpsProxy,
+		HTTPProxy:   httpProxy,
+		HTTPSProxy:  httpsProxy,
+		ProxyCACert: proxyCACert,
 	}
 
 	if DefaultProxy.HTTPProxy == "" {
@@ -44,8 +46,9 @@ func NewProxyDefaults(httpProxy, httpsProxy, noProxy string) (*ProxyConfig, erro
 // the corresponding environment variable is checked.
 func NewProxyConfig() (*ProxyConfig, error) {
 	config := ProxyConfig{
-		HTTPProxy:  DefaultProxy.HTTPProxy,
-		HTTPSProxy: DefaultProxy.HTTPSProxy,
+		HTTPProxy:   DefaultProxy.HTTPProxy,
+		HTTPSProxy:  DefaultProxy.HTTPSProxy,
+		ProxyCACert: DefaultProxy.ProxyCACert,
 	}
 
 	config.noProxy = defaultNoProxies


### PR DESCRIPTION
## Solution/Idea

This PR is try to automate the steps which are part of https://github.com/code-ready/crc/wiki/Custom-CA-cert-for-proxy page

## Proposed changes

List main as well as consequential changes you introduced or had to introduce.

- Add the `proxy-ca-file` option in the config

## Testing

- Create the ssl cert using openssl
```
$ openssl req -new -newkey rsa:2048 -sha256 -days 365 -nodes -x509 -extensions v3_ca -keyout myCA.pem  -out myCA.pem
```
- Use the specific squid config to test it out
```
$ cat squid.conf
#
# Recommended minimum configuration:
#

# Example rule allowing access from your local networks.
# Adapt to list your (internal) IP networks from where browsing
# should be allowed
acl localnet src 0.0.0.1-0.255.255.255	# RFC 1122 "this" network (LAN)
acl localnet src 10.142.0.0/8		# RFC 1918 local private network (LAN)
acl localnet src 172.16.0.0/12		# RFC 1918 local private network (LAN)
acl localnet src 192.168.0.0/16		# RFC 1918 local private network (LAN)
acl localnet src 103.127.32.1		# RFC 1918 local private network (LAN)
acl localnet src 35.237.1.197		# RFC 1918 local private network (LAN)

acl SSL_ports port 443
acl Safe_ports port 80		# http
acl Safe_ports port 21		# ftp
acl Safe_ports port 443		# https
acl Safe_ports port 70		# gopher
acl Safe_ports port 210		# wais
acl Safe_ports port 1025-65535	# unregistered ports
acl Safe_ports port 280		# http-mgmt
acl Safe_ports port 488		# gss-http
acl Safe_ports port 591		# filemaker
acl Safe_ports port 777		# multiling http
acl CONNECT method CONNECT

#
# Recommended minimum Access Permission configuration:
#
# Deny requests to certain unsafe ports
http_access deny !Safe_ports

# Deny CONNECT to other than secure SSL ports
http_access deny CONNECT !SSL_ports

# Only allow cachemgr access from localhost
http_access allow localhost manager
http_access deny manager

# We strongly recommend the following be uncommented to protect innocent
# web applications running on the proxy server who think the only
# one who can access services on "localhost" is a local user
http_access deny to_localhost

#
# INSERT YOUR OWN RULE(S) HERE TO ALLOW ACCESS FROM YOUR CLIENTS
#

# Example rule allowing access from your local networks.
# Adapt localnet in the ACL section to list your (internal) IP networks
# from where browsing should be allowed
http_access allow localnet
http_access allow localhost

# And finally deny all other access to this proxy
http_access deny all

# Squid normally listens to port 3128
http_port 3128 ssl-bump \
  cert=/etc/squid/ssl_cert/myCA.pem \
  generate-host-certificates=on dynamic_cert_mem_cache_size=16MB
# Uncomment and adjust the following to add a disk cache directory.
#cache_dir ufs /var/spool/squid 100 16 256

# Leave coredumps in the first cache dir
coredump_dir /var/spool/squid

#
# Add any of your own refresh_pattern entries above these.
#
refresh_pattern ^ftp:		1440	20%	10080
refresh_pattern ^gopher:	1440	0%	1440
refresh_pattern -i (/cgi-bin/|\?) 0	0%	0
refresh_pattern .		0	20%	4320
acl to_metadata dst 169.254.169.254
http_access deny to_metadata

sslcrtd_program  /usr/lib64/squid/security_file_certgen -s /var/lib/ssl_db -M 4MB
acl step1 at_step SslBump1

ssl_bump peek step1
ssl_bump bump all
ssl_bump splice all
```
- Run the squid container image with mount of those file
```
$ podman run --name squid -v <host_path>/squid.conf:/etc/squid/squid.conf:Z -v <host_path>/myCA.pem:/etc/squid/ssl_cert/myCA.pem:Z -p 3128:3128 -d  quay.io/crcont/squid
```
- Run the CRC with proxy
```
$ ./crc config view
- http-proxy                            : http://192.168.130.1:3128
- https-proxy                           : http://192.168.130.1:3128
- proxy-ca-file                         : <PATH>/myCA.pem
```

- Check the proxy logs from podman
```
$ podman exec -it squid /bin/bash
<container> # tail -f /var/log/squid/access.log
```