### PR TITLE
console: Don't return early when printing url/credentials

### DIFF
--- a/cmd/crc/cmd/console.go
+++ b/cmd/crc/cmd/console.go
@@ -81,8 +81,9 @@ func (s *consoleResult) prettyPrintTo(writer io.Writer) error {
 		return errors.New(s.Error)
 	}
 	if s.consolePrintURL {
-		_, err := fmt.Fprintln(writer, s.ClusterConfig.WebConsoleURL)
-		return err
+		if _, err := fmt.Fprintln(writer, s.ClusterConfig.WebConsoleURL); err != nil {
+			return err
+		}
 	}
 
 	if s.consolePrintCredentials {
@@ -90,9 +91,10 @@ func (s *consoleResult) prettyPrintTo(writer io.Writer) error {
 			s.ClusterConfig.DeveloperCredentials.Username, s.ClusterConfig.DeveloperCredentials.Password, s.ClusterConfig.URL); err != nil {
 			return err
 		}
-		_, err := fmt.Fprintf(writer, "To login as an admin, run 'oc login -u %s -p %s %s'\n",
-			s.ClusterConfig.AdminCredentials.Username, s.ClusterConfig.AdminCredentials.Password, s.ClusterConfig.URL)
-		return err
+		if _, err := fmt.Fprintf(writer, "To login as an admin, run 'oc login -u %s -p %s %s'\n",
+			s.ClusterConfig.AdminCredentials.Username, s.ClusterConfig.AdminCredentials.Password, s.ClusterConfig.URL); err != nil {
+			return err
+		}
 	}
 	if s.consolePrintURL || s.consolePrintCredentials {
 		return nil

--- a/cmd/crc/cmd/console_test.go
+++ b/cmd/crc/cmd/console_test.go
@@ -29,6 +29,16 @@ To login as an admin, run 'oc login -u kubeadmin -p %s %s'
 	assert.Equal(t, expectedOut, out.String())
 }
 
+func TestConsoleWithPrintCredentialsAndURLPlainSuccess(t *testing.T) {
+	expectedOut := fmt.Sprintf(`%s
+To login as a regular user, run 'oc login -u developer -p developer %s'.
+To login as an admin, run 'oc login -u kubeadmin -p %s %s'
+`, fakemachine.DummyClusterConfig.WebConsoleURL, fakemachine.DummyClusterConfig.ClusterAPI, fakemachine.DummyClusterConfig.KubeAdminPass, fakemachine.DummyClusterConfig.ClusterAPI)
+	out := new(bytes.Buffer)
+	assert.NoError(t, runConsole(out, fakemachine.NewClient(), true, true, ""))
+	assert.Equal(t, expectedOut, out.String())
+}
+
 func TestConsoleJSONSuccess(t *testing.T) {
 	expectedJSONOut := fmt.Sprintf(`{
   "success": true,


### PR DESCRIPTION
When there is no error after printing either the console URL or the console
credentials, we should not return early as the user might have passed multiple
command line arguments (--url --credentials).
This fixes https://github.com/code-ready/crc/issues/1580



**Fixes:** Issue #1580

## Testing

1. `crc console --url --credentials` shows both the console URL and the credentials