### PR TITLE
Proxy refactorings: logs and instanceIP in NO_PROXY

### DIFF
--- a/cmd/crc/cmd/root.go
+++ b/cmd/crc/cmd/root.go
@@ -101,8 +101,7 @@ func setProxyDefaults() {
 	}
 
 	if proxyConfig.IsEnabled() {
-		logging.Debugf("HTTP-PROXY: %s, HTTPS-PROXY: %s, NO-PROXY: %s, proxyCAFile: %s", proxyConfig.HTTPProxyForDisplay(),
-			proxyConfig.HTTPSProxyForDisplay(), proxyConfig.GetNoProxyString(), proxyCAFile)
+		logging.Debugf("Proxy configuration: %s", proxyConfig.String())
 		proxyConfig.ApplyToEnvironment()
 	}
 }

--- a/cmd/crc/cmd/root.go
+++ b/cmd/crc/cmd/root.go
@@ -2,8 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"io/ioutil"
-	"strings"
 
 	cmdConfig "github.com/code-ready/crc/cmd/crc/cmd/config"
 	crcConfig "github.com/code-ready/crc/pkg/crc/config"
@@ -97,12 +95,7 @@ func setProxyDefaults() {
 	noProxy := config.Get(cmdConfig.NoProxy).AsString()
 	proxyCAFile := config.Get(cmdConfig.ProxyCAFile).AsString()
 
-	proxyCAData, err := getProxyCAData(proxyCAFile)
-	if err != nil {
-		exit.WithMessage(1, fmt.Sprintf("not able to read proxyCAFile %s: %v", proxyCAFile, err.Error()))
-	}
-
-	proxyConfig, err := network.NewProxyDefaults(httpProxy, httpsProxy, noProxy, proxyCAData)
+	proxyConfig, err := network.NewProxyDefaults(httpProxy, httpsProxy, noProxy, proxyCAFile)
 	if err != nil {
 		exit.WithMessage(1, err.Error())
 	}
@@ -112,22 +105,6 @@ func setProxyDefaults() {
 			proxyConfig.HTTPSProxyForDisplay(), proxyConfig.GetNoProxyString(), proxyCAFile)
 		proxyConfig.ApplyToEnvironment()
 	}
