### PR TITLE
Documentation: Fix minor wording and formatting errors

### DIFF
--- a/docs/source/topics/proc_starting-codeready-containers-behind-proxy.adoc
+++ b/docs/source/topics/proc_starting-codeready-containers-behind-proxy.adoc
@@ -11,9 +11,7 @@ For more information about using the embedded [command]`oc` binary, see link:{cr
 
 .Procedure
 
-* To start {prod} behind a proxy:
-
-  . Define a proxy using the `http_proxy` and `https_proxy` environment variables or using the [command]`{bin} config set` command as follows:
+. Define a proxy using the `http_proxy` and `https_proxy` environment variables or using the [command]`{bin} config set` command as follows:
 +
 [subs="+quotes,attributes"]
 ----
@@ -21,16 +19,13 @@ $ {bin} config set http-proxy http://proxy.example.com:__<port>__
 $ {bin} config set https-proxy http://proxy.example.com:__<port>__
 $ {bin} config set no-proxy __<comma-separated-no-proxy-entries>__
 ----
-+
 
-. If proxy uses custom CA then use the `{bin} config set` command as follows:
+. If the proxy uses a custom CA certificate file, set it as follows:
 +
 [subs="+quotes,attributes"]
 ----
-$ {bin} config set proxy-ca-file __<Path to custom CA file>__
+$ {bin} config set proxy-ca-file __<path-to-custom-ca-file>__
 ----
-+
-
 
 The [command]`{bin}` binary will be able to use the defined proxy once set through environment variables or {prod} configuration.
 

--- a/docs/source/topics/proc_starting-monitoring-alerting-telemetry.adoc
+++ b/docs/source/topics/proc_starting-monitoring-alerting-telemetry.adoc
@@ -11,8 +11,8 @@ Telemetry functionality is responsible for listing your cluster in the link:http
 For more information, see link:{crc-gsg-url}#accessing-the-openshift-cluster-with-oc_gsg[Accessing the OpenShift cluster with `oc`].
 * You must log in through [command]`oc` as the `kubeadmin` user.
 * You must assign additional memory to the {prod} virtual machine.
-At least 14 GiB of memory (a value of `14336`) is recommended, for core functionality. 
-For additional workload additional memory will be required.
+At least 14 GiB of memory (a value of `14336`) is recommended for core functionality. 
+Increased workloads will require more memory.
 For more information, see link:{crc-gsg-url}#configuring-the-virtual-machine_gsg[Configuring the virtual machine].
 
 .Procedure


### PR DESCRIPTION
## Solution/Idea

Minor edits and changes to the wording and formatting of the documentation to align this repository with downstream documentation changes.