### PR TITLE
Fix unit test for startHandler of daemon api

### DIFF
--- a/pkg/crc/api/api_test.go
+++ b/pkg/crc/api/api_test.go
@@ -90,6 +90,7 @@ func TestApi(t *testing.T) {
 					"ClusterAPI":    "",
 					"WebConsoleURL": "",
 					"ProxyConfig":   nil,
+					"ClusterCACert": "",
 				},
 			},
 		},
@@ -102,6 +103,7 @@ func TestApi(t *testing.T) {
 				"Error":          "",
 				"KubeletStarted": true,
 				"ClusterConfig": map[string]interface{}{
+					"ClusterCACert": "MIIDODCCAiCgAwIBAgIIRVfCKNUa1wIwDQYJ",
 					"KubeConfig":    "/tmp/kubeconfig",
 					"KubeAdminPass": "foobar",
 					"ClusterAPI":    "https://foo.testing:6443",


### PR DESCRIPTION
A new field `ClusterCACert` was added to `ClusterConfig` struct
which caused the unit test to fail, added it to the expected cluster config