### PR TITLE
Add OKD compatibility to crc for building CRC for OKD bundles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,15 @@
 SHELL := /bin/bash
 
-BUNDLE_VERSION = 4.5.0-0.okd-2020-08-12-020541
+BUNDLE_VERSION ?= 4.5.7
 # OC_VERSION and BUNDLE_VERSION are going to same for release artifacts but
 # different for nightly and CI bits where bundle version would be any random
 # string or dd-mm-yyyy format.
 OC_VERSION ?= ${BUNDLE_VERSION}
+OPENSHIFT_VERSION ?= ${BUNDLE_VERSION}
 BUNDLE_EXTENSION = crcbundle
 CRC_VERSION = 1.15.0
 COMMIT_SHA=$(shell git rev-parse --short HEAD)
+MIRROR ?= https://mirror.openshift.com/pub/openshift-v4/clients/ocp
 
 # Go and compilation related variables
 BUILD_DIR ?= out
@@ -49,8 +51,9 @@ __check_defined = \
 
 # Linker flags
 VERSION_VARIABLES := -X $(REPOPATH)/pkg/crc/version.crcVersion=$(CRC_VERSION) \
-    -X $(REPOPATH)/pkg/crc/version.bundleVersion=$(BUNDLE_VERSION) \
+    -X $(REPOPATH)/pkg/crc/version.bundleVersion=$(OPENSHIFT_VERSION) \
     -X $(REPOPATH)/pkg/crc/version.ocVersion=$(OC_VERSION) \
+	-X $(REPOPATH)/pkg/crc/version.defaultOcURLBase=$(MIRROR) \
 	-X $(REPOPATH)/pkg/crc/version.commitSha=$(COMMIT_SHA)
 
 # https://golang.org/cmd/link/
@@ -130,13 +133,13 @@ ifndef PULL_SECRET_FILE
 	PULL_SECRET_FILE = --pull-secret-file=$(HOME)/Downloads/crc-pull-secret
 endif
 ifndef BUNDLE_LOCATION
-	BUNDLE_LOCATION = --bundle-location=$(HOME)/Downloads/crc_libvirt_$(BUNDLE_VERSION).$(BUNDLE_EXTENSION)
+	BUNDLE_LOCATION = --bundle-location=$(HOME)/Downloads/crc_libvirt_$(OPENSHIFT_VERSION).$(BUNDLE_EXTENSION)
 endif
 ifndef CRC_BINARY
 	CRC_BINARY = --crc-binary=$(GOPATH)/bin
 endif
 integration:
-	@go test --timeout=120m $(REPOPATH)/test/integration -v $(PULL_SECRET_FILE) $(BUNDLE_LOCATION) $(CRC_BINARY) --bundle-version=$(BUNDLE_VERSION) $(GODOG_OPTS)
+	@go test --timeout=120m $(REPOPATH)/test/integration -v $(PULL_SECRET_FILE) $(BUNDLE_LOCATION) $(CRC_BINARY) --bundle-version=$(OPENSHIFT_VERSION) $(GODOG_OPTS)
 
 .PHONY: fmt
 fmt:
@@ -159,7 +162,7 @@ cross-lint: $(GOPATH)/bin/golangci-lint
 gen_release_info:
 	@cat release-info.json.sample | sed s/@CRC_VERSION@/\"$(CRC_VERSION)\"/ > $(RELEASE_INFO)
 	@sed -i s/@GIT_COMMIT_SHA@/\"$(COMMIT_SHA)\"/ $(RELEASE_INFO)
-	@sed -i s/@OPENSHIFT_VERSION@/\"$(BUNDLE_VERSION)\"/ $(RELEASE_INFO)
+	@sed -i s/@OPENSHIFT_VERSION@/\"$(OPENSHIFT_VERSION)\"/ $(RELEASE_INFO)
 
 .PHONY: release
 release: cross-lint embed_bundle build_docs_pdf gen_release_info
@@ -181,9 +184,9 @@ release: cross-lint embed_bundle build_docs_pdf gen_release_info
 	
 	pushd $(RELEASE_DIR) && sha256sum * > sha256sum.txt && popd
 
