### PR TITLE
Issue #1492 Only windows 10 Home edition doesn't support Hyperv

### DIFF
--- a/docs/source/topics/ref_minimum-system-requirements.adoc
+++ b/docs/source/topics/ref_minimum-system-requirements.adoc
@@ -26,8 +26,8 @@ To assign more resources to the {prod} virtual machine, see link:{crc-gsg-url}#c
 
 === {msw}
 
-* On {msw}, {prod} requires the Windows 10 Pro Fall Creators Update (version 1709) or newer.
-{prod} does not work on earlier versions or editions of {msw}.
+* On {msw}, {prod} requires the Windows 10 Fall Creators Update (version 1709) or newer.
+{prod} does not work on earlier versions of {msw}.
 {msw} 10 Home Edition is not supported.
 
 === {mac}

--- a/pkg/crc/preflight/preflight_checks_windows.go
+++ b/pkg/crc/preflight/preflight_checks_windows.go
@@ -53,16 +53,11 @@ func checkWindowsEdition() error {
 	windowsEdition := strings.TrimSpace(stdOut)
 	logging.Debugf("Running on Windows %s edition", windowsEdition)
 
-	if strings.HasPrefix(windowsEdition, "Professional") {
-		return nil
+	if strings.HasPrefix(windowsEdition, "Home") {
+		return fmt.Errorf("Windows Home edition is not supported")
 	}
 
-	switch windowsEdition {
-	case "Enterprise":
-		return nil
-	default:
-		return fmt.Errorf("Supported Windows editions are Professional and Enterprise. Windows %s edition is not supported", windowsEdition)
-	}
+	return nil
 }
 
 func checkHyperVInstalled() error {


### PR DESCRIPTION
As per the chart in wikipedia all the other editions of windows
has support for running vms using hyperv, so only filtering out
Home edition of windows in the preflight check
https://en.wikipedia.org/wiki/Windows_10_editions#Comparison_chart


Fixes: #1492 


## Solution/Idea

As mentioned in the issue, Win10 Education edition supports Hyperv so crc can run on it, therefore modified the pre-flight check to filter out only Home edition.
## Testing

Should be able to run `crc start` successfully on win10 Education edition, (all others excluding Home edition)