### PR TITLE
Recreate config object before calling each handler to always get the latest configs

### DIFF
--- a/cmd/crc/cmd/daemon.go
+++ b/cmd/crc/cmd/daemon.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	crcConfig "github.com/code-ready/crc/pkg/crc/config"
 	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/code-ready/crc/pkg/crc/logging"
 	"github.com/spf13/cobra"
@@ -20,6 +21,11 @@ var daemonCmd = &cobra.Command{
 		logging.CloseLogging()
 		logging.InitLogrus(logging.LogLevel, constants.DaemonLogFilePath)
 
-		runDaemon(config)
+		runDaemon()
 	},
+}
+
+func newConfig() (crcConfig.Storage, error) {
+	config, _, err := newViperConfig()
+	return config, err
 }

--- a/cmd/crc/cmd/daemon_nonwin.go
+++ b/cmd/crc/cmd/daemon_nonwin.go
@@ -6,15 +6,14 @@ import (
 	"os"
 
 	"github.com/code-ready/crc/pkg/crc/api"
-	crcConfig "github.com/code-ready/crc/pkg/crc/config"
 	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/code-ready/crc/pkg/crc/logging"
 )
 
-func runDaemon(config crcConfig.Storage) {
+func runDaemon() {
 	// Remove if an old socket is present
 	os.Remove(constants.DaemonSocketPath)
-	crcAPIServer, err := api.CreateAPIServer(constants.DaemonSocketPath, config)
+	crcAPIServer, err := api.CreateAPIServer(constants.DaemonSocketPath, newConfig)
 	if err != nil {
 		logging.Fatal("Failed to launch daemon", err)
 	}

--- a/cmd/crc/cmd/daemon_windows.go
+++ b/cmd/crc/cmd/daemon_windows.go
@@ -4,12 +4,11 @@ import (
 	"os"
 
 	"github.com/code-ready/crc/pkg/crc/api"
-	crcConfig "github.com/code-ready/crc/pkg/crc/config"
 	"github.com/code-ready/crc/pkg/crc/constants"
 )
 
-func runDaemon(config crcConfig.Storage) {
+func runDaemon() {
 	// Remove if an old socket is present
 	os.Remove(constants.DaemonSocketPath)
-	api.RunCrcDaemonService("CodeReady Containers", false, config)
+	api.RunCrcDaemonService("CodeReady Containers", false, newConfig)
 }

--- a/cmd/crc/cmd/root.go
+++ b/cmd/crc/cmd/root.go
@@ -44,14 +44,10 @@ func init() {
 		logging.Fatal(err.Error())
 	}
 	var err error
-	viper, err = crcConfig.NewViperStorage(constants.ConfigPath, constants.CrcEnvPrefix)
+	config, viper, err = newViperConfig()
 	if err != nil {
 		logging.Fatal(err.Error())
 	}
-	config = crcConfig.New(viper)
-	cmdConfig.RegisterSettings(config)
-
-	preflight.RegisterSettings(config)
 
 	// subcommands
 	rootCmd.AddCommand(cmdConfig.GetConfigCmd(config))
@@ -132,4 +128,15 @@ func getProxyCAData(proxyCAFile string) (string, error) {
 
 func trimTrailingEOL(s string) string {
 	return strings.TrimRight(s, "\n")
+}
+
+func newViperConfig() (*crcConfig.Config, *crcConfig.ViperStorage, error) {
+	viper, err := crcConfig.NewViperStorage(constants.ConfigPath, constants.CrcEnvPrefix)
+	if err != nil {
+		return nil, nil, err
+	}
+	cfg := crcConfig.New(viper)
+	cmdConfig.RegisterSettings(cfg)
+	preflight.RegisterSettings(cfg)
+	return cfg, viper, nil
 }

--- a/pkg/crc/api/api.go
+++ b/pkg/crc/api/api.go
@@ -6,25 +6,24 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/code-ready/crc/pkg/crc/config"
 	"github.com/code-ready/crc/pkg/crc/logging"
 	"github.com/code-ready/crc/pkg/crc/machine"
 )
 
-func CreateAPIServer(socketPath string, config config.Storage) (CrcAPIServer, error) {
+func CreateAPIServer(socketPath string, newConfig newConfigFunc) (CrcAPIServer, error) {
 	listener, err := net.Listen("unix", socketPath)
 	if err != nil {
 		logging.Error("Failed to create socket: ", err.Error())
 		return CrcAPIServer{}, err
 	}
-	return createAPIServerWithListener(listener, machine.NewClient(), config)
+	return createAPIServerWithListener(listener, machine.NewClient(), newConfig)
 }
 
-func createAPIServerWithListener(listener net.Listener, client machine.Client, config config.Storage) (CrcAPIServer, error) {
+func createAPIServerWithListener(listener net.Listener, client machine.Client, newConfig newConfigFunc) (CrcAPIServer, error) {
 	apiServer := CrcAPIServer{
 		client:                 client,
-		config:                 config,
 		listener:               listener,
+		newConfig:              newConfig,
 		clusterOpsRequestsChan: make(chan clusterOpsRequest, 10),
 		handlers: map[string]handlerFunc{
 			"start":         startHandler,
@@ -63,7 +62,12 @@ func (api CrcAPIServer) handleRequest(req commandRequest, conn net.Conn) {
 	defer conn.Close()
 	var result string
 	if handler, ok := api.handlers[req.Command]; ok {
-		result = handler(api.client, api.config, req.Args)
+		config, err := api.newConfig()
+		if err != nil {
+			result = encodeErrorToJSON(fmt.Sprintf("Failed to initialize new config store: %v", err))
+		} else {
+			result = handler(api.client, config, req.Args)
+		}
 	} else {
 		result = encodeErrorToJSON(fmt.Sprintf("Unknown command supplied: %s", req.Command))
 	}

--- a/pkg/crc/api/api_test.go
+++ b/pkg/crc/api/api_test.go
@@ -19,6 +19,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type fakeHandler struct {
+	*Handler
+}
+
+func newFakeHandler(client *fakemachine.Client) *fakeHandler {
+	return &fakeHandler{
+		&Handler{
+			MachineClient: client,
+		}}
+}
+
 func TestApi(t *testing.T) {
 	dir, err := ioutil.TempDir("", "api")
 	require.NoError(t, err)
@@ -29,7 +40,7 @@ func TestApi(t *testing.T) {
 	require.NoError(t, err)
 
 	client := fakemachine.NewClient()
-	api, err := createAPIServerWithListener(listener, client, setupNewInMemoryConfig)
+	api, err := createAPIServerWithListener(listener, setupNewInMemoryConfig, newFakeHandler(client))
 	require.NoError(t, err)
 	go api.Serve()
 
@@ -210,8 +221,7 @@ func setupAPIServer(t *testing.T) (string, func()) {
 	require.NoError(t, err)
 
 	client := fakemachine.NewClient()
-
-	api, err := createAPIServerWithListener(listener, client, setupNewInMemoryConfig)
+	api, err := createAPIServerWithListener(listener, setupNewInMemoryConfig, newFakeHandler(client))
 	require.NoError(t, err)
 	go api.Serve()
 

--- a/pkg/crc/api/handlers.go
+++ b/pkg/crc/api/handlers.go
@@ -17,7 +17,7 @@ import (
 	"github.com/code-ready/crc/pkg/crc/version"
 )
 
-func statusHandler(client machine.Client, crcConfig crcConfig.Storage, _ json.RawMessage) string {
+func statusHandler(client machine.Client, _ crcConfig.Storage, _ json.RawMessage) string {
 	statusConfig := machine.ClusterStatusConfig{Name: constants.DefaultName}
 	clusterStatus, _ := client.Status(statusConfig)
 	return encodeStructToJSON(clusterStatus)

--- a/pkg/crc/api/handlers.go
+++ b/pkg/crc/api/handlers.go
@@ -23,7 +23,7 @@ func statusHandler(client machine.Client, _ crcConfig.Storage, _ json.RawMessage
 	return encodeStructToJSON(clusterStatus)
 }
 
-func stopHandler(client machine.Client, crcConfig crcConfig.Storage, _ json.RawMessage) string {
+func stopHandler(client machine.Client, _ crcConfig.Storage, _ json.RawMessage) string {
 	stopConfig := machine.StopConfig{
 		Name:  constants.DefaultName,
 		Debug: true,
@@ -69,7 +69,7 @@ func getStartConfig(cfg crcConfig.Storage, args startArgs) machine.StartConfig {
 	return startConfig
 }
 
-func versionHandler(client machine.Client, crcConfig crcConfig.Storage, _ json.RawMessage) string {
+func versionHandler(client machine.Client, _ crcConfig.Storage, _ json.RawMessage) string {
 	v := &machine.VersionResult{
 		CrcVersion:       version.GetCRCVersion(),
 		CommitSha:        version.GetCommitSha(),
@@ -93,13 +93,13 @@ func getPullSecretFileContent(path string) func() (string, error) {
 	}
 }
 
-func deleteHandler(client machine.Client, crcConfig crcConfig.Storage, _ json.RawMessage) string {
+func deleteHandler(client machine.Client, _ crcConfig.Storage, _ json.RawMessage) string {
 	delConfig := machine.DeleteConfig{Name: constants.DefaultName}
 	r, _ := client.Delete(delConfig)
 	return encodeStructToJSON(r)
 }
 
-func webconsoleURLHandler(client machine.Client, crcConfig crcConfig.Storage, _ json.RawMessage) string {
+func webconsoleURLHandler(client machine.Client, _ crcConfig.Storage, _ json.RawMessage) string {
 	consoleConfig := machine.ConsoleConfig{Name: constants.DefaultName}
 	r, _ := client.GetConsoleURL(consoleConfig)
 	return encodeStructToJSON(r)

--- a/pkg/crc/api/types.go
+++ b/pkg/crc/api/types.go
@@ -25,6 +25,18 @@ type CrcAPIServer struct {
 	handlers               map[string]handlerFunc // relates commands to handler func
 }
 
+type RequestHandler interface {
+	Start(config.Storage, json.RawMessage) string
+	Stop() string
+	Status() string
+	Delete() string
+	GetVersion() string
+	SetConfig(config.Storage, json.RawMessage) string
+	UnsetConfig(config.Storage, json.RawMessage) string
+	GetConfig(config.Storage, json.RawMessage) string
+	GetWebconsoleInfo() string
+}
+
 // clusterOpsRequest struct is used to store the command request and associated socket
 type clusterOpsRequest struct {
 	command commandRequest

--- a/pkg/crc/api/types.go
+++ b/pkg/crc/api/types.go
@@ -11,13 +11,15 @@ import (
 
 type handlerFunc func(machine.Client, config.Storage, json.RawMessage) string
 
+type newConfigFunc func() (config.Storage, error)
+
 type commandError struct {
 	Err string
 }
 
 type CrcAPIServer struct {
 	client                 machine.Client
-	config                 config.Storage
+	newConfig              newConfigFunc
 	listener               net.Listener
 	clusterOpsRequestsChan chan clusterOpsRequest
 	handlers               map[string]handlerFunc // relates commands to handler func

--- a/pkg/crc/api/types.go
+++ b/pkg/crc/api/types.go
@@ -5,11 +5,7 @@ import (
 	"net"
 
 	"github.com/code-ready/crc/pkg/crc/config"
-
-	"github.com/code-ready/crc/pkg/crc/machine"
 )
-
-type handlerFunc func(machine.Client, config.Storage, json.RawMessage) string
 
 type newConfigFunc func() (config.Storage, error)
 
@@ -18,11 +14,10 @@ type commandError struct {
 }
 
 type CrcAPIServer struct {
-	client                 machine.Client
 	newConfig              newConfigFunc
 	listener               net.Listener
 	clusterOpsRequestsChan chan clusterOpsRequest
-	handlers               map[string]handlerFunc // relates commands to handler func
+	handler                RequestHandler
 }
 
 type RequestHandler interface {

--- a/pkg/crc/config/viper_config.go
+++ b/pkg/crc/config/viper_config.go
@@ -33,7 +33,6 @@ func NewViperStorage(configFile, envPrefix string) (*ViperStorage, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error reading configuration file '%s': %v", configFile, err)
 	}
-	v.WatchConfig()
 	return &ViperStorage{
 		viper:      v,
 		configFile: configFile,

--- a/pkg/crc/config/viper_config_test.go
+++ b/pkg/crc/config/viper_config_test.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
@@ -209,27 +208,6 @@ func TestViperConfigCastSet(t *testing.T) {
 	bin, err := ioutil.ReadFile(configFile)
 	assert.NoError(t, err)
 	assert.JSONEq(t, `{"cpus": 5}`, string(bin))
-}
-
-func TestViperConfigWatch(t *testing.T) {
-	dir, err := ioutil.TempDir("", "cfg")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
-	configFile := filepath.Join(dir, "crc.json")
-
-	config, err := newTestConfig(configFile, "CRC")
-	require.NoError(t, err)
-
-	assert.Equal(t, SettingValue{
-		Value:     4,
-		IsDefault: true,
-	}, config.Get(CPUs))
-
-	assert.NoError(t, ioutil.WriteFile(configFile, []byte("{\"cpus\": 5}"), 0600))
-
-	assert.Eventually(t, func() bool {
-		return config.Get(CPUs).Value == 5
-	}, time.Second, 10*time.Millisecond)
 }
 
 func TestCannotSetWithWrongType(t *testing.T) {


### PR DESCRIPTION
Fixes #1557 
Fixes #1576 

The `viper.WatchConfig` is not able to update the config properties on the daemon side, when the  same config property is set via cli and also from daemon. 
To solve this for config 'set' we watch writes to the config file and use `set` method from `config` to explicitly set the config properties read from the config file

## Testing

Below what am trying to do is, set/get config by mixing cli and the daemon api, whatever was set last should be returned from both cli and daemon.

```bash
## Checking the current config
╭─anjan@Anjans-MacBook-Pro ~/github.com/code-ready/crc ‹config_watch›
╰─$ nc -U ~/.crc/crc.sock
{"command":"getconfig", "args":{"properties":["cpus"]}}
{"Error":"","Configs":{"cpus":5}}%

## Set cpus using cli                                                                                                                                                                                                          ╭─anjan@Anjans-MacBook-Pro ~/github.com/code-ready/crc ‹config_watch›
╰─$ crc config set cpus 8
Changes to configuration property 'cpus' are only applied when a new CRC instance is created.
If you already have a CRC instance, then for this configuration change to take effect, delete the CRC instance with 'crc delete' and start a new one with 'crc start'.

## Set cpus using daemon api
╭─anjan@Anjans-MacBook-Pro ~/github.com/code-ready/crc ‹config_watch›
╰─$ nc -U ~/.crc/crc.sock
{"command":"setconfig", "args":{"properties":{"cpus":9}}}
{"Error":"","Properties":["cpus"]}%                                                                                                                                                                                                         

## Get cpus using cli
╭─anjan@Anjans-MacBook-Pro ~/github.com/code-ready/crc ‹config_watch›
╰─$ crc config view
- cpus                                  : 9

## Again set using cli
╭─anjan@Anjans-MacBook-Pro ~/github.com/code-ready/crc ‹config_watch›
╰─$ crc config set cpus 10                                                                                                                                                                                                            130 ↵
Changes to configuration property 'cpus' are only applied when a new CRC instance is created.
If you already have a CRC instance, then for this configuration change to take effect, delete the CRC instance with 'crc delete' and start a new one with 'crc start'.

## Get using daemon api
╭─anjan@Anjans-MacBook-Pro ~/github.com/code-ready/crc ‹config_watch›
╰─$ nc -U ~/.crc/crc.sock
{"command":"getconfig", "args":{"properties":["cpus"]}}
{"Error":"","Configs":{"cpus":10}}%
```