### PR TITLE
Create only one immutable sshRunner in machine.Start

### DIFF
--- a/pkg/crc/constants/constants.go
+++ b/pkg/crc/constants/constants.go
@@ -16,6 +16,7 @@ const (
 	DefaultMemory = 9216
 
 	DefaultSSHUser = "core"
+	DefaultSSHPort = 22
 
 	CrcEnvPrefix = "CRC"
 

--- a/pkg/crc/ssh/ssh.go
+++ b/pkg/crc/ssh/ssh.go
@@ -10,20 +10,21 @@ import (
 	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/code-ready/crc/pkg/crc/logging"
 	crcos "github.com/code-ready/crc/pkg/os"
-	"github.com/code-ready/machine/libmachine/drivers"
+	"github.com/code-ready/machine/libmachine/ssh"
 )
 
 type Runner struct {
-	driver        drivers.Driver
+	ip            string
+	port          int
 	privateSSHKey string
 }
 
-func CreateRunner(driver drivers.Driver) *Runner {
-	return CreateRunnerWithPrivateKey(driver, constants.GetPrivateKeyPath())
-}
-
-func CreateRunnerWithPrivateKey(driver drivers.Driver, privateKey string) *Runner {
-	return &Runner{driver: driver, privateSSHKey: privateKey}
+func CreateRunnerWithPrivateKey(ip string, port int, privateKey string) *Runner {
+	return &Runner{
+		ip:            ip,
+		port:          port,
+		privateSSHKey: privateKey,
+	}
 }
 
 // Create a host using the driver's config
@@ -57,7 +58,9 @@ func (runner *Runner) CopyFile(srcFilename string, destFilename string, mode os.
 }
 
 func (runner *Runner) runSSHCommandFromDriver(command string, runPrivate bool) (string, error) {
-	client, err := drivers.GetSSHClientFromDriver(runner.driver, runner.privateSSHKey)
+	client, err := ssh.NewClient(constants.DefaultSSHUser, runner.ip, runner.port, &ssh.Auth{
+		Keys: []string{runner.privateSSHKey},
+	})
 	if err != nil {
 		return "", err
 	}

--- a/pkg/crc/ssh/ssh_test.go
+++ b/pkg/crc/ssh/ssh_test.go
@@ -51,7 +51,7 @@ func TestRunner(t *testing.T) {
 	for _, clientType := range []machinessh.ClientType{machinessh.External, machinessh.Native} {
 		machinessh.SetDefaultClient(clientType)
 		addr := listener.Addr().String()
-		runner := CreateRunnerWithPrivateKey(ipFor(addr), portFor(addr), clientKeyFile)
+		runner := CreateRunner(ipFor(addr), portFor(addr), clientKeyFile)
 
 		bin, err := runner.Run("echo hello")
 		assert.NoError(t, err)

--- a/pkg/crc/ssh/ssh_test.go
+++ b/pkg/crc/ssh/ssh_test.go
@@ -15,7 +15,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/code-ready/machine/drivers/errdriver"
 	machinessh "github.com/code-ready/machine/libmachine/ssh"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -51,9 +50,8 @@ func TestRunner(t *testing.T) {
 
 	for _, clientType := range []machinessh.ClientType{machinessh.External, machinessh.Native} {
 		machinessh.SetDefaultClient(clientType)
-		runner := CreateRunnerWithPrivateKey(&mockDriver{
-			addr: listener.Addr().String(),
-		}, clientKeyFile)
+		addr := listener.Addr().String()
+		runner := CreateRunnerWithPrivateKey(ipFor(addr), portFor(addr), clientKeyFile)
 
 		bin, err := runner.Run("echo hello")
 		assert.NoError(t, err)
@@ -144,24 +142,11 @@ func writePrivateKey(t *testing.T, clientKeyFile string, clientKey *rsa.PrivateK
 	}))
 }
 
-type mockDriver struct {
-	addr string
-
-	errdriver.Driver
+func ipFor(addr string) string {
+	return strings.Split(addr, ":")[0]
 }
 
-func (d *mockDriver) GetSSHHostname() (string, error) {
-	return strings.Split(d.addr, ":")[0], nil
-}
-
-func (mockDriver) GetSSHKeyPath() string {
-	return ""
-}
-
-func (d *mockDriver) GetSSHPort() (int, error) {
-	return strconv.Atoi(strings.Split(d.addr, ":")[1])
-}
-
-func (mockDriver) GetSSHUsername() string {
-	return "core"
+func portFor(addr string) int {
+	port, _ := strconv.Atoi(strings.Split(addr, ":")[1])
+	return port
 }


### PR DESCRIPTION
This sshRunner now uses 2 private keys: one from the bundle, one that we created for the rotation.
If the ssh key rotation was aborted by the user (ctrl+c at the wrong moment, or so), machine.Start will be able to recover the next time.

It also removes the dependency on drivers.Driver in ssh package.