### PR TITLE
Add json output format for `crc start`

### DIFF
--- a/cmd/crc/cmd/cleanup.go
+++ b/cmd/crc/cmd/cleanup.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"github.com/code-ready/crc/pkg/crc/exit"
 	"github.com/code-ready/crc/pkg/crc/output"
 	"github.com/code-ready/crc/pkg/crc/preflight"
 	"github.com/spf13/cobra"
@@ -20,6 +21,8 @@ var cleanupCmd = &cobra.Command{
 }
 
 func runCleanup(arguments []string) {
-	preflight.CleanUpHost()
+	if err := preflight.CleanUpHost(); err != nil {
+		exit.WithMessage(1, err.Error())
+	}
 	output.Outln("Cleanup finished")
 }

--- a/cmd/crc/cmd/setup.go
+++ b/cmd/crc/cmd/setup.go
@@ -31,7 +31,9 @@ func runSetup(arguments []string) error {
 	if crcConfig.GetBool(config.ExperimentalFeatures.Name) {
 		preflight.EnableExperimentalFeatures = true
 	}
-	preflight.SetupHost()
+	if err := preflight.SetupHost(); err != nil {
+		return err
+	}
 	var bundle string
 	if !constants.BundleEmbedded() {
 		bundle = " -b $bundlename"

--- a/cmd/crc/cmd/start.go
+++ b/cmd/crc/cmd/start.go
@@ -66,10 +66,6 @@ func runStart(arguments []string) error {
 	if err != nil {
 		return err
 	}
-	if result.Status != "Running" {
-		return fmt.Errorf("Unexpected status of the OpenShift cluster: %s", result.Status)
-	}
-
 	logging.Warn("The cluster might report a degraded or error state. This is expected since several operators have been disabled to lower the resource usage. For more information, please consult the documentation")
 
 	output.Outln("Started the OpenShift cluster.")

--- a/cmd/crc/cmd/start.go
+++ b/cmd/crc/cmd/start.go
@@ -25,7 +25,16 @@ import (
 func init() {
 	rootCmd.AddCommand(startCmd)
 	addOutputFormatFlag(startCmd)
-	startCmd.Flags().AddFlagSet(startCmdFlagSet)
+
+	flagSet := pflag.NewFlagSet("start", pflag.ExitOnError)
+	flagSet.StringP(config.Bundle.Name, "b", constants.DefaultBundlePath, "The system bundle used for deployment of the OpenShift cluster")
+	flagSet.StringP(config.PullSecretFile.Name, "p", "", fmt.Sprintf("File path of image pull secret (download from %s)", constants.CrcLandingPageURL))
+	flagSet.IntP(config.CPUs.Name, "c", constants.DefaultCPUs, "Number of CPU cores to allocate to the OpenShift cluster")
+	flagSet.IntP(config.Memory.Name, "m", constants.DefaultMemory, "MiB of memory to allocate to the OpenShift cluster")
+	flagSet.StringP(config.NameServer.Name, "n", "", "IPv4 address of nameserver to use for the OpenShift cluster")
+	flagSet.Bool(config.DisableUpdateCheck.Name, false, "Don't check for update")
+
+	startCmd.Flags().AddFlagSet(flagSet)
 
 	_ = crcConfig.BindFlagSet(startCmd.Flags())
 }
@@ -135,18 +144,6 @@ func (s *startResult) prettyPrintTo(writer io.Writer) error {
 		"You can now run 'crc console' and use these credentials to access the OpenShift web console.",
 	}, "\n"))
 	return err
-}
-
-func initStartCmdFlagSet() *pflag.FlagSet {
-	flagSet := pflag.NewFlagSet("start", pflag.ExitOnError)
-	flagSet.StringP(config.Bundle.Name, "b", constants.DefaultBundlePath, "The system bundle used for deployment of the OpenShift cluster")
-	flagSet.StringP(config.PullSecretFile.Name, "p", "", fmt.Sprintf("File path of image pull secret (download from %s)", constants.CrcLandingPageURL))
-	flagSet.IntP(config.CPUs.Name, "c", constants.DefaultCPUs, "Number of CPU cores to allocate to the OpenShift cluster")
-	flagSet.IntP(config.Memory.Name, "m", constants.DefaultMemory, "MiB of memory to allocate to the OpenShift cluster")
-	flagSet.StringP(config.NameServer.Name, "n", "", "IPv4 address of nameserver to use for the OpenShift cluster")
-	flagSet.Bool(config.DisableUpdateCheck.Name, false, "Don't check for update")
-
-	return flagSet
 }
 
 func isDebugLog() bool {

--- a/cmd/crc/cmd/start.go
+++ b/cmd/crc/cmd/start.go
@@ -52,7 +52,9 @@ func runStart(arguments []string) error {
 
 	checkIfNewVersionAvailable(crcConfig.GetBool(config.DisableUpdateCheck.Name))
 
-	preflight.StartPreflightChecks()
+	if err := preflight.StartPreflightChecks(); err != nil {
+		return err
+	}
 
 	startConfig := machine.StartConfig{
 		Name:          constants.DefaultName,

--- a/cmd/crc/cmd/start_test.go
+++ b/cmd/crc/cmd/start_test.go
@@ -1,0 +1,87 @@
+package cmd
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/code-ready/crc/pkg/crc/constants"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRenderActionPlainSuccess(t *testing.T) {
+	out := new(bytes.Buffer)
+	assert.NoError(t, render(&startResult{
+		Success: true,
+		ClusterConfig: &clusterConfig{
+			URL: constants.DefaultAPIURL,
+			AdminCredentials: credentials{
+				Username: "kubeadmin",
+				Password: "secret",
+			},
+			DeveloperCredentials: credentials{
+				Username: "developer",
+				Password: "developer",
+			},
+		},
+	}, out, ""))
+	assert.Equal(t, `Started the OpenShift cluster
+
+To access the cluster, first set up your environment by following 'crc oc-env' instructions.
+Then you can access it by running 'oc login -u developer -p developer https://api.crc.testing:6443'.
+To login as an admin, run 'oc login -u kubeadmin -p secret https://api.crc.testing:6443'.
+To access the cluster, first set up your environment by following 'crc oc-env' instructions.
+
+You can now run 'crc console' and use these credentials to access the OpenShift web console.
+`, out.String())
+}
+
+func TestRenderActionPlainFailure(t *testing.T) {
+	out := new(bytes.Buffer)
+	assert.EqualError(t, render(&startResult{
+		Success: false,
+		Error:   "broken",
+	}, out, ""), "broken")
+	assert.Equal(t, "", out.String())
+}
+
+func TestRenderActionJSONSuccess(t *testing.T) {
+	out := new(bytes.Buffer)
+	assert.NoError(t, render(&startResult{
+		Success: true,
+		ClusterConfig: &clusterConfig{
+			URL: constants.DefaultAPIURL,
+			AdminCredentials: credentials{
+				Username: "kubeadmin",
+				Password: "secret",
+			},
+			DeveloperCredentials: credentials{
+				Username: "developer",
+				Password: "developer",
+			},
+		},
+	}, out, jsonFormat))
+	assert.Equal(t, `{
+  "success": true,
+  "clusterConfig": {
+    "url": "https://api.crc.testing:6443",
+    "adminCredentials": {
+      "username": "kubeadmin",
+      "password": "secret"
+    },
+    "developerCredentials": {
+      "username": "developer",
+      "password": "developer"
+    }
+  }
+}
+`, out.String())
+}
+
+func TestRenderActionJSONFailure(t *testing.T) {
+	out := new(bytes.Buffer)
+	assert.NoError(t, render(&startResult{
+		Success: false,
+		Error:   "broken",
+	}, out, jsonFormat))
+	assert.Equal(t, "{\n  \"success\": false,\n  \"error\": \"broken\"\n}\n", out.String())
+}

--- a/pkg/crc/machine/machine.go
+++ b/pkg/crc/machine/machine.go
@@ -407,6 +407,7 @@ func (client *client) Start(startConfig StartConfig) (StartResult, error) {
 		waitForProxyPropagation(ocConfig, proxyConfig)
 	}
 
+	logging.Warn("The cluster might report a degraded or error state. This is expected since several operators have been disabled to lower the resource usage. For more information, please consult the documentation")
 	return StartResult{
 		Name:           startConfig.Name,
 		KubeletStarted: true,

--- a/pkg/crc/machine/machine.go
+++ b/pkg/crc/machine/machine.go
@@ -193,9 +193,15 @@ func (client *client) Start(startConfig StartConfig) (StartResult, error) {
 			} else {
 				logging.Infof("A CodeReady Containers VM for OpenShift %s is already running", openshiftVersion)
 			}
+			clusterConfig, err := getClusterConfig(crcBundleMetadata)
+			if err != nil {
+				return startError(startConfig.Name, "Cannot create cluster configuration", err)
+			}
 			return StartResult{
-				Name:   startConfig.Name,
-				Status: vmState.String(),
+				Name:           startConfig.Name,
+				Status:         vmState.String(),
+				ClusterConfig:  *clusterConfig,
+				KubeletStarted: true,
 			}, nil
 		}
 

--- a/pkg/crc/preflight/preflight.go
+++ b/pkg/crc/preflight/preflight.go
@@ -163,3 +163,17 @@ func doRegisterSettings(checks []Check) {
 		}
 	}
 }
+
+// StartPreflightChecks performs the preflight checks before starting the cluster
+func StartPreflightChecks() {
+	doPreflightChecks(getPreflightChecks())
+}
+
+// SetupHost performs the prerequisite checks and setups the host to run the cluster
+func SetupHost() {
+	doFixPreflightChecks(getPreflightChecks())
+}
+
+func RegisterSettings() {
+	doRegisterSettings(getPreflightChecks())
+}

--- a/pkg/crc/preflight/preflight.go
+++ b/pkg/crc/preflight/preflight.go
@@ -105,7 +105,7 @@ func (check *Check) doCleanUp() error {
 	return check.cleanup()
 }
 
-func doPreflightChecks(checks []Check) {
+func doPreflightChecks(checks []Check) error {
 	for _, check := range checks {
 		if check.flags&SetupOnly == SetupOnly || check.flags&CleanUpOnly == CleanUpOnly {
 			continue
@@ -115,13 +115,14 @@ func doPreflightChecks(checks []Check) {
 			if check.shouldWarn() {
 				logging.Warn(err.Error())
 			} else {
-				logging.Fatal(err.Error())
+				return err
 			}
 		}
 	}
+	return nil
 }
 
-func doFixPreflightChecks(checks []Check) {
+func doFixPreflightChecks(checks []Check) error {
 	for _, check := range checks {
 		if check.flags&StartOnly == StartOnly || check.flags&CleanUpOnly == CleanUpOnly {
 			continue
@@ -135,13 +136,14 @@ func doFixPreflightChecks(checks []Check) {
 			if check.shouldWarn() {
 				logging.Warn(err.Error())
 			} else {
-				logging.Fatal(err.Error())
+				return err
 			}
 		}
 	}
+	return nil
 }
 
-func doCleanUpPreflightChecks(checks []Check) {
+func doCleanUpPreflightChecks(checks []Check) error {
 	// Do the cleanup in reverse order to avoid any dependency during cleanup
 	for i := len(checks) - 1; i >= 0; i-- {
 		check := checks[i]
@@ -150,9 +152,10 @@ func doCleanUpPreflightChecks(checks []Check) {
 		}
 		err := check.doCleanUp()
 		if err != nil {
-			logging.Fatal(err.Error())
+			return err
 		}
 	}
+	return nil
 }
 
 func doRegisterSettings(checks []Check) {
@@ -165,13 +168,13 @@ func doRegisterSettings(checks []Check) {
 }
 
 // StartPreflightChecks performs the preflight checks before starting the cluster
-func StartPreflightChecks() {
-	doPreflightChecks(getPreflightChecks())
+func StartPreflightChecks() error {
+	return doPreflightChecks(getPreflightChecks())
 }
 
 // SetupHost performs the prerequisite checks and setups the host to run the cluster
-func SetupHost() {
-	doFixPreflightChecks(getPreflightChecks())
+func SetupHost() error {
+	return doFixPreflightChecks(getPreflightChecks())
 }
 
 func RegisterSettings() {

--- a/pkg/crc/preflight/preflight_darwin.go
+++ b/pkg/crc/preflight/preflight_darwin.go
@@ -110,20 +110,6 @@ func getPreflightChecks() []Check {
 	return checks
 }
 
-// StartPreflightChecks performs the preflight checks before starting the cluster
-func StartPreflightChecks() {
-	doPreflightChecks(getPreflightChecks())
-}
-
-// SetupHost performs the prerequisite checks and setups the host to run the cluster
-func SetupHost() {
-	doFixPreflightChecks(getPreflightChecks())
-}
-
-func RegisterSettings() {
-	doRegisterSettings(getPreflightChecks())
-}
-
 func CleanUpHost() {
 	// A user can use setup with experiment flag
 	// and not use cleanup with same flag, to avoid

--- a/pkg/crc/preflight/preflight_darwin.go
+++ b/pkg/crc/preflight/preflight_darwin.go
@@ -110,7 +110,7 @@ func getPreflightChecks() []Check {
 	return checks
 }
 
-func CleanUpHost() {
+func CleanUpHost() error {
 	// A user can use setup with experiment flag
 	// and not use cleanup with same flag, to avoid
 	// any extra step/confusion we are just adding the checks
@@ -118,5 +118,5 @@ func CleanUpHost() {
 	// perform action in a sane way.
 	checks := getPreflightChecks()
 	checks = append(checks, traySetupChecks[:]...)
-	doCleanUpPreflightChecks(checks)
+	return doCleanUpPreflightChecks(checks)
 }

--- a/pkg/crc/preflight/preflight_linux.go
+++ b/pkg/crc/preflight/preflight_linux.go
@@ -121,20 +121,6 @@ func getPreflightChecks() []Check {
 	return checks
 }
 
-// StartPreflightChecks performs the preflight checks before starting the cluster
-func StartPreflightChecks() {
-	doPreflightChecks(getPreflightChecks())
-}
-
-// SetupHost performs the prerequisite checks and setups the host to run the cluster
-func SetupHost() {
-	doFixPreflightChecks(getPreflightChecks())
-}
-
-func RegisterSettings() {
-	doRegisterSettings(getPreflightChecks())
-}
-
 func CleanUpHost() {
 	doCleanUpPreflightChecks(getPreflightChecks())
 }

--- a/pkg/crc/preflight/preflight_linux.go
+++ b/pkg/crc/preflight/preflight_linux.go
@@ -121,6 +121,6 @@ func getPreflightChecks() []Check {
 	return checks
 }
 
-func CleanUpHost() {
-	doCleanUpPreflightChecks(getPreflightChecks())
+func CleanUpHost() error {
+	return doCleanUpPreflightChecks(getPreflightChecks())
 }

--- a/pkg/crc/preflight/preflight_windows.go
+++ b/pkg/crc/preflight/preflight_windows.go
@@ -94,7 +94,7 @@ func getPreflightChecks() []Check {
 	return checks
 }
 
-func CleanUpHost() {
+func CleanUpHost() error {
 	// A user can use setup with experiment flag
 	// and not use cleanup with same flag, to avoid
 	// any extra step/confusion we are just adding the checks
@@ -102,5 +102,5 @@ func CleanUpHost() {
 	// perform action in a sane way.
 	checks := getPreflightChecks()
 	checks = append(checks, traySetupChecks[:]...)
-	doCleanUpPreflightChecks(checks)
+	return doCleanUpPreflightChecks(checks)
 }

--- a/pkg/crc/preflight/preflight_windows.go
+++ b/pkg/crc/preflight/preflight_windows.go
@@ -94,20 +94,6 @@ func getPreflightChecks() []Check {
 	return checks
 }
 
-// StartPreflightChecks performs the preflight checks before starting the cluster
-func StartPreflightChecks() {
-	doPreflightChecks(getPreflightChecks())
-}
-
-// SetupHost performs the prerequisite checks and setups the host to run the cluster
-func SetupHost() {
-	doFixPreflightChecks(getPreflightChecks())
-}
-
-func RegisterSettings() {
-	doRegisterSettings(getPreflightChecks())
-}
-
 func CleanUpHost() {
 	// A user can use setup with experiment flag
 	// and not use cleanup with same flag, to avoid


### PR DESCRIPTION
User can now do `crc start -o json`. Plain text behaviour is unchanged.
Only difference with json is that the status code is always 0 (this can be discussed maybe - it was easier).

```
$ crc start -o json
....
{
  "success": false,
  "error": "Failed to get pull secret: interrupt"
}
$ echo $?
0

$ crc start -o json
....
{
  "success": true,
  "clusterConfig": {
    "url": "https://api.crc.testing:6443",
    "adminCredentials": {
      "username": "kubeadmin",
      "password": "ILWgF-VfgcQ-p6mJ4-Jztez"
    },
    "developerCredentials": {
      "username": "developer",
      "password": "developer"
    }
  }
}
$ echo $?
0
```

Unit tests could be better if we could mock config and preflights.