### PR TITLE
Hide the config complexity behind an interface

### DIFF
--- a/cmd/crc/cmd/config/config.go
+++ b/cmd/crc/cmd/config/config.go
@@ -12,21 +12,21 @@ import (
 var (
 	// Start command settings in config
 
-	Bundle         = cfg.AddSetting("bundle", nil, []cfg.ValidationFnType{cfg.ValidateBundle}, []cfg.SetFn{cfg.SuccessfullyApplied})
-	CPUs           = cfg.AddSetting("cpus", constants.DefaultCPUs, []cfg.ValidationFnType{cfg.ValidateCPUs}, []cfg.SetFn{cfg.RequiresRestartMsg})
-	Memory         = cfg.AddSetting("memory", constants.DefaultMemory, []cfg.ValidationFnType{cfg.ValidateMemory}, []cfg.SetFn{cfg.RequiresRestartMsg})
-	NameServer     = cfg.AddSetting("nameserver", nil, []cfg.ValidationFnType{cfg.ValidateIPAddress}, []cfg.SetFn{cfg.SuccessfullyApplied})
-	PullSecretFile = cfg.AddSetting("pull-secret-file", nil, []cfg.ValidationFnType{cfg.ValidatePath}, []cfg.SetFn{cfg.SuccessfullyApplied})
+	Bundle         = cfg.AddSetting("bundle", nil, cfg.ValidateBundle, cfg.SuccessfullyApplied)
+	CPUs           = cfg.AddSetting("cpus", constants.DefaultCPUs, cfg.ValidateCPUs, cfg.RequiresRestartMsg)
+	Memory         = cfg.AddSetting("memory", constants.DefaultMemory, cfg.ValidateMemory, cfg.RequiresRestartMsg)
+	NameServer     = cfg.AddSetting("nameserver", nil, cfg.ValidateIPAddress, cfg.SuccessfullyApplied)
+	PullSecretFile = cfg.AddSetting("pull-secret-file", nil, cfg.ValidatePath, cfg.SuccessfullyApplied)
 
-	DisableUpdateCheck   = cfg.AddSetting("disable-update-check", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})
-	ExperimentalFeatures = cfg.AddSetting("enable-experimental-features", nil, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})
+	DisableUpdateCheck   = cfg.AddSetting("disable-update-check", nil, cfg.ValidateBool, cfg.SuccessfullyApplied)
+	ExperimentalFeatures = cfg.AddSetting("enable-experimental-features", nil, cfg.ValidateBool, cfg.SuccessfullyApplied)
 
 	// Proxy Configuration
 
