### PR TITLE
Remove kubeconfig file copy to instance

### DIFF
--- a/pkg/crc/machine/machine.go
+++ b/pkg/crc/machine/machine.go
@@ -739,13 +739,6 @@ func updateSSHKeyAndCopyKubeconfigToVM(sshRunner *crcssh.Runner, startConfig Sta
 	if err != nil {
 		return fmt.Errorf("Error copying kubeconfig file to instance dir: %v", err)
 	}
-
-	logging.Info("Copying kubeconfig file to CRC VM ...")
-	err = sshRunner.CopyFile(kubeConfigFilePath, "/opt/kubeconfig", 0644)
-	if err != nil {
-		return fmt.Errorf("Error copying kubeconfig file to VM: %v", err)
-	}
-
 	return nil
 }
 

--- a/pkg/crc/machine/machine.go
+++ b/pkg/crc/machine/machine.go
@@ -245,7 +245,7 @@ func (client *client) Start(startConfig StartConfig) (StartResult, error) {
 	// Post VM start immediately update SSH key and copy kubeconfig to instance
 	// dir and VM
 	if !exists {
-		if err := updateSSHKeyAndCopyKubeconfigToVM(sshRunner, startConfig, crcBundleMetadata); err != nil {
+		if err := updateSSHKeyAndCopyKubeconfig(sshRunner, startConfig, crcBundleMetadata); err != nil {
 			return startError(startConfig.Name, "Error updating public key", err)
 		}
 	}
@@ -723,7 +723,7 @@ func updateSSHKeyPair(sshRunner *crcssh.Runner) error {
 	return err
 }
 
-func updateSSHKeyAndCopyKubeconfigToVM(sshRunner *crcssh.Runner, startConfig StartConfig, crcBundleMetadata *bundle.CrcBundleInfo) error {
+func updateSSHKeyAndCopyKubeconfig(sshRunner *crcssh.Runner, startConfig StartConfig, crcBundleMetadata *bundle.CrcBundleInfo) error {
 	logging.Info("Generating new SSH Key pair ...")
 	if err := updateSSHKeyPair(sshRunner); err != nil {
 		return fmt.Errorf("Error updating SSH Keys: %v", err)


### PR DESCRIPTION
We have added it as part of cf3064e but since now this file
is copied during snc/createdisk step, we don't need to copy
it over here again.

- https://github.com/code-ready/snc/pull/222