### PR TITLE
config: Don't preallocate array in configurableFields

### DIFF
--- a/cmd/crc/cmd/config/config.go
+++ b/cmd/crc/cmd/config/config.go
@@ -78,7 +78,7 @@ func less(lhsKey, rhsKey string) bool {
 
 func configurableFields() string {
 	var fields []string
-	var keys = make([]string, len(cfg.AllConfigs()))
+	var keys []string
 
 	for key := range cfg.AllConfigs() {
 		keys = append(keys, key)


### PR DESCRIPTION
If we preallocate the 'keys' array in configurableFields() to the number
of config keys, and then append the config keys to that preallocated
array, we'll end up with an array containing len(cfg.AllConfigs()) empty
keys followed by the len(cfg.AllConfigs()) keys, which is not what we
want.

This commit removes the preallocation of the 'keys' array as this is
unlikely to make a noticeable difference when the 'config' command is
being used.

This fixes https://github.com/code-ready/crc/issues/1487



**Fixes:** Issue #1487

## Testing

1. crc config -h no longer have N empty entries `* ` followed by N `* config-name` entries