### PR TITLE
Rework cert renewal process

### DIFF
--- a/pkg/crc/cluster/cert-renewal.go
+++ b/pkg/crc/cluster/cert-renewal.go
@@ -5,52 +5,64 @@ import (
 	"strings"
 	"time"
 
-	"github.com/code-ready/crc/pkg/crc/errors"
+	crcerrors "github.com/code-ready/crc/pkg/crc/errors"
 	"github.com/code-ready/crc/pkg/crc/logging"
 	"github.com/code-ready/crc/pkg/crc/oc"
+	"github.com/code-ready/crc/pkg/crc/ssh"
 )
 
-func waitForPendingCsrs(ocConfig oc.Config, signerName string) error {
-	waitForPendingCsr := func() error {
+func waitForPendingCSRs(ocConfig oc.Config, signerName string) error {
+	return crcerrors.RetryAfter(8*time.Minute, func() error {
 		output, _, err := ocConfig.RunOcCommand("get", "csr")
 		if err != nil {
-			return &errors.RetriableError{Err: err}
+			return &crcerrors.RetriableError{Err: err}
 		}
 		if strings.Contains(output, "Pending") && strings.Contains(output, signerName) {
 			return nil
 		}
-		return &errors.RetriableError{Err: fmt.Errorf("No Pending CSR with signerName %s", signerName)}
-	}
-
-	return errors.RetryAfter(8*time.Minute, waitForPendingCsr, time.Second*5)
+		return &crcerrors.RetriableError{Err: fmt.Errorf("No Pending CSR with signerName %s", signerName)}
+	}, time.Second*5)
 }
 
-func WaitAndApprovePendingCSRs(ocConfig oc.Config, client, server bool) error {
-	/* 2 CSRs to approve, one right after kubelet restart, the other one a few dozen seconds after
-	approving the first one
-	- First one is requested by system:serviceaccount:openshift-machine-config-operator:node-bootstrapper
-	- Second one is requested by system:node:<node_name> */
+func ApproveCSRAndWaitForCertsRenewal(sshRunner *ssh.Runner, ocConfig oc.Config, client, server bool) error {
+	// First, kubelet starts and tries to connect to API server. If its certificate is expired, it asks for a new one
+	// Admin needs to approve it. The Kubernetes controller manager will then issue the cert, kubelet will fetch it and use it.
+	// Kubelet stores the cert in /var/lib/kubelet/pki/kubelet-client-current.pem
 	if client {
 		logging.Info("Kubelet client certificate has expired, renewing it... [will take up to 8 minutes]")
-		if err := waitForPendingCsrs(ocConfig, "kubernetes.io/kube-apiserver-client-kubelet"); err != nil {
+		if err := waitForPendingCSRs(ocConfig, kubeletClientSignerName); err != nil {
 			logging.Debugf("Error waiting for pending kube-apiserver-client-kubelet CSR: %v", err)
 			return err
 		}
-		if err := ApproveNodeCSR(ocConfig, "kubernetes.io/kube-apiserver-client-kubelet"); err != nil {
+		if err := approveNodeCSR(ocConfig, kubeletClientSignerName); err != nil {
+			logging.Debugf("Error approving pending kube-apiserver-client-kubelet CSR: %v", err)
+			return err
+		}
+		if err := crcerrors.RetryAfter(5*time.Minute, waitForCertRenewal(sshRunner, kubeletClientCert), time.Second*5); err != nil {
 			logging.Debugf("Error approving pending kube-apiserver-client-kubelet CSR: %v", err)
 			return err
 		}
 	}
+	// API server needs to connect to kubelet for some features like logs, port forwards. This communication is backed by a cert
+	// store in /var/lib/kubelet/pki/kubelet-server-current.pem
+	// After kubelet connected to the API server, if the serving cert is expireed, kubelet asks for a new CSR.
+	// This CSR is automatically approved by the cluster-machine-approver. The k8s controller manager issues the cert and kubelet fetches it.
 	if server {
 		logging.Info("Kubelet serving certificate has expired, waiting for automatic renewal... [will take up to 8 minutes]")
-		if err := waitForPendingCsrs(ocConfig, "kubernetes.io/kubelet-serving"); err != nil {
-			logging.Debugf("Error waiting for pending kubelet-serving CSR: %v", err)
-			return err
-		}
-		if err := ApproveNodeCSR(ocConfig, "kubernetes.io/kubelet-serving"); err != nil {
-			logging.Debugf("Error approving pending kubelet-serving CSR: %v", err)
-			return err
-		}
+		return crcerrors.RetryAfter(5*time.Minute, waitForCertRenewal(sshRunner, kubeletServerCert), time.Second*5)
 	}
 	return nil
+}
+
+func waitForCertRenewal(sshRunner *ssh.Runner, cert string) func() error {
+	return func() error {
+		expired, err := checkCertValidity(sshRunner, cert)
+		if err != nil {
+			return err
+		}
+		if !expired {
+			return nil
+		}
+		return &crcerrors.RetriableError{Err: fmt.Errorf("certificate %s still expired", cert)}
+	}
 }

--- a/pkg/crc/cluster/cert-renewal.go
+++ b/pkg/crc/cluster/cert-renewal.go
@@ -8,8 +8,6 @@ import (
 	"github.com/code-ready/crc/pkg/crc/errors"
 	"github.com/code-ready/crc/pkg/crc/logging"
 	"github.com/code-ready/crc/pkg/crc/oc"
-	"github.com/code-ready/crc/pkg/crc/ssh"
-	"github.com/code-ready/crc/pkg/crc/systemd"
 )
 
 func waitForPendingCsrs(ocConfig oc.Config) error {
@@ -31,43 +29,26 @@ func waitForPendingCsrs(ocConfig oc.Config) error {
 	return errors.RetryAfter(8*time.Minute, waitForPendingCsr, time.Second*5)
 }
 
-func RegenerateCertificates(sshRunner *ssh.Runner, ocConfig oc.Config) error {
-	sd := systemd.NewInstanceSystemdCommander(sshRunner)
-	err := sd.Start("kubelet")
-	if err != nil {
-		logging.Debugf("Error starting kubelet service: %v", err)
-		return err
-	}
-	// FIXME: regression compared to previous API
-	startedKubelet := false
-	if startedKubelet {
-		defer sd.Stop("kubelet") //nolint:errcheck
-	}
+func RegenerateCertificates(ocConfig oc.Config) error {
 	/* 2 CSRs to approve, one right after kubelet restart, the other one a few dozen seconds after
 	approving the first one
 	- First one is requested by system:serviceaccount:openshift-machine-config-operator:node-bootstrapper
 	- Second one is requested by system:node:<node_name> */
-	err = waitForPendingCsrs(ocConfig)
-	if err != nil {
+	if err := waitForPendingCsrs(ocConfig); err != nil {
 		logging.Debugf("Error waiting for first pending (node-bootstrapper) CSR: %v", err)
 		return err
 	}
-	err = ApproveNodeCSR(ocConfig)
-	if err != nil {
+	if err := ApproveNodeCSR(ocConfig); err != nil {
 		logging.Debugf("Error approving first pending (node-bootstrapper) CSR: %v", err)
 		return err
 	}
-
-	err = waitForPendingCsrs(ocConfig)
-	if err != nil {
+	if err := waitForPendingCsrs(ocConfig); err != nil {
 		logging.Debugf("Error waiting for second pending (system:node) CSR: %v", err)
 		return err
 	}
-	err = ApproveNodeCSR(ocConfig)
-	if err != nil {
+	if err := ApproveNodeCSR(ocConfig); err != nil {
 		logging.Debugf("Error approving second pending (system:node) CSR: %v", err)
 		return err
 	}
-
 	return nil
 }

--- a/pkg/crc/cluster/cert-renewal.go
+++ b/pkg/crc/cluster/cert-renewal.go
@@ -2,7 +2,7 @@ package cluster
 
 import (
 	"fmt"
-	"regexp"
+	"strings"
 	"time"
 
 	"github.com/code-ready/crc/pkg/crc/errors"
@@ -10,45 +10,47 @@ import (
 	"github.com/code-ready/crc/pkg/crc/oc"
 )
 
-func waitForPendingCsrs(ocConfig oc.Config) error {
+func waitForPendingCsrs(ocConfig oc.Config, signerName string) error {
 	waitForPendingCsr := func() error {
 		output, _, err := ocConfig.RunOcCommand("get", "csr")
 		if err != nil {
 			return &errors.RetriableError{Err: err}
 		}
-		matched, err := regexp.MatchString("Pending", output)
-		if err != nil {
-			return &errors.RetriableError{Err: err}
+		if strings.Contains(output, "Pending") && strings.Contains(output, signerName) {
+			return nil
 		}
-		if !matched {
-			return &errors.RetriableError{Err: fmt.Errorf("No Pending CSR")}
-		}
-		return nil
+		return &errors.RetriableError{Err: fmt.Errorf("No Pending CSR with signerName %s", signerName)}
 	}
 
 	return errors.RetryAfter(8*time.Minute, waitForPendingCsr, time.Second*5)
 }
 
-func RegenerateCertificates(ocConfig oc.Config) error {
+func WaitAndApprovePendingCSRs(ocConfig oc.Config, client, server bool) error {
 	/* 2 CSRs to approve, one right after kubelet restart, the other one a few dozen seconds after
 	approving the first one
 	- First one is requested by system:serviceaccount:openshift-machine-config-operator:node-bootstrapper
 	- Second one is requested by system:node:<node_name> */
-	if err := waitForPendingCsrs(ocConfig); err != nil {
-		logging.Debugf("Error waiting for first pending (node-bootstrapper) CSR: %v", err)
-		return err
+	if client {
+		logging.Info("Kubelet client certificate has expired, renewing it... [will take up to 8 minutes]")
+		if err := waitForPendingCsrs(ocConfig, "kubernetes.io/kube-apiserver-client-kubelet"); err != nil {
+			logging.Debugf("Error waiting for pending kube-apiserver-client-kubelet CSR: %v", err)
+			return err
+		}
+		if err := ApproveNodeCSR(ocConfig, "kubernetes.io/kube-apiserver-client-kubelet"); err != nil {
+			logging.Debugf("Error approving pending kube-apiserver-client-kubelet CSR: %v", err)
+			return err
+		}
 	}
-	if err := ApproveNodeCSR(ocConfig); err != nil {
-		logging.Debugf("Error approving first pending (node-bootstrapper) CSR: %v", err)
-		return err
-	}
-	if err := waitForPendingCsrs(ocConfig); err != nil {
-		logging.Debugf("Error waiting for second pending (system:node) CSR: %v", err)
-		return err
-	}
-	if err := ApproveNodeCSR(ocConfig); err != nil {
-		logging.Debugf("Error approving second pending (system:node) CSR: %v", err)
-		return err
+	if server {
+		logging.Info("Kubelet serving certificate has expired, waiting for automatic renewal... [will take up to 8 minutes]")
+		if err := waitForPendingCsrs(ocConfig, "kubernetes.io/kubelet-serving"); err != nil {
+			logging.Debugf("Error waiting for pending kubelet-serving CSR: %v", err)
+			return err
+		}
+		if err := ApproveNodeCSR(ocConfig, "kubernetes.io/kubelet-serving"); err != nil {
+			logging.Debugf("Error approving pending kubelet-serving CSR: %v", err)
+			return err
+		}
 	}
 	return nil
 }

--- a/pkg/crc/cluster/clusteroperator.go
+++ b/pkg/crc/cluster/clusteroperator.go
@@ -17,6 +17,9 @@ type k8sResource struct {
 		Metadata struct {
 			Name string `json:"name"`
 		} `json:"metadata"`
+		Spec struct {
+			SignerName string `json:"signerName"`
+		}
 		Status struct {
 			Conditions []struct {
 				LastTransitionTime time.Time `json:"lastTransitionTime"`

--- a/pkg/crc/cluster/clusteroperator.go
+++ b/pkg/crc/cluster/clusteroperator.go
@@ -12,7 +12,7 @@ import (
 
 var ignoreClusterOperators = []string{"monitoring", "machine-config", "marketplace", "insights"}
 
-type K8sResource struct {
+type k8sResource struct {
 	Items []struct {
 		Metadata struct {
 			Name string `json:"name"`
@@ -54,7 +54,7 @@ func getStatus(ocConfig oc.Config, selector []string) (*Status, error) {
 		return cs, fmt.Errorf("%s", stderr)
 	}
 
-	var co K8sResource
+	var co k8sResource
 	if err := json.Unmarshal([]byte(data), &co); err != nil {
 		return cs, err
 	}

--- a/pkg/crc/cluster/csr.go
+++ b/pkg/crc/cluster/csr.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/code-ready/crc/pkg/crc/errors"
+	crcerrors "github.com/code-ready/crc/pkg/crc/errors"
 	"github.com/code-ready/crc/pkg/crc/logging"
 	"github.com/code-ready/crc/pkg/crc/oc"
 )
@@ -16,39 +16,44 @@ func WaitForOpenshiftResource(ocConfig oc.Config, resource string) error {
 		stdout, stderr, err := ocConfig.RunOcCommand("get", resource)
 		if err != nil {
 			logging.Debug(stderr)
-			return &errors.RetriableError{Err: err}
+			return &crcerrors.RetriableError{Err: err}
 		}
 		logging.Debug(stdout)
 		return nil
 	}
-	return errors.RetryAfter(80*time.Second, waitForAPIServer, time.Second)
+	return crcerrors.RetryAfter(80*time.Second, waitForAPIServer, time.Second)
 }
 
 // ApproveNodeCSR approves the certificate for the node.
-func ApproveNodeCSR(ocConfig oc.Config) error {
+func ApproveNodeCSR(ocConfig oc.Config, signerName string) error {
 	err := WaitForOpenshiftResource(ocConfig, "csr")
 	if err != nil {
 		return err
 	}
 
 	logging.Debug("Approving pending CSRs")
-	// Execute 'oc get csr -oname' and store the output
-	csrsJSON, stderr, err := ocConfig.RunOcCommandPrivate("get", "csr", "-ojson")
+	output, stderr, err := ocConfig.RunOcCommandPrivate("get", "csr", "-ojson")
 	if err != nil {
-		return fmt.Errorf("Not able to get csr names (%v : %s)", err, stderr)
+		return fmt.Errorf("Failed to get all certificate signing requests: %v %s", err, stderr)
 	}
 	var csrs k8sResource
-	if err := json.Unmarshal([]byte(csrsJSON), &csrs); err != nil {
+	err = json.Unmarshal([]byte(output), &csrs)
+	if err != nil {
 		return err
 	}
 	for _, csr := range csrs.Items {
 		/* When the CSR hasn't been approved, csr.status is empty in the json data */
-		if len(csr.Status.Conditions) == 0 {
-			logging.Debugf("Approving csr %s", csr.Metadata.Name)
-			_, stderr, err := ocConfig.RunOcCommand("adm", "certificate", "approve", csr.Metadata.Name)
-			if err != nil {
-				return fmt.Errorf("Not able to approve csr (%v : %s)", err, stderr)
-			}
+		if len(csr.Status.Conditions) != 0 {
+			continue
+		}
+		if signerName != csr.Spec.SignerName {
+			logging.Debugf("Unexpected unapproved csr %s (signerName: %s)", csr.Metadata.Name, csr.Spec.SignerName)
+			continue
+		}
+		logging.Debugf("Approving csr %s (signerName: %s)", csr.Metadata.Name, csr.Spec.SignerName)
+		_, stderr, err := ocConfig.RunOcCommand("adm", "certificate", "approve", csr.Metadata.Name)
+		if err != nil {
+			return fmt.Errorf("Not able to approve csr (%v : %s)", err, stderr)
 		}
 	}
 	return nil

--- a/pkg/crc/cluster/csr.go
+++ b/pkg/crc/cluster/csr.go
@@ -24,13 +24,8 @@ func WaitForOpenshiftResource(ocConfig oc.Config, resource string) error {
 	return crcerrors.RetryAfter(80*time.Second, waitForAPIServer, time.Second)
 }
 
-// ApproveNodeCSR approves the certificate for the node.
-func ApproveNodeCSR(ocConfig oc.Config, signerName string) error {
-	err := WaitForOpenshiftResource(ocConfig, "csr")
-	if err != nil {
-		return err
-	}
-
+// approveNodeCSR approves the certificate for the node.
+func approveNodeCSR(ocConfig oc.Config, signerName string) error {
 	logging.Debug("Approving pending CSRs")
 	output, stderr, err := ocConfig.RunOcCommandPrivate("get", "csr", "-ojson")
 	if err != nil {

--- a/pkg/crc/cluster/csr.go
+++ b/pkg/crc/cluster/csr.go
@@ -37,9 +37,8 @@ func ApproveNodeCSR(ocConfig oc.Config) error {
 	if err != nil {
 		return fmt.Errorf("Not able to get csr names (%v : %s)", err, stderr)
 	}
-	var csrs K8sResource
-	err = json.Unmarshal([]byte(csrsJSON), &csrs)
-	if err != nil {
+	var csrs k8sResource
+	if err := json.Unmarshal([]byte(csrsJSON), &csrs); err != nil {
 		return err
 	}
 	for _, csr := range csrs.Items {

--- a/pkg/crc/machine/machine.go
+++ b/pkg/crc/machine/machine.go
@@ -400,11 +400,6 @@ func (client *client) Start(startConfig StartConfig) (StartResult, error) {
 		log.Warnf("Cannot update kubeconfig: %v", err)
 	}
 
-	// Approve the node certificate.
-	if err := cluster.ApproveNodeCSR(ocConfig); err != nil {
-		return startError(startConfig.Name, "Error approving the node csr", err)
-	}
-
 	if proxyConfig.IsEnabled() {
 		logging.Info("Waiting for the proxy configuration to be applied ...")
 		waitForProxyPropagation(ocConfig, proxyConfig)

--- a/pkg/crc/machine/machine.go
+++ b/pkg/crc/machine/machine.go
@@ -335,7 +335,7 @@ func (client *client) Start(startConfig StartConfig) (StartResult, error) {
 
 	ocConfig := oc.UseOCWithSSH(sshRunner)
 
-	if err := cluster.WaitAndApprovePendingCSRs(ocConfig, clientExpired, serverExpired); err != nil {
+	if err := cluster.ApproveCSRAndWaitForCertsRenewal(sshRunner, ocConfig, clientExpired, serverExpired); err != nil {
 		logBundleDate(crcBundleMetadata)
 		return startError(startConfig.Name, "Failed to renew TLS certificates: please check if a newer CodeReady Containers release is available", err)
 	}


### PR DESCRIPTION
cert renewal is not accurate (at least from what I saw). We only have one cert to approve. The second one is automatically approved by the cluster machine approver. This PR removes the race.