### PR TITLE
Get golangci-lint binary without updating go mod

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,7 +145,7 @@ fmt:
 	@gofmt -l -w $(SOURCE_DIRS)
 
 $(GOPATH)/bin/golangci-lint:
-	go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.27.0
+	pushd /tmp && GO111MODULE=on go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.27.0 && popd
 
 # Run golangci-lint against code
 .PHONY: lint cross-lint


### PR DESCRIPTION
Currently when we update the golangci-lint version it also
update the go.mod file which is unwanted.

- https://stackoverflow.com/questions/56842385/using-go-get-to-download-binaries-without-adding-them-to-go-mod

