### PR TITLE
Add json support for setup/stop/delete/cleanup commands

### DIFF
--- a/cmd/crc/cmd/console.go
+++ b/cmd/crc/cmd/console.go
@@ -8,6 +8,7 @@ import (
 	"github.com/code-ready/crc/pkg/crc/exit"
 	"github.com/code-ready/crc/pkg/crc/machine"
 	"github.com/code-ready/crc/pkg/crc/output"
+	"github.com/code-ready/machine/libmachine/state"
 	"github.com/pkg/browser"
 	"github.com/spf13/cobra"
 )
@@ -62,7 +63,7 @@ func runConsole(arguments []string) error {
 		return nil
 	}
 
-	if !machine.IsRunning(result.State) {
+	if result.State != state.Running {
 		return errors.New("The OpenShift cluster is not running, cannot open the OpenShift Web Console")
 	}
 	output.Outln("Opening the OpenShift Web Console in the default browser...")

--- a/cmd/crc/cmd/delete.go
+++ b/cmd/crc/cmd/delete.go
@@ -1,14 +1,15 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/code-ready/crc/pkg/crc/exit"
 	"github.com/code-ready/crc/pkg/crc/input"
 	"github.com/code-ready/crc/pkg/crc/machine"
-	"github.com/code-ready/crc/pkg/crc/output"
 	"github.com/spf13/cobra"
 )
 
@@ -17,6 +18,7 @@ var clearCache bool
 func init() {
 	deleteCmd.Flags().BoolVarP(&clearCache, "clear-cache", "", false,
 		fmt.Sprintf("Clear the OpenShift cluster cache at: %s", constants.MachineCacheDir))
+	addOutputFormatFlag(deleteCmd)
 	rootCmd.AddCommand(deleteCmd)
 }
 
