### PR TITLE
Revert back to use of old libvirt-kvm-driver

### DIFF
--- a/pkg/crc/machine/libvirt/constants.go
+++ b/pkg/crc/machine/libvirt/constants.go
@@ -17,7 +17,7 @@ const (
 
 const (
 	MachineDriverCommand = "crc-driver-libvirt"
-	MachineDriverVersion = "0.12.9"
+	MachineDriverVersion = "0.12.8"
 )
 
 var (


### PR DESCRIPTION
latest driver have vsock enabled as part of domain def. and this
is broken RHEL-7 since libvirt/qemu packages which are part of default
repo doesn't support vsock

```
ERRO Error creating machine: Error creating the VM: Error creating machine: Error in driver during machine creation: virError(Code=67, Domain=10, Message='unsupported configuration: unable to open vhost-vsock device')
Error creating machine: Error creating the VM: Error creating machine: Error in driver during machine creation: virError(Code=67, Domain=10, Message='unsupported configuration: unable to open vhost-vsock device')
```