### PR TITLE
Bump macOS system tray version to v1.0.0-alpha.6

### DIFF
--- a/pkg/crc/version/version.go
+++ b/pkg/crc/version/version.go
@@ -28,7 +28,7 @@ var (
 const (
 	releaseInfoLink = "https://mirror.openshift.com/pub/openshift-v4/clients/crc/latest/release-info.json"
 	// Tray version to be embedded in binary
-	crcMacTrayVersion = "1.0.0-alpha.5"
+	crcMacTrayVersion = "1.0.0-alpha.6"
 	// Windows forms application version type major.minor.buildnumber.revesion
 	crcWindowsTrayVersion = "0.2.0.0"
 )


### PR DESCRIPTION
Update for macOS System tray.