-	HTTPProxy   = cfg.AddSetting("http-proxy", nil, []cfg.ValidationFnType{cfg.ValidateURI}, []cfg.SetFn{cfg.SuccessfullyApplied})
-	HTTPSProxy  = cfg.AddSetting("https-proxy", nil, []cfg.ValidationFnType{cfg.ValidateURI}, []cfg.SetFn{cfg.SuccessfullyApplied})
-	NoProxy     = cfg.AddSetting("no-proxy", nil, []cfg.ValidationFnType{cfg.ValidateNoProxy}, []cfg.SetFn{cfg.SuccessfullyApplied})
-	ProxyCAFile = cfg.AddSetting("proxy-ca-file", nil, []cfg.ValidationFnType{cfg.ValidatePath}, []cfg.SetFn{cfg.SuccessfullyApplied})
+	HTTPProxy   = cfg.AddSetting("http-proxy", nil, cfg.ValidateURI, cfg.SuccessfullyApplied)
+	HTTPSProxy  = cfg.AddSetting("https-proxy", nil, cfg.ValidateURI, cfg.SuccessfullyApplied)
+	NoProxy     = cfg.AddSetting("no-proxy", nil, cfg.ValidateNoProxy, cfg.SuccessfullyApplied)
+	ProxyCAFile = cfg.AddSetting("proxy-ca-file", nil, cfg.ValidatePath, cfg.SuccessfullyApplied)
 )
 
 var (

--- a/cmd/crc/cmd/config/config.go
+++ b/cmd/crc/cmd/config/config.go
@@ -25,18 +25,18 @@ const (
 
 func RegisterSettings() {
 	// Start command settings in config
-	cfg.AddSetting(Bundle, nil, cfg.ValidateBundle, cfg.SuccessfullyApplied)
+	cfg.AddSetting(Bundle, constants.DefaultBundlePath, cfg.ValidateBundle, cfg.SuccessfullyApplied)
 	cfg.AddSetting(CPUs, constants.DefaultCPUs, cfg.ValidateCPUs, cfg.RequiresRestartMsg)
 	cfg.AddSetting(Memory, constants.DefaultMemory, cfg.ValidateMemory, cfg.RequiresRestartMsg)
-	cfg.AddSetting(NameServer, nil, cfg.ValidateIPAddress, cfg.SuccessfullyApplied)
-	cfg.AddSetting(PullSecretFile, nil, cfg.ValidatePath, cfg.SuccessfullyApplied)
-	cfg.AddSetting(DisableUpdateCheck, nil, cfg.ValidateBool, cfg.SuccessfullyApplied)
+	cfg.AddSetting(NameServer, "", cfg.ValidateIPAddress, cfg.SuccessfullyApplied)
+	cfg.AddSetting(PullSecretFile, "", cfg.ValidatePath, cfg.SuccessfullyApplied)
+	cfg.AddSetting(DisableUpdateCheck, false, cfg.ValidateBool, cfg.SuccessfullyApplied)
 	// Proxy Configuration
-	cfg.AddSetting(ExperimentalFeatures, nil, cfg.ValidateBool, cfg.SuccessfullyApplied)
-	cfg.AddSetting(HTTPProxy, nil, cfg.ValidateURI, cfg.SuccessfullyApplied)
-	cfg.AddSetting(HTTPSProxy, nil, cfg.ValidateURI, cfg.SuccessfullyApplied)
-	cfg.AddSetting(NoProxy, nil, cfg.ValidateNoProxy, cfg.SuccessfullyApplied)
-	cfg.AddSetting(ProxyCAFile, nil, cfg.ValidatePath, cfg.SuccessfullyApplied)
+	cfg.AddSetting(ExperimentalFeatures, false, cfg.ValidateBool, cfg.SuccessfullyApplied)
+	cfg.AddSetting(HTTPProxy, "", cfg.ValidateURI, cfg.SuccessfullyApplied)
+	cfg.AddSetting(HTTPSProxy, "", cfg.ValidateURI, cfg.SuccessfullyApplied)
+	cfg.AddSetting(NoProxy, "", cfg.ValidateNoProxy, cfg.SuccessfullyApplied)
+	cfg.AddSetting(ProxyCAFile, "", cfg.ValidatePath, cfg.SuccessfullyApplied)
 }
 
 var (

--- a/cmd/crc/cmd/config/config.go
+++ b/cmd/crc/cmd/config/config.go
@@ -9,25 +9,35 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var (
-	// Start command settings in config
-
-	Bundle         = cfg.AddSetting("bundle", nil, cfg.ValidateBundle, cfg.SuccessfullyApplied)
-	CPUs           = cfg.AddSetting("cpus", constants.DefaultCPUs, cfg.ValidateCPUs, cfg.RequiresRestartMsg)
-	Memory         = cfg.AddSetting("memory", constants.DefaultMemory, cfg.ValidateMemory, cfg.RequiresRestartMsg)
-	NameServer     = cfg.AddSetting("nameserver", nil, cfg.ValidateIPAddress, cfg.SuccessfullyApplied)
-	PullSecretFile = cfg.AddSetting("pull-secret-file", nil, cfg.ValidatePath, cfg.SuccessfullyApplied)
-
-	DisableUpdateCheck   = cfg.AddSetting("disable-update-check", nil, cfg.ValidateBool, cfg.SuccessfullyApplied)
-	ExperimentalFeatures = cfg.AddSetting("enable-experimental-features", nil, cfg.ValidateBool, cfg.SuccessfullyApplied)
-
-	// Proxy Configuration
-
-	HTTPProxy   = cfg.AddSetting("http-proxy", nil, cfg.ValidateURI, cfg.SuccessfullyApplied)
-	HTTPSProxy  = cfg.AddSetting("https-proxy", nil, cfg.ValidateURI, cfg.SuccessfullyApplied)
-	NoProxy     = cfg.AddSetting("no-proxy", nil, cfg.ValidateNoProxy, cfg.SuccessfullyApplied)
-	ProxyCAFile = cfg.AddSetting("proxy-ca-file", nil, cfg.ValidatePath, cfg.SuccessfullyApplied)
+const (
+	Bundle               = "bundle"
+	CPUs                 = "cpus"
+	Memory               = "memory"
+	NameServer           = "nameserver"
+	PullSecretFile       = "pull-secret-file"
+	DisableUpdateCheck   = "disable-update-check"
+	ExperimentalFeatures = "enable-experimental-features"
+	HTTPProxy            = "http-proxy"
+	HTTPSProxy           = "https-proxy"
+	NoProxy              = "no-proxy"
+	ProxyCAFile          = "proxy-ca-file"
 )
+
+func init() {
+	// Start command settings in config
+	cfg.AddSetting(Bundle, nil, cfg.ValidateBundle, cfg.SuccessfullyApplied)
+	cfg.AddSetting(CPUs, constants.DefaultCPUs, cfg.ValidateCPUs, cfg.RequiresRestartMsg)
+	cfg.AddSetting(Memory, constants.DefaultMemory, cfg.ValidateMemory, cfg.RequiresRestartMsg)
+	cfg.AddSetting(NameServer, nil, cfg.ValidateIPAddress, cfg.SuccessfullyApplied)
+	cfg.AddSetting(PullSecretFile, nil, cfg.ValidatePath, cfg.SuccessfullyApplied)
+	cfg.AddSetting(DisableUpdateCheck, nil, cfg.ValidateBool, cfg.SuccessfullyApplied)
+	// Proxy Configuration
+	cfg.AddSetting(ExperimentalFeatures, nil, cfg.ValidateBool, cfg.SuccessfullyApplied)
+	cfg.AddSetting(HTTPProxy, nil, cfg.ValidateURI, cfg.SuccessfullyApplied)
+	cfg.AddSetting(HTTPSProxy, nil, cfg.ValidateURI, cfg.SuccessfullyApplied)
+	cfg.AddSetting(NoProxy, nil, cfg.ValidateNoProxy, cfg.SuccessfullyApplied)
+	cfg.AddSetting(ProxyCAFile, nil, cfg.ValidatePath, cfg.SuccessfullyApplied)
+}
 
 var (
 	configCmd = &cobra.Command{

--- a/cmd/crc/cmd/config/config.go
+++ b/cmd/crc/cmd/config/config.go
@@ -23,7 +23,7 @@ const (
 	ProxyCAFile          = "proxy-ca-file"
 )
 
-func init() {
+func RegisterSettings() {
 	// Start command settings in config
 	cfg.AddSetting(Bundle, nil, cfg.ValidateBundle, cfg.SuccessfullyApplied)
 	cfg.AddSetting(CPUs, constants.DefaultCPUs, cfg.ValidateCPUs, cfg.RequiresRestartMsg)

--- a/cmd/crc/cmd/config/config.go
+++ b/cmd/crc/cmd/config/config.go
@@ -49,11 +49,6 @@ var (
 	}
 )
 
-func init() {
-	configCmd.Long = `Modifies crc configuration properties.
-Configurable properties (enter after SUBCOMMAND): ` + "\n\n" + configurableFields()
-}
-
 func isPreflightKey(key string) bool {
 	return strings.HasPrefix(key, "skip-") || strings.HasPrefix(key, "warn-")
 }

--- a/cmd/crc/cmd/config/get.go
+++ b/cmd/crc/cmd/config/get.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"fmt"
+
 	"github.com/code-ready/crc/pkg/crc/config"
 	"github.com/code-ready/crc/pkg/crc/exit"
 	"github.com/code-ready/crc/pkg/crc/output"
@@ -24,9 +26,13 @@ var configGetCmd = &cobra.Command{
 }
 
 func runConfigGet(key string) {
-	v, err := config.Get(key)
-	if err != nil {
-		exit.WithMessage(1, err.Error())
+	v := config.Get(key)
+	switch {
+	case v.Invalid:
+		exit.WithMessage(1, fmt.Sprintf("Configuration property '%s' does not exist", key))
+	case v.IsDefault:
+		exit.WithMessage(1, fmt.Sprintf("Configuration property '%s' is not set. Default value is '%s'", key, v.AsString()))
+	default:
+		output.Outln(key, ":", v.AsString())
 	}
-	output.Outln(key, ":", v)
 }

--- a/cmd/crc/cmd/config/get.go
+++ b/cmd/crc/cmd/config/get.go
@@ -9,30 +9,25 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func init() {
-	configCmd.AddCommand(configGetCmd)
-}
-
-var configGetCmd = &cobra.Command{
-	Use:   "get CONFIG-KEY",
-	Short: "Get a crc configuration property",
-	Long:  `Gets a crc configuration property.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		if len(args) < 1 {
-			exit.WithMessage(1, "Please provide a configuration property to get")
-		}
-		runConfigGet(args[0])
-	},
-}
-
-func runConfigGet(key string) {
-	v := config.Get(key)
-	switch {
-	case v.Invalid:
-		exit.WithMessage(1, fmt.Sprintf("Configuration property '%s' does not exist", key))
-	case v.IsDefault:
-		exit.WithMessage(1, fmt.Sprintf("Configuration property '%s' is not set. Default value is '%s'", key, v.AsString()))
-	default:
-		output.Outln(key, ":", v.AsString())
+func configGetCmd(config config.Storage) *cobra.Command {
+	return &cobra.Command{
+		Use:   "get CONFIG-KEY",
+		Short: "Get a crc configuration property",
+		Long:  `Gets a crc configuration property.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			if len(args) < 1 {
+				exit.WithMessage(1, "Please provide a configuration property to get")
+			}
+			key := args[0]
+			v := config.Get(key)
+			switch {
+			case v.Invalid:
+				exit.WithMessage(1, fmt.Sprintf("Configuration property '%s' does not exist", key))
+			case v.IsDefault:
+				exit.WithMessage(1, fmt.Sprintf("Configuration property '%s' is not set. Default value is '%s'", key, v.AsString()))
+			default:
+				output.Outln(key, ":", v.AsString())
+			}
+		},
 	}
 }

--- a/cmd/crc/cmd/config/set.go
+++ b/cmd/crc/cmd/config/set.go
@@ -7,29 +7,23 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func init() {
-	configCmd.AddCommand(configSetCmd)
-}
+func configSetCmd(config config.Storage) *cobra.Command {
+	return &cobra.Command{
+		Use:   "set CONFIG-KEY VALUE",
+		Short: "Set a crc configuration property",
+		Long:  `Sets a crc configuration property.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			if len(args) < 2 {
+				exit.WithMessage(1, "Please provide a configuration property and its value as in 'crc config set KEY VALUE'")
+			}
+			setMessage, err := config.Set(args[0], args[1])
+			if err != nil {
+				exit.WithMessage(1, err.Error())
+			}
 
-var configSetCmd = &cobra.Command{
-	Use:   "set CONFIG-KEY VALUE",
-	Short: "Set a crc configuration property",
-	Long:  `Sets a crc configuration property.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		if len(args) < 2 {
-			exit.WithMessage(1, "Please provide a configuration property and its value as in 'crc config set KEY VALUE'")
-		}
-		runConfigSet(args[0], args[1])
-	},
-}
-
-func runConfigSet(key string, value interface{}) {
-	setMessage, err := config.Set(key, value)
-	if err != nil {
-		exit.WithMessage(1, err.Error())
-	}
-
-	if setMessage != "" {
-		output.Outln(setMessage)
+			if setMessage != "" {
+				output.Outln(setMessage)
+			}
+		},
 	}
 }

--- a/cmd/crc/cmd/config/set.go
+++ b/cmd/crc/cmd/config/set.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"github.com/code-ready/crc/pkg/crc/config"
-	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/code-ready/crc/pkg/crc/exit"
 	"github.com/code-ready/crc/pkg/crc/output"
 	"github.com/spf13/cobra"
@@ -28,10 +27,6 @@ func runConfigSet(key string, value interface{}) {
 	setMessage, err := config.Set(key, value)
 	if err != nil {
 		exit.WithMessage(1, err.Error())
-	}
-
-	if err := config.WriteConfig(); err != nil {
-		exit.WithMessage(1, "Error writing configuration to file '%s': %s", constants.ConfigPath, err.Error())
 	}
 
 	if setMessage != "" {

--- a/cmd/crc/cmd/config/unset.go
+++ b/cmd/crc/cmd/config/unset.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"github.com/code-ready/crc/pkg/crc/config"
-	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/code-ready/crc/pkg/crc/exit"
 	"github.com/code-ready/crc/pkg/crc/output"
 	"github.com/spf13/cobra"
@@ -29,10 +28,6 @@ func runConfigUnset(key string) {
 	if err != nil {
 		exit.WithMessage(1, err.Error())
 	}
-	if err := config.WriteConfig(); err != nil {
-		exit.WithMessage(1, "Error writing configuration to file '%s': %s", constants.ConfigPath, err.Error())
-	}
-
 	if unsetMessage != "" {
 		output.Outln(unsetMessage)
 	}

--- a/cmd/crc/cmd/config/unset.go
+++ b/cmd/crc/cmd/config/unset.go
@@ -7,28 +7,22 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func init() {
-	configCmd.AddCommand(configUnsetCmd)
-}
-
-var configUnsetCmd = &cobra.Command{
-	Use:   "unset CONFIG-KEY",
-	Short: "Unset a crc configuration property",
-	Long:  `Unsets a crc configuration property.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		if len(args) != 1 {
-			exit.WithMessage(1, "Please provide a configuration property to unset")
-		}
-		runConfigUnset(args[0])
-	},
-}
-
-func runConfigUnset(key string) {
-	unsetMessage, err := config.Unset(key)
-	if err != nil {
-		exit.WithMessage(1, err.Error())
-	}
-	if unsetMessage != "" {
-		output.Outln(unsetMessage)
+func configUnsetCmd(config config.Storage) *cobra.Command {
+	return &cobra.Command{
+		Use:   "unset CONFIG-KEY",
+		Short: "Unset a crc configuration property",
+		Long:  `Unsets a crc configuration property.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			if len(args) != 1 {
+				exit.WithMessage(1, "Please provide a configuration property to unset")
+			}
+			unsetMessage, err := config.Unset(args[0])
+			if err != nil {
+				exit.WithMessage(1, err.Error())
+			}
+			if unsetMessage != "" {
+				output.Outln(unsetMessage)
+			}
+		},
 	}
 }

--- a/cmd/crc/cmd/config/view.go
+++ b/cmd/crc/cmd/config/view.go
@@ -39,7 +39,7 @@ var configViewCmd = &cobra.Command{
 		if err != nil {
 			logging.Fatal(err)
 		}
-		if err := runConfigView(config.ChangedConfigs(), tmpl, os.Stdout); err != nil {
+		if err := runConfigView(config.AllConfigs(), tmpl, os.Stdout); err != nil {
 			logging.Fatal(err)
 		}
 	},
@@ -53,10 +53,13 @@ func determineTemplate(tempFormat string) (*template.Template, error) {
 	return tmpl, nil
 }
 
-func runConfigView(cfg map[string]interface{}, tmpl *template.Template, writer io.Writer) error {
+func runConfigView(cfg map[string]config.SettingValue, tmpl *template.Template, writer io.Writer) error {
 	var lines []string
 	for k, v := range cfg {
-		viewTmplt := configViewTemplate{k, v}
+		if v.IsDefault {
+			continue
+		}
+		viewTmplt := configViewTemplate{k, v.AsString()}
 		var buffer bytes.Buffer
 		if err := tmpl.Execute(&buffer, viewTmplt); err != nil {
 			return err

--- a/cmd/crc/cmd/config/view.go
+++ b/cmd/crc/cmd/config/view.go
@@ -24,25 +24,24 @@ type configViewTemplate struct {
 	ConfigValue interface{}
 }
 
-func init() {
-	configCmd.AddCommand(configViewCmd)
+func configViewCmd(config config.Storage) *cobra.Command {
+	configViewCmd := &cobra.Command{
+		Use:   "view",
+		Short: "Display all assigned crc configuration properties",
+		Long:  `Displays all assigned crc configuration properties and their values.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			tmpl, err := determineTemplate(configViewFormat)
+			if err != nil {
+				logging.Fatal(err)
+			}
+			if err := runConfigView(config.AllConfigs(), tmpl, os.Stdout); err != nil {
+				logging.Fatal(err)
+			}
+		},
+	}
 	configViewCmd.Flags().StringVar(&configViewFormat, "format", DefaultConfigViewFormat,
 		`Go template format to apply to the configuration file. For more information about Go templates, see: https://golang.org/pkg/text/template/`)
-}
-
-var configViewCmd = &cobra.Command{
-	Use:   "view",
-	Short: "Display all assigned crc configuration properties",
-	Long:  `Displays all assigned crc configuration properties and their values.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		tmpl, err := determineTemplate(configViewFormat)
-		if err != nil {
-			logging.Fatal(err)
-		}
-		if err := runConfigView(config.AllConfigs(), tmpl, os.Stdout); err != nil {
-			logging.Fatal(err)
-		}
-	},
+	return configViewCmd
 }
 
 func determineTemplate(tempFormat string) (*template.Template, error) {

--- a/cmd/crc/cmd/daemon.go
+++ b/cmd/crc/cmd/daemon.go
@@ -20,6 +20,6 @@ var daemonCmd = &cobra.Command{
 		logging.CloseLogging()
 		logging.InitLogrus(logging.LogLevel, constants.DaemonLogFilePath)
 
-		runDaemon()
+		runDaemon(config)
 	},
 }

--- a/cmd/crc/cmd/daemon_nonwin.go
+++ b/cmd/crc/cmd/daemon_nonwin.go
@@ -6,14 +6,15 @@ import (
 	"os"
 
 	"github.com/code-ready/crc/pkg/crc/api"
+	crcConfig "github.com/code-ready/crc/pkg/crc/config"
 	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/code-ready/crc/pkg/crc/logging"
 )
 
-func runDaemon() {
+func runDaemon(config crcConfig.Storage) {
 	// Remove if an old socket is present
 	os.Remove(constants.DaemonSocketPath)
-	crcAPIServer, err := api.CreateAPIServer(constants.DaemonSocketPath)
+	crcAPIServer, err := api.CreateAPIServer(constants.DaemonSocketPath, config)
 	if err != nil {
 		logging.Fatal("Failed to launch daemon", err)
 	}

--- a/cmd/crc/cmd/daemon_windows.go
+++ b/cmd/crc/cmd/daemon_windows.go
@@ -4,11 +4,12 @@ import (
 	"os"
 
 	"github.com/code-ready/crc/pkg/crc/api"
+	crcConfig "github.com/code-ready/crc/pkg/crc/config"
 	"github.com/code-ready/crc/pkg/crc/constants"
 )
 
-func runDaemon() {
+func runDaemon(config crcConfig.Storage) {
 	// Remove if an old socket is present
 	os.Remove(constants.DaemonSocketPath)
-	api.RunCrcDaemonService("CodeReady Containers", false)
+	api.RunCrcDaemonService("CodeReady Containers", false, config)
 }

--- a/cmd/crc/cmd/root.go
+++ b/cmd/crc/cmd/root.go
@@ -48,7 +48,6 @@ func init() {
 	cmdConfig.RegisterSettings()
 
 	preflight.RegisterSettings()
-	setConfigDefaults()
 
 	// subcommands
 	rootCmd.AddCommand(cmdConfig.GetConfigCmd())
@@ -79,10 +78,6 @@ func Execute() {
 	if err := rootCmd.Execute(); err != nil {
 		logging.Fatal(err)
 	}
-}
-
-func setConfigDefaults() {
-	config.SetDefaults()
 }
 
 func checkIfMachineMissing(client machine.Client, name string) error {

--- a/cmd/crc/cmd/root.go
+++ b/cmd/crc/cmd/root.go
@@ -45,6 +45,7 @@ func init() {
 	if err := config.InitViper(); err != nil {
 		logging.Fatal(err.Error())
 	}
+	cmdConfig.RegisterSettings()
 
 	preflight.RegisterSettings()
 	setConfigDefaults()

--- a/cmd/crc/cmd/root.go
+++ b/cmd/crc/cmd/root.go
@@ -39,9 +39,6 @@ func init() {
 	if err := constants.EnsureBaseDirExists(); err != nil {
 		logging.Fatal(err.Error())
 	}
-	if err := config.EnsureConfigFileExists(); err != nil {
-		logging.Fatal(err.Error())
-	}
 	if err := config.InitViper(); err != nil {
 		logging.Fatal(err.Error())
 	}

--- a/cmd/crc/cmd/root.go
+++ b/cmd/crc/cmd/root.go
@@ -96,10 +96,10 @@ func checkIfMachineMissing(client machine.Client, name string) error {
 }
 
 func setProxyDefaults() {
-	httpProxy := config.GetString(cmdConfig.HTTPProxy.Name)
-	httpsProxy := config.GetString(cmdConfig.HTTPSProxy.Name)
-	noProxy := config.GetString(cmdConfig.NoProxy.Name)
-	proxyCAFile := config.GetString(cmdConfig.ProxyCAFile.Name)
+	httpProxy := config.Get(cmdConfig.HTTPProxy.Name).AsString()
+	httpsProxy := config.Get(cmdConfig.HTTPSProxy.Name).AsString()
+	noProxy := config.Get(cmdConfig.NoProxy.Name).AsString()
+	proxyCAFile := config.Get(cmdConfig.ProxyCAFile.Name).AsString()
 
 	proxyCAData, err := getProxyCAData(proxyCAFile)
 	if err != nil {

--- a/cmd/crc/cmd/root.go
+++ b/cmd/crc/cmd/root.go
@@ -96,10 +96,10 @@ func checkIfMachineMissing(client machine.Client, name string) error {
 }
 
 func setProxyDefaults() {
-	httpProxy := config.Get(cmdConfig.HTTPProxy.Name).AsString()
-	httpsProxy := config.Get(cmdConfig.HTTPSProxy.Name).AsString()
-	noProxy := config.Get(cmdConfig.NoProxy.Name).AsString()
-	proxyCAFile := config.Get(cmdConfig.ProxyCAFile.Name).AsString()
+	httpProxy := config.Get(cmdConfig.HTTPProxy).AsString()
+	httpsProxy := config.Get(cmdConfig.HTTPSProxy).AsString()
+	noProxy := config.Get(cmdConfig.NoProxy).AsString()
+	proxyCAFile := config.Get(cmdConfig.ProxyCAFile).AsString()
 
 	proxyCAData, err := getProxyCAData(proxyCAFile)
 	if err != nil {

--- a/cmd/crc/cmd/setup.go
+++ b/cmd/crc/cmd/setup.go
@@ -15,7 +15,7 @@ import (
 )
 
 func init() {
-	setupCmd.Flags().Bool(config.ExperimentalFeatures.Name, false, "Allow the use of experimental features")
+	setupCmd.Flags().Bool(config.ExperimentalFeatures, false, "Allow the use of experimental features")
 	addOutputFormatFlag(setupCmd)
 	rootCmd.AddCommand(setupCmd)
 }
@@ -35,7 +35,7 @@ var setupCmd = &cobra.Command{
 }
 
 func runSetup(arguments []string) error {
-	if crcConfig.Get(config.ExperimentalFeatures.Name).AsBool() {
+	if crcConfig.Get(config.ExperimentalFeatures).AsBool() {
 		preflight.EnableExperimentalFeatures = true
 	}
 	err := preflight.SetupHost()

--- a/cmd/crc/cmd/setup.go
+++ b/cmd/crc/cmd/setup.go
@@ -35,7 +35,7 @@ var setupCmd = &cobra.Command{
 }
 
 func runSetup(arguments []string) error {
-	if crcConfig.GetBool(config.ExperimentalFeatures.Name) {
+	if crcConfig.Get(config.ExperimentalFeatures.Name).AsBool() {
 		preflight.EnableExperimentalFeatures = true
 	}
 	err := preflight.SetupHost()

--- a/cmd/crc/cmd/setup.go
+++ b/cmd/crc/cmd/setup.go
@@ -16,7 +16,6 @@ import (
 
 func init() {
 	setupCmd.Flags().Bool(config.ExperimentalFeatures.Name, false, "Allow the use of experimental features")
-	_ = crcConfig.BindFlagSet(setupCmd.Flags())
 	addOutputFormatFlag(setupCmd)
 	rootCmd.AddCommand(setupCmd)
 }
@@ -26,6 +25,9 @@ var setupCmd = &cobra.Command{
 	Short: "Set up prerequisites for the OpenShift cluster",
 	Long:  "Set up local virtualization and networking infrastructure for the OpenShift cluster",
 	Run: func(cmd *cobra.Command, args []string) {
+		if err := crcConfig.BindFlagSet(cmd.Flags()); err != nil {
+			exit.WithMessage(1, err.Error())
+		}
 		if err := runSetup(args); err != nil {
 			exit.WithMessage(1, err.Error())
 		}

--- a/cmd/crc/cmd/setup.go
+++ b/cmd/crc/cmd/setup.go
@@ -6,8 +6,7 @@ import (
 	"io"
 	"os"
 
-	"github.com/code-ready/crc/cmd/crc/cmd/config"
-	crcConfig "github.com/code-ready/crc/pkg/crc/config"
+	cmdConfig "github.com/code-ready/crc/cmd/crc/cmd/config"
 	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/code-ready/crc/pkg/crc/exit"
 	"github.com/code-ready/crc/pkg/crc/preflight"
@@ -15,7 +14,7 @@ import (
 )
 
 func init() {
-	setupCmd.Flags().Bool(config.ExperimentalFeatures, false, "Allow the use of experimental features")
+	setupCmd.Flags().Bool(cmdConfig.ExperimentalFeatures, false, "Allow the use of experimental features")
 	addOutputFormatFlag(setupCmd)
 	rootCmd.AddCommand(setupCmd)
 }
@@ -25,7 +24,7 @@ var setupCmd = &cobra.Command{
 	Short: "Set up prerequisites for the OpenShift cluster",
 	Long:  "Set up local virtualization and networking infrastructure for the OpenShift cluster",
 	Run: func(cmd *cobra.Command, args []string) {
-		if err := crcConfig.BindFlagSet(cmd.Flags()); err != nil {
+		if err := viper.BindFlagSet(cmd.Flags()); err != nil {
 			exit.WithMessage(1, err.Error())
 		}
 		if err := runSetup(args); err != nil {
@@ -35,10 +34,10 @@ var setupCmd = &cobra.Command{
 }
 
 func runSetup(arguments []string) error {
-	if crcConfig.Get(config.ExperimentalFeatures).AsBool() {
+	if config.Get(cmdConfig.ExperimentalFeatures).AsBool() {
 		preflight.EnableExperimentalFeatures = true
 	}
-	err := preflight.SetupHost()
+	err := preflight.SetupHost(config)
 	return render(&setupResult{
 		Success: err == nil,
 		Error:   errorMessage(err),

--- a/cmd/crc/cmd/start.go
+++ b/cmd/crc/cmd/start.go
@@ -56,7 +56,7 @@ func runStart(arguments []string) (*machine.StartResult, error) {
 		return nil, err
 	}
 
-	checkIfNewVersionAvailable(crcConfig.GetBool(config.DisableUpdateCheck.Name))
+	checkIfNewVersionAvailable(crcConfig.Get(config.DisableUpdateCheck.Name).AsBool())
 
 	if err := preflight.StartPreflightChecks(); err != nil {
 		return nil, err
@@ -64,10 +64,10 @@ func runStart(arguments []string) (*machine.StartResult, error) {
 
 	startConfig := machine.StartConfig{
 		Name:          constants.DefaultName,
-		BundlePath:    crcConfig.GetString(config.Bundle.Name),
-		Memory:        crcConfig.GetInt(config.Memory.Name),
-		CPUs:          crcConfig.GetInt(config.CPUs.Name),
-		NameServer:    crcConfig.GetString(config.NameServer.Name),
+		BundlePath:    crcConfig.Get(config.Bundle.Name).AsString(),
+		Memory:        crcConfig.Get(config.Memory.Name).AsInt(),
+		CPUs:          crcConfig.Get(config.CPUs.Name).AsInt(),
+		NameServer:    crcConfig.Get(config.NameServer.Name).AsString(),
 		GetPullSecret: getPullSecretFileContent,
 		Debug:         isDebugLog(),
 	}
@@ -154,17 +154,17 @@ func isDebugLog() bool {
 }
 
 func validateStartFlags() error {
-	if err := validation.ValidateMemory(crcConfig.GetInt(config.Memory.Name)); err != nil {
+	if err := validation.ValidateMemory(crcConfig.Get(config.Memory.Name).AsInt()); err != nil {
 		return err
 	}
-	if err := validation.ValidateCPUs(crcConfig.GetInt(config.CPUs.Name)); err != nil {
+	if err := validation.ValidateCPUs(crcConfig.Get(config.CPUs.Name).AsInt()); err != nil {
 		return err
 	}
-	if err := validation.ValidateBundle(crcConfig.GetString(config.Bundle.Name)); err != nil {
+	if err := validation.ValidateBundle(crcConfig.Get(config.Bundle.Name).AsString()); err != nil {
 		return err
 	}
-	if crcConfig.GetString(config.NameServer.Name) != "" {
-		if err := validation.ValidateIPAddress(crcConfig.GetString(config.NameServer.Name)); err != nil {
+	if crcConfig.Get(config.NameServer.Name).AsString() != "" {
+		if err := validation.ValidateIPAddress(crcConfig.Get(config.NameServer.Name).AsString()); err != nil {
 			return err
 		}
 	}
@@ -178,7 +178,7 @@ func getPullSecretFileContent() (string, error) {
 	)
 
 	// In case user doesn't provide a file in start command or in config then ask for it.
-	if crcConfig.GetString(config.PullSecretFile.Name) == "" {
+	if crcConfig.Get(config.PullSecretFile.Name).AsString() == "" {
 		pullsecret, err = input.PromptUserForSecret("Image pull secret", fmt.Sprintf("Copy it from %s", constants.CrcLandingPageURL))
 		// This is just to provide a new line after user enter the pull secret.
 		fmt.Println()
@@ -187,7 +187,7 @@ func getPullSecretFileContent() (string, error) {
 		}
 	} else {
 		// Read the file content
-		data, err := ioutil.ReadFile(crcConfig.GetString(config.PullSecretFile.Name))
+		data, err := ioutil.ReadFile(crcConfig.Get(config.PullSecretFile.Name).AsString())
 		if err != nil {
 			return "", errors.New(err.Error())
 		}

--- a/cmd/crc/cmd/start.go
+++ b/cmd/crc/cmd/start.go
@@ -27,12 +27,12 @@ func init() {
 	addOutputFormatFlag(startCmd)
 
 	flagSet := pflag.NewFlagSet("start", pflag.ExitOnError)
-	flagSet.StringP(config.Bundle.Name, "b", constants.DefaultBundlePath, "The system bundle used for deployment of the OpenShift cluster")
-	flagSet.StringP(config.PullSecretFile.Name, "p", "", fmt.Sprintf("File path of image pull secret (download from %s)", constants.CrcLandingPageURL))
-	flagSet.IntP(config.CPUs.Name, "c", constants.DefaultCPUs, "Number of CPU cores to allocate to the OpenShift cluster")
-	flagSet.IntP(config.Memory.Name, "m", constants.DefaultMemory, "MiB of memory to allocate to the OpenShift cluster")
-	flagSet.StringP(config.NameServer.Name, "n", "", "IPv4 address of nameserver to use for the OpenShift cluster")
-	flagSet.Bool(config.DisableUpdateCheck.Name, false, "Don't check for update")
+	flagSet.StringP(config.Bundle, "b", constants.DefaultBundlePath, "The system bundle used for deployment of the OpenShift cluster")
+	flagSet.StringP(config.PullSecretFile, "p", "", fmt.Sprintf("File path of image pull secret (download from %s)", constants.CrcLandingPageURL))
+	flagSet.IntP(config.CPUs, "c", constants.DefaultCPUs, "Number of CPU cores to allocate to the OpenShift cluster")
+	flagSet.IntP(config.Memory, "m", constants.DefaultMemory, "MiB of memory to allocate to the OpenShift cluster")
+	flagSet.StringP(config.NameServer, "n", "", "IPv4 address of nameserver to use for the OpenShift cluster")
+	flagSet.Bool(config.DisableUpdateCheck, false, "Don't check for update")
 
 	startCmd.Flags().AddFlagSet(flagSet)
 }
@@ -56,7 +56,7 @@ func runStart(arguments []string) (*machine.StartResult, error) {
 		return nil, err
 	}
 
-	checkIfNewVersionAvailable(crcConfig.Get(config.DisableUpdateCheck.Name).AsBool())
+	checkIfNewVersionAvailable(crcConfig.Get(config.DisableUpdateCheck).AsBool())
 
 	if err := preflight.StartPreflightChecks(); err != nil {
 		return nil, err
@@ -64,10 +64,10 @@ func runStart(arguments []string) (*machine.StartResult, error) {
 
 	startConfig := machine.StartConfig{
 		Name:          constants.DefaultName,
-		BundlePath:    crcConfig.Get(config.Bundle.Name).AsString(),
-		Memory:        crcConfig.Get(config.Memory.Name).AsInt(),
-		CPUs:          crcConfig.Get(config.CPUs.Name).AsInt(),
-		NameServer:    crcConfig.Get(config.NameServer.Name).AsString(),
+		BundlePath:    crcConfig.Get(config.Bundle).AsString(),
+		Memory:        crcConfig.Get(config.Memory).AsInt(),
+		CPUs:          crcConfig.Get(config.CPUs).AsInt(),
+		NameServer:    crcConfig.Get(config.NameServer).AsString(),
 		GetPullSecret: getPullSecretFileContent,
 		Debug:         isDebugLog(),
 	}
@@ -154,17 +154,17 @@ func isDebugLog() bool {
 }
 
 func validateStartFlags() error {
-	if err := validation.ValidateMemory(crcConfig.Get(config.Memory.Name).AsInt()); err != nil {
+	if err := validation.ValidateMemory(crcConfig.Get(config.Memory).AsInt()); err != nil {
 		return err
 	}
-	if err := validation.ValidateCPUs(crcConfig.Get(config.CPUs.Name).AsInt()); err != nil {
+	if err := validation.ValidateCPUs(crcConfig.Get(config.CPUs).AsInt()); err != nil {
 		return err
 	}
-	if err := validation.ValidateBundle(crcConfig.Get(config.Bundle.Name).AsString()); err != nil {
+	if err := validation.ValidateBundle(crcConfig.Get(config.Bundle).AsString()); err != nil {
 		return err
 	}
-	if crcConfig.Get(config.NameServer.Name).AsString() != "" {
-		if err := validation.ValidateIPAddress(crcConfig.Get(config.NameServer.Name).AsString()); err != nil {
+	if crcConfig.Get(config.NameServer).AsString() != "" {
+		if err := validation.ValidateIPAddress(crcConfig.Get(config.NameServer).AsString()); err != nil {
 			return err
 		}
 	}
@@ -178,7 +178,7 @@ func getPullSecretFileContent() (string, error) {
 	)
 
 	// In case user doesn't provide a file in start command or in config then ask for it.
-	if crcConfig.Get(config.PullSecretFile.Name).AsString() == "" {
+	if crcConfig.Get(config.PullSecretFile).AsString() == "" {
 		pullsecret, err = input.PromptUserForSecret("Image pull secret", fmt.Sprintf("Copy it from %s", constants.CrcLandingPageURL))
 		// This is just to provide a new line after user enter the pull secret.
 		fmt.Println()
@@ -187,7 +187,7 @@ func getPullSecretFileContent() (string, error) {
 		}
 	} else {
 		// Read the file content
-		data, err := ioutil.ReadFile(crcConfig.Get(config.PullSecretFile.Name).AsString())
+		data, err := ioutil.ReadFile(crcConfig.Get(config.PullSecretFile).AsString())
 		if err != nil {
 			return "", errors.New(err.Error())
 		}

--- a/cmd/crc/cmd/start.go
+++ b/cmd/crc/cmd/start.go
@@ -35,8 +35,6 @@ func init() {
 	flagSet.Bool(config.DisableUpdateCheck.Name, false, "Don't check for update")
 
 	startCmd.Flags().AddFlagSet(flagSet)
-
-	_ = crcConfig.BindFlagSet(startCmd.Flags())
 }
 
 var startCmd = &cobra.Command{
@@ -44,6 +42,9 @@ var startCmd = &cobra.Command{
 	Short: "Start the OpenShift cluster",
 	Long:  "Start the OpenShift cluster",
 	Run: func(cmd *cobra.Command, args []string) {
+		if err := crcConfig.BindFlagSet(cmd.Flags()); err != nil {
+			exit.WithMessage(1, err.Error())
+		}
 		if err := renderStartResult(runStart(args)); err != nil {
 			exit.WithMessage(1, err.Error())
 		}

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.4.2
+	github.com/spf13/cast v1.3.0
 	github.com/spf13/cobra v0.0.6
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.4.0

--- a/pkg/crc/api/api_test.go
+++ b/pkg/crc/api/api_test.go
@@ -10,6 +10,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	cmdConfig "github.com/code-ready/crc/cmd/crc/cmd/config"
+
 	"github.com/code-ready/crc/pkg/crc/config"
 	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/code-ready/crc/pkg/crc/machine/fakemachine"
@@ -104,6 +106,7 @@ func TestSetconfigApi(t *testing.T) {
 	assert.NoError(t, err)
 	err = config.InitViper()
 	assert.NoError(t, err)
+	cmdConfig.RegisterSettings()
 
 	socket, cleanup := setupAPIServer(t)
 	client, err := net.Dial("unix", socket)
@@ -138,6 +141,7 @@ func TestGetconfigApi(t *testing.T) {
 	assert.NoError(t, err)
 	err = config.InitViper()
 	assert.NoError(t, err)
+	cmdConfig.RegisterSettings()
 
 	socket, cleanup := setupAPIServer(t)
 	client, err := net.Dial("unix", socket)

--- a/pkg/crc/api/api_test.go
+++ b/pkg/crc/api/api_test.go
@@ -102,8 +102,6 @@ func TestSetconfigApi(t *testing.T) {
 	// setup viper
 	err := constants.EnsureBaseDirExists()
 	assert.NoError(t, err)
-	err = config.EnsureConfigFileExists()
-	assert.NoError(t, err)
 	err = config.InitViper()
 	assert.NoError(t, err)
 	cmdConfig.RegisterSettings()
@@ -136,8 +134,6 @@ func TestSetconfigApi(t *testing.T) {
 func TestGetconfigApi(t *testing.T) {
 	// setup viper
 	err := constants.EnsureBaseDirExists()
-	assert.NoError(t, err)
-	err = config.EnsureConfigFileExists()
 	assert.NoError(t, err)
 	err = config.InitViper()
 	assert.NoError(t, err)

--- a/pkg/crc/api/api_test.go
+++ b/pkg/crc/api/api_test.go
@@ -164,7 +164,7 @@ func TestGetconfigApi(t *testing.T) {
 	assert.NoError(t, json.Unmarshal(payload[:n], &getconfigRes))
 
 	configs := make(map[string]interface{})
-	configs["cpus"] = "5"
+	configs["cpus"] = 5.0
 
 	assert.Equal(t, getConfigResult{
 		Error:   "",

--- a/pkg/crc/api/handlers.go
+++ b/pkg/crc/api/handlers.go
@@ -105,11 +105,6 @@ func setConfigHandler(_ machine.Client, args json.RawMessage) string {
 			multiError.Collect(err)
 			continue
 		}
-		err = crcConfig.WriteConfig()
-		if err != nil {
-			multiError.Collect(err)
-			continue
-		}
 		successProps = append(successProps, k)
 	}
 
@@ -143,11 +138,6 @@ func unsetConfigHandler(_ machine.Client, args json.RawMessage) string {
 	keysToUnset := keys["properties"]
 	for _, key := range keysToUnset {
 		_, err := crcConfig.Unset(key)
-		if err != nil {
-			multiError.Collect(err)
-			continue
-		}
-		err = crcConfig.WriteConfig()
 		if err != nil {
 			multiError.Collect(err)
 			continue

--- a/pkg/crc/api/handlers.go
+++ b/pkg/crc/api/handlers.go
@@ -183,11 +183,11 @@ func getConfigHandler(_ machine.Client, args json.RawMessage) string {
 	var configs = make(map[string]interface{})
 
 	for _, key := range keys {
-		v, err := crcConfig.Get(key)
-		if err != nil {
+		v := crcConfig.Get(key)
+		if v.Invalid {
 			continue
 		}
-		configs[key] = v
+		configs[key] = v.Value
 	}
 	if len(configs) == 0 {
 		configResult.Error = "Unable to get configs"

--- a/pkg/crc/api/handlers.go
+++ b/pkg/crc/api/handlers.go
@@ -33,10 +33,10 @@ func stopHandler(client machine.Client, _ json.RawMessage) string {
 func startHandler(client machine.Client, _ json.RawMessage) string {
 	startConfig := machine.StartConfig{
 		Name:          constants.DefaultName,
-		BundlePath:    crcConfig.GetString(config.Bundle.Name),
-		Memory:        crcConfig.GetInt(config.Memory.Name),
-		CPUs:          crcConfig.GetInt(config.CPUs.Name),
-		NameServer:    crcConfig.GetString(config.NameServer.Name),
+		BundlePath:    crcConfig.Get(config.Bundle.Name).AsString(),
+		Memory:        crcConfig.Get(config.Memory.Name).AsInt(),
+		CPUs:          crcConfig.Get(config.CPUs.Name).AsInt(),
+		NameServer:    crcConfig.Get(config.NameServer.Name).AsString(),
 		GetPullSecret: getPullSecretFileContent,
 		Debug:         true,
 	}
@@ -55,7 +55,7 @@ func versionHandler(client machine.Client, _ json.RawMessage) string {
 }
 
 func getPullSecretFileContent() (string, error) {
-	data, err := ioutil.ReadFile(crcConfig.GetString(config.PullSecretFile.Name))
+	data, err := ioutil.ReadFile(crcConfig.Get(config.PullSecretFile.Name).AsString())
 	if err != nil {
 		return "", err
 	}

--- a/pkg/crc/api/handlers.go
+++ b/pkg/crc/api/handlers.go
@@ -33,10 +33,10 @@ func stopHandler(client machine.Client, _ json.RawMessage) string {
 func startHandler(client machine.Client, _ json.RawMessage) string {
 	startConfig := machine.StartConfig{
 		Name:          constants.DefaultName,
-		BundlePath:    crcConfig.Get(config.Bundle.Name).AsString(),
-		Memory:        crcConfig.Get(config.Memory.Name).AsInt(),
-		CPUs:          crcConfig.Get(config.CPUs.Name).AsInt(),
-		NameServer:    crcConfig.Get(config.NameServer.Name).AsString(),
+		BundlePath:    crcConfig.Get(config.Bundle).AsString(),
+		Memory:        crcConfig.Get(config.Memory).AsInt(),
+		CPUs:          crcConfig.Get(config.CPUs).AsInt(),
+		NameServer:    crcConfig.Get(config.NameServer).AsString(),
 		GetPullSecret: getPullSecretFileContent,
 		Debug:         true,
 	}
@@ -55,7 +55,7 @@ func versionHandler(client machine.Client, _ json.RawMessage) string {
 }
 
 func getPullSecretFileContent() (string, error) {
-	data, err := ioutil.ReadFile(crcConfig.Get(config.PullSecretFile.Name).AsString())
+	data, err := ioutil.ReadFile(crcConfig.Get(config.PullSecretFile).AsString())
 	if err != nil {
 		return "", err
 	}

--- a/pkg/crc/api/handlers.go
+++ b/pkg/crc/api/handlers.go
@@ -166,7 +166,10 @@ func getConfigHandler(_ machine.Client, args json.RawMessage) string {
 	if args == nil {
 		allConfigs := crcConfig.AllConfigs()
 		configResult.Error = ""
-		configResult.Configs = allConfigs
+		configResult.Configs = make(map[string]interface{})
+		for k, v := range allConfigs {
+			configResult.Configs[k] = v.Value
+		}
 		return encodeStructToJSON(configResult)
 	}
 

--- a/pkg/crc/api/types.go
+++ b/pkg/crc/api/types.go
@@ -4,10 +4,12 @@ import (
 	"encoding/json"
 	"net"
 
+	"github.com/code-ready/crc/pkg/crc/config"
+
 	"github.com/code-ready/crc/pkg/crc/machine"
 )
 
-type handlerFunc func(machine.Client, json.RawMessage) string
+type handlerFunc func(machine.Client, config.Storage, json.RawMessage) string
 
 type commandError struct {
 	Err string
@@ -15,6 +17,7 @@ type commandError struct {
 
 type CrcAPIServer struct {
 	client                 machine.Client
+	config                 config.Storage
 	listener               net.Listener
 	clusterOpsRequestsChan chan clusterOpsRequest
 	handlers               map[string]handlerFunc // relates commands to handler func

--- a/pkg/crc/config/callbacks.go
+++ b/pkg/crc/config/callbacks.go
@@ -4,12 +4,12 @@ import (
 	"fmt"
 )
 
-func RequiresRestartMsg(key, _ string) string {
+func RequiresRestartMsg(key string, _ interface{}) string {
 	return fmt.Sprintf("Changes to configuration property '%s' are only applied when a new CRC instance is created.\n"+
 		"If you already have a CRC instance, then for this configuration change to take effect, "+
 		"delete the CRC instance with 'crc delete' and start a new one with 'crc start'.", key)
 }
 
-func SuccessfullyApplied(key, value string) string {
+func SuccessfullyApplied(key string, value interface{}) string {
 	return fmt.Sprintf("Successfully configured %s to %s", key, value)
 }

--- a/pkg/crc/config/config.go
+++ b/pkg/crc/config/config.go
@@ -1,0 +1,164 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+
+	"github.com/code-ready/crc/pkg/crc/constants"
+	"github.com/spf13/cast"
+	"github.com/spf13/pflag"
+)
+
+const (
+	configPropDoesntExistMsg = "Configuration property '%s' does not exist"
+)
+
+var defaultConfig *Config
+
+type Config struct {
+	storage     RawStorage
+	allSettings map[string]*Setting
+}
+
+func New(storage RawStorage) *Config {
+	return &Config{
+		storage:     storage,
+		allSettings: make(map[string]*Setting),
+	}
+}
+
+// InitViper initializes viper
+func InitViper() error {
+	storage, err := NewViperStorage(constants.ConfigPath, constants.CrcEnvPrefix)
+	if err != nil {
+		return err
+	}
+	defaultConfig = New(storage)
+	return nil
+}
+
+// AllConfigs returns all the known configs
+// A known config is one which was registered through AddSetting
+// - config with a default value
+// - config with a value set
+// - config with no value set
+func AllConfigs() map[string]SettingValue {
+	return defaultConfig.AllConfigs()
+}
+
+func (c *Config) AllConfigs() map[string]SettingValue {
+	var allConfigs = make(map[string]SettingValue)
+	for key := range c.allSettings {
+		allConfigs[key] = c.Get(key)
+	}
+	return allConfigs
+}
+
+// BindFlagset binds a flagset to their respective config properties
+func BindFlagSet(flagSet *pflag.FlagSet) error {
+	return defaultConfig.BindFlagSet(flagSet)
+}
+
+func (c *Config) BindFlagSet(flagSet *pflag.FlagSet) error {
+	if v, ok := c.storage.(*ViperStorage); ok {
+		return v.BindFlagSet(flagSet)
+	}
+	return errors.New("not implemented")
+}
+
+// AddSetting returns a filled struct of ConfigSetting
+// takes the config name and default value as arguments
+func AddSetting(name string, defValue interface{}, validationFn ValidationFnType, callbackFn SetFn) *Setting {
+	return defaultConfig.AddSetting(name, defValue, validationFn, callbackFn)
+}
+
+func (c *Config) AddSetting(name string, defValue interface{}, validationFn ValidationFnType, callbackFn SetFn) *Setting {
+	s := Setting{Name: name, defaultValue: defValue, validationFn: validationFn, callbackFn: callbackFn}
+	c.allSettings[name] = &s
+	return &s
+}
+
+// Set sets the value for a given config key
+func Set(key string, value interface{}) (string, error) {
+	return defaultConfig.Set(key, value)
+}
+
+func (c *Config) Set(key string, value interface{}) (string, error) {
+	setting, ok := c.allSettings[key]
+	if !ok {
+		return "", fmt.Errorf(configPropDoesntExistMsg, key)
+	}
+
+	var castValue interface{}
+	switch setting.defaultValue.(type) {
+	case int:
+		castValue = cast.ToInt(value)
+	case string:
+		castValue = cast.ToString(value)
+	case bool:
+		castValue = cast.ToBool(value)
+	}
+
+	ok, expectedValue := c.allSettings[key].validationFn(castValue)
+	if !ok {
+		return "", fmt.Errorf("Value '%s' for configuration property '%s' is invalid, reason: %s", castValue, key, expectedValue)
+	}
+
+	if err := c.storage.Set(key, castValue); err != nil {
+		return "", err
+	}
+
+	return c.allSettings[key].callbackFn(key, castValue), nil
+}
+
+// Unset unsets a given config key
+func Unset(key string) (string, error) {
+	return defaultConfig.Unset(key)
+}
+
+func (c *Config) Unset(key string) (string, error) {
+	_, ok := c.allSettings[key]
+	if !ok {
+		return "", fmt.Errorf(configPropDoesntExistMsg, key)
+	}
+
+	if err := c.storage.Unset(key); err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("Successfully unset configuration property '%s'", key), nil
+}
+
+func Get(key string) SettingValue {
+	return defaultConfig.Get(key)
+}
+
+func (c *Config) Get(key string) SettingValue {
+	setting, ok := c.allSettings[key]
+	if !ok {
+		return SettingValue{
+			Invalid: true,
+		}
+	}
+	value := c.storage.Get(key)
+	if value == nil {
+		value = setting.defaultValue
+	}
+	switch setting.defaultValue.(type) {
+	case int:
+		value = cast.ToInt(value)
+	case string:
+		value = cast.ToString(value)
+	case bool:
+		value = cast.ToBool(value)
+	default:
+		return SettingValue{
+			Invalid: true,
+		}
+	}
+	return SettingValue{
+		Value:     value,
+		IsDefault: reflect.DeepEqual(setting.defaultValue, value),
+	}
+}

--- a/pkg/crc/config/config.go
+++ b/pkg/crc/config/config.go
@@ -1,20 +1,15 @@
 package config
 
 import (
-	"errors"
 	"fmt"
 	"reflect"
 
-	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/spf13/cast"
-	"github.com/spf13/pflag"
 )
 
 const (
 	configPropDoesntExistMsg = "Configuration property '%s' does not exist"
 )
-
-var defaultConfig *Config
 
 type Config struct {
 	storage        RawStorage
@@ -28,25 +23,11 @@ func New(storage RawStorage) *Config {
 	}
 }
 
-// InitViper initializes viper
-func InitViper() error {
-	storage, err := NewViperStorage(constants.ConfigPath, constants.CrcEnvPrefix)
-	if err != nil {
-		return err
-	}
-	defaultConfig = New(storage)
-	return nil
-}
-
 // AllConfigs returns all the known configs
 // A known config is one which was registered through AddSetting
 // - config with a default value
 // - config with a value set
 // - config with no value set
-func AllConfigs() map[string]SettingValue {
-	return defaultConfig.AllConfigs()
-}
-
 func (c *Config) AllConfigs() map[string]SettingValue {
 	var allConfigs = make(map[string]SettingValue)
 	for key := range c.settingsByName {
@@ -55,24 +36,8 @@ func (c *Config) AllConfigs() map[string]SettingValue {
 	return allConfigs
 }
 
-// BindFlagset binds a flagset to their respective config properties
-func BindFlagSet(flagSet *pflag.FlagSet) error {
-	return defaultConfig.BindFlagSet(flagSet)
-}
-
-func (c *Config) BindFlagSet(flagSet *pflag.FlagSet) error {
-	if v, ok := c.storage.(*ViperStorage); ok {
-		return v.BindFlagSet(flagSet)
-	}
-	return errors.New("not implemented")
-}
-
 // AddSetting returns a filled struct of ConfigSetting
 // takes the config name and default value as arguments
-func AddSetting(name string, defValue interface{}, validationFn ValidationFnType, callbackFn SetFn) {
-	defaultConfig.AddSetting(name, defValue, validationFn, callbackFn)
-}
-
 func (c *Config) AddSetting(name string, defValue interface{}, validationFn ValidationFnType, callbackFn SetFn) {
 	c.settingsByName[name] = Setting{
 		Name:         name,
@@ -83,10 +48,6 @@ func (c *Config) AddSetting(name string, defValue interface{}, validationFn Vali
 }
 
 // Set sets the value for a given config key
-func Set(key string, value interface{}) (string, error) {
-	return defaultConfig.Set(key, value)
-}
-
 func (c *Config) Set(key string, value interface{}) (string, error) {
 	setting, ok := c.settingsByName[key]
 	if !ok {
@@ -116,10 +77,6 @@ func (c *Config) Set(key string, value interface{}) (string, error) {
 }
 
 // Unset unsets a given config key
-func Unset(key string) (string, error) {
-	return defaultConfig.Unset(key)
-}
-
 func (c *Config) Unset(key string) (string, error) {
 	_, ok := c.settingsByName[key]
 	if !ok {
@@ -131,10 +88,6 @@ func (c *Config) Unset(key string) (string, error) {
 	}
 
 	return fmt.Sprintf("Successfully unset configuration property '%s'", key), nil
-}
-
-func Get(key string) SettingValue {
-	return defaultConfig.Get(key)
 }
 
 func (c *Config) Get(key string) SettingValue {

--- a/pkg/crc/config/inmemory.go
+++ b/pkg/crc/config/inmemory.go
@@ -1,0 +1,29 @@
+package config
+
+type InMemoryStorage struct {
+	storage map[string]interface{}
+}
+
+func NewEmptyInMemoryStorage() *InMemoryStorage {
+	return NewInMemoryStorage(make(map[string]interface{}))
+}
+
+func NewInMemoryStorage(init map[string]interface{}) *InMemoryStorage {
+	return &InMemoryStorage{
+		storage: init,
+	}
+}
+
+func (s *InMemoryStorage) Get(key string) interface{} {
+	return s.storage[key]
+}
+
+func (s *InMemoryStorage) Set(key string, value interface{}) error {
+	s.storage[key] = value
+	return nil
+}
+
+func (s *InMemoryStorage) Unset(key string) error {
+	delete(s.storage, key)
+	return nil
+}

--- a/pkg/crc/config/types.go
+++ b/pkg/crc/config/types.go
@@ -2,6 +2,17 @@ package config
 
 import "github.com/spf13/cast"
 
+type Storage interface {
+	Get(key string) SettingValue
+	Set(key string, value interface{}) (string, error)
+	Unset(key string) (string, error)
+	AllConfigs() map[string]SettingValue
+}
+
+type Schema interface {
+	AddSetting(name string, defValue interface{}, validationFn ValidationFnType, callbackFn SetFn)
+}
+
 type Setting struct {
 	Name         string
 	defaultValue interface{}

--- a/pkg/crc/config/types.go
+++ b/pkg/crc/config/types.go
@@ -1,0 +1,32 @@
+package config
+
+import "github.com/spf13/cast"
+
+type Setting struct {
+	Name         string
+	defaultValue interface{}
+	validationFn ValidationFnType
+	callbackFn   SetFn
+}
+
+type SettingValue struct {
+	Value     interface{}
+	Invalid   bool
+	IsDefault bool
+}
+
+func (v SettingValue) AsBool() bool {
+	return cast.ToBool(v.Value)
+}
+
+func (v SettingValue) AsString() string {
+	return cast.ToString(v.Value)
+}
+
+func (v SettingValue) AsInt() int {
+	return cast.ToInt(v.Value)
+}
+
+// validationFnType takes the key, value as args and checks if valid
+type ValidationFnType func(interface{}) (bool, string)
+type SetFn func(string, interface{}) string

--- a/pkg/crc/config/types.go
+++ b/pkg/crc/config/types.go
@@ -30,3 +30,10 @@ func (v SettingValue) AsInt() int {
 // validationFnType takes the key, value as args and checks if valid
 type ValidationFnType func(interface{}) (bool, string)
 type SetFn func(string, interface{}) string
+
+// RawStorage stores any key-value pair without validation
+type RawStorage interface {
+	Get(key string) interface{}
+	Set(key string, value interface{}) error
+	Unset(key string) error
+}

--- a/pkg/crc/config/validations.go
+++ b/pkg/crc/config/validations.go
@@ -16,7 +16,7 @@ type ValidationFnType func(interface{}) (bool, string)
 // ValidateBool is a fail safe in the case user
 // makes a typo for boolean config values
 func ValidateBool(value interface{}) (bool, string) {
-	if value.(string) == "true" || value.(string) == "false" {
+	if cast.ToString(value) == "true" || cast.ToString(value) == "false" {
 		return true, ""
 	}
 	return false, "must be true or false"
@@ -48,7 +48,7 @@ func ValidateMemory(value interface{}) (bool, string) {
 
 // ValidateBundle checks if provided bundle path is valid
 func ValidateBundle(value interface{}) (bool, string) {
-	if err := validation.ValidateBundle(value.(string)); err != nil {
+	if err := validation.ValidateBundle(cast.ToString(value)); err != nil {
 		return false, err.Error()
 	}
 	return true, ""
@@ -56,7 +56,7 @@ func ValidateBundle(value interface{}) (bool, string) {
 
 // ValidateIP checks if provided IP is valid
 func ValidateIPAddress(value interface{}) (bool, string) {
-	if err := validation.ValidateIPAddress(value.(string)); err != nil {
+	if err := validation.ValidateIPAddress(cast.ToString(value)); err != nil {
 		return false, err.Error()
 	}
 	return true, ""
@@ -64,7 +64,7 @@ func ValidateIPAddress(value interface{}) (bool, string) {
 
 // ValidatePath checks if provided path is exist
 func ValidatePath(value interface{}) (bool, string) {
-	if err := validation.ValidatePath(value.(string)); err != nil {
+	if err := validation.ValidatePath(cast.ToString(value)); err != nil {
 		return false, err.Error()
 	}
 	return true, ""
@@ -72,7 +72,7 @@ func ValidatePath(value interface{}) (bool, string) {
 
 // ValidateURI checks if given URI is valid
 func ValidateURI(value interface{}) (bool, string) {
-	if err := network.ValidateProxyURL(value.(string)); err != nil {
+	if err := network.ValidateProxyURL(cast.ToString(value)); err != nil {
 		return false, err.Error()
 	}
 	return true, ""
@@ -80,7 +80,7 @@ func ValidateURI(value interface{}) (bool, string) {
 
 // ValidateNoProxy checks if the NoProxy string has the correct format
 func ValidateNoProxy(value interface{}) (bool, string) {
-	if strings.Contains(value.(string), " ") {
+	if strings.Contains(cast.ToString(value), " ") {
 		return false, "NoProxy string can't contain spaces"
 	}
 	return true, ""

--- a/pkg/crc/config/validations.go
+++ b/pkg/crc/config/validations.go
@@ -10,9 +10,6 @@ import (
 	"github.com/spf13/cast"
 )
 
-// validationFnType takes the key, value as args and checks if valid
-type ValidationFnType func(interface{}) (bool, string)
-
 // ValidateBool is a fail safe in the case user
 // makes a typo for boolean config values
 func ValidateBool(value interface{}) (bool, string) {

--- a/pkg/crc/config/validations.go
+++ b/pkg/crc/config/validations.go
@@ -2,12 +2,12 @@ package config
 
 import (
 	"fmt"
-	"strconv"
 	"strings"
 
 	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/code-ready/crc/pkg/crc/network"
 	"github.com/code-ready/crc/pkg/crc/validation"
+	"github.com/spf13/cast"
 )
 
 // validationFnType takes the key, value as args and checks if valid
@@ -24,7 +24,7 @@ func ValidateBool(value interface{}) (bool, string) {
 
 // ValidateCPUs checks if provided cpus count is valid in the config
 func ValidateCPUs(value interface{}) (bool, string) {
-	v, err := strconv.Atoi(value.(string))
+	v, err := cast.ToIntE(value)
 	if err != nil {
 		return false, fmt.Sprintf("requires integer value >= %d", constants.DefaultCPUs)
 	}
@@ -36,7 +36,7 @@ func ValidateCPUs(value interface{}) (bool, string) {
 
 // ValidateMemory checks if provided memory is valid in the config
 func ValidateMemory(value interface{}) (bool, string) {
-	v, err := strconv.Atoi(value.(string))
+	v, err := cast.ToIntE(value)
 	if err != nil {
 		return false, fmt.Sprintf("requires integer value in MiB >= %d", constants.DefaultMemory)
 	}

--- a/pkg/crc/config/viper_config.go
+++ b/pkg/crc/config/viper_config.go
@@ -160,12 +160,7 @@ func Set(key string, value interface{}) (string, error) {
 	globalViper.Set(key, value)
 	changedConfigs[key] = value
 
-	callbackMsg := allSettings[key].callbackFn(key, value)
-	if callbackMsg != "" {
-		return callbackMsg, nil
-	}
-
-	return "", nil
+	return allSettings[key].callbackFn(key, value), WriteConfig()
 }
 
 // Unset unsets a given config key
@@ -180,7 +175,7 @@ func Unset(key string) (string, error) {
 		return "", fmt.Errorf("Error unsetting configuration property '%s': %v", key, err)
 	}
 
-	return fmt.Sprintf("Successfully unset configuration property '%s'", key), nil
+	return fmt.Sprintf("Successfully unset configuration property '%s'", key), WriteConfig()
 }
 
 func Get(key string) SettingValue {

--- a/pkg/crc/config/viper_config.go
+++ b/pkg/crc/config/viper_config.go
@@ -37,11 +37,6 @@ var (
 	allSettings = make(map[string]*Setting)
 )
 
-// GetBool returns the value of a boolean config key
-func GetBool(key string) bool {
-	return globalViper.GetBool(key)
-}
-
 func set(key string, value interface{}) {
 	globalViper.Set(key, value)
 	changedConfigs[key] = value
@@ -80,16 +75,6 @@ func (v SettingValue) AsString() string {
 
 func (v SettingValue) AsInt() int {
 	return cast.ToInt(v.Value)
-}
-
-// GetString return the value of a key in string
-func GetString(key string) string {
-	return globalViper.GetString(key)
-}
-
-// GetInt return the value of a key in int
-func GetInt(key string) int {
-	return globalViper.GetInt(key)
 }
 
 // EnsureConfigFileExists creates the viper config file if it does not exists

--- a/pkg/crc/config/viper_config.go
+++ b/pkg/crc/config/viper_config.go
@@ -177,11 +177,6 @@ func AllConfigs() map[string]interface{} {
 	return allConfigs
 }
 
-// BindFlags binds flags to config properties
-func BindFlag(key string, flag *pflag.Flag) error {
-	return globalViper.BindPFlag(key, flag)
-}
-
 // BindFlagset binds a flagset to their respective config properties
 func BindFlagSet(flagSet *pflag.FlagSet) error {
 	return globalViper.BindPFlags(flagSet)

--- a/pkg/crc/config/viper_config.go
+++ b/pkg/crc/config/viper_config.go
@@ -14,15 +14,6 @@ import (
 	"github.com/spf13/viper"
 )
 
-type SetFn func(string, interface{}) string
-
-type Setting struct {
-	Name         string
-	defaultValue interface{}
-	validationFn ValidationFnType
-	callbackFn   SetFn
-}
-
 const (
 	configPropDoesntExistMsg = "Configuration property '%s' does not exist"
 )
@@ -34,24 +25,6 @@ type Config struct {
 	// allSettings holds all the config settings
 	allSettings map[string]*Setting
 	configFile  string
-}
-
-type SettingValue struct {
-	Value     interface{}
-	Invalid   bool
-	IsDefault bool
-}
-
-func (v SettingValue) AsBool() bool {
-	return cast.ToBool(v.Value)
-}
-
-func (v SettingValue) AsString() string {
-	return cast.ToString(v.Value)
-}
-
-func (v SettingValue) AsInt() int {
-	return cast.ToInt(v.Value)
 }
 
 // ensureConfigFileExists creates the viper config file if it does not exists

--- a/pkg/crc/config/viper_config.go
+++ b/pkg/crc/config/viper_config.go
@@ -110,17 +110,6 @@ func InitViper() error {
 	return v.Unmarshal(&changedConfigs)
 }
 
-// setDefault sets the default for a config
-func setDefault(key string, value interface{}) {
-	globalViper.SetDefault(key, value)
-}
-
-func SetDefaults() {
-	for _, setting := range allSettings {
-		setDefault(setting.Name, setting.defaultValue)
-	}
-}
-
 // WriteConfig write config to file
 func WriteConfig() error {
 	// We recreate a new viper instance, as globalViper.WriteConfig()
@@ -159,6 +148,7 @@ func BindFlagSet(flagSet *pflag.FlagSet) error {
 func AddSetting(name string, defValue interface{}, validationFn ValidationFnType, callbackFn SetFn) *Setting {
 	s := Setting{Name: name, defaultValue: defValue, validationFn: validationFn, callbackFn: callbackFn}
 	allSettings[name] = &s
+	globalViper.SetDefault(name, defValue)
 	return &s
 }
 

--- a/pkg/crc/config/viper_config.go
+++ b/pkg/crc/config/viper_config.go
@@ -67,8 +67,8 @@ func (v SettingValue) AsInt() int {
 	return cast.ToInt(v.Value)
 }
 
-// EnsureConfigFileExists creates the viper config file if it does not exists
-func EnsureConfigFileExists() error {
+// ensureConfigFileExists creates the viper config file if it does not exists
+func ensureConfigFileExists() error {
 	_, err := os.Stat(constants.ConfigPath)
 	if err != nil {
 		f, err := os.Create(constants.ConfigPath)
@@ -83,6 +83,9 @@ func EnsureConfigFileExists() error {
 
 // InitViper initializes viper
 func InitViper() error {
+	if err := ensureConfigFileExists(); err != nil {
+		return err
+	}
 	v := viper.New()
 	v.SetConfigFile(constants.ConfigPath)
 	v.SetConfigType("json")

--- a/pkg/crc/config/viper_config.go
+++ b/pkg/crc/config/viper_config.go
@@ -136,28 +136,15 @@ func WriteConfig() error {
 	return v.WriteConfig()
 }
 
-// ChangedConfigs returns all the changed config keys/values
-// 'changed' means config keys with a value set either because they are set in
-// the config file, or because they were changed at runtime.
-// This does not include config keys with no default value, or with a default value
-func ChangedConfigs() map[string]interface{} {
-	return changedConfigs
-}
-
 // AllConfigs returns all the known configs
 // A known config is one which was registered through AddSetting
 // - config with a default value
 // - config with a value set
 // - config with no value set
-func AllConfigs() map[string]interface{} {
-	var allConfigs = make(map[string]interface{})
-
+func AllConfigs() map[string]SettingValue {
+	var allConfigs = make(map[string]SettingValue)
 	for key := range allSettings {
-		v := Get(key)
-		if v.Invalid {
-			allConfigs[key] = nil
-		}
-		allConfigs[key] = v.Value
+		allConfigs[key] = Get(key)
 	}
 	return allConfigs
 }

--- a/pkg/crc/config/viper_config.go
+++ b/pkg/crc/config/viper_config.go
@@ -37,11 +37,6 @@ var (
 	allSettings = make(map[string]*Setting)
 )
 
-func set(key string, value interface{}) {
-	globalViper.Set(key, value)
-	changedConfigs[key] = value
-}
-
 func syncViperState(viper *viper.Viper) error {
 	encodedConfig, err := json.MarshalIndent(changedConfigs, "", " ")
 	if err != nil {
@@ -52,11 +47,6 @@ func syncViperState(viper *viper.Viper) error {
 		return fmt.Errorf("Error reading configuration file '%s': %v", constants.ConfigFile, err)
 	}
 	return nil
-}
-
-func unset(key string) error {
-	delete(changedConfigs, key)
-	return syncViperState(globalViper)
 }
 
 type SettingValue struct {
@@ -164,7 +154,8 @@ func Set(key string, value interface{}) (string, error) {
 		return "", fmt.Errorf("Value '%s' for configuration property '%s' is invalid, reason: %s", value, key, expectedValue)
 	}
 
-	set(key, value)
+	globalViper.Set(key, value)
+	changedConfigs[key] = value
 
 	callbackMsg := allSettings[key].callbackFn(key, value)
 	if callbackMsg != "" {
@@ -181,7 +172,8 @@ func Unset(key string) (string, error) {
 		return "", fmt.Errorf(configPropDoesntExistMsg, key)
 	}
 
-	if err := unset(key); err != nil {
+	delete(changedConfigs, key)
+	if err := syncViperState(globalViper); err != nil {
 		return "", fmt.Errorf("Error unsetting configuration property '%s': %v", key, err)
 	}
 

--- a/pkg/crc/config/viper_config.go
+++ b/pkg/crc/config/viper_config.go
@@ -4,44 +4,20 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"os"
-	"reflect"
 	"strings"
 
-	"github.com/code-ready/crc/pkg/crc/constants"
-	"github.com/spf13/cast"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 )
 
-const (
-	configPropDoesntExistMsg = "Configuration property '%s' does not exist"
-)
-
-var defaultConfig *Config
-
-type Config struct {
-	globalViper *viper.Viper
-	// allSettings holds all the config settings
-	allSettings map[string]*Setting
-	configFile  string
+type ViperStorage struct {
+	viper      *viper.Viper
+	configFile string
 }
 
-// ensureConfigFileExists creates the viper config file if it does not exists
-func ensureConfigFileExists(configFile string) error {
-	_, err := os.Stat(configFile)
-	if err != nil {
-		f, err := os.Create(configFile)
-		if err == nil {
-			_, err = f.WriteString("{}")
-			f.Close()
-		}
-		return err
-	}
-	return nil
-}
-
-func New(configFile, envPrefix string) (*Config, error) {
+func NewViperStorage(configFile, envPrefix string) (*ViperStorage, error) {
 	if err := ensureConfigFileExists(configFile); err != nil {
 		return nil, err
 	}
@@ -55,145 +31,48 @@ func New(configFile, envPrefix string) (*Config, error) {
 	v.SetTypeByDefaultValue(true)
 	err := v.ReadInConfig()
 	if err != nil {
-		return nil, fmt.Errorf("Error reading configuration file '%s': %v", configFile, err)
+		return nil, fmt.Errorf("error reading configuration file '%s': %v", configFile, err)
 	}
 	v.WatchConfig()
-	return &Config{
-		globalViper: v,
-		allSettings: make(map[string]*Setting),
-		configFile:  configFile,
+	return &ViperStorage{
+		viper:      v,
+		configFile: configFile,
 	}, nil
 }
 
-// InitViper initializes viper
-func InitViper() error {
-	var err error
-	defaultConfig, err = New(constants.ConfigPath, constants.CrcEnvPrefix)
-	return err
+func (c *ViperStorage) Get(key string) interface{} {
+	return c.viper.Get(key)
 }
 
-// AllConfigs returns all the known configs
-// A known config is one which was registered through AddSetting
-// - config with a default value
-// - config with a value set
-// - config with no value set
-func AllConfigs() map[string]SettingValue {
-	return defaultConfig.AllConfigs()
+func (c *ViperStorage) Set(key string, value interface{}) error {
+	c.viper.Set(key, value)
+	return c.viper.WriteConfigAs(c.configFile)
 }
 
-func (c *Config) AllConfigs() map[string]SettingValue {
-	var allConfigs = make(map[string]SettingValue)
-	for key := range c.allSettings {
-		allConfigs[key] = c.Get(key)
-	}
-	return allConfigs
-}
-
-// BindFlagset binds a flagset to their respective config properties
-func BindFlagSet(flagSet *pflag.FlagSet) error {
-	return defaultConfig.BindFlagSet(flagSet)
-}
-
-func (c *Config) BindFlagSet(flagSet *pflag.FlagSet) error {
-	return c.globalViper.BindPFlags(flagSet)
-}
-
-// AddSetting returns a filled struct of ConfigSetting
-// takes the config name and default value as arguments
-func AddSetting(name string, defValue interface{}, validationFn ValidationFnType, callbackFn SetFn) *Setting {
-	return defaultConfig.AddSetting(name, defValue, validationFn, callbackFn)
-}
-
-func (c *Config) AddSetting(name string, defValue interface{}, validationFn ValidationFnType, callbackFn SetFn) *Setting {
-	s := Setting{Name: name, defaultValue: defValue, validationFn: validationFn, callbackFn: callbackFn}
-	c.allSettings[name] = &s
-	return &s
-}
-
-// Set sets the value for a give config key
-func Set(key string, value interface{}) (string, error) {
-	return defaultConfig.Set(key, value)
-}
-
-func (c *Config) Set(key string, value interface{}) (string, error) {
-	setting, ok := c.allSettings[key]
-	if !ok {
-		return "", fmt.Errorf(configPropDoesntExistMsg, key)
-	}
-
-	var castValue interface{}
-	switch setting.defaultValue.(type) {
-	case int:
-		castValue = cast.ToInt(value)
-	case string:
-		castValue = cast.ToString(value)
-	case bool:
-		castValue = cast.ToBool(value)
-	}
-
-	ok, expectedValue := c.allSettings[key].validationFn(castValue)
-	if !ok {
-		return "", fmt.Errorf("Value '%s' for configuration property '%s' is invalid, reason: %s", castValue, key, expectedValue)
-	}
-
-	c.globalViper.Set(key, castValue)
-
-	return c.allSettings[key].callbackFn(key, castValue), c.globalViper.WriteConfig()
-}
-
-// Unset unsets a given config key
-func Unset(key string) (string, error) {
-	return defaultConfig.Unset(key)
-}
-
-func (c *Config) Unset(key string) (string, error) {
-	_, ok := c.allSettings[key]
-	if !ok {
-		return "", fmt.Errorf(configPropDoesntExistMsg, key)
-	}
-
-	settings := c.globalViper.AllSettings()
+func (c *ViperStorage) Unset(key string) error {
+	settings := c.viper.AllSettings()
 	delete(settings, key)
 	bin, err := json.Marshal(settings)
 	if err != nil {
-		return "", err
+		return err
 	}
-	if err = c.globalViper.ReadConfig(bytes.NewReader(bin)); err != nil {
-		return "", err
+	if err = c.viper.ReadConfig(bytes.NewReader(bin)); err != nil {
+		return err
 	}
 
-	return fmt.Sprintf("Successfully unset configuration property '%s'", key), c.globalViper.WriteConfig()
+	return c.viper.WriteConfigAs(c.configFile)
 }
 
-func Get(key string) SettingValue {
-	return defaultConfig.Get(key)
+// BindFlagset binds a flagset to their respective config properties
+func (c *ViperStorage) BindFlagSet(flagSet *pflag.FlagSet) error {
+	return c.viper.BindPFlags(flagSet)
 }
 
-func (c *Config) Get(key string) SettingValue {
-	setting, ok := c.allSettings[key]
-	if !ok || c.globalViper == nil {
-		return SettingValue{
-			Invalid: true,
-		}
+// ensureConfigFileExists creates the viper config file if it does not exists
+func ensureConfigFileExists(file string) error {
+	_, err := os.Stat(file)
+	if os.IsNotExist(err) {
+		return ioutil.WriteFile(file, []byte("{}\n"), 0600)
 	}
-	value := c.globalViper.Get(key)
-	if value == nil {
-		value = setting.defaultValue
-	}
-	switch setting.defaultValue.(type) {
-	case int:
-		value = cast.ToInt(value)
-	case string:
-		value = cast.ToString(value)
-	case bool:
-		value = cast.ToBool(value)
-	default:
-		return SettingValue{
-			Invalid: true,
-		}
-	}
-	return SettingValue{
-		Value:     value,
-		IsDefault: reflect.DeepEqual(setting.defaultValue, value),
-	}
+	return err
 }

--- a/pkg/crc/config/viper_config_test.go
+++ b/pkg/crc/config/viper_config_test.go
@@ -17,10 +17,11 @@ const (
 )
 
 func newTestConfig(configFile, envPrefix string) (*Config, error) {
-	config, err := New(configFile, envPrefix)
+	storage, err := NewViperStorage(configFile, envPrefix)
 	if err != nil {
 		return nil, err
 	}
+	config := New(storage)
 	config.AddSetting(CPUs, 4, ValidateCPUs, RequiresRestartMsg)
 	config.AddSetting(NameServer, "", ValidateIPAddress, SuccessfullyApplied)
 	return config, nil

--- a/pkg/crc/config/viper_config_test.go
+++ b/pkg/crc/config/viper_config_test.go
@@ -148,14 +148,17 @@ func TestViperConfigBindFlagSet(t *testing.T) {
 	defer os.RemoveAll(dir)
 	configFile := filepath.Join(dir, "crc.json")
 
-	config, err := newTestConfig(configFile, "CRC")
+	storage, err := NewViperStorage(configFile, "CRC")
 	require.NoError(t, err)
+	config := New(storage)
+	config.AddSetting(CPUs, 4, ValidateCPUs, RequiresRestartMsg)
+	config.AddSetting(NameServer, "", ValidateIPAddress, SuccessfullyApplied)
 
 	flagSet := pflag.NewFlagSet("start", pflag.ExitOnError)
 	flagSet.IntP(CPUs, "c", 4, "")
 	flagSet.StringP(NameServer, "n", "", "")
 
-	_ = config.BindFlagSet(flagSet)
+	_ = storage.BindFlagSet(flagSet)
 
 	assert.Equal(t, SettingValue{
 		Value:     4,

--- a/pkg/crc/config/viper_config_test.go
+++ b/pkg/crc/config/viper_config_test.go
@@ -231,3 +231,29 @@ func TestViperConfigWatch(t *testing.T) {
 		return config.Get(CPUs).Value == 5
 	}, time.Second, 10*time.Millisecond)
 }
+
+func TestCannotSetWithWrongType(t *testing.T) {
+	dir, err := ioutil.TempDir("", "cfg")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+	configFile := filepath.Join(dir, "crc.json")
+
+	config, err := newTestConfig(configFile, "CRC")
+	require.NoError(t, err)
+
+	_, err = config.Set(CPUs, "helloworld")
+	assert.EqualError(t, err, "Value 'helloworld' for configuration property 'cpus' is invalid, reason: unable to cast \"helloworld\" of type string to int")
+}
+
+func TestCannotGetWithWrongType(t *testing.T) {
+	dir, err := ioutil.TempDir("", "cfg")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+	configFile := filepath.Join(dir, "crc.json")
+	assert.NoError(t, ioutil.WriteFile(configFile, []byte("{\"cpus\": \"hello\"}"), 0600))
+
+	config, err := newTestConfig(configFile, "CRC")
+	require.NoError(t, err)
+
+	assert.True(t, config.Get(CPUs).Invalid)
+}

--- a/pkg/crc/config/viper_config_test.go
+++ b/pkg/crc/config/viper_config_test.go
@@ -1,0 +1,182 @@
+package config
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	CPUs       = "cpus"
+	NameServer = "nameservers"
+)
+
+func newTestConfig(configFile, envPrefix string) (*Config, error) {
+	config, err := New(configFile, envPrefix)
+	if err != nil {
+		return nil, err
+	}
+	config.AddSetting(CPUs, 4, ValidateCPUs, RequiresRestartMsg)
+	config.AddSetting(NameServer, "", ValidateIPAddress, SuccessfullyApplied)
+	return config, nil
+}
+
+func TestViperConfigUnknown(t *testing.T) {
+	dir, err := ioutil.TempDir("", "cfg")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+	configFile := filepath.Join(dir, "crc.json")
+
+	config, err := newTestConfig(configFile, "CRC")
+	require.NoError(t, err)
+
+	assert.Equal(t, SettingValue{
+		Invalid: true,
+	}, config.Get("foo"))
+}
+
+func TestViperConfigSetAndGet(t *testing.T) {
+	dir, err := ioutil.TempDir("", "cfg")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+	configFile := filepath.Join(dir, "crc.json")
+
+	config, err := newTestConfig(configFile, "CRC")
+	require.NoError(t, err)
+
+	_, err = config.Set(CPUs, 5)
+	assert.NoError(t, err)
+
+	assert.Equal(t, SettingValue{
+		Value:     5,
+		IsDefault: false,
+	}, config.Get(CPUs))
+
+	bin, err := ioutil.ReadFile(configFile)
+	assert.NoError(t, err)
+	assert.JSONEq(t, `{"cpus":5}`, string(bin))
+}
+
+func TestViperConfigUnsetAndGet(t *testing.T) {
+	dir, err := ioutil.TempDir("", "cfg")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+	configFile := filepath.Join(dir, "crc.json")
+	assert.NoError(t, ioutil.WriteFile(configFile, []byte("{\"cpus\": 5}"), 0600))
+
+	config, err := newTestConfig(configFile, "CRC")
+	require.NoError(t, err)
+
+	_, err = config.Unset(CPUs)
+	assert.NoError(t, err)
+
+	assert.Equal(t, SettingValue{
+		Value:     4,
+		IsDefault: true,
+	}, config.Get(CPUs))
+
+	bin, err := ioutil.ReadFile(configFile)
+	assert.NoError(t, err)
+	assert.Equal(t, "{}", string(bin))
+}
+
+func TestViperConfigSetReloadAndGet(t *testing.T) {
+	dir, err := ioutil.TempDir("", "cfg")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+	configFile := filepath.Join(dir, "crc.json")
+
+	config, err := newTestConfig(configFile, "CRC")
+	require.NoError(t, err)
+
+	_, err = config.Set(CPUs, 5)
+	require.NoError(t, err)
+
+	config, err = newTestConfig(configFile, "CRC")
+	require.NoError(t, err)
+
+	assert.Equal(t, SettingValue{
+		Value:     5,
+		IsDefault: false,
+	}, config.Get(CPUs))
+}
+
+func TestViperConfigLoadDefaultValue(t *testing.T) {
+	dir, err := ioutil.TempDir("", "cfg")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+	configFile := filepath.Join(dir, "crc.json")
+
+	config, err := newTestConfig(configFile, "CRC")
+	require.NoError(t, err)
+
+	assert.Equal(t, SettingValue{
+		Value:     4,
+		IsDefault: true,
+	}, config.Get(CPUs))
+
+	_, err = config.Set(CPUs, 4)
+	assert.NoError(t, err)
+
+	bin, err := ioutil.ReadFile(configFile)
+	assert.NoError(t, err)
+	assert.JSONEq(t, `{"cpus":4}`, string(bin))
+
+	assert.Equal(t, SettingValue{
+		Value:     4,
+		IsDefault: true,
+	}, config.Get(CPUs))
+
+	config, err = newTestConfig(configFile, "CRC")
+	require.NoError(t, err)
+
+	assert.Equal(t, SettingValue{
+		Value:     4,
+		IsDefault: true,
+	}, config.Get(CPUs))
+}
+
+func TestViperConfigBindFlagSet(t *testing.T) {
+	dir, err := ioutil.TempDir("", "cfg")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+	configFile := filepath.Join(dir, "crc.json")
+
+	config, err := newTestConfig(configFile, "CRC")
+	require.NoError(t, err)
+
+	flagSet := pflag.NewFlagSet("start", pflag.ExitOnError)
+	flagSet.IntP(CPUs, "c", 4, "")
+	flagSet.StringP(NameServer, "n", "", "")
+
+	_ = config.BindFlagSet(flagSet)
+
+	assert.Equal(t, SettingValue{
+		Value:     4,
+		IsDefault: true,
+	}, config.Get(CPUs))
+	assert.Equal(t, SettingValue{
+		Value:     "",
+		IsDefault: true,
+	}, config.Get(NameServer))
+
+	assert.NoError(t, flagSet.Set(CPUs, "5"))
+
+	assert.Equal(t, SettingValue{
+		Value:     5,
+		IsDefault: false,
+	}, config.Get(CPUs))
+
+	_, err = config.Set(CPUs, "6")
+	assert.NoError(t, err)
+
+	assert.Equal(t, SettingValue{
+		Value:     6,
+		IsDefault: false,
+	}, config.Get(CPUs))
+}

--- a/pkg/crc/config/viper_config_test.go
+++ b/pkg/crc/config/viper_config_test.go
@@ -180,3 +180,28 @@ func TestViperConfigBindFlagSet(t *testing.T) {
 		IsDefault: false,
 	}, config.Get(CPUs))
 }
+
+func TestViperConfigCastSet(t *testing.T) {
+	dir, err := ioutil.TempDir("", "cfg")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+	configFile := filepath.Join(dir, "crc.json")
+
+	config, err := newTestConfig(configFile, "CRC")
+	require.NoError(t, err)
+
+	_, err = config.Set(CPUs, "5")
+	require.NoError(t, err)
+
+	config, err = newTestConfig(configFile, "CRC")
+	require.NoError(t, err)
+
+	assert.Equal(t, SettingValue{
+		Value:     5,
+		IsDefault: false,
+	}, config.Get(CPUs))
+
+	bin, err := ioutil.ReadFile(configFile)
+	assert.NoError(t, err)
+	assert.JSONEq(t, `{"cpus": 5}`, string(bin))
+}

--- a/pkg/crc/preflight/preflight.go
+++ b/pkg/crc/preflight/preflight.go
@@ -161,8 +161,8 @@ func doCleanUpPreflightChecks(checks []Check) error {
 func doRegisterSettings(checks []Check) {
 	for _, check := range checks {
 		if check.configKeySuffix != "" {
-			cfg.AddSetting(check.getSkipConfigName(), false, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})
-			cfg.AddSetting(check.getWarnConfigName(), false, []cfg.ValidationFnType{cfg.ValidateBool}, []cfg.SetFn{cfg.SuccessfullyApplied})
+			cfg.AddSetting(check.getSkipConfigName(), false, cfg.ValidateBool, cfg.SuccessfullyApplied)
+			cfg.AddSetting(check.getWarnConfigName(), false, cfg.ValidateBool, cfg.SuccessfullyApplied)
 		}
 	}
 }

--- a/pkg/crc/preflight/preflight.go
+++ b/pkg/crc/preflight/preflight.go
@@ -47,7 +47,7 @@ func (check *Check) shouldSkip() bool {
 	if check.configKeySuffix == "" {
 		return false
 	}
-	return cfg.GetBool(check.getSkipConfigName())
+	return cfg.Get(check.getSkipConfigName()).AsBool()
 }
 
 func (check *Check) getWarnConfigName() string {
@@ -61,7 +61,7 @@ func (check *Check) shouldWarn() bool {
 	if check.configKeySuffix == "" {
 		return false
 	}
-	return cfg.GetBool(check.getWarnConfigName())
+	return cfg.Get(check.getWarnConfigName()).AsBool()
 }
 
 func (check *Check) doCheck() error {


### PR DESCRIPTION
We can't mock or tests code that use config if viper and all methods related are global/static. This PR makes it possible to create test config object.