### PR TITLE
Add support for changing memory allocated to an already existing VM 

### DIFF
--- a/pkg/crc/config/callbacks.go
+++ b/pkg/crc/config/callbacks.go
@@ -5,9 +5,9 @@ import (
 )
 
 func RequiresRestartMsg(key string, _ interface{}) string {
-	return fmt.Sprintf("Changes to configuration property '%s' are only applied when a new CRC instance is created.\n"+
-		"If you already have a CRC instance, then for this configuration change to take effect, "+
-		"delete the CRC instance with 'crc delete' and start a new one with 'crc start'.", key)
+	return fmt.Sprintf("Changes to configuration property '%s' are only applied when the CRC instance is started.\n"+
+		"If you already have a running CRC instance, then for this configuration change to take effect, "+
+		"stop the CRC instance with 'crc stop' and restart it with 'crc start'.", key)
 }
 
 func SuccessfullyApplied(key string, value interface{}) string {

--- a/pkg/crc/machine/config/driver.go
+++ b/pkg/crc/machine/config/driver.go
@@ -1,0 +1,14 @@
+package config
+
+import (
+	"github.com/code-ready/machine/libmachine/drivers"
+)
+
+func InitVMDriverFromMachineConfig(machineConfig MachineConfig, driver *drivers.VMDriver) {
+	driver.CPU = machineConfig.CPUs
+	driver.Memory = machineConfig.Memory
+	driver.BundleName = machineConfig.BundleName
+	driver.ImageSourcePath = machineConfig.ImageSourcePath
+	driver.ImageFormat = machineConfig.ImageFormat
+	driver.SSHKeyPath = machineConfig.SSHKeyPath
+}

--- a/pkg/crc/machine/driver.go
+++ b/pkg/crc/machine/driver.go
@@ -1,0 +1,34 @@
+package machine
+
+import (
+	libmachine "github.com/code-ready/machine/libmachine/drivers"
+	"github.com/code-ready/machine/libmachine/host"
+)
+
+type valueSetter func(driver *libmachine.VMDriver)
+
+func updateDriverValue(host *host.Host, setDriverValue valueSetter) error {
+	driver, err := loadDriverConfig(host)
+	if err != nil {
+		return err
+	}
+	setDriverValue(driver.VMDriver)
+
+	return updateDriverConfig(host, driver)
+}
+
+func setMemory(host *host.Host, memorySize int) error {
+	memorySetter := func(driver *libmachine.VMDriver) {
+		driver.Memory = memorySize
+	}
+
+	return updateDriverValue(host, memorySetter)
+}
+
+func setVcpus(host *host.Host, vcpus int) error {
+	vcpuSetter := func(driver *libmachine.VMDriver) {
+		driver.CPU = vcpus
+	}
+
+	return updateDriverValue(host, vcpuSetter)
+}

--- a/pkg/crc/machine/driver_darwin.go
+++ b/pkg/crc/machine/driver_darwin.go
@@ -7,6 +7,7 @@ import (
 	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/code-ready/crc/pkg/crc/machine/config"
 	"github.com/code-ready/crc/pkg/crc/machine/hyperkit"
+	machineHyperkit "github.com/code-ready/machine/drivers/hyperkit"
 	"github.com/code-ready/machine/libmachine"
 	"github.com/code-ready/machine/libmachine/host"
 )
@@ -17,4 +18,20 @@ func newHost(api libmachine.API, machineConfig config.MachineConfig) (*host.Host
 		return nil, errors.New("Failed to marshal driver options")
 	}
 	return api.NewHost("hyperkit", constants.CrcBinDir, json)
+}
+
+func loadDriverConfig(host *host.Host) (*machineHyperkit.Driver, error) {
+	var hyperkitDriver machineHyperkit.Driver
+	err := json.Unmarshal(host.RawDriver, &hyperkitDriver)
+
+	return &hyperkitDriver, err
+}
+
+func updateDriverConfig(host *host.Host, driver *machineHyperkit.Driver) error {
+	driverData, err := json.Marshal(driver)
+	if err != nil {
+		return err
+	}
+
+	return host.UpdateConfig(driverData)
 }

--- a/pkg/crc/machine/driver_linux.go
+++ b/pkg/crc/machine/driver_linux.go
@@ -7,6 +7,7 @@ import (
 	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/code-ready/crc/pkg/crc/machine/config"
 	"github.com/code-ready/crc/pkg/crc/machine/libvirt"
+	machineLibvirt "github.com/code-ready/machine/drivers/libvirt"
 	"github.com/code-ready/machine/libmachine"
 	"github.com/code-ready/machine/libmachine/host"
 )
@@ -18,3 +19,27 @@ func newHost(api libmachine.API, machineConfig config.MachineConfig) (*host.Host
 	}
 	return api.NewHost("libvirt", constants.CrcBinDir, json)
 }
+
+/* FIXME: host.Host is only known here, and libvirt.Driver is only accessible
+ * in libvirt/driver_linux.go
+ */
+func loadDriverConfig(host *host.Host) (*machineLibvirt.Driver, error) {
+	var libvirtDriver machineLibvirt.Driver
+	err := json.Unmarshal(host.RawDriver, &libvirtDriver)
+
+	return &libvirtDriver, err
+}
+
+func updateDriverConfig(host *host.Host, driver *machineLibvirt.Driver) error {
+	driverData, err := json.Marshal(driver)
+	if err != nil {
+		return err
+	}
+	return host.UpdateConfig(driverData)
+}
+
+/*
+func (r *RPCServerDriver) SetConfigRaw(data []byte, _ *struct{}) error {
+	return json.Unmarshal(data, &r.ActualDriver)
+}
+*/

