### PR TITLE
Use a config that discards all preflights for API tests

### DIFF
--- a/pkg/crc/preflight/preflight_checks_common.go
+++ b/pkg/crc/preflight/preflight_checks_common.go
@@ -16,6 +16,7 @@ import (
 
 var genericPreflightChecks = [...]Check{
 	{
+		configKeySuffix:  "check-oc-cached",
 		checkDescription: "Checking if oc binary is cached",
 		check:            checkOcBinaryCached,
 		fixDescription:   "Caching oc binary",
@@ -29,6 +30,7 @@ var genericPreflightChecks = [...]Check{
 		fix:              fixPodmanBinaryCached,
 	},
 	{
+		configKeySuffix:  "check-goodhosts-cached",
 		checkDescription: "Checking if goodhosts binary is cached",
 		check:            checkGoodhostsBinaryCached,
 		fixDescription:   "Caching goodhosts binary",

--- a/pkg/crc/preflight/preflight_linux.go
+++ b/pkg/crc/preflight/preflight_linux.go
@@ -51,6 +51,7 @@ var libvirtPreflightChecks = [...]Check{
 		fix:              fixMachineDriverLibvirtInstalled,
 	},
 	{
+		configKeySuffix:  "check-obsolete-libvirt-driver",
 		checkDescription: "Checking for obsolete crc-driver-libvirt",
 		check:            checkOldMachineDriverLibvirtInstalled,
 		fixDescription:   "Removing older system-wide crc-driver-libvirt",

--- a/pkg/crc/preflight/preflight_test.go
+++ b/pkg/crc/preflight/preflight_test.go
@@ -13,9 +13,9 @@ func TestCountConfigurationOptions(t *testing.T) {
 	cfg := config.New(config.NewEmptyInMemoryStorage())
 	RegisterSettings(cfg)
 	assert.Len(t, cfg.AllConfigs(), map[string]int{
-		"darwin":  16,
-		"linux":   34,
-		"windows": 20,
+		"darwin":  20,
+		"linux":   40,
+		"windows": 24,
 	}[runtime.GOOS])
 }
 


### PR DESCRIPTION
It allows us to test the real implementation of the start handler.
If a check doesn't have a key, it cannot be skipped. Adding missing
ones.

Follow up for #1558