### PR TITLE
Remove bool to hold EnableExperimentalFeatures in preflight checks

### DIFF
--- a/cmd/crc/cmd/setup.go
+++ b/cmd/crc/cmd/setup.go
@@ -34,9 +34,6 @@ var setupCmd = &cobra.Command{
 }
 
 func runSetup(arguments []string) error {
-	if config.Get(cmdConfig.ExperimentalFeatures).AsBool() {
-		preflight.EnableExperimentalFeatures = true
-	}
 	err := preflight.SetupHost(config)
 	return render(&setupResult{
 		Success: err == nil,

--- a/pkg/crc/preflight/preflight.go
+++ b/pkg/crc/preflight/preflight.go
@@ -3,14 +3,12 @@ package preflight
 import (
 	"fmt"
 
+	cmdConfig "github.com/code-ready/crc/cmd/crc/cmd/config"
 	"github.com/code-ready/crc/pkg/crc/config"
 	"github.com/code-ready/crc/pkg/crc/logging"
 )
 
 type Flags uint32
-
-// EnableExperimentalFeatures enables the use of experimental features
-var EnableExperimentalFeatures bool
 
 const (
 	// Indicates a PreflightCheck should only be run as part of "crc setup"
@@ -169,14 +167,14 @@ func doRegisterSettings(cfg config.Schema, checks []Check) {
 
 // StartPreflightChecks performs the preflight checks before starting the cluster
 func StartPreflightChecks(config config.Storage) error {
-	return doPreflightChecks(config, getPreflightChecks())
+	return doPreflightChecks(config, getPreflightChecks(config.Get(cmdConfig.ExperimentalFeatures).AsBool()))
 }
 
 // SetupHost performs the prerequisite checks and setups the host to run the cluster
 func SetupHost(config config.Storage) error {
-	return doFixPreflightChecks(config, getPreflightChecks())
+	return doFixPreflightChecks(config, getPreflightChecks(config.Get(cmdConfig.ExperimentalFeatures).AsBool()))
 }
 
 func RegisterSettings(config config.Schema) {
-	doRegisterSettings(config, getPreflightChecks())
+	doRegisterSettings(config, getPreflightChecks(true))
 }

--- a/pkg/crc/preflight/preflight.go
+++ b/pkg/crc/preflight/preflight.go
@@ -178,3 +178,12 @@ func SetupHost(config config.Storage) error {
 func RegisterSettings(config config.Schema) {
 	doRegisterSettings(config, getPreflightChecks(true))
 }
+
+func CleanUpHost() error {
+	// A user can use setup with experiment flag
+	// and not use cleanup with same flag, to avoid
+	// any extra step/confusion we are just adding the checks
+	// which are behind the experiment flag. This way cleanup
+	// perform action in a sane way.
+	return doCleanUpPreflightChecks(getPreflightChecks(true))
+}

--- a/pkg/crc/preflight/preflight_darwin.go
+++ b/pkg/crc/preflight/preflight_darwin.go
@@ -94,7 +94,7 @@ var traySetupChecks = [...]Check{
 	},
 }
 
-func getPreflightChecks() []Check {
+func getPreflightChecks(experimentalFeatures bool) []Check {
 	checks := []Check{}
 
 	checks = append(checks, genericPreflightChecks[:]...)
@@ -103,7 +103,7 @@ func getPreflightChecks() []Check {
 	checks = append(checks, dnsPreflightChecks[:]...)
 
 	// Experimental feature
-	if EnableExperimentalFeatures {
+	if experimentalFeatures {
 		checks = append(checks, traySetupChecks[:]...)
 	}
 
@@ -116,7 +116,5 @@ func CleanUpHost() error {
 	// any extra step/confusion we are just adding the checks
 	// which are behind the experiment flag. This way cleanup
 	// perform action in a sane way.
-	checks := getPreflightChecks()
-	checks = append(checks, traySetupChecks[:]...)
-	return doCleanUpPreflightChecks(checks)
+	return doCleanUpPreflightChecks(getPreflightChecks(true))
 }

--- a/pkg/crc/preflight/preflight_darwin.go
+++ b/pkg/crc/preflight/preflight_darwin.go
@@ -109,12 +109,3 @@ func getPreflightChecks(experimentalFeatures bool) []Check {
 
 	return checks
 }
-
-func CleanUpHost() error {
-	// A user can use setup with experiment flag
-	// and not use cleanup with same flag, to avoid
-	// any extra step/confusion we are just adding the checks
-	// which are behind the experiment flag. This way cleanup
-	// perform action in a sane way.
-	return doCleanUpPreflightChecks(getPreflightChecks(true))
-}

--- a/pkg/crc/preflight/preflight_linux.go
+++ b/pkg/crc/preflight/preflight_linux.go
@@ -112,7 +112,7 @@ var libvirtPreflightChecks = [...]Check{
 	},
 }
 
-func getPreflightChecks() []Check {
+func getPreflightChecks(experimentalFeatures bool) []Check {
 	checks := []Check{}
 	checks = append(checks, genericPreflightChecks[:]...)
 	checks = append(checks, nonWinPreflightChecks[:]...)
@@ -122,5 +122,5 @@ func getPreflightChecks() []Check {
 }
 
 func CleanUpHost() error {
-	return doCleanUpPreflightChecks(getPreflightChecks())
+	return doCleanUpPreflightChecks(getPreflightChecks(true))
 }

--- a/pkg/crc/preflight/preflight_linux.go
+++ b/pkg/crc/preflight/preflight_linux.go
@@ -120,7 +120,3 @@ func getPreflightChecks(experimentalFeatures bool) []Check {
 
 	return checks
 }
-
-func CleanUpHost() error {
-	return doCleanUpPreflightChecks(getPreflightChecks(true))
-}

--- a/pkg/crc/preflight/preflight_test.go
+++ b/pkg/crc/preflight/preflight_test.go
@@ -9,13 +9,27 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestCount(t *testing.T) {
+func TestCountConfigurationOptions(t *testing.T) {
 	cfg := config.New(config.NewEmptyInMemoryStorage())
 	RegisterSettings(cfg)
 	assert.Len(t, cfg.AllConfigs(), map[string]int{
 		"darwin":  16,
 		"linux":   34,
 		"windows": 20,
+	}[runtime.GOOS])
+}
+
+func TestCountPreflights(t *testing.T) {
+	assert.Len(t, getPreflightChecks(false), map[string]int{
+		"darwin":  10,
+		"linux":   21,
+		"windows": 14,
+	}[runtime.GOOS])
+
+	assert.Len(t, getPreflightChecks(true), map[string]int{
+		"darwin":  16,
+		"linux":   21,
+		"windows": 16,
 	}[runtime.GOOS])
 }
 

--- a/pkg/crc/preflight/preflight_windows.go
+++ b/pkg/crc/preflight/preflight_windows.go
@@ -81,13 +81,13 @@ var traySetupChecks = [...]Check{
 	},
 }
 
-func getPreflightChecks() []Check {
+func getPreflightChecks(experimentalFeatures bool) []Check {
 	checks := []Check{}
 	checks = append(checks, genericPreflightChecks[:]...)
 	checks = append(checks, hypervPreflightChecks[:]...)
 
 	// Experimental feature
-	if EnableExperimentalFeatures {
+	if experimentalFeatures {
 		checks = append(checks, traySetupChecks[:]...)
 	}
 
@@ -100,7 +100,5 @@ func CleanUpHost() error {
 	// any extra step/confusion we are just adding the checks
 	// which are behind the experiment flag. This way cleanup
 	// perform action in a sane way.
-	checks := getPreflightChecks()
-	checks = append(checks, traySetupChecks[:]...)
-	return doCleanUpPreflightChecks(checks)
+	return doCleanUpPreflightChecks(getPreflightChecks(true))
 }

--- a/pkg/crc/preflight/preflight_windows.go
+++ b/pkg/crc/preflight/preflight_windows.go
@@ -93,12 +93,3 @@ func getPreflightChecks(experimentalFeatures bool) []Check {
 
 	return checks
 }
-
-func CleanUpHost() error {
-	// A user can use setup with experiment flag
-	// and not use cleanup with same flag, to avoid
-	// any extra step/confusion we are just adding the checks
-	// which are behind the experiment flag. This way cleanup
-	// perform action in a sane way.
-	return doCleanUpPreflightChecks(getPreflightChecks(true))
-}


### PR DESCRIPTION
This will enable us to also perform some checks during `crc start`