### PR TITLE
Replace use of 'binary' terminology with 'executable'

### DIFF
--- a/cmd/crc-embedder/cmd/embed.go
+++ b/cmd/crc-embedder/cmd/embed.go
@@ -31,8 +31,8 @@ func init() {
 
 var embedCmd = &cobra.Command{
 	Use:   "embed",
-	Short: "Embed data files in crc binary",
-	Long:  `Embed the OpenShift bundle and the binaries needed at runtime in the crc binary`,
+	Short: "Embed data files in crc executable",
+	Long:  `Embed the OpenShift bundle and the binaries needed at runtime in the crc executable`,
 	Run: func(cmd *cobra.Command, args []string) {
 		runEmbed(args)
 	},

--- a/cmd/crc-embedder/cmd/embed.go
+++ b/cmd/crc-embedder/cmd/embed.go
@@ -42,7 +42,7 @@ func runEmbed(args []string) {
 	if len(args) != 1 {
 		logging.Fatal("embed takes exactly one argument")
 	}
-	binaryPath := args[0]
+	executablePath := args[0]
 	destDir, err := ioutil.TempDir("", "crc-embedder")
 	if err != nil {
 		logging.Fatalf("Failed to create temporary directory: %v", err)
@@ -55,20 +55,20 @@ func runEmbed(args []string) {
 
 	bundlePath := path.Join(bundleDir, constants.GetDefaultBundleForOs(goos))
 	downloadedFiles = append(downloadedFiles, bundlePath)
-	err = embedFiles(binaryPath, downloadedFiles)
+	err = embedFiles(executablePath, downloadedFiles)
 	if err != nil {
 		logging.Fatalf("Failed to embed data files: %v", err)
 	}
 }
 
-func embedFiles(binary string, filenames []string) error {
-	appender, err := binappend.MakeAppender(binary)
+func embedFiles(executablePath string, filenames []string) error {
+	appender, err := binappend.MakeAppender(executablePath)
 	if err != nil {
 		return err
 	}
 	defer appender.Close()
 	for _, filename := range filenames {
-		logging.Debugf("Embedding %s in %s", filename, binary)
+		logging.Debugf("Embedding %s in %s", filename, executablePath)
 		f, err := os.Open(filename) // #nosec G304
 		if err != nil {
 			return fmt.Errorf("Failed to open %s: %v", filename, err)
@@ -77,7 +77,7 @@ func embedFiles(binary string, filenames []string) error {
 
 		err = appender.AppendStreamReader(path.Base(filename), f, false)
 		if err != nil {
-			return fmt.Errorf("Failed to append %s to %s: %v", filename, binary, err)
+			return fmt.Errorf("Failed to append %s to %s: %v", filename, executablePath, err)
 		}
 	}
 

--- a/cmd/crc-embedder/cmd/extract.go
+++ b/cmd/crc-embedder/cmd/extract.go
@@ -25,12 +25,12 @@ func runExtract(args []string) {
 	if len(args) != 3 {
 		logging.Fatalf("extract takes exactly three arguments")
 	}
-	binaryPath := args[0]
+	executablePath := args[0]
 	embedName := args[1]
 	destFile := args[2]
-	err := embed.ExtractFromBinary(binaryPath, embedName, destFile)
+	err := embed.ExtractFromExecutable(executablePath, embedName, destFile)
 	if err != nil {
-		logging.Fatalf("Could not extract data embedded in %s: %v", binaryPath, err)
+		logging.Fatalf("Could not extract data embedded in %s: %v", executablePath, err)
 	}
-	output.Outf("Successfully copied embedded '%s' from %s to %s: %v", embedName, binaryPath, destFile, err)
+	output.Outf("Successfully copied embedded '%s' from %s to %s: %v", embedName, executablePath, destFile, err)
 }

--- a/cmd/crc-embedder/cmd/extract.go
+++ b/cmd/crc-embedder/cmd/extract.go
@@ -14,8 +14,8 @@ func init() {
 
 var extractCmd = &cobra.Command{
 	Use:   "extract",
-	Short: "Extract data file embedded in the crc binary",
-	Long:  `Extract a data file which is embedded in the crc binary`,
+	Short: "Extract data file embedded in the crc executable",
+	Long:  `Extract a data file which is embedded in the crc executable`,
 	Run: func(cmd *cobra.Command, args []string) {
 		runExtract(args)
 	},

--- a/cmd/crc-embedder/cmd/list.go
+++ b/cmd/crc-embedder/cmd/list.go
@@ -25,12 +25,12 @@ func runList(args []string) {
 	if len(args) != 1 {
 		logging.Fatalf("list takes exactly one argument")
 	}
-	binaryPath := args[0]
-	extractor, err := binappend.MakeExtractor(binaryPath)
+	executablePath := args[0]
+	extractor, err := binappend.MakeExtractor(executablePath)
 	if err != nil {
-		logging.Fatalf("Could not access data embedded in %s: %v", binaryPath, err)
+		logging.Fatalf("Could not access data embedded in %s: %v", executablePath, err)
 	}
-	output.Outf("Data files embedded in %s:\n", binaryPath)
+	output.Outf("Data files embedded in %s:\n", executablePath)
 	for _, name := range extractor.AvalibleData() {
 		output.Outln("\t", name)
 	}

--- a/cmd/crc-embedder/cmd/list.go
+++ b/cmd/crc-embedder/cmd/list.go
@@ -14,8 +14,8 @@ func init() {
 
 var listCmd = &cobra.Command{
 	Use:   "list",
-	Short: "List data files embedded in the crc binary",
-	Long:  `List all the data files which were embedded in the crc binary`,
+	Short: "List data files embedded in the crc executable",
+	Long:  `List all the data files which were embedded in the crc executable`,
 	Run: func(cmd *cobra.Command, args []string) {
 		runList(args)
 	},

--- a/cmd/crc-embedder/cmd/root.go
+++ b/cmd/crc-embedder/cmd/root.go
@@ -12,7 +12,7 @@ var rootCmd = &cobra.Command{
 	Use:   "crc-embedder [list|embed|extract]",
 	Short: "Build helper for crc for binary embedding",
 	Long: `crc-embedder is a command line utility for listing or appending binary data
-when building the crc binary for release`,
+when building the crc executable for release`,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		runPrerun()
 	},

--- a/cmd/crc/cmd/oc_env.go
+++ b/cmd/crc/cmd/oc_env.go
@@ -16,8 +16,8 @@ var (
 
 var ocEnvCmd = &cobra.Command{
 	Use:   "oc-env",
-	Short: "Add the 'oc' binary to PATH",
-	Long:  `Add the OpenShift client binary 'oc' to PATH`,
+	Short: "Add the 'oc' executable to PATH",
+	Long:  `Add the OpenShift client executable 'oc' to PATH`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if err := runOcEnv(args); err != nil {
 			exit.WithMessage(1, err.Error())

--- a/cmd/crc/cmd/podman_env.go
+++ b/cmd/crc/cmd/podman_env.go
@@ -13,7 +13,7 @@ import (
 var podmanEnvCmd = &cobra.Command{
 	Use:   "podman-env",
 	Short: "Setup podman environment",
-	Long:  `Setup environment for 'podman' binary to access podman on CRC VM`,
+	Long:  `Setup environment for 'podman' executable to access podman on CRC VM`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if err := runPodmanEnv(args); err != nil {
 			exit.WithMessage(1, err.Error())

--- a/cmd/crc/cmd/version.go
+++ b/cmd/crc/cmd/version.go
@@ -63,6 +63,6 @@ func (v *version) lines() []string {
 	}
 	return []string{
 		fmt.Sprintf("CodeReady Containers version: %s+%s\n", v.Version, v.Commit),
-		fmt.Sprintf("OpenShift version: %s (%sembedded in binary)\n", v.OpenshiftVersion, embedded),
+		fmt.Sprintf("OpenShift version: %s (%sembedded in executable)\n", v.OpenshiftVersion, embedded),
 	}
 }

--- a/cmd/crc/cmd/version_test.go
+++ b/cmd/crc/cmd/version_test.go
@@ -16,7 +16,7 @@ func TestPlainVersion(t *testing.T) {
 		Embedded:         false,
 	}, ""))
 	assert.Equal(t, `CodeReady Containers version: 1.13+aabbcc
-OpenShift version: 4.5.4 (not embedded in binary)
+OpenShift version: 4.5.4 (not embedded in executable)
 `, out.String())
 }
 

--- a/pkg/crc/cache/cache.go
+++ b/pkg/crc/cache/cache.go
@@ -124,7 +124,7 @@ func (c *Cache) CacheBinary() error {
 	} else {
 		extractedFiles = append(extractedFiles, assetTmpFile)
 		if filepath.Base(assetTmpFile) != c.binaryName {
-			logging.Warnf("Binary name is %s but extracted file name is %s", c.binaryName, filepath.Base(assetTmpFile))
+			logging.Warnf("Executable name is %s but extracted file name is %s", c.binaryName, filepath.Base(assetTmpFile))
 		}
 	}
 
@@ -148,7 +148,7 @@ func (c *Cache) CacheBinary() error {
 }
 
 func (c *Cache) getBinary(destDir string) (string, error) {
-	logging.Debugf("Trying to extract %s from crc binary", c.binaryName)
+	logging.Debugf("Trying to extract %s from crc executable", c.binaryName)
 	archiveName := filepath.Base(c.archiveURL)
 	destPath := filepath.Join(destDir, archiveName)
 	err := embed.Extract(archiveName, destPath)

--- a/pkg/crc/cache/cache_darwin.go
+++ b/pkg/crc/cache/cache_darwin.go
@@ -19,15 +19,15 @@ func NewHyperKitCache() *Cache {
 	return New(hyperkit.HyperKitCommand, hyperkit.HyperKitDownloadURL, constants.CrcBinDir, hyperkit.HyperKitVersion, getHyperKitVersion)
 }
 
-func getHyperKitMachineDriverVersion(binaryPath string) (string, error) {
-	return getVersionGeneric(binaryPath, "version")
+func getHyperKitMachineDriverVersion(executablePath string) (string, error) {
+	return getVersionGeneric(executablePath, "version")
 }
 
 /* This is very similar to cache.getVersionGeneric, except that it's reading from stderr instead of
  * stdout, and it needs to deal with multiline output
  */
-func getHyperKitVersion(binaryPath string) (string, error) {
-	_, stderr, err := crcos.RunWithDefaultLocale(binaryPath, "-v")
+func getHyperKitVersion(executablePath string) (string, error) {
+	_, stderr, err := crcos.RunWithDefaultLocale(executablePath, "-v")
 	if err != nil {
 		return "", err
 	}
@@ -37,7 +37,7 @@ func getHyperKitVersion(binaryPath string) (string, error) {
 	}
 	parsedOutput := strings.Split(stderr, ":")
 	if len(parsedOutput) < 2 {
-		return "", fmt.Errorf("Unable to parse the version information of %s", binaryPath)
+		return "", fmt.Errorf("Unable to parse the version information of %s", executablePath)
 	}
 	return strings.TrimSpace(parsedOutput[1]), err
 }

--- a/pkg/crc/cache/cache_linux.go
+++ b/pkg/crc/cache/cache_linux.go
@@ -9,6 +9,6 @@ func NewMachineDriverLibvirtCache() *Cache {
 	return New(libvirt.MachineDriverCommand, libvirt.MachineDriverDownloadURL, constants.CrcBinDir, libvirt.MachineDriverVersion, getCurrentLibvirtDriverVersion)
 }
 
-func getCurrentLibvirtDriverVersion(binaryPath string) (string, error) {
-	return getVersionGeneric(binaryPath, "version")
+func getCurrentLibvirtDriverVersion(executablePath string) (string, error) {
+	return getVersionGeneric(executablePath, "version")
 }

--- a/pkg/crc/cluster/clusteroperator_test.go
+++ b/pkg/crc/cluster/clusteroperator_test.go
@@ -60,12 +60,12 @@ type mockRunner struct {
 	file string
 }
 
-func (r *mockRunner) Run(binaryPath string, args ...string) (string, string, error) {
+func (r *mockRunner) Run(executablePath string, args ...string) (string, string, error) {
 	bin, err := ioutil.ReadFile(r.file)
 	return string(bin), "", err
 }
 
-func (r *mockRunner) RunPrivate(binaryPath string, args ...string) (string, string, error) {
+func (r *mockRunner) RunPrivate(executablePath string, args ...string) (string, string, error) {
 	bin, err := ioutil.ReadFile(r.file)
 	return string(bin), "", err
 }

--- a/pkg/crc/constants/constants.go
+++ b/pkg/crc/constants/constants.go
@@ -135,13 +135,13 @@ func EnsureBaseDirExists() error {
 	return nil
 }
 
-// IsBundleEmbedded returns true if the binary was compiled to contain the bundle
+// IsBundleEmbedded returns true if the executable was compiled to contain the bundle
 func BundleEmbedded() bool {
-	binaryPath, err := os.Executable()
+	executablePath, err := os.Executable()
 	if err != nil {
 		return false
 	}
-	extractor, err := binappend.MakeExtractor(binaryPath)
+	extractor, err := binappend.MakeExtractor(executablePath)
 	if err != nil {
 		return false
 	}

--- a/pkg/crc/constants/constants_darwin.go
+++ b/pkg/crc/constants/constants_darwin.go
@@ -3,13 +3,13 @@ package constants
 import "path/filepath"
 
 const (
-	OcBinaryName        = "oc"
-	PodmanBinaryName    = "podman"
-	TrayBinaryName      = "CodeReady Containers.app"
-	GoodhostsBinaryName = "goodhosts"
+	OcExecutableName        = "oc"
+	PodmanExecutableName    = "podman"
+	TrayExecutableName      = "CodeReady Containers.app"
+	GoodhostsExecutableName = "goodhosts"
 )
 
 var (
-	TrayAppBundlePath = filepath.Join(CrcBinDir, TrayBinaryName)
-	TrayBinaryPath    = filepath.Join(TrayAppBundlePath, "Contents", "MacOS", "CodeReady Containers")
+	TrayAppBundlePath  = filepath.Join(CrcBinDir, TrayExecutableName)
+	TrayExecutablePath = filepath.Join(TrayAppBundlePath, "Contents", "MacOS", "CodeReady Containers")
 )

--- a/pkg/crc/constants/constants_linux.go
+++ b/pkg/crc/constants/constants_linux.go
@@ -1,7 +1,7 @@
 package constants
 
 const (
-	OcBinaryName        = "oc"
-	PodmanBinaryName    = "podman"
-	GoodhostsBinaryName = "goodhosts"
+	OcExecutableName        = "oc"
+	PodmanExecutableName    = "podman"
+	GoodhostsExecutableName = "goodhosts"
 )

--- a/pkg/crc/constants/constants_windows.go
+++ b/pkg/crc/constants/constants_windows.go
@@ -3,15 +3,15 @@ package constants
 import "path/filepath"
 
 const (
-	OcBinaryName        = "oc.exe"
-	PodmanBinaryName    = "podman.exe"
-	GoodhostsBinaryName = "goodhosts.exe"
-	TrayBinaryName      = "tray-windows.exe"
-	DaemonServiceName   = "CodeReady Containers"
-	TrayShortcutName    = "tray-windows.lnk"
+	OcExecutableName        = "oc.exe"
+	PodmanExecutableName    = "podman.exe"
+	GoodhostsExecutableName = "goodhosts.exe"
+	TrayExecutableName      = "tray-windows.exe"
+	DaemonServiceName       = "CodeReady Containers"
+	TrayShortcutName        = "tray-windows.lnk"
 )
 
 var (
-	TrayBinaryDir  = filepath.Join(CrcBinDir, "tray-windows")
-	TrayBinaryPath = filepath.Join(TrayBinaryDir, TrayBinaryName)
+	TrayExecutableDir  = filepath.Join(CrcBinDir, "tray-windows")
+	TrayExecutablePath = filepath.Join(TrayExecutableDir, TrayExecutableName)
 )

--- a/pkg/crc/goodhosts/goodhosts_nowin.go
+++ b/pkg/crc/goodhosts/goodhosts_nowin.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	goodhostPath = filepath.Join(constants.CrcBinDir, constants.GoodhostsBinaryName)
+	goodhostPath = filepath.Join(constants.CrcBinDir, constants.GoodhostsExecutableName)
 )
 
 // UpdateHostsFile updates the host's /etc/hosts file with Instance IP.

--- a/pkg/crc/oc/oc.go
+++ b/pkg/crc/oc/oc.go
@@ -9,21 +9,21 @@ import (
 )
 
 type Config struct {
-	Runner         crcos.CommandRunner
-	OcBinaryPath   string
-	KubeconfigPath string
-	Context        string
-	Cluster        string
+	Runner           crcos.CommandRunner
+	OcExecutablePath string
+	KubeconfigPath   string
+	Context          string
+	Cluster          string
 }
 
-// UseOcWithConfig return the oc binary along with valid kubeconfig
+// UseOcWithConfig return the oc executable along with valid kubeconfig
 func UseOCWithConfig(machineName string) Config {
 	return Config{
-		Runner:         crcos.NewLocalCommandRunner(),
-		OcBinaryPath:   filepath.Join(constants.CrcOcBinDir, constants.OcBinaryName),
-		KubeconfigPath: filepath.Join(constants.MachineInstanceDir, machineName, "kubeconfig"),
-		Context:        constants.DefaultContext,
-		Cluster:        constants.DefaultName,
+		Runner:           crcos.NewLocalCommandRunner(),
+		OcExecutablePath: filepath.Join(constants.CrcOcBinDir, constants.OcExecutableName),
+		KubeconfigPath:   filepath.Join(constants.MachineInstanceDir, machineName, "kubeconfig"),
+		Context:          constants.DefaultContext,
+		Cluster:          constants.DefaultName,
 	}
 }
 
@@ -39,10 +39,10 @@ func (oc Config) runCommand(isPrivate bool, args ...string) (string, string, err
 	}
 
 	if isPrivate {
-		return oc.Runner.RunPrivate(oc.OcBinaryPath, args...)
+		return oc.Runner.RunPrivate(oc.OcExecutablePath, args...)
 	}
 
-	return oc.Runner.Run(oc.OcBinaryPath, args...)
+	return oc.Runner.Run(oc.OcExecutablePath, args...)
 }
 
 func (oc Config) RunOcCommand(args ...string) (string, string, error) {
@@ -59,10 +59,10 @@ type SSHRunner struct {
 
 func UseOCWithSSH(sshRunner *ssh.Runner) Config {
 	return Config{
-		Runner:         ssh.NewRemoteCommandRunner(sshRunner),
-		OcBinaryPath:   "oc",
-		KubeconfigPath: "/opt/kubeconfig",
-		Context:        constants.DefaultContext,
-		Cluster:        constants.DefaultName,
+		Runner:           ssh.NewRemoteCommandRunner(sshRunner),
+		OcExecutablePath: "oc",
+		KubeconfigPath:   "/opt/kubeconfig",
+		Context:          constants.DefaultContext,
+		Cluster:          constants.DefaultName,
 	}
 }

--- a/pkg/crc/oc/oc_linux_test.go
+++ b/pkg/crc/oc/oc_linux_test.go
@@ -10,11 +10,11 @@ import (
 
 func TestRunCommand(t *testing.T) {
 	ocConfig := Config{
-		Runner:         crcos.NewLocalCommandRunner(),
-		OcBinaryPath:   "/bin/echo",
-		KubeconfigPath: "kubeconfig-file",
-		Context:        "a-context",
-		Cluster:        "a-cluster",
+		Runner:           crcos.NewLocalCommandRunner(),
+		OcExecutablePath: "/bin/echo",
+		KubeconfigPath:   "kubeconfig-file",
+		Context:          "a-context",
+		Cluster:          "a-cluster",
 	}
 	stdout, _, err := ocConfig.RunOcCommand("a-command")
 	assert.NoError(t, err)
@@ -23,9 +23,9 @@ func TestRunCommand(t *testing.T) {
 
 func TestRunCommandWithoutContextAndCluster(t *testing.T) {
 	ocConfig := Config{
-		Runner:         crcos.NewLocalCommandRunner(),
-		OcBinaryPath:   "/bin/echo",
-		KubeconfigPath: "kubeconfig-file",
+		Runner:           crcos.NewLocalCommandRunner(),
+		OcExecutablePath: "/bin/echo",
+		KubeconfigPath:   "kubeconfig-file",
 	}
 	stdout, _, err := ocConfig.RunOcCommand("a-command")
 	assert.NoError(t, err)

--- a/pkg/crc/preflight/preflight_checks_common.go
+++ b/pkg/crc/preflight/preflight_checks_common.go
@@ -17,30 +17,30 @@ import (
 var genericPreflightChecks = [...]Check{
 	{
 		configKeySuffix:  "check-oc-cached",
-		checkDescription: "Checking if oc binary is cached",
+		checkDescription: "Checking if oc executable is cached",
 		check:            checkOcBinaryCached,
-		fixDescription:   "Caching oc binary",
+		fixDescription:   "Caching oc executable",
 		fix:              fixOcBinaryCached,
 	},
 	{
 		configKeySuffix:  "check-podman-cached",
-		checkDescription: "Checking if podman remote binary is cached",
+		checkDescription: "Checking if podman remote executable is cached",
 		check:            checkPodmanBinaryCached,
-		fixDescription:   "Caching podman remote binary",
+		fixDescription:   "Caching podman remote executable",
 		fix:              fixPodmanBinaryCached,
 	},
 	{
 		configKeySuffix:  "check-goodhosts-cached",
-		checkDescription: "Checking if goodhosts binary is cached",
+		checkDescription: "Checking if goodhosts executable is cached",
 		check:            checkGoodhostsBinaryCached,
-		fixDescription:   "Caching goodhosts binary",
+		fixDescription:   "Caching goodhosts executable",
 		fix:              fixGoodhostsBinaryCached,
 	},
 	{
 		configKeySuffix:  "check-bundle-cached",
 		checkDescription: "Checking if CRC bundle is cached in '$HOME/.crc'",
 		check:            checkBundleCached,
-		fixDescription:   "Unpacking bundle from the CRC binary",
+		fixDescription:   "Unpacking bundle from the CRC executable",
 		fix:              fixBundleCached,
 		flags:            SetupOnly,
 	},
@@ -81,7 +81,7 @@ func fixBundleCached() error {
 
 		return embed.Extract(filepath.Base(constants.DefaultBundlePath), constants.DefaultBundlePath)
 	}
-	return fmt.Errorf("CRC bundle is not embedded in the binary")
+	return fmt.Errorf("CRC bundle is not embedded in the executable")
 }
 
 // Check if oc binary is cached or not
@@ -92,12 +92,12 @@ func checkOcBinaryCached() error {
 
 	oc := cache.NewOcCache()
 	if !oc.IsCached() {
-		return errors.New("oc binary is not cached")
+		return errors.New("oc executable is not cached")
 	}
 	if err := oc.CheckVersion(); err != nil {
 		return err
 	}
-	logging.Debug("oc binary already cached")
+	logging.Debug("oc executable already cached")
 	return nil
 }
 
@@ -106,7 +106,7 @@ func fixOcBinaryCached() error {
 	if err := oc.EnsureIsCached(); err != nil {
 		return fmt.Errorf("Unable to download oc %v", err)
 	}
-	logging.Debug("oc binary cached")
+	logging.Debug("oc executable cached")
 	return nil
 }
 
@@ -120,9 +120,9 @@ func checkPodmanBinaryCached() error {
 func fixPodmanBinaryCached() error {
 	podman := cache.NewPodmanCache()
 	if err := podman.EnsureIsCached(); err != nil {
-		return fmt.Errorf("Unable to download podman remote binary %v", err)
+		return fmt.Errorf("Unable to download podman remote executable %v", err)
 	}
-	logging.Debug("podman remote binary cached")
+	logging.Debug("podman remote executable cached")
 	return nil
 }
 
@@ -130,17 +130,17 @@ func fixPodmanBinaryCached() error {
 func checkGoodhostsBinaryCached() error {
 	goodhost := cache.NewGoodhostsCache()
 	if !goodhost.IsCached() {
-		return errors.New("goodhost binary is not cached")
+		return errors.New("goodhost executable is not cached")
 	}
-	logging.Debug("goodhost binary already cached")
+	logging.Debug("goodhost executable already cached")
 	return checkSuid(goodhost.GetBinaryPath())
 }
 
 func fixGoodhostsBinaryCached() error {
 	goodhost := cache.NewGoodhostsCache()
 	if err := goodhost.EnsureIsCached(); err != nil {
-		return fmt.Errorf("Unable to download goodhost binary %v", err)
+		return fmt.Errorf("Unable to download goodhost executable %v", err)
 	}
-	logging.Debug("goodhost binary cached")
+	logging.Debug("goodhost executable cached")
 	return setSuid(goodhost.GetBinaryPath())
 }

--- a/pkg/crc/preflight/preflight_checks_common.go
+++ b/pkg/crc/preflight/preflight_checks_common.go
@@ -18,23 +18,23 @@ var genericPreflightChecks = [...]Check{
 	{
 		configKeySuffix:  "check-oc-cached",
 		checkDescription: "Checking if oc executable is cached",
-		check:            checkOcBinaryCached,
+		check:            checkOcExecutableCached,
 		fixDescription:   "Caching oc executable",
-		fix:              fixOcBinaryCached,
+		fix:              fixOcExecutableCached,
 	},
 	{
 		configKeySuffix:  "check-podman-cached",
 		checkDescription: "Checking if podman remote executable is cached",
-		check:            checkPodmanBinaryCached,
+		check:            checkPodmanExecutableCached,
 		fixDescription:   "Caching podman remote executable",
-		fix:              fixPodmanBinaryCached,
+		fix:              fixPodmanExecutableCached,
 	},
 	{
 		configKeySuffix:  "check-goodhosts-cached",
 		checkDescription: "Checking if goodhosts executable is cached",
-		check:            checkGoodhostsBinaryCached,
+		check:            checkGoodhostsExecutableCached,
 		fixDescription:   "Caching goodhosts executable",
-		fix:              fixGoodhostsBinaryCached,
+		fix:              fixGoodhostsExecutableCached,
 	},
 	{
 		configKeySuffix:  "check-bundle-cached",
@@ -84,9 +84,9 @@ func fixBundleCached() error {
 	return fmt.Errorf("CRC bundle is not embedded in the executable")
 }
 
-// Check if oc binary is cached or not
-func checkOcBinaryCached() error {
-	// Remove oc binary from older location and ignore the error
+// Check if oc executable is cached or not
+func checkOcExecutableCached() error {
+	// Remove oc executable from older location and ignore the error
 	// We should remove this code after 3-4 releases. (after 2020-07-10)
 	os.Remove(filepath.Join(constants.CrcBinDir, "oc"))
 
@@ -101,7 +101,7 @@ func checkOcBinaryCached() error {
 	return nil
 }
 
-func fixOcBinaryCached() error {
+func fixOcExecutableCached() error {
 	oc := cache.NewOcCache()
 	if err := oc.EnsureIsCached(); err != nil {
 		return fmt.Errorf("Unable to download oc %v", err)
@@ -110,14 +110,14 @@ func fixOcBinaryCached() error {
 	return nil
 }
 
-// Check if podman binary is cached or not
-func checkPodmanBinaryCached() error {
+// Check if podman executable is cached or not
+func checkPodmanExecutableCached() error {
 	// Disable the podman cache until further notice
 	logging.Debug("Currently podman remote is not supported")
 	return nil
 }
 
-func fixPodmanBinaryCached() error {
+func fixPodmanExecutableCached() error {
 	podman := cache.NewPodmanCache()
 	if err := podman.EnsureIsCached(); err != nil {
 		return fmt.Errorf("Unable to download podman remote executable %v", err)
@@ -126,21 +126,21 @@ func fixPodmanBinaryCached() error {
 	return nil
 }
 
-// Check if goodhost binary is cached or not
-func checkGoodhostsBinaryCached() error {
+// Check if goodhost executable is cached or not
+func checkGoodhostsExecutableCached() error {
 	goodhost := cache.NewGoodhostsCache()
 	if !goodhost.IsCached() {
 		return errors.New("goodhost executable is not cached")
 	}
 	logging.Debug("goodhost executable already cached")
-	return checkSuid(goodhost.GetBinaryPath())
+	return checkSuid(goodhost.GetExecutablePath())
 }
 
-func fixGoodhostsBinaryCached() error {
+func fixGoodhostsExecutableCached() error {
 	goodhost := cache.NewGoodhostsCache()
 	if err := goodhost.EnsureIsCached(); err != nil {
 		return fmt.Errorf("Unable to download goodhost executable %v", err)
 	}
 	logging.Debug("goodhost executable cached")
-	return setSuid(goodhost.GetBinaryPath())
+	return setSuid(goodhost.GetExecutablePath())
 }

--- a/pkg/crc/preflight/preflight_checks_darwin.go
+++ b/pkg/crc/preflight/preflight_checks_darwin.go
@@ -20,9 +20,9 @@ const (
 func checkHyperKitInstalled() error {
 	h := cache.NewHyperKitCache()
 	if !h.IsCached() {
-		return fmt.Errorf("%s executable is not cached", h.GetBinaryName())
+		return fmt.Errorf("%s executable is not cached", h.GetExecutableName())
 	}
-	hyperkitPath := h.GetBinaryPath()
+	hyperkitPath := h.GetExecutablePath()
 	err := unix.Access(hyperkitPath, unix.X_OK)
 	if err != nil {
 		return fmt.Errorf("%s not executable", hyperkitPath)
@@ -36,37 +36,37 @@ func checkHyperKitInstalled() error {
 func fixHyperKitInstallation() error {
 	h := cache.NewHyperKitCache()
 
-	logging.Debugf("Installing %s", h.GetBinaryName())
+	logging.Debugf("Installing %s", h.GetExecutableName())
 
 	if err := h.EnsureIsCached(); err != nil {
-		return fmt.Errorf("Unable to download %s : %v", h.GetBinaryName(), err)
+		return fmt.Errorf("Unable to download %s : %v", h.GetExecutableName(), err)
 	}
-	return setSuid(h.GetBinaryPath())
+	return setSuid(h.GetExecutablePath())
 }
 
 func checkMachineDriverHyperKitInstalled() error {
 	hyperkitDriver := cache.NewMachineDriverHyperKitCache()
 
-	logging.Debugf("Checking if %s is installed", hyperkitDriver.GetBinaryName())
+	logging.Debugf("Checking if %s is installed", hyperkitDriver.GetExecutableName())
 	if !hyperkitDriver.IsCached() {
-		return fmt.Errorf("%s executable is not cached", hyperkitDriver.GetBinaryName())
+		return fmt.Errorf("%s executable is not cached", hyperkitDriver.GetExecutableName())
 	}
 
 	if err := hyperkitDriver.CheckVersion(); err != nil {
 		return err
 	}
-	return checkSuid(hyperkitDriver.GetBinaryPath())
+	return checkSuid(hyperkitDriver.GetExecutablePath())
 }
 
 func fixMachineDriverHyperKitInstalled() error {
 	hyperkitDriver := cache.NewMachineDriverHyperKitCache()
 
-	logging.Debugf("Installing %s", hyperkitDriver.GetBinaryName())
+	logging.Debugf("Installing %s", hyperkitDriver.GetExecutableName())
 
 	if err := hyperkitDriver.EnsureIsCached(); err != nil {
-		return fmt.Errorf("Unable to download %s : %v", hyperkitDriver.GetBinaryName(), err)
+		return fmt.Errorf("Unable to download %s : %v", hyperkitDriver.GetExecutableName(), err)
 	}
-	return setSuid(hyperkitDriver.GetBinaryPath())
+	return setSuid(hyperkitDriver.GetExecutablePath())
 }
 
 func checkEtcHostsFilePermissions() error {

--- a/pkg/crc/preflight/preflight_checks_darwin.go
+++ b/pkg/crc/preflight/preflight_checks_darwin.go
@@ -20,7 +20,7 @@ const (
 func checkHyperKitInstalled() error {
 	h := cache.NewHyperKitCache()
 	if !h.IsCached() {
-		return fmt.Errorf("%s binary is not cached", h.GetBinaryName())
+		return fmt.Errorf("%s executable is not cached", h.GetBinaryName())
 	}
 	hyperkitPath := h.GetBinaryPath()
 	err := unix.Access(hyperkitPath, unix.X_OK)
@@ -49,7 +49,7 @@ func checkMachineDriverHyperKitInstalled() error {
 
 	logging.Debugf("Checking if %s is installed", hyperkitDriver.GetBinaryName())
 	if !hyperkitDriver.IsCached() {
-		return fmt.Errorf("%s binary is not cached", hyperkitDriver.GetBinaryName())
+		return fmt.Errorf("%s executable is not cached", hyperkitDriver.GetBinaryName())
 	}
 
 	if err := hyperkitDriver.CheckVersion(); err != nil {

--- a/pkg/crc/preflight/preflight_checks_linux.go
+++ b/pkg/crc/preflight/preflight_checks_linux.go
@@ -256,7 +256,7 @@ func checkMachineDriverLibvirtInstalled() error {
 	logging.Debugf("Checking if %s is installed", machineDriverLibvirt.GetBinaryName())
 
 	if !machineDriverLibvirt.IsCached() {
-		return fmt.Errorf("%s binary is not cached", machineDriverLibvirt.GetBinaryName())
+		return fmt.Errorf("%s executable is not cached", machineDriverLibvirt.GetBinaryName())
 	}
 	if err := machineDriverLibvirt.CheckVersion(); err != nil {
 		return err
@@ -282,7 +282,7 @@ func checkOldMachineDriverLibvirtInstalled() error {
 	logging.Debugf("Checking if an older libvirt driver %s is installed", libvirt.MachineDriverCommand)
 	oldLibvirtDriverPath := filepath.Join("/usr/local/bin/", libvirt.MachineDriverCommand)
 	if _, err := os.Stat(oldLibvirtDriverPath); !os.IsNotExist(err) {
-		return fmt.Errorf("Found old system-wide crc-machine-driver binary")
+		return fmt.Errorf("Found old system-wide crc-machine-driver executable")
 	}
 	logging.Debugf("No older %s installation found", libvirt.MachineDriverCommand)
 

--- a/pkg/crc/preflight/preflight_checks_linux.go
+++ b/pkg/crc/preflight/preflight_checks_linux.go
@@ -253,27 +253,27 @@ func fixLibvirtServiceRunning() error {
 func checkMachineDriverLibvirtInstalled() error {
 	machineDriverLibvirt := cache.NewMachineDriverLibvirtCache()
 
-	logging.Debugf("Checking if %s is installed", machineDriverLibvirt.GetBinaryName())
+	logging.Debugf("Checking if %s is installed", machineDriverLibvirt.GetExecutableName())
 
 	if !machineDriverLibvirt.IsCached() {
-		return fmt.Errorf("%s executable is not cached", machineDriverLibvirt.GetBinaryName())
+		return fmt.Errorf("%s executable is not cached", machineDriverLibvirt.GetExecutableName())
 	}
 	if err := machineDriverLibvirt.CheckVersion(); err != nil {
 		return err
 	}
-	logging.Debugf("%s is already installed", machineDriverLibvirt.GetBinaryName())
+	logging.Debugf("%s is already installed", machineDriverLibvirt.GetExecutableName())
 	return nil
 }
 
 func fixMachineDriverLibvirtInstalled() error {
 	machineDriverLibvirt := cache.NewMachineDriverLibvirtCache()
 
-	logging.Debugf("Installing %s", machineDriverLibvirt.GetBinaryName())
+	logging.Debugf("Installing %s", machineDriverLibvirt.GetExecutableName())
 
 	if err := machineDriverLibvirt.EnsureIsCached(); err != nil {
-		return fmt.Errorf("Unable to download %s: %v", machineDriverLibvirt.GetBinaryName(), err)
+		return fmt.Errorf("Unable to download %s: %v", machineDriverLibvirt.GetExecutableName(), err)
 	}
-	logging.Debugf("%s is installed in %s", machineDriverLibvirt.GetBinaryName(), filepath.Dir(machineDriverLibvirt.GetBinaryPath()))
+	logging.Debugf("%s is installed in %s", machineDriverLibvirt.GetExecutableName(), filepath.Dir(machineDriverLibvirt.GetExecutablePath()))
 	return nil
 }
 

--- a/pkg/crc/preflight/preflight_checks_tray_darwin.go
+++ b/pkg/crc/preflight/preflight_checks_tray_darwin.go
@@ -37,7 +37,7 @@ type TrayVersion struct {
 func checkIfDaemonPlistFileExists() error {
 	// crc setup can be ran from any location in the
 	// users computer, and we need to update the plist
-	// file with the path of the crc binary which was
+	// file with the path of the crc executable which was
 	// used to run setup, to force it this check needs
 	// to always fail so the fix routine is triggered
 
@@ -55,7 +55,7 @@ func fixDaemonPlistFileExists() error {
 	}
 	daemonConfig := launchd.AgentConfig{
 		Label:          daemonAgentLabel,
-		BinaryPath:     currentExecutablePath,
+		ExecutablePath: currentExecutablePath,
 		StdOutFilePath: stdOutFilePathDaemon,
 		Args:           []string{"daemon", "--log-level", "debug"},
 	}
@@ -76,7 +76,7 @@ func checkIfTrayPlistFileExists() error {
 func fixTrayPlistFileExists() error {
 	trayConfig := launchd.AgentConfig{
 		Label:          trayAgentLabel,
-		BinaryPath:     constants.TrayBinaryPath,
+		ExecutablePath: constants.TrayExecutablePath,
 		StdOutFilePath: stdOutFilePathTray,
 	}
 	return fixPlistFileExists(trayConfig)
@@ -157,14 +157,14 @@ func fixTrayVersion() error {
 	return launchd.RestartAgent(trayAgentLabel)
 }
 
-func checkTrayBinaryPresent() error {
-	if !os.FileExists(constants.TrayBinaryPath) {
+func checkTrayExecutablePresent() error {
+	if !os.FileExists(constants.TrayExecutablePath) {
 		return fmt.Errorf("Tray executable does not exist")
 	}
 	return nil
 }
 
-func fixTrayBinaryPresent() error {
+func fixTrayExecutablePresent() error {
 	logging.Debug("Downloading/extracting tray executable")
 	return downloadOrExtractTrayApp()
 }

--- a/pkg/crc/preflight/preflight_checks_tray_darwin.go
+++ b/pkg/crc/preflight/preflight_checks_tray_darwin.go
@@ -148,7 +148,7 @@ func checkTrayVersion() error {
 }
 
 func fixTrayVersion() error {
-	logging.Debug("Downloading/extracting tray binary")
+	logging.Debug("Downloading/extracting tray executable")
 	// get the tray app
 	err := downloadOrExtractTrayApp()
 	if err != nil {
@@ -159,13 +159,13 @@ func fixTrayVersion() error {
 
 func checkTrayBinaryPresent() error {
 	if !os.FileExists(constants.TrayBinaryPath) {
-		return fmt.Errorf("Tray binary does not exist")
+		return fmt.Errorf("Tray executable does not exist")
 	}
 	return nil
 }
 
 func fixTrayBinaryPresent() error {
-	logging.Debug("Downloading/extracting tray binary")
+	logging.Debug("Downloading/extracting tray executable")
 	return downloadOrExtractTrayApp()
 }
 
@@ -194,10 +194,10 @@ func downloadOrExtractTrayApp() error {
 		_ = goos.RemoveAll(tmpArchivePath)
 	}()
 
-	logging.Debug("Trying to extract tray from crc binary")
+	logging.Debug("Trying to extract tray from crc executable")
 	err = embed.Extract(filepath.Base(constants.GetCRCMacTrayDownloadURL()), tmpArchivePath)
 	if err != nil {
-		logging.Debug("Could not extract tray from crc binary", err)
+		logging.Debug("Could not extract tray from crc executable", err)
 		logging.Debug("Downloading crc tray")
 		_, err = dl.Download(constants.GetCRCMacTrayDownloadURL(), tmpArchivePath, 0600)
 		if err != nil {

--- a/pkg/crc/preflight/preflight_checks_tray_windows.go
+++ b/pkg/crc/preflight/preflight_checks_tray_windows.go
@@ -20,7 +20,7 @@ import (
 
 func checkIfTrayInstalled() error {
 	/* We want to force installation whenever setup is ran
-	 * as we want the service config to point to the binary
+	 * as we want the service config to point to the executable
 	 * with which the setup command was issued.
 	 */
 
@@ -66,7 +66,7 @@ func fixTrayInstalled() error {
 		password,
 		tempDir,
 		binPathWithArgs,
-		constants.TrayBinaryPath,
+		constants.TrayExecutablePath,
 		constants.TrayShortcutName,
 		constants.DaemonServiceName,
 	)
@@ -111,7 +111,7 @@ func escapeWindowsPassword(password string) string {
 }
 
 func removeTray() error {
-	trayProcessName := constants.TrayBinaryName[:len(constants.TrayBinaryName)-4]
+	trayProcessName := constants.TrayExecutableName[:len(constants.TrayExecutableName)-4]
 
 	tempDir, err := ioutil.TempDir("", "crc")
 	if err != nil {
@@ -145,14 +145,14 @@ func removeTray() error {
 	return nil
 }
 
-func checkTrayBinaryExists() error {
-	if os.FileExists(constants.TrayBinaryPath) {
+func checkTrayExecutableExists() error {
+	if os.FileExists(constants.TrayExecutablePath) {
 		return nil
 	}
 	return fmt.Errorf("Tray executable does not exists")
 }
 
-func fixTrayBinaryExists() error {
+func fixTrayExecutableExists() error {
 	tmpArchivePath, err := ioutil.TempDir("", "crc")
 	if err != nil {
 		logging.Error("Failed creating temporary directory for extracting tray")
@@ -173,7 +173,7 @@ func fixTrayBinaryExists() error {
 		}
 	}
 	archivePath := filepath.Join(tmpArchivePath, filepath.Base(constants.GetCRCWindowsTrayDownloadURL()))
-	_, err = extract.Uncompress(archivePath, constants.TrayBinaryDir, false)
+	_, err = extract.Uncompress(archivePath, constants.TrayExecutableDir, false)
 	if err != nil {
 		return fmt.Errorf("Cannot uncompress '%s': %v", archivePath, err)
 	}

--- a/pkg/crc/preflight/preflight_checks_tray_windows.go
+++ b/pkg/crc/preflight/preflight_checks_tray_windows.go
@@ -149,7 +149,7 @@ func checkTrayBinaryExists() error {
 	if os.FileExists(constants.TrayBinaryPath) {
 		return nil
 	}
-	return fmt.Errorf("Tray binary does not exists")
+	return fmt.Errorf("Tray executable does not exists")
 }
 
 func fixTrayBinaryExists() error {
@@ -162,10 +162,10 @@ func fixTrayBinaryExists() error {
 		_ = goos.RemoveAll(tmpArchivePath)
 	}()
 
-	logging.Debug("Trying to extract tray from crc binary")
+	logging.Debug("Trying to extract tray from crc executable")
 	err = embed.Extract(filepath.Base(constants.GetCRCWindowsTrayDownloadURL()), tmpArchivePath)
 	if err != nil {
-		logging.Debug("Could not extract tray from crc binary", err)
+		logging.Debug("Could not extract tray from crc executable", err)
 		logging.Debug("Downloading crc tray")
 		_, err = dl.Download(constants.GetCRCWindowsTrayDownloadURL(), tmpArchivePath, 0600)
 		if err != nil {

--- a/pkg/crc/preflight/preflight_darwin.go
+++ b/pkg/crc/preflight/preflight_darwin.go
@@ -43,7 +43,7 @@ var dnsPreflightChecks = [...]Check{
 
 var traySetupChecks = [...]Check{
 	{
-		checkDescription: "Checking if tray binary is installed",
+		checkDescription: "Checking if tray executable is installed",
 		check:            checkTrayBinaryPresent,
 		fixDescription:   "Installing and setting up tray",
 		fix:              fixTrayBinaryPresent,

--- a/pkg/crc/preflight/preflight_darwin.go
+++ b/pkg/crc/preflight/preflight_darwin.go
@@ -44,9 +44,9 @@ var dnsPreflightChecks = [...]Check{
 var traySetupChecks = [...]Check{
 	{
 		checkDescription: "Checking if tray executable is installed",
-		check:            checkTrayBinaryPresent,
+		check:            checkTrayExecutablePresent,
 		fixDescription:   "Installing and setting up tray",
-		fix:              fixTrayBinaryPresent,
+		fix:              fixTrayExecutablePresent,
 		flags:            SetupOnly,
 	},
 	{

--- a/pkg/crc/preflight/preflight_tray_powershell_windows.go
+++ b/pkg/crc/preflight/preflight_tray_powershell_windows.go
@@ -10,8 +10,8 @@ var (
 		`$ErrorActionPreference = "Stop"`,
 		`$password = "%s"`,
 		`$tempDir = "%s"`,
-		`$crcBinaryPath = "%s"`,
-		`$trayBinaryPath = "%s"`,
+		`$crcExecutablePath = "%s"`,
+		`$trayExecutablePath = "%s"`,
 		`$traySymlinkName = "%s"`,
 		`$serviceName = "%s"`,
 		`$currentUserSid = (Get-LocalUser -Name "$env:USERNAME").Sid.Value`,
@@ -56,7 +56,7 @@ var (
 		`	$creds = New-Object pscredential ("$env:USERDOMAIN\$env:USERNAME", $secPass)`,
 		`	$params = @{`,
 		`		Name = "$serviceName"`,
-		`		BinaryPathName = "$crcBinaryPath daemon"`,
+		`		ExecutablePathName = "$crcExecutablePath daemon"`,
 		`		DisplayName = "$serviceName"`,
 		`		StartupType = "Automatic"`,
 		`		Description = "CodeReady Containers Daemon service for System Tray."`,
@@ -80,8 +80,8 @@ var (
 		`Remove-Item "$startUpFolder\$traySymlinkName"`,
 
 		`$ErrorActionPreference = "Stop"`,
-		`New-Item -ItemType SymbolicLink -Path "$startUpFolder" -Name "$traySymlinkName" -Value "$trayBinaryPath"`,
-		`Start-Process -FilePath "$trayBinaryPath"`,
+		`New-Item -ItemType SymbolicLink -Path "$startUpFolder" -Name "$traySymlinkName" -Value "$trayExecutablePath"`,
+		`Start-Process -FilePath "$trayExecutablePath"`,
 		`New-Item -ItemType File -Path "$tempDir" -Name "success"`,
 		`Set-Content -Path $tempDir\success "blah blah"`,
 	}
@@ -149,12 +149,12 @@ func getTrayRemovalScriptTemplate() string {
 	return strings.Join(trayRemovalScript, "\n")
 }
 
-func genTrayInstallScript(password, tempDirPath, daemonCmd, trayBinaryPath, traySymlinkName, daemonServiceName string) string {
+func genTrayInstallScript(password, tempDirPath, daemonCmd, trayExecutablePath, traySymlinkName, daemonServiceName string) string {
 	return fmt.Sprintf(getTrayInstallationScriptTemplate(),
 		password,
 		tempDirPath,
 		daemonCmd,
-		trayBinaryPath,
+		trayExecutablePath,
 		traySymlinkName,
 		daemonServiceName,
 	)

--- a/pkg/crc/preflight/preflight_windows.go
+++ b/pkg/crc/preflight/preflight_windows.go
@@ -64,9 +64,9 @@ var hypervPreflightChecks = [...]Check{
 
 var traySetupChecks = [...]Check{
 	{
-		checkDescription: "Checking if tray binary is present",
+		checkDescription: "Checking if tray executable is present",
 		check:            checkTrayBinaryExists,
-		fixDescription:   "Caching tray binary",
+		fixDescription:   "Caching tray executable",
 		fix:              fixTrayBinaryExists,
 		flags:            SetupOnly,
 	},

--- a/pkg/crc/preflight/preflight_windows.go
+++ b/pkg/crc/preflight/preflight_windows.go
@@ -65,9 +65,9 @@ var hypervPreflightChecks = [...]Check{
 var traySetupChecks = [...]Check{
 	{
 		checkDescription: "Checking if tray executable is present",
-		check:            checkTrayBinaryExists,
+		check:            checkTrayExecutableExists,
 		fixDescription:   "Caching tray executable",
-		fix:              fixTrayBinaryExists,
+		fix:              fixTrayExecutableExists,
 		flags:            SetupOnly,
 	},
 	{

--- a/pkg/crc/validation/validation.go
+++ b/pkg/crc/validation/validation.go
@@ -67,7 +67,7 @@ func ValidateBundle(bundle string) error {
 			logging.Warnf("Using unsupported bundle %s", userProvidedBundleVersion)
 			return nil
 		}
-		return fmt.Errorf("%s bundle is not supported by this binary, please use %s", userProvidedBundleVersion, constants.GetDefaultBundle())
+		return fmt.Errorf("%s bundle is not supported by this crc executable, please use %s", userProvidedBundleVersion, constants.GetDefaultBundle())
 	}
 	return nil
 }

--- a/pkg/crc/version/version.go
+++ b/pkg/crc/version/version.go
@@ -15,7 +15,7 @@ var (
 	// The current version of minishift
 	crcVersion = "0.0.0-unset"
 
-	// The SHA-1 of the commit this binary is build off
+	// The SHA-1 of the commit this executable is build off
 	commitSha = "sha-unset"
 
 	// Bundle version which used for the release.
@@ -27,7 +27,7 @@ var (
 
 const (
 	releaseInfoLink = "https://mirror.openshift.com/pub/openshift-v4/clients/crc/latest/release-info.json"
-	// Tray version to be embedded in binary
+	// Tray version to be embedded in executable
 	crcMacTrayVersion = "1.0.0-alpha.6"
 	// Windows forms application version type major.minor.buildnumber.revesion
 	crcWindowsTrayVersion = "0.2.0.0"

--- a/pkg/embed/embed.go
+++ b/pkg/embed/embed.go
@@ -10,29 +10,29 @@ import (
 	"github.com/YourFin/binappend"
 )
 
-func openEmbeddedFile(binaryPath, embedName string) (*binappend.Reader, error) {
-	extractor, err := binappend.MakeExtractor(binaryPath)
+func openEmbeddedFile(executablePath, embedName string) (*binappend.Reader, error) {
+	extractor, err := binappend.MakeExtractor(executablePath)
 	if err != nil {
-		return nil, fmt.Errorf("Could not data embedded in %s: %v", binaryPath, err)
+		return nil, fmt.Errorf("Could not data embedded in %s: %v", executablePath, err)
 	}
 	reader, err := extractor.GetReader(embedName)
 	if err != nil {
-		return nil, fmt.Errorf("Could not open embedded '%s' in %s: %v", embedName, binaryPath, err)
+		return nil, fmt.Errorf("Could not open embedded '%s' in %s: %v", embedName, executablePath, err)
 	}
 	return reader, nil
 }
 
 func Extract(embedName, destFile string) error {
-	binaryPath, err := os.Executable()
+	executablePath, err := os.Executable()
 	if err != nil {
 		return err
 	}
-	return ExtractFromBinary(binaryPath, embedName, destFile)
+	return ExtractFromExecutable(executablePath, embedName, destFile)
 }
 
-func ExtractFromBinary(binaryPath, embedName, destFile string) error {
-	logging.Debugf("Extracting embedded '%s' from %s to %s", embedName, binaryPath, destFile)
-	reader, err := openEmbeddedFile(binaryPath, embedName)
+func ExtractFromExecutable(executablePath, embedName, destFile string) error {
+	logging.Debugf("Extracting embedded '%s' from %s to %s", embedName, executablePath, destFile)
+	reader, err := openEmbeddedFile(executablePath, embedName)
 	if err != nil {
 		return err
 	}
@@ -46,7 +46,7 @@ func ExtractFromBinary(binaryPath, embedName, destFile string) error {
 
 	_, err = io.Copy(writer, reader)
 	if err != nil {
-		return fmt.Errorf("Failed to copy embedded '%s' from %s to %s: %v", embedName, binaryPath, destFile, err)
+		return fmt.Errorf("Failed to copy embedded '%s' from %s to %s: %v", embedName, executablePath, destFile, err)
 	}
 	return nil
 }

--- a/pkg/os/launchd/launchd_darwin.go
+++ b/pkg/os/launchd/launchd_darwin.go
@@ -24,7 +24,7 @@ const (
 			<string>{{ .Label }}</string>
 			<key>ProgramArguments</key>
 			<array>
-				<string>{{ .BinaryPath }}</string>
+				<string>{{ .ExecutablePath }}</string>
 			{{ range .Args }}
 				<string>{{ . }}</string>
 			{{ end }}
@@ -42,7 +42,7 @@ const (
 // AgentConfig is struct to contain configuration for agent plist file
 type AgentConfig struct {
 	Label          string
-	BinaryPath     string
+	ExecutablePath string
 	StdOutFilePath string
 	Args           []string
 }

--- a/test/integration/crcsuite/crcsuite.go
+++ b/test/integration/crcsuite/crcsuite.go
@@ -73,7 +73,7 @@ func FeatureContext(s *godog.Suite) {
 
 		// init CRCBinary if no location provided by user
 		if CRCBinary == "" {
-			fmt.Println("Expecting the CRC binary to be in $HOME/go/bin.")
+			fmt.Println("Expecting the CRC executable to be in $HOME/go/bin.")
 			usr, _ := user.Current()
 			CRCBinary = filepath.Join(usr.HomeDir, "go", "bin")
 		}
@@ -88,7 +88,7 @@ func FeatureContext(s *godog.Suite) {
 		}
 
 		if bundleURL == "embedded" {
-			fmt.Println("Expecting the bundle to be embedded in the CRC binary.")
+			fmt.Println("Expecting the bundle to be embedded in the CRC executable.")
 			bundleEmbedded = true
 			if bundleVersion == "" {
 				fmt.Println("User must specify --bundle-version if bundle is embedded")

--- a/test/integration/crcsuite/crcsuite.go
+++ b/test/integration/crcsuite/crcsuite.go
@@ -22,7 +22,7 @@ import (
 
 var (
 	CRCHome        string
-	CRCBinary      string
+	CRCExecutable  string
 	bundleEmbedded bool
 	bundleName     string
 	bundleURL      string
@@ -71,16 +71,16 @@ func FeatureContext(s *godog.Suite) {
 		usr, _ := user.Current()
 		CRCHome = filepath.Join(usr.HomeDir, ".crc")
 
-		// init CRCBinary if no location provided by user
-		if CRCBinary == "" {
+		// init CRCExecutable if no location provided by user
+		if CRCExecutable == "" {
 			fmt.Println("Expecting the CRC executable to be in $HOME/go/bin.")
 			usr, _ := user.Current()
-			CRCBinary = filepath.Join(usr.HomeDir, "go", "bin")
+			CRCExecutable = filepath.Join(usr.HomeDir, "go", "bin")
 		}
 
-		// put CRC binary location on top of PATH
+		// put CRC executable location on top of PATH
 		path := os.Getenv("PATH")
-		newPath := fmt.Sprintf("%s%c%s", CRCBinary, os.PathListSeparator, path)
+		newPath := fmt.Sprintf("%s%c%s", CRCExecutable, os.PathListSeparator, path)
 		err := os.Setenv("PATH", newPath)
 		if err != nil {
 			fmt.Println("Could not put CRC location on top of PATH")

--- a/test/integration/crcsuite/prepare.go
+++ b/test/integration/crcsuite/prepare.go
@@ -122,6 +122,6 @@ func ParseFlags() {
 
 	flag.StringVar(&bundleURL, "bundle-location", "embedded", "Path to the bundle to be used in tests")
 	flag.StringVar(&pullSecretFile, "pull-secret-file", "", "Path to the file containing pull secret")
-	flag.StringVar(&CRCBinary, "crc-binary", "", "Path to the CRC executable to be tested")
+	flag.StringVar(&CRCExecutable, "crc-binary", "", "Path to the CRC executable to be tested")
 	flag.StringVar(&bundleVersion, "bundle-version", "", "Version of the bundle used in tests")
 }

--- a/test/integration/crcsuite/prepare.go
+++ b/test/integration/crcsuite/prepare.go
@@ -122,6 +122,6 @@ func ParseFlags() {
 
 	flag.StringVar(&bundleURL, "bundle-location", "embedded", "Path to the bundle to be used in tests")
 	flag.StringVar(&pullSecretFile, "pull-secret-file", "", "Path to the file containing pull secret")
-	flag.StringVar(&CRCBinary, "crc-binary", "", "Path to the CRC binary to be tested")
+	flag.StringVar(&CRCBinary, "crc-binary", "", "Path to the CRC executable to be tested")
 	flag.StringVar(&bundleVersion, "bundle-version", "", "Version of the bundle used in tests")
 }

--- a/test/integration/features/basic.feature
+++ b/test/integration/features/basic.feature
@@ -37,7 +37,7 @@ Feature: Basic test
     @linux
     Scenario: CRC setup on Linux
         When executing "crc setup" succeeds
-        Then stderr should contain "Caching oc binary"
+        Then stderr should contain "Caching oc executable"
         And stderr should contain "Checking if CRC bundle is cached in '$HOME/.crc'"
         And stderr should contain "Checking if running as non-root"
         And stderr should contain "Checking if Virtualization is enabled"
@@ -67,7 +67,7 @@ Feature: Basic test
     @darwin
     Scenario: CRC setup on Mac
         When executing "crc setup" succeeds
-        Then stderr should contain "Caching oc binary"
+        Then stderr should contain "Caching oc executable"
         And stderr should contain "Checking if running as non-root"
         And stderr should contain "Checking if HyperKit is installed"
         And stderr should contain "Checking if crc-driver-hyperkit is installed"
@@ -79,8 +79,8 @@ Feature: Basic test
     @windows
     Scenario: CRC setup on Windows
         When executing "crc setup" succeeds
-        Then stderr should contain "Caching oc binary"
-        Then stderr should contain "Unpacking bundle from the CRC binary" if bundle is embedded
+        Then stderr should contain "Caching oc executable"
+        Then stderr should contain "Unpacking bundle from the CRC executable" if bundle is embedded
         Then stderr should contain "Checking Windows 10 release"
         Then stderr should contain "Checking if Hyper-V is installed"
         Then stderr should contain "Checking if user is a member of the Hyper-V Administrators group"


### PR DESCRIPTION
Fixes: Issue #1613

## Solution/Idea

This replaces the 'binary' terminology when talking about an executable file with 'executable'. As pointed out in #1613, 'binary' can be ambiguous.

## Proposed changes

List main as well as consequential changes you introduced or had to introduce.

1. There should only be cosmetic changes to user visible strings ('binary' -> 'executable'), with no change in behaviour.