-}
-
-func getProxyCAData(proxyCAFile string) (string, error) {
-	if proxyCAFile == "" {
-		return "", nil
-	}
-	proxyCACert, err := ioutil.ReadFile(proxyCAFile)
-	if err != nil {
-		return "", err
-	}
-	// Before passing string back to caller function, remove the empty lines in the end
-	return trimTrailingEOL(string(proxyCACert)), nil
-}
-
-func trimTrailingEOL(s string) string {
-	return strings.TrimRight(s, "\n")
 }
 
 func newViperConfig() (*crcConfig.Config, *crcConfig.ViperStorage, error) {

--- a/cmd/crc/cmd/root.go
+++ b/cmd/crc/cmd/root.go
@@ -95,11 +95,11 @@ func setProxyDefaults() {
 	noProxy := config.Get(cmdConfig.NoProxy).AsString()
 	proxyCAFile := config.Get(cmdConfig.ProxyCAFile).AsString()
 
-	proxyConfig, err := network.NewProxyDefaults(httpProxy, httpsProxy, noProxy, proxyCAFile)
-	if err != nil {
-		exit.WithMessage(1, err.Error())
+	if err := network.SetProxyDefaults(httpProxy, httpsProxy, noProxy, proxyCAFile); err != nil {
+		exit.WithMessage(1, fmt.Sprintf("Cannot set proxy configuration: %s", err.Error()))
 	}
 
+	proxyConfig := network.GetProxyConfig()
 	if proxyConfig.IsEnabled() {
 		logging.Debugf("Proxy configuration: %s", proxyConfig.String())
 		proxyConfig.ApplyToEnvironment()

--- a/pkg/crc/machine/machine.go
+++ b/pkg/crc/machine/machine.go
@@ -310,7 +310,7 @@ func (client *client) Start(startConfig StartConfig) (*StartResult, error) {
 
 	// Check DNS lookup from host to VM
 	logging.Info("Check DNS query from host ...")
-	if err := network.CheckCRCLocalDNSReachableFromHost(crcBundleMetadata, instanceIP); err != nil {
+	if err := dns.CheckCRCLocalDNSReachableFromHost(crcBundleMetadata, instanceIP); err != nil {
 		return nil, errors.Wrap(err, "Failed to query DNS from host")
 	}
 

--- a/pkg/crc/machine/machine.go
+++ b/pkg/crc/machine/machine.go
@@ -715,14 +715,10 @@ func updateSSHKeyAndCopyKubeconfig(sshRunner *crcssh.Runner, name string, crcBun
 }
 
 func getProxyConfig(baseDomainName string) (*network.ProxyConfig, error) {
-	proxy, err := network.NewProxyConfig()
-	if err != nil {
-		return nil, err
-	}
+	proxy := network.GetProxyConfig()
 	if proxy.IsEnabled() {
 		proxy.AddNoProxy(fmt.Sprintf(".%s", baseDomainName))
 	}
-
 	return proxy, nil
 }
 

--- a/pkg/crc/network/proxy.go
+++ b/pkg/crc/network/proxy.go
@@ -97,6 +97,11 @@ func getProxyFromEnv(proxyScheme string) string {
 	return p
 }
 
+func setProxyEnv(key, value string) {
+	setEnv(strings.ToLower(key), value)
+	setEnv(strings.ToUpper(key), value)
+}
+
 func setEnv(key, value string) {
 	before := os.Getenv(key)
 	if before != value {
@@ -130,16 +135,13 @@ func (p *ProxyConfig) ApplyToEnvironment() {
 	}
 
 	if p.HTTPProxy != "" {
-		setEnv("HTTP_PROXY", p.HTTPProxy)
-		setEnv("http_proxy", p.HTTPProxy)
+		setProxyEnv("http_proxy", p.HTTPProxy)
 	}
 	if p.HTTPSProxy != "" {
-		setEnv("HTTPS_PROXY", p.HTTPSProxy)
-		setEnv("https_proxy", p.HTTPSProxy)
+		setProxyEnv("https_proxy", p.HTTPSProxy)
 	}
 	if len(p.NoProxy) != 0 {
-		setEnv("NO_PROXY", p.GetNoProxyString())
-		setEnv("no_proxy", p.GetNoProxyString())
+		setProxyEnv("no_proxy", p.GetNoProxyString())
 	}
 }
 

--- a/pkg/crc/network/proxy.go
+++ b/pkg/crc/network/proxy.go
@@ -23,10 +23,12 @@ type ProxyConfig struct {
 	ProxyCACert string
 }
 
-func NewProxyDefaults(httpProxy, httpsProxy, noProxy, proxyCAFile string) (*ProxyConfig, error) {
+// SetProxyDefaults specifies proxy configuration. If an empty string is passed the corresponding environment variable
+// is checked.
+func SetProxyDefaults(httpProxy, httpsProxy, noProxy, proxyCAFile string) error {
 	proxyCACert, err := getProxyCAData(proxyCAFile)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	DefaultProxy = ProxyConfig{
@@ -44,11 +46,11 @@ func NewProxyDefaults(httpProxy, httpsProxy, noProxy, proxyCAFile string) (*Prox
 	}
 
 	if err := ValidateProxyURL(DefaultProxy.HTTPProxy); err != nil {
-		return nil, err
+		return err
 	}
 
 	if err := ValidateProxyURL(DefaultProxy.HTTPSProxy); err != nil {
-		return nil, err
+		return err
 	}
 
 	if noProxy == "" {
@@ -56,12 +58,11 @@ func NewProxyDefaults(httpProxy, httpsProxy, noProxy, proxyCAFile string) (*Prox
 	}
 	DefaultProxy.setNoProxyString(noProxy)
 
-	return NewProxyConfig()
+	return nil
 }
 
-// NewProxyConfig creates a proxy configuration with the specified parameters. If an empty string is passed
-// the corresponding environment variable is checked.
-func NewProxyConfig() (*ProxyConfig, error) {
+// GetProxyConfig retrieve the proxy configuration previously set.
+func GetProxyConfig() *ProxyConfig {
 	config := ProxyConfig{
 		HTTPProxy:   DefaultProxy.HTTPProxy,
 		HTTPSProxy:  DefaultProxy.HTTPSProxy,
@@ -74,7 +75,7 @@ func NewProxyConfig() (*ProxyConfig, error) {
 		config.AddNoProxy(DefaultProxy.NoProxy...)
 	}
 
-	return &config, nil
+	return &config
 }
 
 func getProxyCAData(proxyCAFile string) (string, error) {

--- a/pkg/crc/network/proxy.go
+++ b/pkg/crc/network/proxy.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	DefaultProxy     ProxyConfig
+	globalProxy      ProxyConfig
 	defaultNoProxies = []string{"127.0.0.1", "localhost"}
 )
 
@@ -31,32 +31,32 @@ func SetProxyDefaults(httpProxy, httpsProxy, noProxy, proxyCAFile string) error 
 		return err
 	}
 
-	DefaultProxy = ProxyConfig{
+	globalProxy = ProxyConfig{
 		HTTPProxy:   httpProxy,
 		HTTPSProxy:  httpsProxy,
 		ProxyCAFile: proxyCAFile,
 		ProxyCACert: proxyCACert,
 	}
 
-	if DefaultProxy.HTTPProxy == "" {
-		DefaultProxy.HTTPProxy = getProxyFromEnv("http_proxy")
+	if globalProxy.HTTPProxy == "" {
+		globalProxy.HTTPProxy = getProxyFromEnv("http_proxy")
 	}
-	if DefaultProxy.HTTPSProxy == "" {
-		DefaultProxy.HTTPSProxy = getProxyFromEnv("https_proxy")
+	if globalProxy.HTTPSProxy == "" {
+		globalProxy.HTTPSProxy = getProxyFromEnv("https_proxy")
 	}
 
-	if err := ValidateProxyURL(DefaultProxy.HTTPProxy); err != nil {
+	if err := ValidateProxyURL(globalProxy.HTTPProxy); err != nil {
 		return err
 	}
 
-	if err := ValidateProxyURL(DefaultProxy.HTTPSProxy); err != nil {
+	if err := ValidateProxyURL(globalProxy.HTTPSProxy); err != nil {
 		return err
 	}
 
 	if noProxy == "" {
 		noProxy = getProxyFromEnv("no_proxy")
 	}
-	DefaultProxy.setNoProxyString(noProxy)
+	globalProxy.setNoProxyString(noProxy)
 
 	return nil
 }
@@ -64,17 +64,15 @@ func SetProxyDefaults(httpProxy, httpsProxy, noProxy, proxyCAFile string) error 
 // GetProxyConfig retrieve the proxy configuration previously set.
 func GetProxyConfig() *ProxyConfig {
 	config := ProxyConfig{
-		HTTPProxy:   DefaultProxy.HTTPProxy,
-		HTTPSProxy:  DefaultProxy.HTTPSProxy,
-		ProxyCAFile: DefaultProxy.ProxyCAFile,
-		ProxyCACert: DefaultProxy.ProxyCACert,
+		HTTPProxy:   globalProxy.HTTPProxy,
+		HTTPSProxy:  globalProxy.HTTPSProxy,
+		ProxyCAFile: globalProxy.ProxyCAFile,
+		ProxyCACert: globalProxy.ProxyCACert,
+		NoProxy:     defaultNoProxies,
 	}
-
-	config.NoProxy = defaultNoProxies
-	if len(DefaultProxy.NoProxy) != 0 {
-		config.AddNoProxy(DefaultProxy.NoProxy...)
+	if len(globalProxy.NoProxy) != 0 {
+		config.AddNoProxy(globalProxy.NoProxy...)
 	}
-
 	return &config
 }
 

--- a/pkg/crc/network/proxy.go
+++ b/pkg/crc/network/proxy.go
@@ -102,16 +102,11 @@ func getProxyFromEnv(proxyScheme string) string {
 	return p
 }
 
-// HTTPProxy with hidden credentials
-func (p *ProxyConfig) HTTPProxyForDisplay() string {
-	httpProxy, _ := URIStringForDisplay(p.HTTPProxy)
-	return httpProxy
-}
-
-// HTTPSProxy with hidden credentials
-func (p *ProxyConfig) HTTPSProxyForDisplay() string {
-	httpsProxy, _ := URIStringForDisplay(p.HTTPSProxy)
-	return httpsProxy
+func (p *ProxyConfig) String() string {
+	httpProxy, _ := hidePassword(p.HTTPProxy)
+	httpsProxy, _ := hidePassword(p.HTTPSProxy)
+	return fmt.Sprintf("HTTPProxy: %s, HTTPSProxy: %s, NoProxy: %s, ProxyCAFile: %s",
+		httpProxy, httpsProxy, p.GetNoProxyString(), p.ProxyCAFile)
 }
 
 // AddNoProxy appends the specified host to the list of no proxied hosts.

--- a/pkg/crc/network/proxy.go
+++ b/pkg/crc/network/proxy.go
@@ -42,6 +42,15 @@ func NewProxyDefaults(httpProxy, httpsProxy, noProxy, proxyCAFile string) (*Prox
 	if DefaultProxy.HTTPSProxy == "" {
 		DefaultProxy.HTTPSProxy = getProxyFromEnv("https_proxy")
 	}
+
+	if err := ValidateProxyURL(DefaultProxy.HTTPProxy); err != nil {
+		return nil, err
+	}
+
+	if err := ValidateProxyURL(DefaultProxy.HTTPSProxy); err != nil {
+		return nil, err
+	}
+
 	if noProxy == "" {
 		noProxy = getProxyFromEnv("no_proxy")
 	}
@@ -63,16 +72,6 @@ func NewProxyConfig() (*ProxyConfig, error) {
 	config.NoProxy = defaultNoProxies
 	if len(DefaultProxy.NoProxy) != 0 {
 		config.AddNoProxy(DefaultProxy.NoProxy...)
-	}
-
-	err := ValidateProxyURL(config.HTTPProxy)
-	if err != nil {
-		return nil, err
-	}
-
-	err = ValidateProxyURL(config.HTTPSProxy)
-	if err != nil {
-		return nil, err
 	}
 
 	return &config, nil

--- a/pkg/crc/network/proxy.go
+++ b/pkg/crc/network/proxy.go
@@ -18,7 +18,7 @@ var (
 type ProxyConfig struct {
 	HTTPProxy   string
 	HTTPSProxy  string
-	noProxy     []string
+	NoProxy     []string
 	ProxyCAFile string
 	ProxyCACert string
 }
@@ -60,9 +60,9 @@ func NewProxyConfig() (*ProxyConfig, error) {
 		ProxyCACert: DefaultProxy.ProxyCACert,
 	}
 
-	config.noProxy = defaultNoProxies
-	if len(DefaultProxy.noProxy) != 0 {
-		config.AddNoProxy(DefaultProxy.noProxy...)
+	config.NoProxy = defaultNoProxies
+	if len(DefaultProxy.NoProxy) != 0 {
+		config.AddNoProxy(DefaultProxy.NoProxy...)
 	}
 
 	err := ValidateProxyURL(config.HTTPProxy)
@@ -116,18 +116,18 @@ func (p *ProxyConfig) HTTPSProxyForDisplay() string {
 
 // AddNoProxy appends the specified host to the list of no proxied hosts.
 func (p *ProxyConfig) AddNoProxy(host ...string) {
-	p.noProxy = append(p.noProxy, host...)
+	p.NoProxy = append(p.NoProxy, host...)
 }
 
 func (p *ProxyConfig) setNoProxyString(noProxies string) {
 	if noProxies == "" {
 		return
 	}
-	p.noProxy = strings.Split(noProxies, ",")
+	p.NoProxy = strings.Split(noProxies, ",")
 }
 
 func (p *ProxyConfig) GetNoProxyString() string {
-	return strings.Join(p.noProxy, ",")
+	return strings.Join(p.NoProxy, ",")
 }
 
 // Sets the current config as environment variables in the current process.
@@ -144,7 +144,7 @@ func (p *ProxyConfig) ApplyToEnvironment() {
 		os.Setenv("HTTPS_PROXY", p.HTTPSProxy)
 		os.Setenv("https_proxy", p.HTTPSProxy)
 	}
-	if len(p.noProxy) != 0 {
+	if len(p.NoProxy) != 0 {
 		os.Setenv("NO_PROXY", p.GetNoProxyString())
 		os.Setenv("no_proxy", p.GetNoProxyString())
 	}

--- a/pkg/crc/network/proxy.go
+++ b/pkg/crc/network/proxy.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/asaskevich/govalidator"
+	"github.com/code-ready/crc/pkg/crc/logging"
 )
 
 var (
@@ -96,6 +97,16 @@ func getProxyFromEnv(proxyScheme string) string {
 	return p
 }
 
+func setEnv(key, value string) {
+	before := os.Getenv(key)
+	if before != value {
+		logging.Warnf("Overriding environment variable %s: previously %s, now %s", key, before, value)
+	}
+	if err := os.Setenv(key, value); err != nil {
+		logging.Errorf("Cannot set environment variable %s: %v", key, err)
+	}
+}
+
 func (p *ProxyConfig) String() string {
 	httpProxy, _ := hidePassword(p.HTTPProxy)
 	httpsProxy, _ := hidePassword(p.HTTPSProxy)
@@ -119,16 +130,16 @@ func (p *ProxyConfig) ApplyToEnvironment() {
 	}
 
 	if p.HTTPProxy != "" {
-		os.Setenv("HTTP_PROXY", p.HTTPProxy)
-		os.Setenv("http_proxy", p.HTTPProxy)
+		setEnv("HTTP_PROXY", p.HTTPProxy)
+		setEnv("http_proxy", p.HTTPProxy)
 	}
 	if p.HTTPSProxy != "" {
-		os.Setenv("HTTPS_PROXY", p.HTTPSProxy)
-		os.Setenv("https_proxy", p.HTTPSProxy)
+		setEnv("HTTPS_PROXY", p.HTTPSProxy)
+		setEnv("https_proxy", p.HTTPSProxy)
 	}
 	if len(p.NoProxy) != 0 {
-		os.Setenv("NO_PROXY", p.GetNoProxyString())
-		os.Setenv("no_proxy", p.GetNoProxyString())
+		setEnv("NO_PROXY", p.GetNoProxyString())
+		setEnv("no_proxy", p.GetNoProxyString())
 	}
 }
 

--- a/pkg/crc/network/proxy_test.go
+++ b/pkg/crc/network/proxy_test.go
@@ -24,10 +24,10 @@ func TestMarshal(t *testing.T) {
 	bin, err := json.Marshal(&ProxyConfig{
 		HTTPProxy:   "http://proxy.org",
 		HTTPSProxy:  "http://proxy.org",
-		noProxy:     defaultNoProxies,
+		NoProxy:     defaultNoProxies,
 		ProxyCAFile: "/home/john/ca.crt",
 		ProxyCACert: "very long string",
 	})
 	assert.NoError(t, err)
-	assert.JSONEq(t, `{"HTTPProxy":"http://proxy.org", "HTTPSProxy":"http://proxy.org", "ProxyCACert":"very long string", "ProxyCAFile":"/home/john/ca.crt"}`, string(bin))
+	assert.JSONEq(t, `{"HTTPProxy":"http://proxy.org", "HTTPSProxy":"http://proxy.org", "NoProxy":["127.0.0.1", "localhost"], "ProxyCACert":"very long string", "ProxyCAFile":"/home/john/ca.crt"}`, string(bin))
 }

--- a/pkg/crc/network/proxy_test.go
+++ b/pkg/crc/network/proxy_test.go
@@ -15,7 +15,7 @@ func TestValidateProxyURL(t *testing.T) {
 }
 
 func TestHidePassword(t *testing.T) {
-	url, err := URIStringForDisplay("https://user:secret@proxy.org:123")
+	url, err := hidePassword("https://user:secret@proxy.org:123")
 	assert.NoError(t, err)
 	assert.Equal(t, "https://user:xxx@proxy.org:123", url)
 }

--- a/pkg/crc/network/proxy_test.go
+++ b/pkg/crc/network/proxy_test.go
@@ -12,3 +12,9 @@ func TestValidateProxyURL(t *testing.T) {
 	assert.EqualError(t, ValidateProxyURL("company.com:8080"), "Proxy URL 'company.com:8080' is not valid: url should start with http://")
 	assert.EqualError(t, ValidateProxyURL("https://company.com"), "Proxy URL 'https://company.com' is not valid: https is not supported")
 }
+
+func TestHidePassword(t *testing.T) {
+	url, err := URIStringForDisplay("https://user:secret@proxy.org:123")
+	assert.NoError(t, err)
+	assert.Equal(t, "https://user:xxx@proxy.org:123", url)
+}

--- a/pkg/crc/network/proxy_test.go
+++ b/pkg/crc/network/proxy_test.go
@@ -1,6 +1,7 @@
 package network
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -17,4 +18,16 @@ func TestHidePassword(t *testing.T) {
 	url, err := URIStringForDisplay("https://user:secret@proxy.org:123")
 	assert.NoError(t, err)
 	assert.Equal(t, "https://user:xxx@proxy.org:123", url)
+}
+
+func TestMarshal(t *testing.T) {
+	bin, err := json.Marshal(&ProxyConfig{
+		HTTPProxy:   "http://proxy.org",
+		HTTPSProxy:  "http://proxy.org",
+		noProxy:     defaultNoProxies,
+		ProxyCAFile: "/home/john/ca.crt",
+		ProxyCACert: "very long string",
+	})
+	assert.NoError(t, err)
+	assert.JSONEq(t, `{"HTTPProxy":"http://proxy.org", "HTTPSProxy":"http://proxy.org", "ProxyCACert":"very long string", "ProxyCAFile":"/home/john/ca.crt"}`, string(bin))
 }

--- a/pkg/crc/network/utils.go
+++ b/pkg/crc/network/utils.go
@@ -2,13 +2,7 @@ package network
 
 import (
 	"fmt"
-	"net"
 	"net/url"
-	"runtime"
-
-	"github.com/code-ready/crc/pkg/crc/logging"
-	"github.com/code-ready/crc/pkg/crc/machine/bundle"
-	crcos "github.com/code-ready/crc/pkg/os"
 )
 
 func URIStringForDisplay(uri string) (string, error) {
@@ -20,50 +14,4 @@ func URIStringForDisplay(uri string) (string, error) {
 		return fmt.Sprintf("%s://%s:xxx@%s", u.Scheme, u.User.Username(), u.Host), nil
 	}
 	return uri, nil
-}
-
-func matchIP(ips []net.IP, expectedIP string) bool {
-	for _, ip := range ips {
-		if ip.String() == expectedIP {
-			return true
-		}
-	}
-
-	return false
-}
-func CheckCRCLocalDNSReachableFromHost(bundle *bundle.CrcBundleInfo, expectedIP string) error {
-	apiHostname := bundle.GetAPIHostname()
-	ip, err := net.LookupIP(apiHostname)
-	if err != nil {
-		return err
-	}
-	logging.Debugf("%s resolved to %s", apiHostname, ip)
-	if !matchIP(ip, expectedIP) {
-		logging.Warnf("%s resolved to %s but %s was expected", apiHostname, ip, expectedIP)
-		return fmt.Errorf("Invalid IP for %s", apiHostname)
-	}
-
-	if runtime.GOOS != "darwin" {
-		/* This check will fail with !CGO_ENABLED builds on darwin as
-		 * in this case, /etc/resolver/ will not be used, so we won't
-		 * have wildcard DNS for our domains
-		 */
-		appsHostname := bundle.GetAppHostname("foo")
-		ip, err = net.LookupIP(appsHostname)
-		if err != nil {
-			// Right now goodhosts fallback is not implemented in windows so
-			// this checks should still return the error.
-			if crcos.CurrentOS() == crcos.WINDOWS {
-				return err
-			}
-			logging.Warnf("Wildcard DNS resolution for %s does not appear to be working", bundle.ClusterInfo.AppsDomain)
-			return nil
-		}
-		logging.Debugf("%s resolved to %s", appsHostname, ip)
-		if !matchIP(ip, expectedIP) {
-			logging.Warnf("%s resolved to %s but %s was expected", appsHostname, ip, expectedIP)
-			return fmt.Errorf("Invalid IP for %s", appsHostname)
-		}
-	}
-	return nil
 }

--- a/pkg/crc/network/utils.go
+++ b/pkg/crc/network/utils.go
@@ -5,7 +5,7 @@ import (
 	"net/url"
 )
 
-func URIStringForDisplay(uri string) (string, error) {
+func hidePassword(uri string) (string, error) {
 	u, err := url.Parse(uri)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
* Add in proxy struct where the proxy CA is coming from
* Log when overriding proxy env variables.
* Add instanceIP in NO_PROXY at the top and not only in a small part of `machine.Start()`

After this one, we can open a follow-up that removes calls to `ApplyToEnvironment` in machine pkg. Since `oc` is called with ssh, we don't need it (apart from crc version check but it's done in cmd pkg).