### PR TITLE
Docs: Add port 443 to remote haproxy configuration

### DIFF
--- a/docs/source/topics/proc_setting-up-remote-server.adoc
+++ b/docs/source/topics/proc_setting-up-remote-server.adoc
@@ -83,7 +83,7 @@ backend apps
     mode tcp
     balance roundrobin
     option ssl-hello-chk
-    server webserver1 $CRC_IP check
+    server webserver1 $CRC_IP:443 check
 
 frontend api
     bind 0.0.0.0:6443


### PR DESCRIPTION
**Relates to:** Issue #705