### PR TITLE
Enable creating CRC for OKD 4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL := /bin/bash
 
-BUNDLE_VERSION = 4.5.9
+BUNDLE_VERSION ?= 4.5.9
 # OC_VERSION and BUNDLE_VERSION are going to same for release artifacts but
 # different for nightly and CI bits where bundle version would be any random
 # string or dd-mm-yyyy format.
@@ -8,6 +8,7 @@ OC_VERSION ?= ${BUNDLE_VERSION}
 BUNDLE_EXTENSION = crcbundle
 CRC_VERSION = 1.16.0
 COMMIT_SHA=$(shell git rev-parse --short HEAD)
+OC_BASE_URL ?= https://mirror.openshift.com/pub/openshift-v4/clients/ocp
 
 # Go and compilation related variables
 BUILD_DIR ?= out
@@ -49,6 +50,7 @@ __check_defined = \
 VERSION_VARIABLES := -X $(REPOPATH)/pkg/crc/version.crcVersion=$(CRC_VERSION) \
     -X $(REPOPATH)/pkg/crc/version.bundleVersion=$(BUNDLE_VERSION) \
     -X $(REPOPATH)/pkg/crc/version.ocVersion=$(OC_VERSION) \
+	-X $(REPOPATH)/pkg/crc/version.defaultOcURLBase=$(OC_BASE_URL) \
 	-X $(REPOPATH)/pkg/crc/version.commitSha=$(COMMIT_SHA)
 
 # https://golang.org/cmd/link/

--- a/README.adoc
+++ b/README.adoc
@@ -50,6 +50,20 @@ This will create a [filename]`docs/build/master.html` file which you can view in
 
 Developers who want to work on CodeReady Containers should visit the link:./developing.adoc[Developing CodeReady Containers] document.
 
+=== Building CodeReady Containers for OKD 4
+
+You can build the crc binaries with OKD 4 embedded images by overriding a couple of environment variables:
+
+You first need to have OKD 4 crcbundle images built from: link:https://github.com/code-ready/snc[https://github.com/code-ready/snc]
+
+```bash
+export BUNDLE_VERSION=4.5.0-0.okd-2020-08-12-020541               # The version that you built snc from
+export OC_BASE_URL=https://github.com/openshift/okd/releases/download
+export BUNDLE_DIR=/path/to/your/snc/bundles
+
+make embed_bundle
+```
+
 [[community]]
 == Community
 

--- a/pkg/crc/constants/constants.go
+++ b/pkg/crc/constants/constants.go
@@ -27,7 +27,6 @@ const (
 	DaemonLogFile        = "crcd.log"
 	CrcLandingPageURL    = "https://cloud.redhat.com/openshift/install/crc/installer-provisioned" // #nosec G101
 
-	DefaultOcURLBase          = "https://mirror.openshift.com/pub/openshift-v4/clients/ocp"
 	DefaultPodmanURLBase      = "https://storage.googleapis.com/libpod-master-releases"
 	DefaultGoodhostsCliBase   = "https://github.com/code-ready/goodhosts-cli/releases/download/v1.0.0"
 	CRCMacTrayDownloadURL     = "https://github.com/code-ready/tray-macos/releases/download/v%s/crc-tray-macos.tar.gz"
@@ -36,9 +35,9 @@ const (
 )
 
 var ocURLForOs = map[string]string{
-	"darwin":  fmt.Sprintf("%s/%s/%s", DefaultOcURLBase, version.GetOcVersion(), "openshift-client-mac.tar.gz"),
-	"linux":   fmt.Sprintf("%s/%s/%s", DefaultOcURLBase, version.GetOcVersion(), "openshift-client-linux.tar.gz"),
-	"windows": fmt.Sprintf("%s/%s/%s", DefaultOcURLBase, version.GetOcVersion(), "openshift-client-windows.zip"),
+	"darwin":  fmt.Sprintf("%s/%s/%s-%s.%s", version.GetDefaultOcURLBase(), version.GetOcVersion(), "openshift-client-mac", version.GetOcVersion(), "tar.gz"),
+	"linux":   fmt.Sprintf("%s/%s/%s-%s.%s", version.GetDefaultOcURLBase(), version.GetOcVersion(), "openshift-client-linux", version.GetOcVersion(), "tar.gz"),
+	"windows": fmt.Sprintf("%s/%s/%s-%s.%s", version.GetDefaultOcURLBase(), version.GetOcVersion(), "openshift-client-windows", version.GetOcVersion(), "zip"),
 }
 
 func GetOcURLForOs(os string) string {

--- a/pkg/crc/version/version.go
+++ b/pkg/crc/version/version.go
@@ -23,6 +23,9 @@ var (
 
 	// OC version which should be used.
 	ocVersion = "0.0.0-unset"
+
+	// Base URL for oc download
+	defaultOcURLBase = "url-unset"
 )
 
 const (
@@ -53,6 +56,10 @@ func GetBundleVersion() string {
 
 func GetOcVersion() string {
 	return ocVersion
+}
+
+func GetDefaultOcURLBase() string {
+	return defaultOcURLBase
 }
 
 func GetCRCMacTrayVersion() string {


### PR DESCRIPTION
**Fixes:** Issue #977 

**Relates to:** https://github.com/code-ready/snc/issues/212

## Solution/Idea

I modified Makefile, constants.go, and version.go to allow for building a `crc` image which uses OKD instead of OCP.  The building of `crc` should not be affected by these changes, as it is the default.   `crc` for OKD can be built by setting environment variables.

## Proposed changes

1. Removed `DefaultOcURLBase` from `constants.go` and added it as a build config variable to `version.go`
1. Modified the creation of `ocURLForOs` to account for okd vs. ocp URLs
1. Modified `Makefile` to allow overriding `BUNDLE_VERSION`
1. Modified `Makefile` to add `OC_BASE_URL` as an override for `version.defaultOcURLBase` and added `https://mirror.openshift.com/pub/openshift-v4/clients/ocp` as a default value.
1. Added docs to README for build crc for OKD 4.

## Testing

I have tested the OKD builds of snc and crc.  I do not have the facility to test OCP builds.

To build for OKD:

Build `snc`:  See Pull Request - https://github.com/code-ready/snc/pull/230

```bash
export BUNDLE_VERSION=${OPENSHIFT_VERSION}                                  # Using OPENSHIFT_VERSION that was set for snc.
export OC_BASE_URL=https://github.com/openshift/okd/releases/download     
export BUNDLE_DIR=/tmp/snc                                                                      # where snc was built in /tmp/snc

make embed_bundle
```

Use `{"auths":{"fake":{"auth": "Zm9vOmJhcgo="}}}` as your pull secret when prompted during `crc start`

