### PR TITLE
Better display MultiError when errors are the same

### DIFF
--- a/pkg/crc/api/handlers.go
+++ b/pkg/crc/api/handlers.go
@@ -114,7 +114,7 @@ func setConfigHandler(_ machine.Client, args json.RawMessage) string {
 	}
 
 	if len(multiError.Errors) != 0 {
-		setConfigResult.Error = fmt.Sprintf("%v", multiError.ToError())
+		setConfigResult.Error = fmt.Sprintf("%v", multiError)
 	}
 
 	setConfigResult.Properties = successProps
@@ -155,7 +155,7 @@ func unsetConfigHandler(_ machine.Client, args json.RawMessage) string {
 		successProps = append(successProps, key)
 	}
 	if len(multiError.Errors) != 0 {
-		unsetConfigResult.Error = fmt.Sprintf("%v", multiError.ToError())
+		unsetConfigResult.Error = fmt.Sprintf("%v", multiError)
 	}
 	unsetConfigResult.Properties = successProps
 	return encodeStructToJSON(unsetConfigResult)

--- a/pkg/crc/errors/multierror.go
+++ b/pkg/crc/errors/multierror.go
@@ -36,7 +36,7 @@ type RetriableError struct {
 }
 
 func (r RetriableError) Error() string {
-	return "Temporary Error: " + r.Err.Error()
+	return "Temporary error: " + r.Err.Error()
 }
 
 // RetryAfter retries a number of attempts, after a delay

--- a/pkg/crc/errors/multierror.go
+++ b/pkg/crc/errors/multierror.go
@@ -12,22 +12,43 @@ type MultiError struct {
 	Errors []error
 }
 
+func (m MultiError) Error() string {
+	if len(m.Errors) == 0 {
+		return ""
+	}
+	if len(m.Errors) == 1 {
+		return m.Errors[0].Error()
+	}
+
+	var aggregatedErrors []string
+
+	count := 1
+	current := m.Errors[0].Error()
+	for i := 1; i < len(m.Errors); i++ {
+		if m.Errors[i].Error() == current {
+			count++
+			continue
+		}
+		aggregatedErrors = append(aggregatedErrors, errorWithCount(current, count))
+		count = 1
+		current = m.Errors[i].Error()
+	}
+	aggregatedErrors = append(aggregatedErrors, errorWithCount(current, count))
+
+	return strings.Join(aggregatedErrors, "\n")
+}
+
 func (m *MultiError) Collect(err error) {
 	if err != nil {
 		m.Errors = append(m.Errors, err)
 	}
 }
 
-func (m MultiError) ToError() error {
-	if len(m.Errors) == 0 {
-		return nil
+func errorWithCount(current string, count int) string {
+	if count == 1 {
+		return current
 	}
-
-	errStrings := []string{}
-	for _, err := range m.Errors {
-		errStrings = append(errStrings, err.Error())
-	}
-	return fmt.Errorf(strings.Join(errStrings, "\n"))
+	return fmt.Sprintf("%s (x%d)", current, count)
 }
 
 // RetriableError is an error that can be tried again
@@ -40,26 +61,24 @@ func (r RetriableError) Error() string {
 }
 
 // RetryAfter retries a number of attempts, after a delay
-func RetryAfter(attempts int, callback func() error, d time.Duration) (err error) {
+func RetryAfter(attempts int, callback func() error, d time.Duration) error {
 	m := MultiError{}
 	for i := 0; i < attempts; i++ {
 		if i > 0 {
 			logging.Debugf("retry loop: attempt %d out of %d", i, attempts)
 		}
-		err = callback()
+		err := callback()
 		if err == nil {
 			return nil
 		}
 		m.Collect(err)
 		if _, ok := err.(*RetriableError); !ok {
 			logging.Debugf("non-retriable error: %v", err)
-			return m.ToError()
+			return m
 		}
 		logging.Debugf("error: %v - sleeping %s", err, d)
 		time.Sleep(d)
 	}
-	err = m.ToError()
-
 	logging.Debugf("RetryAfter timeout after %d tries", attempts)
-	return err
+	return m
 }

--- a/pkg/crc/errors/multierror_test.go
+++ b/pkg/crc/errors/multierror_test.go
@@ -33,7 +33,7 @@ func TestRetryAfterMaxAttempts(t *testing.T) {
 		calls++
 		return &RetriableError{Err: errors.New("failed")}
 	}, 0)
-	assert.EqualError(t, ret, "Temporary Error: failed\nTemporary Error: failed\nTemporary Error: failed")
+	assert.EqualError(t, ret, "Temporary error: failed\nTemporary error: failed\nTemporary error: failed")
 	assert.Equal(t, 3, calls)
 }
 

--- a/pkg/crc/errors/multierror_test.go
+++ b/pkg/crc/errors/multierror_test.go
@@ -33,7 +33,7 @@ func TestRetryAfterMaxAttempts(t *testing.T) {
 		calls++
 		return &RetriableError{Err: errors.New("failed")}
 	}, 0)
-	assert.EqualError(t, ret, "Temporary error: failed\nTemporary error: failed\nTemporary error: failed")
+	assert.EqualError(t, ret, "Temporary error: failed (x3)")
 	assert.Equal(t, 3, calls)
 }
 
@@ -48,4 +48,25 @@ func TestRetryAfterSuccessAfterFailures(t *testing.T) {
 	}, 0)
 	assert.NoError(t, ret)
 	assert.Equal(t, 3, calls)
+}
+
+func TestMultiErrorString(t *testing.T) {
+	assert.Equal(t, "Temporary Error: No Pending CSR (x4)", MultiError{
+		Errors: []error{
+			errors.New("Temporary Error: No Pending CSR"),
+			errors.New("Temporary Error: No Pending CSR"),
+			errors.New("Temporary Error: No Pending CSR"),
+			errors.New("Temporary Error: No Pending CSR"),
+		},
+	}.Error())
+
+	assert.Equal(t, "No Pending CSR (x2)\nConnection refused (x2)\nNo Pending CSR", MultiError{
+		Errors: []error{
+			errors.New("No Pending CSR"),
+			errors.New("No Pending CSR"),
+			errors.New("Connection refused"),
+			errors.New("Connection refused"),
+			errors.New("No Pending CSR"),
+		},
+	}.Error())
 }


### PR DESCRIPTION
Before:

```
Failed to renew TLS certificates: please check if a newer CodeReady Containers release is available: Temporary Error: No Pending CSR
Temporary Error: No Pending CSR
Temporary Error: No Pending CSR
Temporary Error: No Pending CSR
Temporary Error: No Pending CSR
Temporary Error: No Pending CSR
Temporary Error: No Pending CSR
Temporary Error: No Pending CSR
Temporary Error: No Pending CSR
...
my console is full :)
``` 

After

```
Failed to renew TLS certificates: please check if a newer CodeReady Containers release is available: Temporary error: No Pending CSR (x37)
Temporary error: ssh command error:
command : oc get csr --context admin --cluster crc --kubeconfig /opt/kubeconfig
err     : exit status 1
output  : The connection to the server api.crc.testing:6443 was refused - did you specify the right host or port?
 (x1)
Temporary error: No Pending CSR (x82)
```

Slightly better as it fits on one screen.