### PR TITLE
Only check bundle version if the bundle is embedded

### DIFF
--- a/pkg/crc/validation/validation.go
+++ b/pkg/crc/validation/validation.go
@@ -56,6 +56,10 @@ func ValidateBundle(bundle string) error {
 	releaseBundleVersion := version.GetBundleVersion()
 	userProvidedBundleVersion := filepath.Base(bundle)
 	if !strings.Contains(userProvidedBundleVersion, fmt.Sprintf("%s.crcbundle", releaseBundleVersion)) {
+		if !constants.BundleEmbedded() {
+			logging.Warnf("Using unsupported bundle %s", userProvidedBundleVersion)
+			return nil
+		}
 		return fmt.Errorf("%s bundle is not supported by this binary, please use %s", userProvidedBundleVersion, constants.GetDefaultBundle())
 	}
 	return nil


### PR DESCRIPTION
This check is useful for released version of crc. For development, we need to be able to launch any bundle.