### PR TITLE
Fix loading of kvm/kvm_intel/kvm_amd modules

### DIFF
--- a/centos_ci.sh
+++ b/centos_ci.sh
@@ -46,7 +46,6 @@ function install_required_packages() {
   yum -y install make \
                  git \
                  curl \
-                 kvm \
                  qemu-kvm \
                  libvirt \
                  libvirt-devel \

--- a/pkg/crc/preflight/preflight_checks_linux.go
+++ b/pkg/crc/preflight/preflight_checks_linux.go
@@ -80,7 +80,7 @@ func checkKvmEnabled() error {
 
 func fixKvmEnabled() error {
 	logging.Debug("Trying to load kvm module")
-	stdOut, stdErr, err := crcos.RunWithDefaultLocale("modprobe", "kvm")
+	stdOut, stdErr, err := crcos.RunWithPrivilege("Load kvm kernel module","modprobe", "kvm")
 	if err != nil {
 		return fmt.Errorf("Failed to load kvm module: %s %v: %s", stdOut, err, stdErr)
 	}

--- a/pkg/crc/preflight/preflight_checks_linux.go
+++ b/pkg/crc/preflight/preflight_checks_linux.go
@@ -80,13 +80,9 @@ func checkKvmEnabled() error {
 
 func fixKvmEnabled() error {
 	logging.Debug("Trying to load kvm module")
-	cmd := exec.Command("modprobe", "kvm")
-	buf := new(bytes.Buffer)
-	cmd.Stderr = buf
-	err := cmd.Run()
+	stdOut, stdErr, err := crcos.RunWithDefaultLocale("modprobe", "kvm")
 	if err != nil {
-		logging.Debugf("%v : %s", err, buf.String())
-		return fmt.Errorf("Failed to load kvm module")
+		return fmt.Errorf("Failed to load kvm module: %s %v: %s", stdOut, err, stdErr)
 	}
 	logging.Debug("kvm module loaded")
 	return nil
@@ -308,13 +304,11 @@ func fixLibvirtCrcNetworkAvailable() error {
 	// For time being we are going to override the crc network according what we have in our binary template.
 	// We also don't care about the error or output from those commands atm.
 	// #nosec G204
-	cmd := exec.Command("virsh", "--connect", "qemu:///system", "net-destroy", libvirt.DefaultNetwork)
-	_ = cmd.Run()
+	_, _, _ = crcos.RunWithDefaultLocale("virsh", "--connect", "qemu:///system", "net-destroy", libvirt.DefaultNetwork)
 	// #nosec G204
-	cmd = exec.Command("virsh", "--connect", "qemu:///system", "net-undefine", libvirt.DefaultNetwork)
-	_ = cmd.Run()
+	_, _, _ = crcos.RunWithDefaultLocale("virsh", "--connect", "qemu:///system", "net-undefine", libvirt.DefaultNetwork)
 	// Create the network according to our defined template
-	cmd = exec.Command("virsh", "--connect", "qemu:///system", "net-define", "/dev/stdin")
+	cmd := exec.Command("virsh", "--connect", "qemu:///system", "net-define", "/dev/stdin")
 	cmd.Stdin = strings.NewReader(netXMLDef)
 	buf := new(bytes.Buffer)
 	cmd.Stderr = buf
@@ -434,18 +428,13 @@ func checkLibvirtCrcNetworkActive() error {
 
 func fixLibvirtCrcNetworkActive() error {
 	logging.Debug("Starting libvirt 'crc' network")
-	cmd := exec.Command("virsh", "--connect", "qemu:///system", "net-start", "crc")
-	buf := new(bytes.Buffer)
-	cmd.Stderr = buf
-	err := cmd.Run()
+	stdOut, stdErr, err := crcos.RunWithDefaultLocale("virsh", "--connect", "qemu:///system", "net-start", "crc")
 	if err != nil {
-		logging.Debugf("%v : %s", err, buf.String())
-		return fmt.Errorf("Failed to start libvirt 'crc' network")
+		return fmt.Errorf("Failed to start libvirt 'crc' network %s %v: %s", stdOut, err, stdErr)
 	}
-	cmd = exec.Command("virsh", "--connect", "qemu:///system", "net-autostart", "crc")
-	err = cmd.Run()
+	stdOut, stdErr, err = crcos.RunWithDefaultLocale("virsh", "--connect", "qemu:///system", "net-autostart", "crc")
 	if err != nil {
-		return fmt.Errorf("Failed to autostart libvirt 'crc' network")
+		return fmt.Errorf("Failed to autostart libvirt 'crc' network %s %v: %s", stdOut, err, stdErr)
 	}
 	logging.Debug("libvirt 'crc' network started")
 	return nil


### PR DESCRIPTION
**Fixes:** Issue #1449 


## Solution/Idea
Enable the kvm_intel and kvm_amd kernel module according to processor.

## Testing

With current master following will fail to start the crc
```
$ sudo modprobe -r kvm_intel
$ $ lsmod | grep kvm
$ crc setup
DEBU Trying to load kvm module                    
DEBU exit status 1 : modprobe: ERROR: could not insert 'kvm': Operation not permitted 
FATA Failed to load kvm module
```

If you manually execute the `sudo modprobe kvm` then the start will fail
```
$ sudo modprobe kvm
$ $ lsmod | grep kvm
kvm                   815104  0
irqbypass              16384  1 kvm
$ ./crc setup
$ crc start
...
DEBU Checking if /dev/kvm exists                  
DEBU kvm kernel module is not loaded              
FATA kvm kernel module is not loaded  
```
