### PR TITLE
Use 0755 mode for creating the cache dir in case bundle is embedded

### DIFF
--- a/pkg/crc/preflight/preflight_checks_common.go
+++ b/pkg/crc/preflight/preflight_checks_common.go
@@ -64,9 +64,15 @@ func checkBundleCached() error {
 }
 
 func fixBundleCached() error {
+	// Should be removed after 1.19 release
+	// This check will ensure correct mode for `~/.crc/cache` directory
+	// in case it exists.
+	if err := os.Chmod(constants.MachineCacheDir, 0775); err != nil {
+		logging.Debugf("Error changing %s permissions to 0775", constants.MachineCacheDir)
+	}
 	if constants.BundleEmbedded() {
 		bundleDir := filepath.Dir(constants.DefaultBundlePath)
-		err := os.MkdirAll(bundleDir, 0700)
+		err := os.MkdirAll(bundleDir, 0775)
 		if err != nil && !os.IsExist(err) {
 			return fmt.Errorf("Cannot create directory %s", bundleDir)
 		}


### PR DESCRIPTION
~/.crc/cache directory is created with `0700` in case the bundle is
embedded to the binary and `0775` if a user uses `-b <bundle>` option
from the start. This 2 different path for directory permisison is causing
issue from linux when we use the backing file for qemu.

```
Error creating machine: Error creating the VM: Error creating machine: Error in driver during machine creation: virError(Code=38, Domain=18, Message='Cannot access backing file '/home/cloud-user/.crc/cache/crc_libvirt_4.5.14/crc.qcow2' of storage file '/home/cloud-user/.crc/machines/crc/crc.qcow2' (as uid:107, gid:107): Permission denied')
```