-HYPERKIT_BUNDLENAME = $(BUNDLE_DIR)/crc_hyperkit_$(BUNDLE_VERSION).$(BUNDLE_EXTENSION)
-HYPERV_BUNDLENAME = $(BUNDLE_DIR)/crc_hyperv_$(BUNDLE_VERSION).$(BUNDLE_EXTENSION)
-LIBVIRT_BUNDLENAME = $(BUNDLE_DIR)/crc_libvirt_$(BUNDLE_VERSION).$(BUNDLE_EXTENSION)
+HYPERKIT_BUNDLENAME = $(BUNDLE_DIR)/crc_hyperkit_$(OPENSHIFT_VERSION).$(BUNDLE_EXTENSION)
+HYPERV_BUNDLENAME = $(BUNDLE_DIR)/crc_hyperv_$(OPENSHIFT_VERSION).$(BUNDLE_EXTENSION)
+LIBVIRT_BUNDLENAME = $(BUNDLE_DIR)/crc_libvirt_$(OPENSHIFT_VERSION).$(BUNDLE_EXTENSION)
 
 .PHONY: embed_bundle check_bundledir
 check_bundledir:

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,6 @@ BUNDLE_VERSION ?= 4.5.7
 # different for nightly and CI bits where bundle version would be any random
 # string or dd-mm-yyyy format.
 OC_VERSION ?= ${BUNDLE_VERSION}
-OPENSHIFT_VERSION ?= ${BUNDLE_VERSION}
 BUNDLE_EXTENSION = crcbundle
 CRC_VERSION = 1.15.0
 COMMIT_SHA=$(shell git rev-parse --short HEAD)
@@ -51,7 +50,7 @@ __check_defined = \
 
 # Linker flags
 VERSION_VARIABLES := -X $(REPOPATH)/pkg/crc/version.crcVersion=$(CRC_VERSION) \
-    -X $(REPOPATH)/pkg/crc/version.bundleVersion=$(OPENSHIFT_VERSION) \
+    -X $(REPOPATH)/pkg/crc/version.bundleVersion=$(BUNDLE_VERSION) \
     -X $(REPOPATH)/pkg/crc/version.ocVersion=$(OC_VERSION) \
 	-X $(REPOPATH)/pkg/crc/version.defaultOcURLBase=$(MIRROR) \
 	-X $(REPOPATH)/pkg/crc/version.commitSha=$(COMMIT_SHA)
@@ -133,13 +132,13 @@ ifndef PULL_SECRET_FILE
 	PULL_SECRET_FILE = --pull-secret-file=$(HOME)/Downloads/crc-pull-secret
 endif
 ifndef BUNDLE_LOCATION
-	BUNDLE_LOCATION = --bundle-location=$(HOME)/Downloads/crc_libvirt_$(OPENSHIFT_VERSION).$(BUNDLE_EXTENSION)
+	BUNDLE_LOCATION = --bundle-location=$(HOME)/Downloads/crc_libvirt_$(BUNDLE_VERSION).$(BUNDLE_EXTENSION)
 endif
 ifndef CRC_BINARY
 	CRC_BINARY = --crc-binary=$(GOPATH)/bin
 endif
 integration:
-	@go test --timeout=120m $(REPOPATH)/test/integration -v $(PULL_SECRET_FILE) $(BUNDLE_LOCATION) $(CRC_BINARY) --bundle-version=$(OPENSHIFT_VERSION) $(GODOG_OPTS)
+	@go test --timeout=120m $(REPOPATH)/test/integration -v $(PULL_SECRET_FILE) $(BUNDLE_LOCATION) $(CRC_BINARY) --bundle-version=$(BUNDLE_VERSION) $(GODOG_OPTS)
 
 .PHONY: fmt
 fmt:
@@ -162,7 +161,7 @@ cross-lint: $(GOPATH)/bin/golangci-lint
 gen_release_info:
 	@cat release-info.json.sample | sed s/@CRC_VERSION@/\"$(CRC_VERSION)\"/ > $(RELEASE_INFO)
 	@sed -i s/@GIT_COMMIT_SHA@/\"$(COMMIT_SHA)\"/ $(RELEASE_INFO)
