### PR TITLE
Issue #1613 Docs: Use "executable" instead of "binary"

### DIFF
--- a/docs/source/topics/assembly_accessing-the-openshift-cluster.adoc
+++ b/docs/source/topics/assembly_accessing-the-openshift-cluster.adoc
@@ -1,7 +1,7 @@
 [id="accessing-the-openshift-cluster_{context}"]
 = Accessing the OpenShift cluster
 
-Access the OpenShift cluster running in the {prod} virtual machine through the OpenShift web console or client binary ([command]`oc`).
+Access the OpenShift cluster running in the {prod} virtual machine through the OpenShift web console or client executable ([command]`oc`).
 
 include::proc_accessing-the-openshift-web-console.adoc[leveloffset=+1]
 

--- a/docs/source/topics/con_about-codeready-containers-configuration.adoc
+++ b/docs/source/topics/con_about-codeready-containers-configuration.adoc
@@ -1,7 +1,7 @@
 [id="about-codeready-containers-configuration_{context}"]
 = About {prod} configuration
 
-Use the [command]`{bin} config` command to configure both the [command]`{bin}` binary and the {prod} virtual machine.
+Use the [command]`{bin} config` command to configure both the [command]`{bin}` executable and the {prod} virtual machine.
 The [command]`{bin} config` command requires a subcommand to act on the configuration.
 The available subcommands are `get`, `set,` `unset`, and `view`.
 The `get`, `set`, and `unset` subcommands operate on named configurable properties.

--- a/docs/source/topics/proc_accessing-the-openshift-cluster-with-oc.adoc
+++ b/docs/source/topics/proc_accessing-the-openshift-cluster-with-oc.adoc
@@ -10,7 +10,7 @@ For more information, see link:{crc-gsg-url}#starting-the-virtual-machine_gsg[St
 
 To access the OpenShift cluster through the [command]`oc` command, follow these steps:
 
-. Run the [command]`{bin} oc-env` command to print the command needed to add the cached [command]`oc` binary to your `_PATH_`:
+. Run the [command]`{bin} oc-env` command to print the command needed to add the cached [command]`oc` executable to your `_PATH_`:
 +
 [subs="+quotes,attributes"]
 ----

