### PR TITLE
Bump tray version

### DIFF
--- a/pkg/crc/version/version.go
+++ b/pkg/crc/version/version.go
@@ -30,7 +30,7 @@ const (
 	// Tray version to be embedded in binary
 	crcTrayVersion = "1.0.0-alpha.5"
 	// Windows forms application version type major.minor.buildnumber.revesion
-	crcWindowsTrayVersion = "0.1.0.0"
+	crcWindowsTrayVersion = "0.2.0.0"
 )
 
 type CrcReleaseInfo struct {

--- a/pkg/crc/version/version.go
+++ b/pkg/crc/version/version.go
@@ -28,7 +28,7 @@ var (
 const (
 	releaseInfoLink = "https://mirror.openshift.com/pub/openshift-v4/clients/crc/latest/release-info.json"
 	// Tray version to be embedded in binary
-	crcTrayVersion = "1.0.0-alpha.4"
+	crcTrayVersion = "1.0.0-alpha.5"
 	// Windows forms application version type major.minor.buildnumber.revesion
 	crcWindowsTrayVersion = "0.1.0.0"
 )


### PR DESCRIPTION
Update system tray version for both Windows and macOS