### PR TITLE
Use time limit instead of number of attempts for retry loops

### DIFF
--- a/pkg/crc/cluster/cert-renewal.go
+++ b/pkg/crc/cluster/cert-renewal.go
@@ -28,7 +28,7 @@ func waitForPendingCsrs(ocConfig oc.Config) error {
 		return nil
 	}
 
-	return errors.RetryAfter(120, waitForPendingCsr, time.Second*5)
+	return errors.RetryAfter(8*time.Minute, waitForPendingCsr, time.Second*5)
 }
 
 func RegenerateCertificates(sshRunner *ssh.Runner, ocConfig oc.Config) error {

--- a/pkg/crc/cluster/cluster.go
+++ b/pkg/crc/cluster/cluster.go
@@ -25,7 +25,7 @@ func WaitForSSH(sshRunner *ssh.Runner) error {
 		return nil
 	}
 
-	return errors.RetryAfter(60, checkSSHConnectivity, time.Second)
+	return errors.RetryAfter(60*time.Second, checkSSHConnectivity, time.Second)
 }
 
 type CertExpiryState int
@@ -263,7 +263,7 @@ func WaitforRequestHeaderClientCaFile(ocConfig oc.Config) error {
 		logging.Debugf("Found .data.requestheader-client-ca-file: %s", stdout)
 		return nil
 	}
-	return errors.RetryAfter(90, lookupRequestHeaderClientCa, 2*time.Second)
+	return errors.RetryAfter(8*time.Minute, lookupRequestHeaderClientCa, 2*time.Second)
 }
 
 func DeleteOpenshiftAPIServerPods(ocConfig oc.Config) error {
@@ -280,7 +280,7 @@ func DeleteOpenshiftAPIServerPods(ocConfig oc.Config) error {
 		return nil
 	}
 
-	return errors.RetryAfter(60, deleteOpenshiftAPIServerPods, time.Second)
+	return errors.RetryAfter(60*time.Second, deleteOpenshiftAPIServerPods, time.Second)
 }
 
 func CheckProxySettingsForOperator(ocConfig oc.Config, proxy *network.ProxyConfig, deployment, namespace string) (bool, error) {

--- a/pkg/crc/cluster/csr.go
+++ b/pkg/crc/cluster/csr.go
@@ -21,7 +21,7 @@ func WaitForOpenshiftResource(ocConfig oc.Config, resource string) error {
 		logging.Debug(stdout)
 		return nil
 	}
-	return errors.RetryAfter(80, waitForAPIServer, time.Second)
+	return errors.RetryAfter(80*time.Second, waitForAPIServer, time.Second)
 }
 
 // ApproveNodeCSR approves the certificate for the node.

--- a/pkg/crc/errors/multierror.go
+++ b/pkg/crc/errors/multierror.go
@@ -65,7 +65,7 @@ func RetryAfter(limit time.Duration, callback func() error, d time.Duration) err
 	m := MultiError{}
 	timeLimit := time.Now().Add(limit)
 	attempt := 0
-	for time.Now().Before(timeLimit) {
+	for time.Now().Before(timeLimit) || attempt < 2 {
 		logging.Debugf("retry loop: attempt %d", attempt)
 		err := callback()
 		if err == nil {

--- a/pkg/crc/errors/multierror_test.go
+++ b/pkg/crc/errors/multierror_test.go
@@ -29,6 +29,20 @@ func TestRetryAfterFailure(t *testing.T) {
 	assert.Equal(t, 1, calls)
 }
 
+func TestRetryAfterSlowFailure(t *testing.T) {
+	calls := 0
+	ret := RetryAfter(time.Millisecond, func() error {
+		time.Sleep(50 * time.Millisecond)
+		calls++
+		if calls < 2 {
+			return &RetriableError{Err: errors.New("failed")}
+		}
+		return nil
+	}, 0)
+	assert.NoError(t, ret)
+	assert.Equal(t, 2, calls)
+}
+
 func TestRetryAfterMaxAttempts(t *testing.T) {
 	calls := 0
 	ret := RetryAfter(10*time.Millisecond, func() error {

--- a/pkg/crc/machine/kubeconfig.go
+++ b/pkg/crc/machine/kubeconfig.go
@@ -32,7 +32,7 @@ const (
 )
 
 func eventuallyWriteKubeconfig(ocConfig oc.Config, ip string, clusterConfig *ClusterConfig) error {
-	if err := errors.RetryAfter(60, func() error {
+	if err := errors.RetryAfter(60*time.Second, func() error {
 		status, err := cluster.GetClusterOperatorStatus(ocConfig, "authentication")
 		if err != nil {
 			return &errors.RetriableError{Err: err}

--- a/pkg/crc/machine/machine.go
+++ b/pkg/crc/machine/machine.go
@@ -800,7 +800,7 @@ func waitForProxyPropagation(ocConfig oc.Config, proxyConfig *network.ProxyConfi
 		return nil
 	}
 
-	if err := errors.RetryAfter(60, checkProxySettingsForOperator, 2*time.Second); err != nil {
+	if err := errors.RetryAfter(60*time.Second, checkProxySettingsForOperator, 2*time.Second); err != nil {
 		logging.Debug("Failed to propagate proxy settings to cluster")
 	}
 }

--- a/pkg/crc/services/dns/dns.go
+++ b/pkg/crc/services/dns/dns.go
@@ -97,7 +97,7 @@ func CheckCRCLocalDNSReachable(serviceConfig services.ServicePostStartConfig) (s
 		return nil
 	}
 
-	if err := errors.RetryAfter(30, checkLocalDNSReach, time.Second); err != nil {
+	if err := errors.RetryAfter(30*time.Second, checkLocalDNSReach, time.Second); err != nil {
 		return queryOutput, err
 	}
 	return queryOutput, err

--- a/pkg/crc/services/dns/dns_darwin.go
+++ b/pkg/crc/services/dns/dns_darwin.go
@@ -128,7 +128,7 @@ func waitForNetwork() error {
 		return nil
 	}
 
-	if err := errors.RetryAfter(10, getResolvValueFromHost, time.Second); err != nil {
+	if err := errors.RetryAfter(10*time.Second, getResolvValueFromHost, time.Second); err != nil {
 		return fmt.Errorf("Unable to read host resolv file (%v)", err)
 	}
 	// retry up to 5 times


### PR DESCRIPTION
Writing the maximum duration the program will wait is more precise than
using a number of attempts.

Example:
errors.RetryAfter(120, waitForPendingCsr, time.Second*5) is equivalent
of waiting 120 * (execution time of waitForPendingCsr + 5 seconds).
This is way more than 120 seconds, the duration expected to last when
this line was added.
Now, it will try as much as possible within 120 seconds and wait 5
seconds between each try.