### PR TITLE
Add 10m timeout to golangci run to stop travis CI failure

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,7 @@
 run:
   build-tags:
     - build
+  timeout: 10m
 
 linters:
   enable:


### PR DESCRIPTION
By default the timeout set to `1m` which is way to less for
travis CI to run the linter.


