### PR TITLE
Remove etcd srv entry from the dnsmasq

### DIFF
--- a/pkg/crc/services/dns/template.go
+++ b/pkg/crc/services/dns/template.go
@@ -13,11 +13,9 @@ port= {{ .Port }}
 bind-interfaces
 expand-hosts
 log-queries
-srv-host=_etcd-server-ssl._tcp.{{ .ClusterName}}.{{ .BaseDomain }},etcd-0.{{ .ClusterName}}.{{ .BaseDomain }},2380,10
 local=/{{ .ClusterName}}.{{ .BaseDomain }}/
 domain={{ .ClusterName}}.{{ .BaseDomain }}
 address=/{{ .AppsDomain }}/{{ .IP }}
-address=/etcd-0.{{ .ClusterName}}.{{ .BaseDomain }}/{{ .IP }}
 address=/api.{{ .ClusterName}}.{{ .BaseDomain }}/{{ .IP }}
 address=/api-int.{{ .ClusterName}}.{{ .BaseDomain }}/{{ .IP }}
 address=/{{ .Hostname }}.{{ .ClusterName}}.{{ .BaseDomain }}/{{ .InternalIP }}


### PR DESCRIPTION
From openshift-4.4 onwards etcd doesn't depend on the dns and it
uses the node IP address so better to remove it from crc side also.

- https://github.com/openshift/installer/commit/b0ed309b90a82239c6d74c934147c1b3bb9df89b