--- a/docs/source/topics/proc_connecting-to-remote-instance.adoc
+++ b/docs/source/topics/proc_connecting-to-remote-instance.adoc
@@ -16,7 +16,7 @@ Follow this procedure to connect a client machine to a remote server running a {
 For more information, see link:{crc-gsg-url}#setting-up-remote-server_gsg[Setting up {prod} on a remote server].
 * NetworkManager is installed and running.
 * You know the external IP address of the server.
-* You have the link:{oc-download-url}[latest OpenShift client binary ([command]`oc`)] in your `$PATH` on the client.
+* You have the link:{oc-download-url}[latest OpenShift client executable ([command]`oc`)] in your `$PATH` on the client.
 
 .Procedure
 

--- a/docs/source/topics/proc_setting-up-codeready-containers.adoc
+++ b/docs/source/topics/proc_setting-up-codeready-containers.adoc
@@ -12,8 +12,8 @@ On {msw}, ensure that your user account can elevate to Administrator privileges.
 
 [NOTE]
 ====
-* Do not run the [command]`{bin}` binary as `root` (or Administrator).
-Always run the [command]`{bin}` binary with your user account.
+* Do not run the [command]`{bin}` executable as `root` (or Administrator).
+Always run the [command]`{bin}` executable with your user account.
 * If you are setting up a new version, capture any changes made to the virtual machine before setting up a new {prod} release.
 ====
 

--- a/docs/source/topics/proc_starting-codeready-containers-behind-proxy.adoc
+++ b/docs/source/topics/proc_starting-codeready-containers-behind-proxy.adoc
@@ -3,10 +3,10 @@
 
 .Prerequisites
 
-* To use an existing [command]`oc` binary on your host machine, export the `.testing` domain as part of the `no_proxy` environment variable.
+* To use an existing [command]`oc` executable on your host machine, export the `.testing` domain as part of the `no_proxy` environment variable.
 
-* The embedded [command]`oc` binary does not require manual settings.
-For more information about using the embedded [command]`oc` binary, see link:{crc-gsg-url}#accessing-the-openshift-cluster-with-oc_gsg[Accessing the OpenShift cluster with `oc`].
+* The embedded [command]`oc` executable does not require manual settings.
+For more information about using the embedded [command]`oc` executable, see link:{crc-gsg-url}#accessing-the-openshift-cluster-with-oc_gsg[Accessing the OpenShift cluster with `oc`].
 
 
 .Procedure
@@ -27,7 +27,7 @@ $ {bin} config set no-proxy __<comma-separated-no-proxy-entries>__
 $ {bin} config set proxy-ca-file __<path-to-custom-ca-file>__
 ----
 
-The [command]`{bin}` binary will be able to use the defined proxy once set through environment variables or {prod} configuration.
+The [command]`{bin}` executable will be able to use the defined proxy once set through environment variables or {prod} configuration.
 
 [NOTE]
 ====

--- a/docs/source/topics/proc_troubleshooting-expired-certificates.adoc
+++ b/docs/source/topics/proc_troubleshooting-expired-certificates.adoc
@@ -7,9 +7,9 @@ As of the {prod} 1.10.0 release, the certificate renewal process is not working 
 Follow this procedure to avoid potential errors due to certificate expiration.
 ====
 
-The system bundle in each released [command]`{bin}` binary expires 30 days after the release.
+The system bundle in each released [command]`{bin}` executable expires 30 days after the release.
 This expiration is due to certificates embedded in the OpenShift cluster.
-As a result, using an older [command]`{bin}` binary or system bundle can result in an expired certificates error.
+As a result, using an older [command]`{bin}` executable or system bundle can result in an expired certificates error.
 
 Starting from {prod} 1.2.0, the embedded certificates can be automatically renewed by [command]`{bin}`.
 The [command]`{bin} start` command triggers the certificate renewal process when needed.
@@ -19,7 +19,7 @@ Certificate renewal can add up to five minutes to the start time of the cluster.
 
 To resolve expired certificate errors that cannot be automatically renewed:
 
-. link:{crc-download-url}[Download the latest {prod} release] and place the [command]`{bin}` binary in your `$PATH`.
+. link:{crc-download-url}[Download the latest {prod} release] and place the [command]`{bin}` executable in your `$PATH`.
 
 . Remove the cluster with certificate errors using the [command]`{bin} delete` command:
 +

--- a/docs/source/topics/proc_upgrading-codeready-containers.adoc
+++ b/docs/source/topics/proc_upgrading-codeready-containers.adoc
@@ -1,7 +1,7 @@
 [id="upgrading-codeready-containers_{context}"]
 = Upgrading {prod}
 
-Newer versions of the {prod} binary require manual set up to prevent potential incompatibilities with earlier versions.
+Newer versions of the {prod} executable require manual set up to prevent potential incompatibilities with earlier versions.
 
 .Procedure
 
@@ -11,8 +11,8 @@ Newer versions of the {prod} binary require manual set up to prevent potential i
 +
 include::snip_crc-delete.adoc[]
 
-. Replace the earlier [command]`{bin}` binary with the binary of the latest release.
-Verify that the new [command]`{bin}` binary is in use by checking its version:
+. Replace the earlier [command]`{bin}` executable with the executable of the latest release.
+Verify that the new [command]`{bin}` executable is in use by checking its version:
 +
 [subs="+quotes,attributes"]
 ----

--- a/docs/source/topics/proc_viewing-codeready-containers-configuration.adoc
+++ b/docs/source/topics/proc_viewing-codeready-containers-configuration.adoc
@@ -1,7 +1,7 @@
 [id="viewing-codeready-containers-configuration_{context}"]
 = Viewing {prod} configuration
 
-The {prod} binary provides commands to view configurable properties and the current {prod} configuration.
+The {prod} executable provides commands to view configurable properties and the current {prod} configuration.
 
 .Procedure
 

--- a/docs/source/topics/ref_dns-configuration.adoc
+++ b/docs/source/topics/ref_dns-configuration.adoc
@@ -36,7 +36,7 @@ On {mac}, {prod} expects the following DNS configuration:
 
 * {prod} creates a [filename]`/etc/resolver/testing` file which instructs {mac} to forward all DNS requests  for the `testing` domain to the {prod} virtual machine.
 * {prod} also adds an `api.crc.testing` entry to [filename]`/etc/hosts` pointing at the VM IP address.
-The [command]`oc` binary requires this entry.
+The [command]`oc` executable requires this entry.
 See https://github.com/openshift/origin/issues/23266[OpenShift issue #23266] for more information.
 
 ////


### PR DESCRIPTION
**Fixes:** Issue #1613

## Solution/Idea

"Executable" is more specific and conveys more useful information.