### PR TITLE
Restart openshift-apiserver only if aggregator-client-ca is expired

### DIFF
--- a/pkg/crc/cluster/cert-renewal.go
+++ b/pkg/crc/cluster/cert-renewal.go
@@ -38,7 +38,7 @@ func ApproveCSRAndWaitForCertsRenewal(sshRunner *ssh.Runner, ocConfig oc.Config,
 			logging.Debugf("Error approving pending kube-apiserver-client-kubelet CSR: %v", err)
 			return err
 		}
-		if err := crcerrors.RetryAfter(5*time.Minute, waitForCertRenewal(sshRunner, kubeletClientCert), time.Second*5); err != nil {
+		if err := crcerrors.RetryAfter(5*time.Minute, waitForCertRenewal(sshRunner, KubeletClientCert), time.Second*5); err != nil {
 			logging.Debugf("Error approving pending kube-apiserver-client-kubelet CSR: %v", err)
 			return err
 		}
@@ -49,7 +49,7 @@ func ApproveCSRAndWaitForCertsRenewal(sshRunner *ssh.Runner, ocConfig oc.Config,
 	// This CSR is automatically approved by the cluster-machine-approver. The k8s controller manager issues the cert and kubelet fetches it.
 	if server {
 		logging.Info("Kubelet serving certificate has expired, waiting for automatic renewal... [will take up to 8 minutes]")
-		return crcerrors.RetryAfter(5*time.Minute, waitForCertRenewal(sshRunner, kubeletServerCert), time.Second*5)
+		return crcerrors.RetryAfter(5*time.Minute, waitForCertRenewal(sshRunner, KubeletServerCert), time.Second*5)
 	}
 	return nil
 }

--- a/pkg/crc/cluster/cluster.go
+++ b/pkg/crc/cluster/cluster.go
@@ -37,6 +37,8 @@ const (
 	kubeletClientCert = "/var/lib/kubelet/pki/kubelet-client-current.pem"
 
 	kubeletClientSignerName = "kubernetes.io/kube-apiserver-client-kubelet"
+
+	aggregatorClientCert = "/etc/kubernetes/static-pod-resources/kube-apiserver-certs/configmaps/aggregator-client-ca/ca-bundle.crt"
 )
 
 func CheckCertsValidity(sshRunner *ssh.Runner) (bool, bool, error) {
@@ -65,6 +67,10 @@ func checkCertValidity(sshRunner *ssh.Runner, cert string) (bool, error) {
 		return true, nil
 	}
 	return false, nil
+}
+
+func CheckAggregatorClientCAValidity(sshRunner *ssh.Runner) (bool, error) {
+	return checkCertValidity(sshRunner, aggregatorClientCert)
 }
 
 // Return size of disk, used space in bytes and the mountpoint

--- a/pkg/crc/machine/machine.go
+++ b/pkg/crc/machine/machine.go
@@ -353,7 +353,7 @@ func (client *client) Start(startConfig StartConfig) (*StartResult, error) {
 
 	// Check the certs validity inside the vm
 	logging.Info("Verifying validity of the kubelet certificates ...")
-	clientExpired, serverExpired, err := cluster.CheckCertsValidity(sshRunner)
+	clientExpired, serverExpired, aggregatorClientExpired, err := cluster.CheckCertsValidity(sshRunner)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to check certificate validity")
 	}
@@ -404,11 +404,7 @@ func (client *client) Start(startConfig StartConfig) (*StartResult, error) {
 	// A restart of the openshift-apiserver pod is enough to clear that error and get a working cluster.
 	// This is a work-around while the root cause is being identified.
 	// More info: https://bugzilla.redhat.com/show_bug.cgi?id=1795163
-	expired, err := cluster.CheckAggregatorClientCAValidity(sshRunner)
-	if err != nil {
-		return nil, errors.Wrap(err, "Cannot check expiry date of the aggregator client ca")
-	}
-	if expired {
+	if aggregatorClientExpired {
 		logging.Debug("Waiting for the renewal of the request header client ca...")
 		if err := cluster.WaitForRequestHeaderClientCaFile(sshRunner); err != nil {
 			return nil, errors.Wrap(err, "Failed to wait for aggregator client ca renewal")

--- a/pkg/crc/machine/machine.go
+++ b/pkg/crc/machine/machine.go
@@ -353,7 +353,7 @@ func (client *client) Start(startConfig StartConfig) (*StartResult, error) {
 
 	// Check the certs validity inside the vm
 	logging.Info("Verifying validity of the kubelet certificates ...")
-	clientExpired, serverExpired, aggregatorClientExpired, err := cluster.CheckCertsValidity(sshRunner)
+	certsExpired, err := cluster.CheckCertsValidity(sshRunner)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to check certificate validity")
 	}
@@ -366,7 +366,7 @@ func (client *client) Start(startConfig StartConfig) (*StartResult, error) {
 
 	ocConfig := oc.UseOCWithSSH(sshRunner)
 
-	if err := cluster.ApproveCSRAndWaitForCertsRenewal(sshRunner, ocConfig, clientExpired, serverExpired); err != nil {
+	if err := cluster.ApproveCSRAndWaitForCertsRenewal(sshRunner, ocConfig, certsExpired[cluster.KubeletClientCert], certsExpired[cluster.KubeletServerCert]); err != nil {
 		logBundleDate(crcBundleMetadata)
 		return nil, errors.Wrap(err, "Failed to renew TLS certificates: please check if a newer CodeReady Containers release is available")
 	}
@@ -404,7 +404,7 @@ func (client *client) Start(startConfig StartConfig) (*StartResult, error) {
 	// A restart of the openshift-apiserver pod is enough to clear that error and get a working cluster.
 	// This is a work-around while the root cause is being identified.
 	// More info: https://bugzilla.redhat.com/show_bug.cgi?id=1795163
-	if aggregatorClientExpired {
+	if certsExpired[cluster.AggregatorClientCert] {
 		logging.Debug("Waiting for the renewal of the request header client ca...")
 		if err := cluster.WaitForRequestHeaderClientCaFile(sshRunner); err != nil {
 			return nil, errors.Wrap(err, "Failed to wait for aggregator client ca renewal")

--- a/pkg/crc/machine/machine.go
+++ b/pkg/crc/machine/machine.go
@@ -410,7 +410,7 @@ func (client *client) Start(startConfig StartConfig) (*StartResult, error) {
 	}
 	if expired {
 		logging.Debug("Waiting for the renewal of the request header client ca...")
-		if err := cluster.WaitforRequestHeaderClientCaFile(ocConfig); err != nil {
+		if err := cluster.WaitForRequestHeaderClientCaFile(sshRunner); err != nil {
 			return nil, errors.Wrap(err, "Failed to wait for aggregator client ca renewal")
 		}
 


### PR DESCRIPTION
This cert is eventually renewed at startup. If it is renewed, we need to
wait for it and restart openshift-apiserver. Since this cert is located
both in a configmap and on the disk, we prefer to read it from the disk:
it is faster to access and more reliable.

If the cert is not expired, openshift-apiserver will correctly start.
`crc start` will take less time when the bundle is fresh (< 30 days).

follow up of https://github.com/code-ready/crc/pull/1532