--- a/pkg/crc/machine/driver_windows.go
+++ b/pkg/crc/machine/driver_windows.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/code-ready/crc/pkg/crc/machine/config"
 	"github.com/code-ready/crc/pkg/crc/machine/hyperv"
+	machineHyperv "github.com/code-ready/machine/drivers/hyperv"
 	"github.com/code-ready/machine/libmachine"
 	"github.com/code-ready/machine/libmachine/host"
 )
@@ -16,4 +17,19 @@ func newHost(api libmachine.API, machineConfig config.MachineConfig) (*host.Host
 		return nil, errors.New("Failed to marshal driver options")
 	}
 	return api.NewHost("hyperv", "", json)
+}
+
+func loadDriverConfig(host *host.Host) (*machineHyperv.Driver, error) {
+	var hypervDriver machineHyperv.Driver
+	err := json.Unmarshal(host.RawDriver, &hypervDriver)
+
+	return &hypervDriver, err
+}
+
+func updateDriverConfig(host *host.Host, driver *machineHyperv.Driver) error {
+	driverData, err := json.Marshal(driver)
+	if err != nil {
+		return err
+	}
+	return host.UpdateConfig(driverData)
 }

--- a/pkg/crc/machine/hyperkit/driver_darwin.go
+++ b/pkg/crc/machine/hyperkit/driver_darwin.go
@@ -11,16 +11,12 @@ import (
 func CreateHost(machineConfig config.MachineConfig) *hyperkit.Driver {
 	hyperkitDriver := hyperkit.NewDriver(machineConfig.Name, constants.MachineBaseDir)
 
-	hyperkitDriver.BundleName = machineConfig.BundleName
-	hyperkitDriver.Memory = machineConfig.Memory
-	hyperkitDriver.CPU = machineConfig.CPUs
+	config.InitVMDriverFromMachineConfig(machineConfig, hyperkitDriver.VMDriver)
+
 	hyperkitDriver.UUID = "c3d68012-0208-11ea-9fd7-f2189899ab08"
 	hyperkitDriver.Cmdline = machineConfig.KernelCmdLine
 	hyperkitDriver.VmlinuzPath = machineConfig.Kernel
 	hyperkitDriver.InitrdPath = machineConfig.Initramfs
-	hyperkitDriver.ImageSourcePath = machineConfig.ImageSourcePath
-	hyperkitDriver.ImageFormat = machineConfig.ImageFormat
-	hyperkitDriver.SSHKeyPath = machineConfig.SSHKeyPath
 	hyperkitDriver.HyperKitPath = filepath.Join(constants.CrcBinDir, "hyperkit")
 
 	return hyperkitDriver

--- a/pkg/crc/machine/hyperv/driver_windows.go
+++ b/pkg/crc/machine/hyperv/driver_windows.go
@@ -12,20 +12,12 @@ import (
 func CreateHost(machineConfig config.MachineConfig) *hyperv.Driver {
 	hypervDriver := hyperv.NewDriver(machineConfig.Name, constants.MachineBaseDir)
 
-	hypervDriver.CPU = machineConfig.CPUs
-	hypervDriver.BundleName = machineConfig.BundleName
+	config.InitVMDriverFromMachineConfig(machineConfig, hypervDriver.VMDriver)
 
-	// memory related settings
 	hypervDriver.DisableDynamicMemory = true
-	hypervDriver.Memory = machineConfig.Memory
 
-	// Determine the Virtual Switch to be used
 	_, switchName := winnet.SelectSwitchByNameOrDefault(AlternativeNetwork)
 	hypervDriver.VirtualSwitch = switchName
-
-	hypervDriver.ImageSourcePath = machineConfig.ImageSourcePath
-	hypervDriver.ImageFormat = machineConfig.ImageFormat
-	hypervDriver.SSHKeyPath = machineConfig.SSHKeyPath
 
 	return hypervDriver
 }

--- a/pkg/crc/machine/libvirt/driver_linux.go
+++ b/pkg/crc/machine/libvirt/driver_linux.go
@@ -9,13 +9,9 @@ import (
 func CreateHost(machineConfig config.MachineConfig) *libvirt.Driver {
 	libvirtDriver := libvirt.NewDriver(machineConfig.Name, constants.MachineBaseDir)
 
-	libvirtDriver.CPU = machineConfig.CPUs
-	libvirtDriver.Memory = machineConfig.Memory
-	libvirtDriver.BundleName = machineConfig.BundleName
+	config.InitVMDriverFromMachineConfig(machineConfig, libvirtDriver.VMDriver)
+
 	libvirtDriver.Network = DefaultNetwork
-	libvirtDriver.ImageSourcePath = machineConfig.ImageSourcePath
-	libvirtDriver.ImageFormat = machineConfig.ImageFormat
-	libvirtDriver.SSHKeyPath = machineConfig.SSHKeyPath
 
 	return libvirtDriver
 }


### PR DESCRIPTION
**Fixes:** Issue #N

**Relates to:** Issue #127 , https://github.com/code-ready/machine-driver-libvirt/pull/53 https://github.com/code-ready/machine/pull/39

## Solution/Idea

Once all these PRs are in, it will be possible to change the memory allocated to a CRC instance each time `crc start` is called, through the already existing `--memory` argument.

## Proposed changes

The only user-visible change is that  `--memory` works for stopped VMs, while before it would only work if the VM was not already existing. This is done through the introduction of a `host.UpdateConfig` helper in `libmachine`, which makes use of a new `UpdateConfigRaw` method in machine drivers.

## Testing

(I forgot to update/add integration tests for this...)

1. `start` succeeds first time after `setup` succeeded
2. `stop` succeeds
3. `start --memory 12000` succeeds 
4. `virsh -c qemu:///system dominfo crc` reports 12GB memory for the CRC VM