-	@sed -i s/@OPENSHIFT_VERSION@/\"$(OPENSHIFT_VERSION)\"/ $(RELEASE_INFO)
+	@sed -i s/@BUNDLE_VERSION@/\"$(BUNDLE_VERSION)\"/ $(RELEASE_INFO)
 
 .PHONY: release
 release: cross-lint embed_bundle build_docs_pdf gen_release_info
@@ -184,9 +183,9 @@ release: cross-lint embed_bundle build_docs_pdf gen_release_info
 	
 	pushd $(RELEASE_DIR) && sha256sum * > sha256sum.txt && popd
 
-HYPERKIT_BUNDLENAME = $(BUNDLE_DIR)/crc_hyperkit_$(OPENSHIFT_VERSION).$(BUNDLE_EXTENSION)
-HYPERV_BUNDLENAME = $(BUNDLE_DIR)/crc_hyperv_$(OPENSHIFT_VERSION).$(BUNDLE_EXTENSION)
-LIBVIRT_BUNDLENAME = $(BUNDLE_DIR)/crc_libvirt_$(OPENSHIFT_VERSION).$(BUNDLE_EXTENSION)
+HYPERKIT_BUNDLENAME = $(BUNDLE_DIR)/crc_hyperkit_$(BUNDLE_VERSION).$(BUNDLE_EXTENSION)
+HYPERV_BUNDLENAME = $(BUNDLE_DIR)/crc_hyperv_$(BUNDLE_VERSION).$(BUNDLE_EXTENSION)
+LIBVIRT_BUNDLENAME = $(BUNDLE_DIR)/crc_libvirt_$(BUNDLE_VERSION).$(BUNDLE_EXTENSION)
 
 .PHONY: embed_bundle check_bundledir
 check_bundledir:

--- a/Makefile
+++ b/Makefile
@@ -161,7 +161,7 @@ cross-lint: $(GOPATH)/bin/golangci-lint
 gen_release_info:
 	@cat release-info.json.sample | sed s/@CRC_VERSION@/\"$(CRC_VERSION)\"/ > $(RELEASE_INFO)
 	@sed -i s/@GIT_COMMIT_SHA@/\"$(COMMIT_SHA)\"/ $(RELEASE_INFO)
-	@sed -i s/@BUNDLE_VERSION@/\"$(BUNDLE_VERSION)\"/ $(RELEASE_INFO)
+	@sed -i s/@OPENSHIFT_VERSION@/\"$(BUNDLE_VERSION)\"/ $(RELEASE_INFO)
 
 .PHONY: release
 release: cross-lint embed_bundle build_docs_pdf gen_release_info

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL := /bin/bash
 
-BUNDLE_VERSION = 4.5.7
+BUNDLE_VERSION = 4.5.0-0.okd-2020-08-12-020541
 # OC_VERSION and BUNDLE_VERSION are going to same for release artifacts but
 # different for nightly and CI bits where bundle version would be any random
 # string or dd-mm-yyyy format.

