### PR TITLE
Disk resize

### DIFF
--- a/cmd/crc/cmd/config/config.go
+++ b/cmd/crc/cmd/config/config.go
@@ -13,6 +13,7 @@ const (
 	Bundle               = "bundle"
 	CPUs                 = "cpus"
 	Memory               = "memory"
+	DiskSize             = "disk-size"
 	NameServer           = "nameserver"
 	PullSecretFile       = "pull-secret-file"
 	DisableUpdateCheck   = "disable-update-check"
@@ -28,6 +29,7 @@ func RegisterSettings(cfg *config.Config) {
 	cfg.AddSetting(Bundle, constants.DefaultBundlePath, config.ValidateBundle, config.SuccessfullyApplied)
 	cfg.AddSetting(CPUs, constants.DefaultCPUs, config.ValidateCPUs, config.RequiresRestartMsg)
 	cfg.AddSetting(Memory, constants.DefaultMemory, config.ValidateMemory, config.RequiresRestartMsg)
+	cfg.AddSetting(DiskSize, constants.DefaultDiskSize, config.ValidateDiskSize, config.RequiresRestartMsg)
 	cfg.AddSetting(NameServer, "", config.ValidateIPAddress, config.SuccessfullyApplied)
 	cfg.AddSetting(PullSecretFile, "", config.ValidatePath, config.SuccessfullyApplied)
 	cfg.AddSetting(DisableUpdateCheck, false, config.ValidateBool, config.SuccessfullyApplied)

--- a/cmd/crc/cmd/start.go
+++ b/cmd/crc/cmd/start.go
@@ -31,6 +31,7 @@ func init() {
 	flagSet.StringP(cmdConfig.PullSecretFile, "p", "", fmt.Sprintf("File path of image pull secret (download from %s)", constants.CrcLandingPageURL))
 	flagSet.IntP(cmdConfig.CPUs, "c", constants.DefaultCPUs, "Number of CPU cores to allocate to the OpenShift cluster")
 	flagSet.IntP(cmdConfig.Memory, "m", constants.DefaultMemory, "MiB of memory to allocate to the OpenShift cluster")
+	flagSet.UintP(cmdConfig.DiskSize, "d", constants.DefaultDiskSize, "Total size in GiB of the disk used by the OpenShift cluster")
 	flagSet.StringP(cmdConfig.NameServer, "n", "", "IPv4 address of nameserver to use for the OpenShift cluster")
 	flagSet.Bool(cmdConfig.DisableUpdateCheck, false, "Don't check for update")
 
@@ -65,6 +66,7 @@ func runStart(arguments []string) (*machine.StartResult, error) {
 	startConfig := machine.StartConfig{
 		BundlePath: config.Get(cmdConfig.Bundle).AsString(),
 		Memory:     config.Get(cmdConfig.Memory).AsInt(),
+		DiskSize:   config.Get(cmdConfig.DiskSize).AsInt(),
 		CPUs:       config.Get(cmdConfig.CPUs).AsInt(),
 		NameServer: config.Get(cmdConfig.NameServer).AsString(),
 		PullSecret: &cluster.PullSecret{
@@ -159,6 +161,9 @@ func validateStartFlags() error {
 		return err
 	}
 	if err := validation.ValidateCPUs(config.Get(cmdConfig.CPUs).AsInt()); err != nil {
+		return err
+	}
+	if err := validation.ValidateDiskSize(config.Get(cmdConfig.DiskSize).AsInt()); err != nil {
 		return err
 	}
 	if err := validation.ValidateBundle(config.Get(cmdConfig.Bundle).AsString()); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/cavaliercoder/grab v2.0.0+incompatible
 	github.com/cheggaaa/pb/v3 v3.0.4
 	github.com/code-ready/clicumber v0.0.0-20200728062640-1203dda97f67
-	github.com/code-ready/machine v0.0.0-20201008083613-1420a5d7f1e2
+	github.com/code-ready/machine v0.0.0-20201022100236-4405fef4d0cc
 	github.com/cucumber/godog v0.9.0
 	github.com/cucumber/messages-go/v10 v10.0.3
 	github.com/docker/docker v1.13.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -119,8 +119,8 @@ github.com/cockroachdb/cockroach-go v0.0.0-20181001143604-e0a95dfd547c/go.mod h1
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/code-ready/clicumber v0.0.0-20200728062640-1203dda97f67 h1:C+EVPWw8sjASF/529T8BMddoACTb+ruHB8yrZoYscek=
 github.com/code-ready/clicumber v0.0.0-20200728062640-1203dda97f67/go.mod h1:ZPZUcYGpv/FQGnwakUuhiHP9x/IIcU2SKbn8xPe4ROc=
-github.com/code-ready/machine v0.0.0-20201008083613-1420a5d7f1e2 h1:qfXZn0/voilXKONlr3dGv6Ctk3YtrelK3r2v9plfO1o=
-github.com/code-ready/machine v0.0.0-20201008083613-1420a5d7f1e2/go.mod h1:g30jKsf0FV9yJjsqZFAuFzVxwJE2h5cqDXSuMUV1G/U=
+github.com/code-ready/machine v0.0.0-20201022100236-4405fef4d0cc h1:9Tp3sGd10JVbS2OhRmsxtsRytRbZoS6akW7DR8hk6Jw=
+github.com/code-ready/machine v0.0.0-20201022100236-4405fef4d0cc/go.mod h1:g30jKsf0FV9yJjsqZFAuFzVxwJE2h5cqDXSuMUV1G/U=
 github.com/codegangsta/negroni v1.0.0/go.mod h1:v0y3T5G7Y1UlFfyxFn/QLRU4a2EuNau2iZY63YTKWo0=
 github.com/container-storage-interface/spec v1.2.0/go.mod h1:6URME8mwIBbpVyZV93Ce5St17xBiQJQY67NDsuohiy4=
 github.com/containerd/cgroups v0.0.0-20190919134610-bf292b21730f/go.mod h1:OApqhQ4XNSNC13gXIwDjhOQxjWa/NxkwZXJ1EvqT0ko=

--- a/pkg/crc/config/validations.go
+++ b/pkg/crc/config/validations.go
@@ -19,6 +19,19 @@ func ValidateBool(value interface{}) (bool, string) {
 	return false, "must be true or false"
 }
 
+// ValidateDiskSize checks if provided disk size is valid in the config
+func ValidateDiskSize(value interface{}) (bool, string) {
+	diskSize, err := cast.ToIntE(value)
+	if err != nil {
+		return false, fmt.Sprintf("could not convert '%s' to integer", value)
+	}
+	if err := validation.ValidateDiskSize(diskSize); err != nil {
+		return false, err.Error()
+	}
+
+	return true, ""
+}
+
 // ValidateCPUs checks if provided cpus count is valid in the config
 func ValidateCPUs(value interface{}) (bool, string) {
 	v, err := cast.ToIntE(value)

--- a/pkg/crc/constants/constants.go
+++ b/pkg/crc/constants/constants.go
@@ -11,9 +11,10 @@ import (
 )
 
 const (
-	DefaultName   = "crc"
-	DefaultCPUs   = 4
-	DefaultMemory = 9216
+	DefaultName     = "crc"
+	DefaultCPUs     = 4
+	DefaultMemory   = 9216
+	DefaultDiskSize = 31
 
 	DefaultSSHUser = "core"
 	DefaultSSHPort = 22

--- a/pkg/crc/machine/driver.go
+++ b/pkg/crc/machine/driver.go
@@ -32,3 +32,15 @@ func setVcpus(host *host.Host, vcpus int) error {
 
 	return updateDriverValue(host, vcpuSetter)
 }
+
+func convertGiBToBytes(gib int) uint64 {
+	return uint64(gib) * 1024 * 1024 * 1024
+}
+
+func setDiskSize(host *host.Host, diskSizeGiB int) error {
+	diskSizeSetter := func(driver *libmachine.VMDriver) {
+		driver.DiskCapacity = convertGiBToBytes(diskSizeGiB)
+	}
+
+	return updateDriverValue(host, diskSizeSetter)
+}

--- a/pkg/crc/machine/libvirt/constants.go
+++ b/pkg/crc/machine/libvirt/constants.go
@@ -6,7 +6,8 @@ import "fmt"
 
 const (
 	// Defaults
-	DefaultNetwork = "crc"
+	DefaultNetwork     = "crc"
+	DefaultStoragePool = "crc"
 
 	// Static addresses
 	MACAddress = "52:fd:fc:07:21:82"

--- a/pkg/crc/machine/libvirt/driver_linux.go
+++ b/pkg/crc/machine/libvirt/driver_linux.go
@@ -12,6 +12,7 @@ func CreateHost(machineConfig config.MachineConfig) *libvirt.Driver {
 	config.InitVMDriverFromMachineConfig(machineConfig, libvirtDriver.VMDriver)
 
 	libvirtDriver.Network = DefaultNetwork
+	libvirtDriver.StoragePool = DefaultStoragePool
 
 	return libvirtDriver
 }

--- a/pkg/crc/machine/machine.go
+++ b/pkg/crc/machine/machine.go
@@ -114,13 +114,17 @@ func (client *client) updateVMConfig(startConfig StartConfig, api libmachine.API
 	logging.Debugf("Updating CRC VM configuration")
 	if err := setMemory(host, startConfig.Memory); err != nil {
 		logging.Debugf("Failed to update CRC VM configuration: %v", err)
-		if err != drivers.ErrNotImplemented {
+		if err == drivers.ErrNotImplemented {
+			logging.Warn("Memory configuration change has been ignored as the machine driver does not support it")
+		} else {
 			return err
 		}
 	}
 	if err := setVcpus(host, startConfig.CPUs); err != nil {
 		logging.Debugf("Failed to update CRC VM configuration: %v", err)
-		if err != drivers.ErrNotImplemented {
+		if err == drivers.ErrNotImplemented {
+			logging.Warn("CPU configuration change has been ignored as the machine driver does not support it")
+		} else {
 			return err
 		}
 	}
@@ -132,7 +136,9 @@ func (client *client) updateVMConfig(startConfig StartConfig, api libmachine.API
 	if startConfig.DiskSize != constants.DefaultDiskSize {
 		if err := setDiskSize(host, startConfig.DiskSize); err != nil {
 			logging.Debugf("Failed to update CRC disk configuration: %v", err)
-			if err != drivers.ErrNotImplemented {
+			if err == drivers.ErrNotImplemented {
+				logging.Warn("Disk size configuration change has been ignored as the machine driver does not support it")
+			} else {
 				return err
 			}
 		}

--- a/pkg/crc/machine/types.go
+++ b/pkg/crc/machine/types.go
@@ -11,8 +11,9 @@ type StartConfig struct {
 	BundlePath string
 
 	// Hypervisor
-	Memory int
-	CPUs   int
+	Memory   int // Memory size in MiB
+	CPUs     int
+	DiskSize int // Disk size in GiB
 
 	// Nameserver
 	NameServer string

--- a/pkg/crc/validation/validation.go
+++ b/pkg/crc/validation/validation.go
@@ -31,6 +31,13 @@ func ValidateMemory(value int) error {
 	return ValidateEnoughMemory(value)
 }
 
+func ValidateDiskSize(value int) error {
+	if value <= constants.DefaultDiskSize {
+		return fmt.Errorf("requires disk size in GiB >= %d", constants.DefaultDiskSize)
+	}
+	return nil
+}
+
 // ValidateEnoughMemory checks if enough memory is installed on the host
 func ValidateEnoughMemory(value int) error {
 	totalMemory := memory.TotalMemory()

--- a/vendor/github.com/code-ready/machine/drivers/hyperkit/driver_darwin.go
+++ b/vendor/github.com/code-ready/machine/drivers/hyperkit/driver_darwin.go
@@ -19,6 +19,7 @@ type Driver struct {
 	InitrdPath    string
 	KernelCmdLine string
 	HyperKitPath  string
+	VMNet         bool
 }
 
 func NewDriver(hostName, storePath string) *Driver {

--- a/vendor/github.com/code-ready/machine/drivers/libvirt/driver_linux.go
+++ b/vendor/github.com/code-ready/machine/drivers/libvirt/driver_linux.go
@@ -8,10 +8,11 @@ type Driver struct {
 	*drivers.VMDriver
 
 	// Driver specific configuration
-	Network   string
-	CacheMode string
-	IOMode    string
-	VSock     bool
+	Network     string
+	CacheMode   string
+	IOMode      string
+	VSock       bool
+	StoragePool string
 }
 
 const (

--- a/vendor/github.com/code-ready/machine/libmachine/drivers/base.go
+++ b/vendor/github.com/code-ready/machine/libmachine/drivers/base.go
@@ -29,6 +29,7 @@ type VMDriver struct {
 	ImageFormat     string
 	Memory          int
 	CPU             int
+	DiskCapacity    uint64
 }
 
 // DriverName returns the name of the driver

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -24,7 +24,7 @@ github.com/cheggaaa/pb/v3/termutil
 # github.com/code-ready/clicumber v0.0.0-20200728062640-1203dda97f67
 github.com/code-ready/clicumber/testsuite
 github.com/code-ready/clicumber/util
-# github.com/code-ready/machine v0.0.0-20201008083613-1420a5d7f1e2
+# github.com/code-ready/machine v0.0.0-20201022100236-4405fef4d0cc
 github.com/code-ready/machine/drivers/errdriver
 github.com/code-ready/machine/drivers/hyperkit
 github.com/code-ready/machine/drivers/hyperv


### PR DESCRIPTION
**Fixes:** Issue #127

## Solution/Idea

This uses the machine driver's "UpdateConfigRaw" API introduced in the previous release in order to implement disk resizing support. This needs machine driver support as well.

## Proposed changes

List main as well as consequential changes you introduced or had to introduce.

1. Added --disk-size argument to the `start` command.
2. Added 'disk-size' config key

disk size is always in GiB (1024*1024*1024 bytes) and can't be less than 31 GiB as this is the size used by our bundles, and disks can't be shrunk.

## Testing

What is the _bottom-line_ functionality that needs testing? Describe in pseudo-code or in English. Use verifiable statements that tie your changes to existing functionality.

1. `start` without any argument/special configuration succeeds
2. `crc start --disk-size xxx` succeeds and resizes the disk
3. `crc start` succeeds after `crc config set disk-size xxx`
4. in both cases, disk is resized (can be checked with `ssh ... df -h`, or on linux through `virsh vol-info crc.qcow2 crc`)

For now this is not supported on macos
6. `start` fails after `start` succeeded or after `status` says CRC is `Running`
7. ...