@@ -25,17 +27,21 @@ var deleteCmd = &cobra.Command{
 	Short: "Delete the OpenShift cluster",
 	Long:  "Delete the OpenShift cluster",
 	Run: func(cmd *cobra.Command, args []string) {
-		if err := runDelete(machine.NewClient()); err != nil {
+		if err := runDelete(os.Stdout, machine.NewClient(), clearCache, constants.MachineCacheDir, outputFormat != jsonFormat, globalForce, outputFormat); err != nil {
 			exit.WithMessage(1, err.Error())
 		}
 	},
 }
 
-func runDelete(client machine.Client) error {
+func deleteMachine(client machine.Client, clearCache bool, cacheDir string, interactive, force bool) error {
+	if !interactive && !force {
+		return errors.New("non-interactive deletion requires --force")
+	}
+
 	if clearCache {
-		yes := input.PromptUserForYesOrNo("Do you want to delete the OpenShift cluster cache", globalForce)
+		yes := input.PromptUserForYesOrNo("Do you want to delete the OpenShift cluster cache", force)
 		if yes {
-			_ = os.RemoveAll(constants.MachineCacheDir)
+			_ = os.RemoveAll(cacheDir)
 		}
 	}
 
@@ -43,15 +49,33 @@ func runDelete(client machine.Client) error {
 		return err
 	}
 
-	yes := input.PromptUserForYesOrNo("Do you want to delete the OpenShift cluster", globalForce)
+	yes := input.PromptUserForYesOrNo("Do you want to delete the OpenShift cluster", force)
 	if yes {
 		_, err := client.Delete(machine.DeleteConfig{
 			Name: constants.DefaultName,
 		})
-		if err != nil {
-			return err
-		}
-		output.Outln("Deleted the OpenShift cluster")
+		return err
 	}
 	return nil
+}
+
+func runDelete(writer io.Writer, client machine.Client, clearCache bool, cacheDir string, interactive, force bool, outputFormat string) error {
+	err := deleteMachine(client, clearCache, cacheDir, interactive, force)
+	return render(&deleteResult{
+		Success: err == nil,
+		Error:   errorMessage(err),
+	}, writer, outputFormat)
+}
+
+type deleteResult struct {
+	Success bool   `json:"success"`
+	Error   string `json:"error,omitempty"`
+}
+
+func (s *deleteResult) prettyPrintTo(writer io.Writer) error {
+	if s.Error != "" {
+		return errors.New(s.Error)
+	}
+	_, err := fmt.Fprintln(writer, "Deleted the OpenShift cluster")
+	return err
 }

--- a/cmd/crc/cmd/delete_test.go
+++ b/cmd/crc/cmd/delete_test.go
@@ -1,0 +1,38 @@
+package cmd
+
+import (
+	"bytes"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/code-ready/crc/pkg/crc/machine/fakemachine"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPlainDelete(t *testing.T) {
+	cacheDir, err := ioutil.TempDir("", "cache")
+	require.NoError(t, err)
+	defer os.RemoveAll(cacheDir)
+
+	out := new(bytes.Buffer)
+	assert.NoError(t, runDelete(out, fakemachine.NewClient(), true, cacheDir, true, true, ""))
+	assert.Equal(t, "Deleted the OpenShift cluster\n", out.String())
+
+	_, err = os.Stat(cacheDir)
+	assert.True(t, os.IsNotExist(err))
+}
+
+func TestJSONDelete(t *testing.T) {
+	cacheDir, err := ioutil.TempDir("", "cache")
+	require.NoError(t, err)
+	defer os.RemoveAll(cacheDir)
+
+	out := new(bytes.Buffer)
+	assert.NoError(t, runDelete(out, fakemachine.NewClient(), true, cacheDir, false, true, jsonFormat))
+	assert.JSONEq(t, `{"success": true}`, out.String())
+
+	_, err = os.Stat(cacheDir)
+	assert.True(t, os.IsNotExist(err))
+}

--- a/cmd/crc/cmd/setup_test.go
+++ b/cmd/crc/cmd/setup_test.go
@@ -1,0 +1,42 @@
+package cmd
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSetupRenderActionPlainSuccess(t *testing.T) {
+	out := new(bytes.Buffer)
+	assert.NoError(t, render(&setupResult{
+		Success: true,
+	}, out, ""))
+	assert.Equal(t, "Setup is complete, you can now run 'crc start -b $bundlename' to start the OpenShift cluster\n", out.String())
+}
+
+func TestSetupRenderActionPlainFailure(t *testing.T) {
+	out := new(bytes.Buffer)
+	assert.EqualError(t, render(&setupResult{
+		Success: false,
+		Error:   "broken",
+	}, out, ""), "broken")
+	assert.Equal(t, "", out.String())
+}
+
+func TestSetupRenderActionJSONSuccess(t *testing.T) {
+	out := new(bytes.Buffer)
+	assert.NoError(t, render(&setupResult{
+		Success: true,
+	}, out, jsonFormat))
+	assert.JSONEq(t, `{"success": true}`, out.String())
+}
+
+func TestSetupRenderActionJSONFailure(t *testing.T) {
+	out := new(bytes.Buffer)
+	assert.NoError(t, render(&setupResult{
+		Success: false,
+		Error:   "broken",
+	}, out, jsonFormat))
+	assert.JSONEq(t, `{"success": false, "error": "broken"}`, out.String())
+}

--- a/cmd/crc/cmd/start.go
+++ b/cmd/crc/cmd/start.go
@@ -89,7 +89,8 @@ func toClusterConfig(result *machine.StartResult) *clusterConfig {
 		return nil
 	}
 	return &clusterConfig{
-		URL: result.ClusterConfig.ClusterAPI,
+		WebConsoleURL: result.ClusterConfig.WebConsoleURL,
+		URL:           result.ClusterConfig.ClusterAPI,
 		AdminCredentials: credentials{
 			Username: "kubeadmin",
 			Password: result.ClusterConfig.KubeAdminPass,
@@ -109,6 +110,7 @@ func errorMessage(err error) string {
 }
 
 type clusterConfig struct {
+	WebConsoleURL        string      `json:"webConsoleUrl"`
 	URL                  string      `json:"url"`
 	AdminCredentials     credentials `json:"adminCredentials"`
 	DeveloperCredentials credentials `json:"developerCredentials"`

--- a/cmd/crc/cmd/start_test.go
+++ b/cmd/crc/cmd/start_test.go
@@ -85,5 +85,5 @@ func TestRenderActionJSONFailure(t *testing.T) {
 		Success: false,
 		Error:   "broken",
 	}, out, jsonFormat))
-	assert.Equal(t, "{\n  \"success\": false,\n  \"error\": \"broken\"\n}\n", out.String())
+	assert.JSONEq(t, `{"success": false, "error": "broken"}`, out.String())
 }

--- a/cmd/crc/cmd/start_test.go
+++ b/cmd/crc/cmd/start_test.go
@@ -49,7 +49,8 @@ func TestRenderActionJSONSuccess(t *testing.T) {
 	assert.NoError(t, render(&startResult{
 		Success: true,
 		ClusterConfig: &clusterConfig{
-			URL: constants.DefaultAPIURL,
+			WebConsoleURL: constants.DefaultWebConsoleURL,
+			URL:           constants.DefaultAPIURL,
 			AdminCredentials: credentials{
 				Username: "kubeadmin",
 				Password: "secret",
@@ -63,6 +64,7 @@ func TestRenderActionJSONSuccess(t *testing.T) {
 	assert.Equal(t, `{
   "success": true,
   "clusterConfig": {
+    "webConsoleUrl": "https://console-openshift-console.apps-crc.testing",
     "url": "https://api.crc.testing:6443",
     "adminCredentials": {
       "username": "kubeadmin",

--- a/cmd/crc/cmd/stop.go
+++ b/cmd/crc/cmd/stop.go
@@ -1,17 +1,21 @@
 package cmd
 
 import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+
 	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/code-ready/crc/pkg/crc/exit"
 	"github.com/code-ready/crc/pkg/crc/input"
-	"github.com/code-ready/crc/pkg/crc/logging"
 	"github.com/code-ready/crc/pkg/crc/machine"
-	"github.com/code-ready/crc/pkg/crc/output"
 	"github.com/code-ready/machine/libmachine/state"
 	"github.com/spf13/cobra"
 )
 
 func init() {
+	addOutputFormatFlag(stopCmd)
 	rootCmd.AddCommand(stopCmd)
 }
 
@@ -20,16 +24,15 @@ var stopCmd = &cobra.Command{
 	Short: "Stop the OpenShift cluster",
 	Long:  "Stop the OpenShift cluster",
 	Run: func(cmd *cobra.Command, args []string) {
-		if err := runStop(); err != nil {
-			exit.WithMessage(1, err.Error())
+		if renderErr := runStop(os.Stdout, machine.NewClient(), outputFormat != jsonFormat, globalForce, outputFormat); renderErr != nil {
+			exit.WithMessage(1, renderErr.Error())
 		}
 	},
 }
 
-func runStop() error {
-	client := machine.NewClient()
+func stopMachine(client machine.Client, interactive, force bool) (bool, error) {
 	if err := checkIfMachineMissing(client, constants.DefaultName); err != nil {
-		return err
+		return false, err
 	}
 
 	result, err := client.Stop(machine.StopConfig{
@@ -37,31 +40,51 @@ func runStop() error {
 		Debug: isDebugLog(),
 	})
 	if err != nil {
+		if !interactive && !force {
+			return false, err
+		}
 		// Here we are checking the VM state and if it is still running then
 		// Ask user to forcefully power off it.
 		if result.State == state.Running {
 			// Most of the time force kill don't work and libvirt throw
 			// Device or resource busy error. To make sure we give some
 			// graceful time to cluster before kill it.
-			yes := input.PromptUserForYesOrNo("Do you want to force power off", globalForce)
+			yes := input.PromptUserForYesOrNo("Do you want to force power off", force)
 			if yes {
 				_, err := client.PowerOff(machine.PowerOffConfig{
 					Name: constants.DefaultName,
 				})
-				if err != nil {
-					return err
-				}
-				output.Outln("Forcibly stopped the OpenShift cluster")
-				return nil
+				return true, err
 			}
 		}
+		return false, err
+	}
+	return false, nil
+}
+
+func runStop(writer io.Writer, client machine.Client, interactive, force bool, outputFormat string) error {
+	forced, err := stopMachine(client, interactive, force)
+	return render(&stopResult{
+		Success: err == nil,
+		Forced:  forced,
+		Error:   errorMessage(err),
+	}, writer, outputFormat)
+}
+
+type stopResult struct {
+	Success bool   `json:"success"`
+	Forced  bool   `json:"forced"`
+	Error   string `json:"error,omitempty"`
+}
+
+func (s *stopResult) prettyPrintTo(writer io.Writer) error {
+	if s.Error != "" {
+		return errors.New(s.Error)
+	}
+	if s.Forced {
+		_, err := fmt.Fprintln(writer, "Forcibly stopped the OpenShift cluster")
 		return err
 	}
-	if result.Success {
-		output.Outln("Stopped the OpenShift cluster")
-	} else {
-		/* If we did not get an error, the status should be true */
-		logging.Warnf("Unexpected status of the OpenShift cluster: %v", result.Success)
-	}
-	return nil
+	_, err := fmt.Fprintln(writer, "Stopped the OpenShift cluster")
+	return err
 }

--- a/cmd/crc/cmd/stop_test.go
+++ b/cmd/crc/cmd/stop_test.go
@@ -1,0 +1,43 @@
+package cmd
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/code-ready/crc/pkg/crc/machine/fakemachine"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStopPlainSuccess(t *testing.T) {
+	out := new(bytes.Buffer)
+	assert.NoError(t, runStop(out, fakemachine.NewClient(), true, false, ""))
+	assert.Equal(t, "Stopped the OpenShift cluster\n", out.String())
+}
+
+func TestStopPlainError(t *testing.T) {
+	out := new(bytes.Buffer)
+	assert.EqualError(t, runStop(out, fakemachine.NewFailingClient(), true, false, ""), "stop failed")
+}
+
+func TestStopWithForcePlainError(t *testing.T) {
+	out := new(bytes.Buffer)
+	assert.EqualError(t, runStop(out, fakemachine.NewFailingClient(), true, true, ""), "poweroff failed")
+}
+
+func TestStopJSONSuccess(t *testing.T) {
+	out := new(bytes.Buffer)
+	assert.NoError(t, runStop(out, fakemachine.NewClient(), false, false, jsonFormat))
+	assert.JSONEq(t, `{"success": true, "forced": false}`, out.String())
+}
+
+func TestStopJSONError(t *testing.T) {
+	out := new(bytes.Buffer)
+	assert.NoError(t, runStop(out, fakemachine.NewFailingClient(), false, false, jsonFormat))
+	assert.JSONEq(t, `{"success": false, "forced": false, "error": "stop failed"}`, out.String())
+}
+
+func TestStopWithForceJSONError(t *testing.T) {
+	out := new(bytes.Buffer)
+	assert.NoError(t, runStop(out, fakemachine.NewFailingClient(), false, true, jsonFormat))
+	assert.JSONEq(t, `{"success": false, "forced": true, "error": "poweroff failed"}`, out.String())
+}

--- a/cmd/crc/cmd/version_test.go
+++ b/cmd/crc/cmd/version_test.go
@@ -29,12 +29,6 @@ func TestJsonVersion(t *testing.T) {
 		Embedded:         false,
 	}, "json"))
 
-	expected := `{
-  "version": "1.13",
-  "commit": "aabbcc",
-  "openshiftVersion": "4.5.4",
-  "embedded": false
-}
-`
-	assert.Equal(t, expected, out.String())
+	expected := `{"version": "1.13", "commit": "aabbcc", "openshiftVersion": "4.5.4", "embedded": false}`
+	assert.JSONEq(t, expected, out.String())
 }

--- a/pkg/crc/input/input.go
+++ b/pkg/crc/input/input.go
@@ -1,16 +1,22 @@
 package input
 
 import (
+	"errors"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/code-ready/crc/pkg/crc/output"
+	"golang.org/x/crypto/ssh/terminal"
 	survey "gopkg.in/AlecAivazis/survey.v1"
 )
 
 func PromptUserForYesOrNo(message string, force bool) bool {
 	if force {
 		return true
+	}
+	if !terminal.IsTerminal(int(os.Stdin.Fd())) {
+		return false
 	}
 	var response string
 	output.Outf(message + "? [y/N]: ")
@@ -22,6 +28,10 @@ func PromptUserForYesOrNo(message string, force bool) bool {
 // PromptUserForSecret can be used for any kind of secret like image pull
 // secret or for password.
 func PromptUserForSecret(message string, help string) (string, error) {
+	if !terminal.IsTerminal(int(os.Stdin.Fd())) {
+		return "", errors.New("cannot ask for secret, crc not launched by a terminal")
+	}
+
 	var secret string
 	prompt := &survey.Password{
 		Message: message,

--- a/pkg/crc/machine/fakemachine/client.go
+++ b/pkg/crc/machine/fakemachine/client.go
@@ -23,7 +23,17 @@ type Client struct {
 }
 
 func (c *Client) Delete(deleteConfig machine.DeleteConfig) (machine.DeleteResult, error) {
-	return machine.DeleteResult{}, errors.New("not implemented")
+	if c.Failing {
+		return machine.DeleteResult{
+			Name:    "crc",
+			Success: false,
+			Error:   "delete failed",
+		}, errors.New("delete failed")
+	}
+	return machine.DeleteResult{
+		Name:    "crc",
+		Success: true,
+	}, nil
 }
 
 func (c *Client) GetConsoleURL(consoleConfig machine.ConsoleConfig) (machine.ConsoleResult, error) {

--- a/pkg/crc/machine/fakemachine/client.go
+++ b/pkg/crc/machine/fakemachine/client.go
@@ -5,10 +5,17 @@ import (
 
 	"github.com/code-ready/crc/pkg/crc/machine"
 	"github.com/code-ready/crc/pkg/crc/network"
+	"github.com/code-ready/machine/libmachine/state"
 )
 
 func NewClient() *Client {
 	return &Client{}
+}
+
+func NewFailingClient() *Client {
+	return &Client{
+		Failing: true,
+	}
 }
 
 type Client struct {
@@ -32,7 +39,17 @@ func (c *Client) IP(ipConfig machine.IPConfig) (machine.IPResult, error) {
 }
 
 func (c *Client) PowerOff(powerOff machine.PowerOffConfig) (machine.PowerOffResult, error) {
-	return machine.PowerOffResult{}, errors.New("not implemented")
+	if c.Failing {
+		return machine.PowerOffResult{
+			Name:    "crc",
+			Success: false,
+			Error:   "poweroff failed",
+		}, errors.New("poweroff failed")
+	}
+	return machine.PowerOffResult{
+		Name:    "crc",
+		Success: true,
+	}, nil
 }
 
 func (c *Client) Start(startConfig machine.StartConfig) (machine.StartResult, error) {
@@ -40,7 +57,19 @@ func (c *Client) Start(startConfig machine.StartConfig) (machine.StartResult, er
 }
 
 func (c *Client) Stop(stopConfig machine.StopConfig) (machine.StopResult, error) {
-	return machine.StopResult{}, errors.New("not implemented")
+	if c.Failing {
+		return machine.StopResult{
+			Name:    "crc",
+			Success: false,
+			Error:   "stop failed",
+			State:   state.Running,
+		}, errors.New("stop failed")
+	}
+	return machine.StopResult{
+		Name:    "crc",
+		Success: true,
+		State:   state.Stopped,
+	}, nil
 }
 
 func (c *Client) Status(statusConfig machine.ClusterStatusConfig) (machine.ClusterStatusResult, error) {

--- a/pkg/crc/machine/machine.go
+++ b/pkg/crc/machine/machine.go
@@ -86,10 +86,6 @@ func getBundleMetadataFromDriver(driver drivers.Driver) (string, *bundle.CrcBund
 	return bundleName, metadata, err
 }
 
-func IsRunning(st state.State) bool {
-	return st == state.Running
-}
-
 func createLibMachineClient(debug bool) (*libmachine.Client, func(), error) {
 	err := setMachineLogging(debug)
 	if err != nil {
@@ -186,7 +182,7 @@ func (client *client) Start(startConfig StartConfig) (StartResult, error) {
 		if err != nil {
 			return startError(startConfig.Name, "Error getting the machine state", err)
 		}
-		if IsRunning(vmState) {
+		if vmState == state.Running {
 			openshiftVersion := crcBundleMetadata.GetOpenshiftVersion()
 			if openshiftVersion == "" {
 				logging.Info("A CodeReady Containers VM is already running")
@@ -557,7 +553,7 @@ func (*client) Status(statusConfig ClusterStatusConfig) (ClusterStatusResult, er
 		return statusError(statusConfig.Name, "Cannot get machine state", err)
 	}
 
-	if IsRunning(vmStatus) {
+	if vmStatus == state.Running {
 		_, crcBundleMetadata, err := getBundleMetadataFromDriver(host.Driver)
 		if err != nil {
 			return statusError(statusConfig.Name, "Error loading bundle metadata", err)

--- a/pkg/crc/machine/machine.go
+++ b/pkg/crc/machine/machine.go
@@ -444,6 +444,7 @@ func (*client) Stop(stopConfig StopConfig) (StopResult, error) {
 
 	state, _ := host.Driver.GetState()
 
+	logging.Info("Stopping the OpenShift cluster, this may take a few minutes...")
 	if err := host.Stop(); err != nil {
 		return stopError(stopConfig.Name, "Cannot stop machine", err)
 	}


### PR DESCRIPTION
**Relates to:** Issue #1227

* Sometimes we prompt the user a yes/no question. With json output, he has to add ` --force` (a little bit like mv/cp).