--- a/pkg/crc/constants/constants.go
+++ b/pkg/crc/constants/constants.go
@@ -35,9 +35,9 @@ const (
 )
 
 var ocURLForOs = map[string]string{
-	"darwin":  fmt.Sprintf("%s/%s/%s-%s.%s", version.GetDefaultOcURLBase(), version.GetOcVersion(), "openshift-client-mac", version.GetOcVersion(), ".tar.gz"),
-	"linux":   fmt.Sprintf("%s/%s/%s-%s.%s", version.GetDefaultOcURLBase(), version.GetOcVersion(), "openshift-client-linux", version.GetOcVersion(), ".tar.gz"),
-	"windows": fmt.Sprintf("%s/%s/%s-%s.%s", version.GetDefaultOcURLBase(), version.GetOcVersion(), "openshift-client-windows", version.GetOcVersion(), ".zip"),
+	"darwin":  fmt.Sprintf("%s/%s/%s-%s.%s", version.GetDefaultOcURLBase(), version.GetOcVersion(), "openshift-client-mac", version.GetOcVersion(), "tar.gz"),
+	"linux":   fmt.Sprintf("%s/%s/%s-%s.%s", version.GetDefaultOcURLBase(), version.GetOcVersion(), "openshift-client-linux", version.GetOcVersion(), "tar.gz"),
+	"windows": fmt.Sprintf("%s/%s/%s-%s.%s", version.GetDefaultOcURLBase(), version.GetOcVersion(), "openshift-client-windows", version.GetOcVersion(), "zip"),
 }
 
 func GetOcURLForOs(os string) string {

--- a/pkg/crc/constants/constants.go
+++ b/pkg/crc/constants/constants.go
@@ -27,7 +27,7 @@ const (
 	DaemonLogFile        = "crcd.log"
 	CrcLandingPageURL    = "https://cloud.redhat.com/openshift/install/crc/installer-provisioned" // #nosec G101
 
-	DefaultOcURLBase          = "https://mirror.openshift.com/pub/openshift-v4/clients/ocp"
+	DefaultOcURLBase          = "https://github.com/openshift/okd/releases/download/"
 	DefaultPodmanURLBase      = "https://storage.googleapis.com/libpod-master-releases"
 	DefaultGoodhostsCliBase   = "https://github.com/code-ready/goodhosts-cli/releases/download/v1.0.0"
 	CRCMacTrayDownloadURL     = "https://github.com/code-ready/tray-macos/releases/download/v%s/crc-tray-macos.tar.gz"
@@ -36,9 +36,9 @@ const (
 )
 
 var ocURLForOs = map[string]string{
-	"darwin":  fmt.Sprintf("%s/%s/%s", DefaultOcURLBase, version.GetOcVersion(), "openshift-client-mac.tar.gz"),
-	"linux":   fmt.Sprintf("%s/%s/%s", DefaultOcURLBase, version.GetOcVersion(), "openshift-client-linux.tar.gz"),
-	"windows": fmt.Sprintf("%s/%s/%s", DefaultOcURLBase, version.GetOcVersion(), "openshift-client-windows.zip"),
+	"darwin":  fmt.Sprintf("%s/%s/%s-%s.%s", DefaultOcURLBase, version.GetOcVersion(), "openshift-client-mac", version.GetOcVersion(), ".tar.gz"),
+	"linux":   fmt.Sprintf("%s/%s/%s-%s.%s", DefaultOcURLBase, version.GetOcVersion(), "openshift-client-linux", version.GetOcVersion(), ".tar.gz"),
+	"windows": fmt.Sprintf("%s/%s/%s-%s.%s", DefaultOcURLBase, version.GetOcVersion(), "openshift-client-windows", version.GetOcVersion(), ".zip"),
 }
 
 func GetOcURLForOs(os string) string {

--- a/pkg/crc/constants/constants.go
+++ b/pkg/crc/constants/constants.go
@@ -27,7 +27,6 @@ const (
 	DaemonLogFile        = "crcd.log"
 	CrcLandingPageURL    = "https://cloud.redhat.com/openshift/install/crc/installer-provisioned" // #nosec G101
 
-	DefaultOcURLBase          = "https://github.com/openshift/okd/releases/download/"
 	DefaultPodmanURLBase      = "https://storage.googleapis.com/libpod-master-releases"
 	DefaultGoodhostsCliBase   = "https://github.com/code-ready/goodhosts-cli/releases/download/v1.0.0"
 	CRCMacTrayDownloadURL     = "https://github.com/code-ready/tray-macos/releases/download/v%s/crc-tray-macos.tar.gz"
@@ -36,9 +35,9 @@ const (
 )
 
 var ocURLForOs = map[string]string{
-	"darwin":  fmt.Sprintf("%s/%s/%s-%s.%s", DefaultOcURLBase, version.GetOcVersion(), "openshift-client-mac", version.GetOcVersion(), ".tar.gz"),
-	"linux":   fmt.Sprintf("%s/%s/%s-%s.%s", DefaultOcURLBase, version.GetOcVersion(), "openshift-client-linux", version.GetOcVersion(), ".tar.gz"),
-	"windows": fmt.Sprintf("%s/%s/%s-%s.%s", DefaultOcURLBase, version.GetOcVersion(), "openshift-client-windows", version.GetOcVersion(), ".zip"),
+	"darwin":  fmt.Sprintf("%s/%s/%s-%s.%s", version.GetDefaultOcURLBase, version.GetOcVersion(), "openshift-client-mac", version.GetOcVersion(), ".tar.gz"),
+	"linux":   fmt.Sprintf("%s/%s/%s-%s.%s", version.GetDefaultOcURLBase, version.GetOcVersion(), "openshift-client-linux", version.GetOcVersion(), ".tar.gz"),
+	"windows": fmt.Sprintf("%s/%s/%s-%s.%s", version.GetDefaultOcURLBase, version.GetOcVersion(), "openshift-client-windows", version.GetOcVersion(), ".zip"),
 }
 
 func GetOcURLForOs(os string) string {

--- a/pkg/crc/constants/constants.go
+++ b/pkg/crc/constants/constants.go
@@ -35,9 +35,9 @@ const (
 )
 
 var ocURLForOs = map[string]string{
-	"darwin":  fmt.Sprintf("%s/%s/%s-%s.%s", version.GetDefaultOcURLBase, version.GetOcVersion(), "openshift-client-mac", version.GetOcVersion(), ".tar.gz"),
-	"linux":   fmt.Sprintf("%s/%s/%s-%s.%s", version.GetDefaultOcURLBase, version.GetOcVersion(), "openshift-client-linux", version.GetOcVersion(), ".tar.gz"),
-	"windows": fmt.Sprintf("%s/%s/%s-%s.%s", version.GetDefaultOcURLBase, version.GetOcVersion(), "openshift-client-windows", version.GetOcVersion(), ".zip"),
+	"darwin":  fmt.Sprintf("%s/%s/%s-%s.%s", version.GetDefaultOcURLBase(), version.GetOcVersion(), "openshift-client-mac", version.GetOcVersion(), ".tar.gz"),
+	"linux":   fmt.Sprintf("%s/%s/%s-%s.%s", version.GetDefaultOcURLBase(), version.GetOcVersion(), "openshift-client-linux", version.GetOcVersion(), ".tar.gz"),
+	"windows": fmt.Sprintf("%s/%s/%s-%s.%s", version.GetDefaultOcURLBase(), version.GetOcVersion(), "openshift-client-windows", version.GetOcVersion(), ".zip"),
 }
 
 func GetOcURLForOs(os string) string {

--- a/pkg/crc/version/version.go
+++ b/pkg/crc/version/version.go
@@ -23,6 +23,8 @@ var (
 
 	// OC version which should be used.
 	ocVersion = "0.0.0-unset"
+
+	defaultOcURLBase = "0.0.0-unset"
 )
 
 const (
@@ -53,6 +55,10 @@ func GetBundleVersion() string {
 
 func GetOcVersion() string {
 	return ocVersion
+}
+
+func GetDefaultOcURLBase() string {
+	return defaultOcURLBase
 }
 
 func GetCRCMacTrayVersion() string {


### PR DESCRIPTION
**Fixes:** Issue #977 

**Relates to:** https://github.com/code-ready/snc/issues/212

## Solution/Idea

I modified Makefile, constants.go, and version.go to allow for building a `crc` image which uses OKD instead of OCP.  The building of `crc` should not be affected by these changes, as it is the default.   `crc` for OKD can be built by setting environment variables.

## Proposed changes

1. Removed `DefaultOcURLBase` from `constants.go` and added it as a build config variable to `version.go`
1. Modified the creation of `ocURLForOs` to account for okd vs. ocp URLs
1. Modified `Makefile` to allow overriding `BUNDLE_VERSION`
1. Modified `Makefile` to add `MIRROR` as an override for `version.defaultOcURLBase` and added `https://mirror.openshift.com/pub/openshift-v4/clients/ocp` as a default value.

## Testing

I have tested the OKD builds of snc and crc.  I do not have the facility to test OCP builds.

To build for OKD:

Build `snc`:  See Pull Request - https://github.com/code-ready/snc/pull/230

```bash
export BUNDLE_VERSION=${OPENSHIFT_VERSION}                                  # Using OPENSHIFT_VERSION that was set for snc.
export MIRROR=https://github.com/openshift/okd/releases/download     
export BUNDLE_DIR=/tmp/snc                                                                      # where snc was built in /tmp/snc

make embed_bundle
```

Use `{"auths":{"fake":{"auth": "Zm9vOmJhcgo="}}}` as your pull secret when prompted during `crc start`

