### PR TITLE
Integration time limit increase from 120m to 180m

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,7 +139,7 @@ ifndef CRC_BINARY
 	CRC_BINARY = --crc-binary=$(GOPATH)/bin
 endif
 integration:
-	@go test --timeout=120m $(REPOPATH)/test/integration -v $(PULL_SECRET_FILE) $(BUNDLE_LOCATION) $(CRC_BINARY) --bundle-version=$(BUNDLE_VERSION) $(GODOG_OPTS)
+	@go test --timeout=180m $(REPOPATH)/test/integration -v $(PULL_SECRET_FILE) $(BUNDLE_LOCATION) $(CRC_BINARY) --bundle-version=$(BUNDLE_VERSION) $(GODOG_OPTS)
 
 .PHONY: fmt
 fmt:


### PR DESCRIPTION
As part of pipeline, some features are executed twice if the first round fails (to mitigate some infra/ad-hoc issues). If that happens a few times, the last feature file does not within the 120min limit. Hence extension.