### PR TITLE
Update 'hyperkit' binary to newer version

### DIFF
--- a/cmd/crc-embedder/cmd/embed.go
+++ b/cmd/crc-embedder/cmd/embed.go
@@ -88,7 +88,7 @@ var (
 	dataFileUrls = map[string][]string{
 		"darwin": {
 			hyperkit.MachineDriverDownloadURL,
-			hyperkit.HyperkitDownloadURL,
+			hyperkit.HyperKitDownloadURL,
 			constants.GetOcURLForOs("darwin"),
 			constants.GetCRCMacTrayDownloadURL(),
 			constants.GetGoodhostsURLForOs("darwin"),

--- a/pkg/crc/cache/cache.go
+++ b/pkg/crc/cache/cache.go
@@ -148,12 +148,11 @@ func (c *Cache) CacheBinary() error {
 }
 
 func (c *Cache) getBinary(destDir string) (string, error) {
-	logging.Debug("Trying to extract oc from crc binary")
+	logging.Debugf("Trying to extract %s from crc binary", c.binaryName)
 	archiveName := filepath.Base(c.archiveURL)
 	destPath := filepath.Join(destDir, archiveName)
 	err := embed.Extract(archiveName, destPath)
 	if err != nil {
-		logging.Debug("Downloading oc")
 		return download.Download(c.archiveURL, destDir, 0600)
 	}
 
@@ -170,12 +169,15 @@ func (c *Cache) CheckVersion() error {
 		return err
 	}
 	if currentVersion != c.version {
-		return &VersionMismatchError{
+		err := &VersionMismatchError{
 			BinaryName:      c.binaryName,
 			CurrentVersion:  currentVersion,
 			ExpectedVersion: c.version,
 		}
+		logging.Debugf("%s", err.Error())
+		return err
 	}
+	logging.Debugf("Found %s version %s", c.binaryName, c.version)
 	return nil
 }
 

--- a/pkg/crc/cache/cache.go
+++ b/pkg/crc/cache/cache.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/code-ready/crc/pkg/crc/logging"
+	"github.com/code-ready/crc/pkg/crc/version"
 	"github.com/code-ready/crc/pkg/download"
 	"github.com/code-ready/crc/pkg/embed"
 	"github.com/code-ready/crc/pkg/extract"
@@ -38,16 +39,25 @@ func New(binaryName string, archiveURL string, destDir string, version string, g
 	return &Cache{binaryName: binaryName, archiveURL: archiveURL, destDir: destDir, version: version, getVersion: getVersion}
 }
 
-func NewOcCache(version string, getVersion func() (string, error)) *Cache {
-	return New(constants.OcBinaryName, constants.GetOcURL(), constants.CrcOcBinDir, version, getVersion)
+func getCurrentOcVersion() (string, error) {
+	ocPath := filepath.Join(constants.CrcOcBinDir, constants.OcBinaryName)
+	stdOut, _, err := crcos.RunWithDefaultLocale(ocPath, "version", "--client")
+	if len(strings.Split(stdOut, ":")) < 2 {
+		return "", fmt.Errorf("Unable to parse the version information of %s", ocPath)
+	}
+	return strings.TrimSpace(strings.Split(stdOut, ":")[1]), err
 }
 
-func NewPodmanCache(version string, getVersion func() (string, error)) *Cache {
-	return New(constants.PodmanBinaryName, constants.GetPodmanURL(), constants.CrcBinDir, version, getVersion)
+func NewOcCache() *Cache {
+	return New(constants.OcBinaryName, constants.GetOcURL(), constants.CrcOcBinDir, version.GetOcVersion(), getCurrentOcVersion)
 }
 
-func NewGoodhostsCache(version string, getVersion func() (string, error)) *Cache {
-	return New(constants.GoodhostsBinaryName, constants.GetGoodhostsURL(), constants.CrcBinDir, version, getVersion)
+func NewPodmanCache() *Cache {
+	return New(constants.PodmanBinaryName, constants.GetPodmanURL(), constants.CrcBinDir, "", nil)
+}
+
+func NewGoodhostsCache() *Cache {
+	return New(constants.GoodhostsBinaryName, constants.GetGoodhostsURL(), constants.CrcBinDir, "", nil)
 }
 
 func (c *Cache) IsCached() bool {

--- a/pkg/crc/cache/cache.go
+++ b/pkg/crc/cache/cache.go
@@ -43,8 +43,12 @@ func getCurrentOcVersion(binaryPath string) (string, error) {
 	return getVersionGeneric(binaryPath, "version", "--client")
 }
 
-func (c *Cache) getBinaryPath() string {
+func (c *Cache) GetBinaryPath() string {
 	return filepath.Join(c.destDir, c.binaryName)
+}
+
+func (c *Cache) GetBinaryName() string {
+	return c.binaryName
 }
 
 /* getVersionGeneric runs the cached binary with 'args', and assumes the version string
@@ -75,7 +79,7 @@ func NewGoodhostsCache() *Cache {
 }
 
 func (c *Cache) IsCached() bool {
-	if _, err := os.Stat(filepath.Join(c.destDir, c.binaryName)); os.IsNotExist(err) {
+	if _, err := os.Stat(c.GetBinaryPath()); os.IsNotExist(err) {
 		return false
 	}
 	return true
@@ -161,7 +165,7 @@ func (c *Cache) CheckVersion() error {
 	if c.version == "" {
 		return nil
 	}
-	currentVersion, err := c.getVersion(c.getBinaryPath())
+	currentVersion, err := c.getVersion(c.GetBinaryPath())
 	if err != nil {
 		return err
 	}

--- a/pkg/crc/cache/cache_darwin.go
+++ b/pkg/crc/cache/cache_darwin.go
@@ -1,13 +1,8 @@
 package cache
 
 import (
-	"fmt"
-	"path/filepath"
-	"strings"
-
 	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/code-ready/crc/pkg/crc/machine/hyperkit"
-	crcos "github.com/code-ready/crc/pkg/os"
 )
 
 func NewMachineDriverHyperkitCache() *Cache {
@@ -18,11 +13,6 @@ func NewHyperkitCache() *Cache {
 	return New(hyperkit.HyperkitCommand, hyperkit.HyperkitDownloadURL, constants.CrcBinDir, "", nil)
 }
 
-func getHyperKitMachineDriverVersion() (string, error) {
-	driverBinPath := filepath.Join(constants.CrcBinDir, hyperkit.MachineDriverCommand)
-	stdOut, _, err := crcos.RunWithDefaultLocale(driverBinPath, "version")
-	if len(strings.Split(stdOut, ":")) < 2 {
-		return "", fmt.Errorf("Unable to parse the version information of %s", driverBinPath)
-	}
-	return strings.TrimSpace(strings.Split(stdOut, ":")[1]), err
+func getHyperKitMachineDriverVersion(binaryPath string) (string, error) {
+	return getVersionGeneric(binaryPath, "version")
 }

--- a/pkg/crc/cache/cache_darwin.go
+++ b/pkg/crc/cache/cache_darwin.go
@@ -1,14 +1,28 @@
 package cache
 
 import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
 	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/code-ready/crc/pkg/crc/machine/hyperkit"
+	crcos "github.com/code-ready/crc/pkg/os"
 )
 
-func NewMachineDriverHyperkitCache(version string, getVersion func() (string, error)) *Cache {
-	return New(hyperkit.MachineDriverCommand, hyperkit.MachineDriverDownloadURL, constants.CrcBinDir, version, getVersion)
+func NewMachineDriverHyperkitCache() *Cache {
+	return New(hyperkit.MachineDriverCommand, hyperkit.MachineDriverDownloadURL, constants.CrcBinDir, hyperkit.MachineDriverVersion, getHyperKitMachineDriverVersion)
 }
 
-func NewHyperkitCache(version string, getVersion func() (string, error)) *Cache {
-	return New(hyperkit.HyperkitCommand, hyperkit.HyperkitDownloadURL, constants.CrcBinDir, version, getVersion)
+func NewHyperkitCache() *Cache {
+	return New(hyperkit.HyperkitCommand, hyperkit.HyperkitDownloadURL, constants.CrcBinDir, "", nil)
+}
+
+func getHyperKitMachineDriverVersion() (string, error) {
+	driverBinPath := filepath.Join(constants.CrcBinDir, hyperkit.MachineDriverCommand)
+	stdOut, _, err := crcos.RunWithDefaultLocale(driverBinPath, "version")
+	if len(strings.Split(stdOut, ":")) < 2 {
+		return "", fmt.Errorf("Unable to parse the version information of %s", driverBinPath)
+	}
+	return strings.TrimSpace(strings.Split(stdOut, ":")[1]), err
 }

--- a/pkg/crc/cache/cache_darwin.go
+++ b/pkg/crc/cache/cache_darwin.go
@@ -5,12 +5,12 @@ import (
 	"github.com/code-ready/crc/pkg/crc/machine/hyperkit"
 )
 
-func NewMachineDriverHyperkitCache() *Cache {
+func NewMachineDriverHyperKitCache() *Cache {
 	return New(hyperkit.MachineDriverCommand, hyperkit.MachineDriverDownloadURL, constants.CrcBinDir, hyperkit.MachineDriverVersion, getHyperKitMachineDriverVersion)
 }
 
-func NewHyperkitCache() *Cache {
-	return New(hyperkit.HyperkitCommand, hyperkit.HyperkitDownloadURL, constants.CrcBinDir, "", nil)
+func NewHyperKitCache() *Cache {
+	return New(hyperkit.HyperKitCommand, hyperkit.HyperKitDownloadURL, constants.CrcBinDir, "", nil)
 }
 
 func getHyperKitMachineDriverVersion(binaryPath string) (string, error) {

--- a/pkg/crc/cache/cache_darwin.go
+++ b/pkg/crc/cache/cache_darwin.go
@@ -1,8 +1,14 @@
 package cache
 
 import (
+	"bufio"
+	"fmt"
+	"io"
+	"strings"
+
 	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/code-ready/crc/pkg/crc/machine/hyperkit"
+	crcos "github.com/code-ready/crc/pkg/os"
 )
 
 func NewMachineDriverHyperKitCache() *Cache {
@@ -10,9 +16,38 @@ func NewMachineDriverHyperKitCache() *Cache {
 }
 
 func NewHyperKitCache() *Cache {
-	return New(hyperkit.HyperKitCommand, hyperkit.HyperKitDownloadURL, constants.CrcBinDir, "", nil)
+	return New(hyperkit.HyperKitCommand, hyperkit.HyperKitDownloadURL, constants.CrcBinDir, hyperkit.HyperKitVersion, getHyperKitVersion)
 }
 
 func getHyperKitMachineDriverVersion(binaryPath string) (string, error) {
 	return getVersionGeneric(binaryPath, "version")
+}
+
+/* This is very similar to cache.getVersionGeneric, except that it's reading from stderr instead of
+ * stdout, and it needs to deal with multiline output
+ */
+func getHyperKitVersion(binaryPath string) (string, error) {
+	_, stderr, err := crcos.RunWithDefaultLocale(binaryPath, "-v")
+	if err != nil {
+		return "", err
+	}
+	stderr, err = getFirstLine(stderr)
+	if err != nil {
+		return "", err
+	}
+	parsedOutput := strings.Split(stderr, ":")
+	if len(parsedOutput) < 2 {
+		return "", fmt.Errorf("Unable to parse the version information of %s", binaryPath)
+	}
+	return strings.TrimSpace(parsedOutput[1]), err
+}
+
+func getFirstLine(s string) (line string, err error) {
+	reader := bufio.NewReader(strings.NewReader(s))
+	line, err = reader.ReadString('\n')
+	if err != nil && err != io.EOF {
+		return "", err
+	}
+
+	return line, nil
 }

--- a/pkg/crc/cache/cache_linux.go
+++ b/pkg/crc/cache/cache_linux.go
@@ -1,10 +1,24 @@
 package cache
 
 import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
 	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/code-ready/crc/pkg/crc/machine/libvirt"
+	crcos "github.com/code-ready/crc/pkg/os"
 )
 
-func NewMachineDriverLibvirtCache(version string, getVersion func() (string, error)) *Cache {
-	return New(libvirt.MachineDriverCommand, libvirt.MachineDriverDownloadURL, constants.CrcBinDir, version, getVersion)
+func NewMachineDriverLibvirtCache() *Cache {
+	return New(libvirt.MachineDriverCommand, libvirt.MachineDriverDownloadURL, constants.CrcBinDir, libvirt.MachineDriverVersion, getCurrentLibvirtDriverVersion)
+}
+
+func getCurrentLibvirtDriverVersion() (string, error) {
+	driverBinPath := filepath.Join(constants.CrcBinDir, libvirt.MachineDriverCommand)
+	stdOut, _, err := crcos.RunWithDefaultLocale(driverBinPath, "version")
+	if len(strings.Split(stdOut, ":")) < 2 {
+		return "", fmt.Errorf("Unable to parse the version information of %s", driverBinPath)
+	}
+	return strings.TrimSpace(strings.Split(stdOut, ":")[1]), err
 }

--- a/pkg/crc/cache/cache_linux.go
+++ b/pkg/crc/cache/cache_linux.go
@@ -1,24 +1,14 @@
 package cache
 
 import (
-	"fmt"
-	"path/filepath"
-	"strings"
-
 	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/code-ready/crc/pkg/crc/machine/libvirt"
-	crcos "github.com/code-ready/crc/pkg/os"
 )
 
 func NewMachineDriverLibvirtCache() *Cache {
 	return New(libvirt.MachineDriverCommand, libvirt.MachineDriverDownloadURL, constants.CrcBinDir, libvirt.MachineDriverVersion, getCurrentLibvirtDriverVersion)
 }
 
-func getCurrentLibvirtDriverVersion() (string, error) {
-	driverBinPath := filepath.Join(constants.CrcBinDir, libvirt.MachineDriverCommand)
-	stdOut, _, err := crcos.RunWithDefaultLocale(driverBinPath, "version")
-	if len(strings.Split(stdOut, ":")) < 2 {
-		return "", fmt.Errorf("Unable to parse the version information of %s", driverBinPath)
-	}
-	return strings.TrimSpace(strings.Split(stdOut, ":")[1]), err
+func getCurrentLibvirtDriverVersion(binaryPath string) (string, error) {
+	return getVersionGeneric(binaryPath, "version")
 }

--- a/pkg/crc/machine/config/config.go
+++ b/pkg/crc/machine/config/config.go
@@ -12,7 +12,7 @@ type MachineConfig struct {
 	DiskPathURL string
 	SSHKeyPath  string
 
-	// Hyperkit specific configuration
+	// HyperKit specific configuration
 	KernelCmdLine string
 	Initramfs     string
 	Kernel        string

--- a/pkg/crc/machine/hyperkit/constants.go
+++ b/pkg/crc/machine/hyperkit/constants.go
@@ -7,10 +7,10 @@ import "fmt"
 const (
 	MachineDriverCommand = "crc-driver-hyperkit"
 	MachineDriverVersion = "0.12.7"
-	HyperkitCommand      = "hyperkit"
+	HyperKitCommand      = "hyperkit"
 )
 
 var (
-	HyperkitDownloadURL      = fmt.Sprintf("https://github.com/code-ready/machine-driver-hyperkit/releases/download/v%s/hyperkit", MachineDriverVersion)
+	HyperKitDownloadURL      = fmt.Sprintf("https://github.com/code-ready/machine-driver-hyperkit/releases/download/v%s/hyperkit", MachineDriverVersion)
 	MachineDriverDownloadURL = fmt.Sprintf("https://github.com/code-ready/machine-driver-hyperkit/releases/download/v%s/crc-driver-hyperkit", MachineDriverVersion)
 )

--- a/pkg/crc/machine/hyperkit/constants.go
+++ b/pkg/crc/machine/hyperkit/constants.go
@@ -8,6 +8,7 @@ const (
 	MachineDriverCommand = "crc-driver-hyperkit"
 	MachineDriverVersion = "0.12.7"
 	HyperKitCommand      = "hyperkit"
+	HyperKitVersion      = "v0.20180403-36-ge3b37f"
 )
 
 var (

--- a/pkg/crc/preflight/preflight_checks_common.go
+++ b/pkg/crc/preflight/preflight_checks_common.go
@@ -120,21 +120,19 @@ func fixPodmanBinaryCached() error {
 
 // Check if goodhost binary is cached or not
 func checkGoodhostsBinaryCached() error {
-	goodhostPath := filepath.Join(constants.CrcBinDir, constants.GoodhostsBinaryName)
 	goodhost := cache.NewGoodhostsCache()
 	if !goodhost.IsCached() {
 		return errors.New("goodhost binary is not cached")
 	}
 	logging.Debug("goodhost binary already cached")
-	return checkSuid(goodhostPath)
+	return checkSuid(goodhost.GetBinaryPath())
 }
 
 func fixGoodhostsBinaryCached() error {
-	goodhostPath := filepath.Join(constants.CrcBinDir, constants.GoodhostsBinaryName)
 	goodhost := cache.NewGoodhostsCache()
 	if err := goodhost.EnsureIsCached(); err != nil {
 		return fmt.Errorf("Unable to download goodhost binary %v", err)
 	}
 	logging.Debug("goodhost binary cached")
-	return setSuid(goodhostPath)
+	return setSuid(goodhost.GetBinaryPath())
 }

--- a/pkg/crc/preflight/preflight_checks_common.go
+++ b/pkg/crc/preflight/preflight_checks_common.go
@@ -5,15 +5,12 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/code-ready/crc/pkg/crc/cache"
 	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/code-ready/crc/pkg/crc/logging"
 	"github.com/code-ready/crc/pkg/crc/validation"
-	"github.com/code-ready/crc/pkg/crc/version"
 	"github.com/code-ready/crc/pkg/embed"
-	crcos "github.com/code-ready/crc/pkg/os"
 	"github.com/docker/go-units"
 )
 
@@ -85,7 +82,7 @@ func checkOcBinaryCached() error {
 	// We should remove this code after 3-4 releases. (after 2020-07-10)
 	os.Remove(filepath.Join(constants.CrcBinDir, "oc"))
 
-	oc := cache.NewOcCache(version.GetOcVersion(), getCurrentOcversion)
+	oc := cache.NewOcCache()
 	if !oc.IsCached() {
 		return errors.New("oc binary is not cached")
 	}
@@ -97,7 +94,7 @@ func checkOcBinaryCached() error {
 }
 
 func fixOcBinaryCached() error {
-	oc := cache.NewOcCache(version.GetOcVersion(), getCurrentOcversion)
+	oc := cache.NewOcCache()
 	if err := oc.EnsureIsCached(); err != nil {
 		return fmt.Errorf("Unable to download oc %v", err)
 	}
@@ -113,7 +110,7 @@ func checkPodmanBinaryCached() error {
 }
 
 func fixPodmanBinaryCached() error {
-	podman := cache.NewPodmanCache("", nil)
+	podman := cache.NewPodmanCache()
 	if err := podman.EnsureIsCached(); err != nil {
 		return fmt.Errorf("Unable to download podman remote binary %v", err)
 	}
@@ -124,7 +121,7 @@ func fixPodmanBinaryCached() error {
 // Check if goodhost binary is cached or not
 func checkGoodhostsBinaryCached() error {
 	goodhostPath := filepath.Join(constants.CrcBinDir, constants.GoodhostsBinaryName)
-	goodhost := cache.NewGoodhostsCache("", nil)
+	goodhost := cache.NewGoodhostsCache()
 	if !goodhost.IsCached() {
 		return errors.New("goodhost binary is not cached")
 	}
@@ -134,19 +131,10 @@ func checkGoodhostsBinaryCached() error {
 
 func fixGoodhostsBinaryCached() error {
 	goodhostPath := filepath.Join(constants.CrcBinDir, constants.GoodhostsBinaryName)
-	goodhost := cache.NewGoodhostsCache("", nil)
+	goodhost := cache.NewGoodhostsCache()
 	if err := goodhost.EnsureIsCached(); err != nil {
 		return fmt.Errorf("Unable to download goodhost binary %v", err)
 	}
 	logging.Debug("goodhost binary cached")
 	return setSuid(goodhostPath)
-}
-
-func getCurrentOcversion() (string, error) {
-	ocPath := filepath.Join(constants.CrcOcBinDir, constants.OcBinaryName)
-	stdOut, _, err := crcos.RunWithDefaultLocale(ocPath, "version", "--client")
-	if len(strings.Split(stdOut, ":")) < 2 {
-		return "", fmt.Errorf("Unable to parse the version information of %s", ocPath)
-	}
-	return strings.TrimSpace(strings.Split(stdOut, ":")[1]), err
 }

--- a/pkg/crc/preflight/preflight_checks_darwin.go
+++ b/pkg/crc/preflight/preflight_checks_darwin.go
@@ -4,12 +4,9 @@ import (
 	"fmt"
 	"os"
 	"os/user"
-	"path/filepath"
 
 	"github.com/code-ready/crc/pkg/crc/cache"
-	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/code-ready/crc/pkg/crc/logging"
-	"github.com/code-ready/crc/pkg/crc/machine/hyperkit"
 	crcos "github.com/code-ready/crc/pkg/os"
 	"golang.org/x/sys/unix"
 )
@@ -23,9 +20,9 @@ const (
 func checkHyperKitInstalled() error {
 	h := cache.NewHyperkitCache()
 	if !h.IsCached() {
-		return fmt.Errorf("%s binary is not cached", hyperkit.HyperkitCommand)
+		return fmt.Errorf("%s binary is not cached", h.GetBinaryName())
 	}
-	hyperkitPath := filepath.Join(constants.CrcBinDir, hyperkit.HyperkitCommand)
+	hyperkitPath := h.GetBinaryPath()
 	err := unix.Access(hyperkitPath, unix.X_OK)
 	if err != nil {
 		return fmt.Errorf("%s not executable", hyperkitPath)
@@ -34,34 +31,40 @@ func checkHyperKitInstalled() error {
 }
 
 func fixHyperKitInstallation() error {
-	logging.Debugf("Installing %s", hyperkit.HyperkitCommand)
 	h := cache.NewHyperkitCache()
+
+	logging.Debugf("Installing %s", h.GetBinaryName())
+
 	if err := h.EnsureIsCached(); err != nil {
-		return fmt.Errorf("Unable to download %s : %v", hyperkit.HyperkitCommand, err)
+		return fmt.Errorf("Unable to download %s : %v", h.GetBinaryName(), err)
 	}
-	return setSuid(filepath.Join(constants.CrcBinDir, hyperkit.HyperkitCommand))
+	return setSuid(h.GetBinaryPath())
 }
 
 func checkMachineDriverHyperKitInstalled() error {
-	logging.Debugf("Checking if %s is installed", hyperkit.MachineDriverCommand)
 	hyperkitDriver := cache.NewMachineDriverHyperkitCache()
+
+	logging.Debugf("Checking if %s is installed", hyperkitDriver.GetBinaryName())
+
 	if !hyperkitDriver.IsCached() {
-		return fmt.Errorf("%s binary is not cached", hyperkit.MachineDriverCommand)
+		return fmt.Errorf("%s binary is not cached", hyperkitDriver.GetBinaryName())
 	}
 
 	if err := hyperkitDriver.CheckVersion(); err != nil {
 		return err
 	}
-	return checkSuid(filepath.Join(constants.CrcBinDir, hyperkit.MachineDriverCommand))
+	return checkSuid(hyperkitDriver.GetBinaryPath())
 }
 
 func fixMachineDriverHyperKitInstalled() error {
-	logging.Debugf("Installing %s", hyperkit.MachineDriverCommand)
 	hyperkitDriver := cache.NewMachineDriverHyperkitCache()
+
+	logging.Debugf("Installing %s", hyperkitDriver.GetBinaryName())
+
 	if err := hyperkitDriver.EnsureIsCached(); err != nil {
-		return fmt.Errorf("Unable to download %s : %v", hyperkit.MachineDriverCommand, err)
+		return fmt.Errorf("Unable to download %s : %v", hyperkitDriver.GetBinaryName(), err)
 	}
-	return setSuid(filepath.Join(constants.CrcBinDir, hyperkit.MachineDriverCommand))
+	return setSuid(hyperkitDriver.GetBinaryPath())
 }
 
 func checkEtcHostsFilePermissions() error {

--- a/pkg/crc/preflight/preflight_checks_darwin.go
+++ b/pkg/crc/preflight/preflight_checks_darwin.go
@@ -27,6 +27,9 @@ func checkHyperKitInstalled() error {
 	if err != nil {
 		return fmt.Errorf("%s not executable", hyperkitPath)
 	}
+	if err := h.CheckVersion(); err != nil {
+		return err
+	}
 	return checkSuid(hyperkitPath)
 }
 

--- a/pkg/crc/preflight/preflight_checks_darwin.go
+++ b/pkg/crc/preflight/preflight_checks_darwin.go
@@ -18,7 +18,7 @@ const (
 )
 
 func checkHyperKitInstalled() error {
-	h := cache.NewHyperkitCache()
+	h := cache.NewHyperKitCache()
 	if !h.IsCached() {
 		return fmt.Errorf("%s binary is not cached", h.GetBinaryName())
 	}
@@ -31,7 +31,7 @@ func checkHyperKitInstalled() error {
 }
 
 func fixHyperKitInstallation() error {
-	h := cache.NewHyperkitCache()
+	h := cache.NewHyperKitCache()
 
 	logging.Debugf("Installing %s", h.GetBinaryName())
 
@@ -42,10 +42,9 @@ func fixHyperKitInstallation() error {
 }
 
 func checkMachineDriverHyperKitInstalled() error {
-	hyperkitDriver := cache.NewMachineDriverHyperkitCache()
+	hyperkitDriver := cache.NewMachineDriverHyperKitCache()
 
 	logging.Debugf("Checking if %s is installed", hyperkitDriver.GetBinaryName())
-
 	if !hyperkitDriver.IsCached() {
 		return fmt.Errorf("%s binary is not cached", hyperkitDriver.GetBinaryName())
 	}
@@ -57,7 +56,7 @@ func checkMachineDriverHyperKitInstalled() error {
 }
 
 func fixMachineDriverHyperKitInstalled() error {
-	hyperkitDriver := cache.NewMachineDriverHyperkitCache()
+	hyperkitDriver := cache.NewMachineDriverHyperKitCache()
 
 	logging.Debugf("Installing %s", hyperkitDriver.GetBinaryName())
 

--- a/pkg/crc/preflight/preflight_checks_darwin.go
+++ b/pkg/crc/preflight/preflight_checks_darwin.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
-	"strings"
 
 	"github.com/code-ready/crc/pkg/crc/cache"
 	"github.com/code-ready/crc/pkg/crc/constants"
@@ -22,7 +21,7 @@ const (
 )
 
 func checkHyperKitInstalled() error {
-	h := cache.NewHyperkitCache("", nil)
+	h := cache.NewHyperkitCache()
 	if !h.IsCached() {
 		return fmt.Errorf("%s binary is not cached", hyperkit.HyperkitCommand)
 	}
@@ -36,7 +35,7 @@ func checkHyperKitInstalled() error {
 
 func fixHyperKitInstallation() error {
 	logging.Debugf("Installing %s", hyperkit.HyperkitCommand)
-	h := cache.NewHyperkitCache("", nil)
+	h := cache.NewHyperkitCache()
 	if err := h.EnsureIsCached(); err != nil {
 		return fmt.Errorf("Unable to download %s : %v", hyperkit.HyperkitCommand, err)
 	}
@@ -45,7 +44,7 @@ func fixHyperKitInstallation() error {
 
 func checkMachineDriverHyperKitInstalled() error {
 	logging.Debugf("Checking if %s is installed", hyperkit.MachineDriverCommand)
-	hyperkitDriver := cache.NewMachineDriverHyperkitCache(hyperkit.MachineDriverVersion, getHyperKitMachineDriverVersion)
+	hyperkitDriver := cache.NewMachineDriverHyperkitCache()
 	if !hyperkitDriver.IsCached() {
 		return fmt.Errorf("%s binary is not cached", hyperkit.MachineDriverCommand)
 	}
@@ -58,7 +57,7 @@ func checkMachineDriverHyperKitInstalled() error {
 
 func fixMachineDriverHyperKitInstalled() error {
 	logging.Debugf("Installing %s", hyperkit.MachineDriverCommand)
-	hyperkitDriver := cache.NewMachineDriverHyperkitCache(hyperkit.MachineDriverVersion, getHyperKitMachineDriverVersion)
+	hyperkitDriver := cache.NewMachineDriverHyperkitCache()
 	if err := hyperkitDriver.EnsureIsCached(); err != nil {
 		return fmt.Errorf("Unable to download %s : %v", hyperkit.MachineDriverCommand, err)
 	}
@@ -156,13 +155,4 @@ func addFileWritePermissionToUser(filename string) error {
 	logging.Debugf("%s is readable/writable by current user", filename)
 
 	return nil
-}
-
-func getHyperKitMachineDriverVersion() (string, error) {
-	driverBinPath := filepath.Join(constants.CrcBinDir, hyperkit.MachineDriverCommand)
-	stdOut, _, err := crcos.RunWithDefaultLocale(driverBinPath, "version")
-	if len(strings.Split(stdOut, ":")) < 2 {
-		return "", fmt.Errorf("Unable to parse the version information of %s", driverBinPath)
-	}
-	return strings.TrimSpace(strings.Split(stdOut, ":")[1]), err
 }

--- a/pkg/crc/preflight/preflight_checks_linux.go
+++ b/pkg/crc/preflight/preflight_checks_linux.go
@@ -219,7 +219,7 @@ func fixLibvirtServiceRunning() error {
 func checkMachineDriverLibvirtInstalled() error {
 	logging.Debugf("Checking if %s is installed", libvirt.MachineDriverCommand)
 
-	machineDriverLibvirt := cache.NewMachineDriverLibvirtCache(libvirt.MachineDriverVersion, getCurrentLibvirtDriverVersion)
+	machineDriverLibvirt := cache.NewMachineDriverLibvirtCache()
 	if !machineDriverLibvirt.IsCached() {
 		return fmt.Errorf("%s binary is not cached", libvirt.MachineDriverCommand)
 	}
@@ -232,7 +232,7 @@ func checkMachineDriverLibvirtInstalled() error {
 
 func fixMachineDriverLibvirtInstalled() error {
 	logging.Debugf("Installing %s", libvirt.MachineDriverCommand)
-	machineDriverLibvirt := cache.NewMachineDriverLibvirtCache(libvirt.MachineDriverVersion, getCurrentLibvirtDriverVersion)
+	machineDriverLibvirt := cache.NewMachineDriverLibvirtCache()
 	if err := machineDriverLibvirt.EnsureIsCached(); err != nil {
 		return fmt.Errorf("Unable to download %s: %v", libvirt.MachineDriverCommand, err)
 	}
@@ -603,15 +603,6 @@ func checkNetworkManagerIsRunning() error {
 
 func fixNetworkManagerIsRunning() error {
 	return fmt.Errorf("NetworkManager is required. Please make sure it is installed and running manually")
-}
-
-func getCurrentLibvirtDriverVersion() (string, error) {
-	driverBinPath := filepath.Join(constants.CrcBinDir, libvirt.MachineDriverCommand)
-	stdOut, _, err := crcos.RunWithDefaultLocale(driverBinPath, "version")
-	if len(strings.Split(stdOut, ":")) < 2 {
-		return "", fmt.Errorf("Unable to parse the version information of %s", driverBinPath)
-	}
-	return strings.TrimSpace(strings.Split(stdOut, ":")[1]), err
 }
 
 func getCPUFlags() (string, error) {

--- a/pkg/crc/preflight/preflight_checks_linux.go
+++ b/pkg/crc/preflight/preflight_checks_linux.go
@@ -217,26 +217,29 @@ func fixLibvirtServiceRunning() error {
 }
 
 func checkMachineDriverLibvirtInstalled() error {
-	logging.Debugf("Checking if %s is installed", libvirt.MachineDriverCommand)
-
 	machineDriverLibvirt := cache.NewMachineDriverLibvirtCache()
+
+	logging.Debugf("Checking if %s is installed", machineDriverLibvirt.GetBinaryName())
+
 	if !machineDriverLibvirt.IsCached() {
-		return fmt.Errorf("%s binary is not cached", libvirt.MachineDriverCommand)
+		return fmt.Errorf("%s binary is not cached", machineDriverLibvirt.GetBinaryName())
 	}
 	if err := machineDriverLibvirt.CheckVersion(); err != nil {
 		return err
 	}
-	logging.Debugf("%s is already installed", libvirt.MachineDriverCommand)
+	logging.Debugf("%s is already installed", machineDriverLibvirt.GetBinaryName())
 	return nil
 }
 
 func fixMachineDriverLibvirtInstalled() error {
-	logging.Debugf("Installing %s", libvirt.MachineDriverCommand)
 	machineDriverLibvirt := cache.NewMachineDriverLibvirtCache()
+
+	logging.Debugf("Installing %s", machineDriverLibvirt.GetBinaryName())
+
 	if err := machineDriverLibvirt.EnsureIsCached(); err != nil {
-		return fmt.Errorf("Unable to download %s: %v", libvirt.MachineDriverCommand, err)
+		return fmt.Errorf("Unable to download %s: %v", machineDriverLibvirt.GetBinaryName(), err)
 	}
-	logging.Debugf("%s is installed in %s", libvirt.MachineDriverCommand, constants.CrcBinDir)
+	logging.Debugf("%s is installed in %s", machineDriverLibvirt.GetBinaryName(), filepath.Dir(machineDriverLibvirt.GetBinaryPath()))
 	return nil
 }
 


### PR DESCRIPTION
## Solution/Idea

This PR does some refactoring of the cache/versioning code, and then adds version checks for the hyperkit binary before updating it to a newer version.

## Proposed changes

List main as well as consequential changes you introduced or had to introduce.

1. machine drivers/oc/goodhosts caching code is refactored, but there should not be any user-visible changes (apart from slightly different debug output)
2. hyperkit binary is upgraded from `v0.20180403-36-ge3b37f` to `v0.20200224-44-gb54460`
4. ...

## Testing

What is the _bottom-line_ functionality that needs testing? Describe in pseudo-code or in English. Use verifiable statements that tie your changes to existing functionality.

1. Check that caching (including older version upgrades) of machine drivers/oc/goodhosts did not regress
2. Check that hyperkit is upgraded to a newer version after `crc setup` (won't work as expected at the moment as the newer binary is not uploaded yet to gtihub.com)