### PR TITLE
Simplify dns package outputs

### DIFF
--- a/pkg/crc/machine/machine.go
+++ b/pkg/crc/machine/machine.go
@@ -294,7 +294,7 @@ func (client *client) Start(startConfig StartConfig) (*StartResult, error) {
 	}
 
 	// Run the DNS server inside the VM
-	if _, err := dns.RunPostStart(servicePostStartConfig); err != nil {
+	if err := dns.RunPostStart(servicePostStartConfig); err != nil {
 		return nil, errors.Wrap(err, "Error running post start")
 	}
 

--- a/pkg/crc/services/dns/dns_linux.go
+++ b/pkg/crc/services/dns/dns_linux.go
@@ -5,16 +5,11 @@ import (
 	"github.com/code-ready/crc/pkg/crc/services"
 )
 
-func runPostStartForOS(serviceConfig services.ServicePostStartConfig, result *services.ServicePostStartResult) (services.ServicePostStartResult, error) {
+func runPostStartForOS(serviceConfig services.ServicePostStartConfig) error {
 	// We might need to set the firewall here to forward
 	// Update /etc/hosts file for host
-	if err := goodhosts.UpdateHostsFile(serviceConfig.IP, serviceConfig.BundleMetadata.GetAPIHostname(),
+	return goodhosts.UpdateHostsFile(serviceConfig.IP, serviceConfig.BundleMetadata.GetAPIHostname(),
 		serviceConfig.BundleMetadata.GetAppHostname("oauth-openshift"),
 		serviceConfig.BundleMetadata.GetAppHostname("console-openshift-console"),
-		serviceConfig.BundleMetadata.GetAppHostname("default-route-openshift-image-registry")); err != nil {
-		result.Success = false
-		return *result, err
-	}
-	result.Success = true
-	return *result, nil
+		serviceConfig.BundleMetadata.GetAppHostname("default-route-openshift-image-registry"))
 }

--- a/pkg/crc/services/dns/dns_windows.go
+++ b/pkg/crc/services/dns/dns_windows.go
@@ -2,7 +2,6 @@ package dns
 
 import (
 	"bufio"
-	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -27,7 +26,7 @@ func runPostStartForOS(serviceConfig services.ServicePostStartConfig) error {
 	time.Sleep(2 * time.Second)
 
 	if !contains(getInterfaceNameserverValues(networkInterface), serviceConfig.IP) {
-		return errors.New("Nameserver not successfully set")
+		return fmt.Errorf("Nameserver %s not successfully set on interface %s", serviceConfig.IP, networkInterface)
 	}
 	return nil
 }

--- a/pkg/crc/services/dns/dns_windows.go
+++ b/pkg/crc/services/dns/dns_windows.go
@@ -18,7 +18,7 @@ const (
 	AlternativeNetwork = "crc"
 )
 
-func runPostStartForOS(serviceConfig services.ServicePostStartConfig, result *services.ServicePostStartResult) (services.ServicePostStartResult, error) {
+func runPostStartForOS(serviceConfig services.ServicePostStartConfig) error {
 	_, switchName := winnet.SelectSwitchByNameOrDefault(AlternativeNetwork)
 	networkInterface := fmt.Sprintf("vEthernet (%s)", switchName)
 
@@ -27,14 +27,9 @@ func runPostStartForOS(serviceConfig services.ServicePostStartConfig, result *se
 	time.Sleep(2 * time.Second)
 
 	if !contains(getInterfaceNameserverValues(networkInterface), serviceConfig.IP) {
-		err := errors.New("Nameserver not successfully set")
-		result.Success = false
-		result.Error = err.Error()
-		return *result, err
+		return errors.New("Nameserver not successfully set")
 	}
-
-	result.Success = true
-	return *result, nil
+	return nil
 }
 
 func getInterfaceNameserverValues(iface string) []string {

--- a/pkg/crc/services/services.go
+++ b/pkg/crc/services/services.go
@@ -5,26 +5,9 @@ import (
 	"github.com/code-ready/crc/pkg/crc/ssh"
 )
 
-type ServicePreStartConfig struct {
-	Name           string
-	BundleMetadata bundle.CrcBundleInfo
-}
-
-type ServicePreStartResult struct {
-	Name    string
-	Success bool
-	Error   string
-}
-
 type ServicePostStartConfig struct {
 	Name           string
 	SSHRunner      *ssh.Runner
 	BundleMetadata bundle.CrcBundleInfo
 	IP             string
-}
-
-type ServicePostStartResult struct {
-	Name    string
-	Success bool
-	Error   string
 }


### PR DESCRIPTION
Removes the last pattern:

```
if err != nil {
  result.Success = false
  result.Error = err.Error()
  return *result, err
}
```