### PR TITLE
Fix display of non-string value in SuccessfullyApplied callback

### DIFF
--- a/pkg/crc/config/callbacks.go
+++ b/pkg/crc/config/callbacks.go
@@ -2,6 +2,8 @@ package config
 
 import (
 	"fmt"
+
+	"github.com/spf13/cast"
 )
 
 func RequiresRestartMsg(key string, _ interface{}) string {
@@ -11,5 +13,5 @@ func RequiresRestartMsg(key string, _ interface{}) string {
 }
 
 func SuccessfullyApplied(key string, value interface{}) string {
-	return fmt.Sprintf("Successfully configured %s to %s", key, value)
+	return fmt.Sprintf("Successfully configured %s to %s", key, cast.ToString(value))
 }

--- a/pkg/crc/config/callbacks_test.go
+++ b/pkg/crc/config/callbacks_test.go
@@ -1,0 +1,12 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSuccessfullyApplied(t *testing.T) {
+	assert.Equal(t, "Successfully configured http-proxy to http://proxy", SuccessfullyApplied("http-proxy", "http://proxy"))
+	assert.Equal(t, "Successfully configured enable-experimental-features to true", SuccessfullyApplied("enable-experimental-features", true))
+}


### PR DESCRIPTION
Use of cast.ToString instead of %v because spf13/cast package is widely used in this package.

This was introduced when enforcing the type of config properties.
