### PR TITLE
Allow daemon start handler to accept pull secret path as an argument

### DIFF
--- a/pkg/crc/api/types.go
+++ b/pkg/crc/api/types.go
@@ -47,3 +47,8 @@ type getConfigResult struct {
 	Error   string
 	Configs map[string]interface{}
 }
+
+// startArgs is used to get the pull secret file path as argument for start handler
+type startArgs struct {
+	PullSecretFile string `json:"pullSecretFile"`
+}

--- a/pkg/crc/machine/fakemachine/client.go
+++ b/pkg/crc/machine/fakemachine/client.go
@@ -83,7 +83,18 @@ func (c *Client) PowerOff(powerOff machine.PowerOffConfig) (machine.PowerOffResu
 }
 
 func (c *Client) Start(startConfig machine.StartConfig) (machine.StartResult, error) {
-	return machine.StartResult{}, errors.New("not implemented")
+	if c.Failing {
+		return machine.StartResult{
+			Name:           startConfig.Name,
+			Error:          "Failed to start",
+			KubeletStarted: false,
+		}, nil
+	}
+	return machine.StartResult{
+		Name:           startConfig.Name,
+		ClusterConfig:  DummyClusterConfig,
+		KubeletStarted: true,
+	}, nil
 }
 
 func (c *Client) Stop(stopConfig machine.StopConfig) (machine.StopResult, error) {


### PR DESCRIPTION
**Relates to:** https://github.com/code-ready/tray-macos/issues/24

## Testing
```bash
$ nc -U ~/.crc/crc.sock
{"command":"start", "args":{"pullSecretFile":"/User/anjan/Downloads/pull-secret-ocp"}}
{"Name":"crc","Status":"","Error":"Failed to get pull secret: open /User/anjan/Downloads/pull-secret-ocp: no such file or directory","ClusterConfig":{"KubeConfig":"","KubeAdminPass":"","ClusterAPI":"","WebConsoleURL":"","ProxyConfig":null},"KubeletStarted":false}
```
