### PR TITLE
Fix crc cleanup expected output in integration tests

### DIFF
--- a/pkg/crc/systemd/systemd.go
+++ b/pkg/crc/systemd/systemd.go
@@ -71,7 +71,7 @@ func (c Commander) service(name string, action actions.Action) (states.State, er
 		err            error
 	)
 	if action.IsPriviledged() {
-		msg := fmt.Sprintf("execute systemctl %s %s", action.String(), name)
+		msg := fmt.Sprintf("executing systemctl %s %s", action.String(), name)
 		stdOut, stdErr, err = c.commandRunner.RunPrivileged(msg, "systemctl", action.String(), name)
 	} else {
 		stdOut, stdErr, err = c.commandRunner.Run("systemctl", action.String(), name)

--- a/test/integration/features/basic.feature
+++ b/test/integration/features/basic.feature
@@ -55,12 +55,12 @@ Feature: Basic test
         And stdout should contain "Writing Network Manager config for crc"
         And stdout should contain "Will use root access: write NetworkManager config in /etc/NetworkManager/conf.d/crc-nm-dnsmasq.conf"
         And stdout should contain "Will use root access: executing systemctl daemon-reload command"
-        And stdout should contain "Will use root access: execute systemctl stop/start command"
+        And stdout should contain "Will use root access: executing systemctl stop/start command"
         And stdout should contain "Checking if /etc/NetworkManager/dnsmasq.d/crc.conf exists"
         And stdout should contain "Writing dnsmasq config for crc"
         And stdout should contain "Will use root access: write dnsmasq configuration in /etc/NetworkManager/dnsmasq.d/crc.conf"
         And stdout should contain "Will use root access: executing systemctl daemon-reload command"
-        And stdout should contain "Will use root access: execute systemctl stop/start command"
+        And stdout should contain "Will use root access: executing systemctl stop/start command"
         And stdout should contain "Setup is complete, you can now run 'crc start -b $bundlename' to start the OpenShift cluster" if bundle is not embedded
         And stdout should contain "Setup is complete, you can now run 'crc start' to start the OpenShift cluster" if bundle is embedded
 
@@ -156,11 +156,11 @@ Feature: Basic test
         And stdout should contain "Removing /etc/NetworkManager/dnsmasq.d/crc.conf file"
         And stdout should contain "Will use root access: removing dnsmasq configuration in /etc/NetworkManager/dnsmasq.d/crc.conf"
         And stdout should contain "Will use root access: executing systemctl daemon-reload command"
-        And stdout should contain "Will use root access: execute systemctl stop/start command"
+        And stdout should contain "Will use root access: executing systemctl reload NetworkManager"
         And stdout should contain "Removing /etc/NetworkManager/conf.d/crc-nm-dnsmasq.conf file"
         And stdout should contain "Will use root access: Removing NetworkManager config in /etc/NetworkManager/conf.d/crc-nm-dnsmasq.conf"
         And stdout should contain "Will use root access: executing systemctl daemon-reload command"
-        And stdout should contain "Will use root access: execute systemctl stop/start command"
+        And stdout should contain "Will use root access: executing systemctl reload NetworkManager"
         And stdout should contain "Removing 'crc' network from libvirt"
         And stdout should contain "Cleanup finished"
 


### PR DESCRIPTION
Fix for https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/code-ready_crc/1460/pull-ci-code-ready-crc-master-e2e-crc/1301421082791645184