### PR TITLE
Simplify oc package

### DIFF
--- a/pkg/crc/cluster/clusteroperator_test.go
+++ b/pkg/crc/cluster/clusteroperator_test.go
@@ -70,6 +70,11 @@ func (r *mockRunner) RunPrivate(binaryPath string, args ...string) (string, stri
 	return string(bin), "", err
 }
 
+func (r *mockRunner) RunPrivileged(reason string, args ...string) (string, string, error) {
+	bin, err := ioutil.ReadFile(r.file)
+	return string(bin), "", err
+}
+
 func (r *mockRunner) GetKubeconfigPath() string {
 	return ""
 }

--- a/pkg/crc/cluster/clusteroperator_test.go
+++ b/pkg/crc/cluster/clusteroperator_test.go
@@ -60,12 +60,12 @@ type mockRunner struct {
 	file string
 }
 
-func (r *mockRunner) Run(args ...string) (string, string, error) {
+func (r *mockRunner) Run(binaryPath string, args ...string) (string, string, error) {
 	bin, err := ioutil.ReadFile(r.file)
 	return string(bin), "", err
 }
 
-func (r *mockRunner) RunPrivate(args ...string) (string, string, error) {
+func (r *mockRunner) RunPrivate(binaryPath string, args ...string) (string, string, error) {
 	bin, err := ioutil.ReadFile(r.file)
 	return string(bin), "", err
 }

--- a/pkg/crc/oc/oc.go
+++ b/pkg/crc/oc/oc.go
@@ -36,23 +36,6 @@ func (oc LocalRunner) RunPrivate(args ...string) (string, string, error) {
 	return crcos.RunWithDefaultLocalePrivate(oc.OcBinaryPath, args...)
 }
 
-type EnvRunner struct {
-	OcBinaryPath  string
-	KubeconfigEnv string
-}
-
-func (oc EnvRunner) Run(args ...string) (string, string, error) {
-	return crcos.RunWithDefaultLocaleAndEnv(oc.OcBinaryPath, args, map[string]string{
-		"KUBECONFIG": oc.KubeconfigEnv,
-	})
-}
-
-func (oc EnvRunner) RunPrivate(args ...string) (string, string, error) {
-	return crcos.RunWithDefaultLocalePrivateAndEnv(oc.OcBinaryPath, args, map[string]string{
-		"KUBECONFIG": oc.KubeconfigEnv,
-	})
-}
-
 // UseOcWithConfig return the oc binary along with valid kubeconfig
 func UseOCWithConfig(machineName string) Config {
 	localRunner := LocalRunner{

--- a/pkg/crc/oc/oc.go
+++ b/pkg/crc/oc/oc.go
@@ -49,24 +49,27 @@ func UseOCWithConfig(machineName string) Config {
 	}
 }
 
-func (oc Config) RunOcCommand(args ...string) (string, string, error) {
+func (oc Config) runCommand(isPrivate bool, args ...string) (string, string, error) {
 	if oc.Context != "" {
 		args = append(args, "--context", oc.Context)
 	}
 	if oc.Cluster != "" {
 		args = append(args, "--cluster", oc.Cluster)
 	}
+
+	if isPrivate {
+		return oc.Runner.RunPrivate(args...)
+	}
+
 	return oc.Runner.Run(args...)
 }
 
+func (oc Config) RunOcCommand(args ...string) (string, string, error) {
+	return oc.runCommand(false, args...)
+}
+
 func (oc Config) RunOcCommandPrivate(args ...string) (string, string, error) {
-	if oc.Context != "" {
-		args = append(args, "--context", oc.Context)
-	}
-	if oc.Cluster != "" {
-		args = append(args, "--cluster", oc.Cluster)
-	}
-	return oc.Runner.RunPrivate(args...)
+	return oc.runCommand(true, args...)
 }
 
 type SSHRunner struct {

--- a/pkg/crc/oc/oc.go
+++ b/pkg/crc/oc/oc.go
@@ -1,43 +1,25 @@
 package oc
 
 import (
-	"fmt"
 	"path/filepath"
-	"strings"
 
 	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/code-ready/crc/pkg/crc/ssh"
 	crcos "github.com/code-ready/crc/pkg/os"
 )
 
-type Runner interface {
-	Run(binaryPath string, args ...string) (string, string, error)
-	RunPrivate(binaryPath string, args ...string) (string, string, error)
-}
-
 type Config struct {
-	Runner         Runner
+	Runner         crcos.CommandRunner
 	OcBinaryPath   string
 	KubeconfigPath string
 	Context        string
 	Cluster        string
 }
 
-type LocalRunner struct {
-}
-
-func (oc LocalRunner) Run(binaryPath string, args ...string) (string, string, error) {
-	return crcos.RunWithDefaultLocale(binaryPath, args...)
-}
-
-func (oc LocalRunner) RunPrivate(binaryPath string, args ...string) (string, string, error) {
-	return crcos.RunWithDefaultLocalePrivate(binaryPath, args...)
-}
-
 // UseOcWithConfig return the oc binary along with valid kubeconfig
 func UseOCWithConfig(machineName string) Config {
 	return Config{
-		Runner:         LocalRunner{},
+		Runner:         crcos.NewLocalCommandRunner(),
 		OcBinaryPath:   filepath.Join(constants.CrcOcBinDir, constants.OcBinaryName),
 		KubeconfigPath: filepath.Join(constants.MachineInstanceDir, machineName, "kubeconfig"),
 		Context:        constants.DefaultContext,
@@ -77,24 +59,10 @@ type SSHRunner struct {
 
 func UseOCWithSSH(sshRunner *ssh.Runner) Config {
 	return Config{
-		Runner: SSHRunner{
-			Runner: sshRunner,
-		},
+		Runner:         ssh.NewRemoteCommandRunner(sshRunner),
 		OcBinaryPath:   "oc",
 		KubeconfigPath: "/opt/kubeconfig",
 		Context:        constants.DefaultContext,
 		Cluster:        constants.DefaultName,
 	}
-}
-
-func (oc SSHRunner) Run(binaryPath string, args ...string) (string, string, error) {
-	command := fmt.Sprintf("%s %s", binaryPath, strings.Join(args, " "))
-	stdout, err := oc.Runner.Run(command)
-	return stdout, "", err
-}
-
-func (oc SSHRunner) RunPrivate(binaryPath string, args ...string) (string, string, error) {
-	command := fmt.Sprintf("%s %s", binaryPath, strings.Join(args, " "))
-	stdout, err := oc.Runner.RunPrivate(command)
-	return stdout, "", err
 }

--- a/pkg/crc/oc/oc_linux_test.go
+++ b/pkg/crc/oc/oc_linux_test.go
@@ -20,16 +20,6 @@ func TestRunCommand(t *testing.T) {
 	assert.Equal(t, "a-command --context a-context --cluster a-cluster --kubeconfig kubeconfig-file\n", stdout)
 }
 
-func TestEnvRunner(t *testing.T) {
-	runner := EnvRunner{
-		OcBinaryPath:  "printenv",
-		KubeconfigEnv: "some-env",
-	}
-	stdout, _, err := runner.Run()
-	assert.NoError(t, err)
-	assert.Contains(t, stdout, "KUBECONFIG=some-env\n")
-}
-
 func TestRunCommandWithoutContextAndCluster(t *testing.T) {
 	ocConfig := Config{
 		Runner: LocalRunner{

--- a/pkg/crc/oc/oc_linux_test.go
+++ b/pkg/crc/oc/oc_linux_test.go
@@ -3,12 +3,14 @@ package oc
 import (
 	"testing"
 
+	crcos "github.com/code-ready/crc/pkg/os"
+
 	"github.com/stretchr/testify/assert"
 )
 
 func TestRunCommand(t *testing.T) {
 	ocConfig := Config{
-		Runner:         LocalRunner{},
+		Runner:         crcos.NewLocalCommandRunner(),
 		OcBinaryPath:   "/bin/echo",
 		KubeconfigPath: "kubeconfig-file",
 		Context:        "a-context",
@@ -21,7 +23,7 @@ func TestRunCommand(t *testing.T) {
 
 func TestRunCommandWithoutContextAndCluster(t *testing.T) {
 	ocConfig := Config{
-		Runner:         LocalRunner{},
+		Runner:         crcos.NewLocalCommandRunner(),
 		OcBinaryPath:   "/bin/echo",
 		KubeconfigPath: "kubeconfig-file",
 	}

--- a/pkg/crc/oc/oc_linux_test.go
+++ b/pkg/crc/oc/oc_linux_test.go
@@ -8,12 +8,11 @@ import (
 
 func TestRunCommand(t *testing.T) {
 	ocConfig := Config{
-		Runner: LocalRunner{
-			OcBinaryPath:   "/bin/echo",
-			KubeconfigPath: "kubeconfig-file",
-		},
-		Context: "a-context",
-		Cluster: "a-cluster",
+		Runner:         LocalRunner{},
+		OcBinaryPath:   "/bin/echo",
+		KubeconfigPath: "kubeconfig-file",
+		Context:        "a-context",
+		Cluster:        "a-cluster",
 	}
 	stdout, _, err := ocConfig.RunOcCommand("a-command")
 	assert.NoError(t, err)
@@ -22,10 +21,9 @@ func TestRunCommand(t *testing.T) {
 
 func TestRunCommandWithoutContextAndCluster(t *testing.T) {
 	ocConfig := Config{
-		Runner: LocalRunner{
-			OcBinaryPath:   "/bin/echo",
-			KubeconfigPath: "kubeconfig-file",
-		},
+		Runner:         LocalRunner{},
+		OcBinaryPath:   "/bin/echo",
+		KubeconfigPath: "kubeconfig-file",
 	}
 	stdout, _, err := ocConfig.RunOcCommand("a-command")
 	assert.NoError(t, err)

--- a/pkg/crc/ssh/ssh.go
+++ b/pkg/crc/ssh/ssh.go
@@ -5,9 +5,11 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"strings"
 
 	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/code-ready/crc/pkg/crc/logging"
+	crcos "github.com/code-ready/crc/pkg/os"
 	"github.com/code-ready/machine/libmachine/drivers"
 )
 
@@ -85,4 +87,34 @@ output  : %s`, command, err, output)
 	}
 
 	return output, nil
+}
+
+type remoteCommandRunner struct {
+	sshRunner *Runner
+}
+
+func (cmdRunner *remoteCommandRunner) Run(cmd string, args ...string) (string, string, error) {
+	commandline := fmt.Sprintf("%s %s", cmd, strings.Join(args, " "))
+	out, err := cmdRunner.sshRunner.Run(commandline)
+	return out, "", err
+}
+
+func (cmdRunner *remoteCommandRunner) RunPrivate(cmd string, args ...string) (string, string, error) {
+	commandline := fmt.Sprintf("%s %s", cmd, strings.Join(args, " "))
+	out, err := cmdRunner.sshRunner.RunPrivate(commandline)
+	return out, "", err
+}
+
+func (cmdRunner *remoteCommandRunner) RunPrivileged(reason string, cmdAndArgs ...string) (string, string, error) {
+	commandline := fmt.Sprintf("sudo %s", strings.Join(cmdAndArgs, " "))
+
+	out, err := cmdRunner.sshRunner.Run(commandline)
+
+	return out, "", err
+}
+
+func NewRemoteCommandRunner(runner *Runner) crcos.CommandRunner {
+	return &remoteCommandRunner{
+		sshRunner: runner,
+	}
 }

--- a/pkg/crc/ssh/ssh_test.go
+++ b/pkg/crc/ssh/ssh_test.go
@@ -59,6 +59,12 @@ func TestRunner(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, "hello", bin)
 		assert.NoError(t, runner.CopyData([]byte(`hello world`), "/hello", 0644))
+
+		cmdRunner := NewRemoteCommandRunner(runner)
+		stdout, stderr, err := cmdRunner.Run("echo", "hello")
+		assert.NoError(t, err)
+		assert.Equal(t, "hello", stdout)
+		assert.Empty(t, stderr)
 	}
 }
 

--- a/pkg/os/exec.go
+++ b/pkg/os/exec.go
@@ -60,3 +60,26 @@ func RunWithDefaultLocale(command string, args ...string) (string, string, error
 func RunWithDefaultLocalePrivate(command string, args ...string) (string, string, error) {
 	return runPrivate(command, args, defaultLocaleEnv)
 }
+
+type CommandRunner interface {
+	Run(command string, args ...string) (string, string, error)
+	RunPrivate(command string, args ...string) (string, string, error)
+	RunPrivileged(reason string, cmdAndArgs ...string) (string, string, error)
+}
+type localRunner struct{}
+
+func (r *localRunner) Run(command string, args ...string) (string, string, error) {
+	return RunWithDefaultLocale(command, args...)
+}
+
+func (r *localRunner) RunPrivate(command string, args ...string) (string, string, error) {
+	return RunWithDefaultLocalePrivate(command, args...)
+}
+
+func (r *localRunner) RunPrivileged(reason string, cmdAndArgs ...string) (string, string, error) {
+	return RunWithPrivilege(reason, cmdAndArgs...)
+}
+
+func NewLocalCommandRunner() CommandRunner {
+	return &localRunner{}
+}

--- a/pkg/os/exec.go
+++ b/pkg/os/exec.go
@@ -51,26 +51,12 @@ func RunWithPrivilege(reason string, cmdAndArgs ...string) (string, string, erro
 	return run(sudo, cmdAndArgs, map[string]string{})
 }
 
+var defaultLocaleEnv = map[string]string{"LC_ALL": "C", "LANG": "C"}
+
 func RunWithDefaultLocale(command string, args ...string) (string, string, error) {
-	return RunWithDefaultLocaleAndEnv(command, args, map[string]string{})
+	return run(command, args, defaultLocaleEnv)
 }
 
 func RunWithDefaultLocalePrivate(command string, args ...string) (string, string, error) {
-	return RunWithDefaultLocalePrivateAndEnv(command, args, map[string]string{})
-}
-
-func RunWithDefaultLocaleAndEnv(command string, args []string, extraEnv map[string]string) (string, string, error) {
-	env := map[string]string{"LC_ALL": "C", "LANG": "C"}
-	for k, v := range extraEnv {
-		env[k] = v
-	}
-	return run(command, args, env)
-}
-
-func RunWithDefaultLocalePrivateAndEnv(command string, args []string, extraEnv map[string]string) (string, string, error) {
-	env := map[string]string{"LC_ALL": "C", "LANG": "C"}
-	for k, v := range extraEnv {
-		env[k] = v
-	}
-	return runPrivate(command, args, env)
+	return runPrivate(command, args, defaultLocaleEnv)
 }


### PR DESCRIPTION
## Solution/Idea

This is just a refactoring of the 'oc' package in order to make it a bit easier to understand, and to have less code duplication. The gist of the changes is the introduction of an os.CommandRunner interface (instead of oc.Runner) which can be reused by the systemd code in the future (https://github.com/cfergeau/crc/commits/systemd)

## Testing

There should be no behaviour change at all, so no specific testing needed, except to make sure things are still working as before.