### PR TITLE
Remove crcos.CurrentOS(), use runtime.GOOS

### DIFF
--- a/pkg/crc/machine/machine.go
+++ b/pkg/crc/machine/machine.go
@@ -42,7 +42,7 @@ import (
 
 func init() {
 	// Force using the golang SSH implementation for windows
-	if runtime.GOOS == crcos.WINDOWS.String() {
+	if runtime.GOOS == "windows" {
 		ssh.SetDefaultClient(ssh.Native)
 	}
 }

--- a/pkg/crc/network/utils.go
+++ b/pkg/crc/network/utils.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/code-ready/crc/pkg/crc/logging"
 	"github.com/code-ready/crc/pkg/crc/machine/bundle"
-	crcos "github.com/code-ready/crc/pkg/os"
 )
 
 func URIStringForDisplay(uri string) (string, error) {
@@ -53,7 +52,7 @@ func CheckCRCLocalDNSReachableFromHost(bundle *bundle.CrcBundleInfo, expectedIP 
 		if err != nil {
 			// Right now goodhosts fallback is not implemented in windows so
 			// this checks should still return the error.
-			if crcos.CurrentOS() == crcos.WINDOWS {
+			if runtime.GOOS == "windows" {
 				return err
 			}
 			logging.Warnf("Wildcard DNS resolution for %s does not appear to be working", bundle.ClusterInfo.AppsDomain)

--- a/pkg/os/util.go
+++ b/pkg/os/util.go
@@ -7,35 +7,10 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 
 	"github.com/code-ready/crc/pkg/crc/logging"
 )
-
-const (
-	LINUX   OS = "linux"
-	DARWIN  OS = "darwin"
-	WINDOWS OS = "windows"
-)
-
-type OS string
-
-func (t OS) String() string {
-	return string(t)
-}
-
-func CurrentOS() OS {
-	switch runtime.GOOS {
-	case "windows":
-		return WINDOWS
-	case "darwin":
-		return DARWIN
-	case "linux":
-		return LINUX
-	}
-	panic("Unexpected OS type")
-}
 
 // ReplaceOrAddEnv changes the value of an environment variable if it exists otherwise add the new variable
 // It drops the existing value and appends the new value in-place


### PR DESCRIPTION
crcos.CurrentOS() failed to replace runtime.GOOS, which is the most
popular way to check os in this codebase.
