### PR TITLE
Use value instead castValue for error message

### DIFF
--- a/pkg/crc/config/config.go
+++ b/pkg/crc/config/config.go
@@ -74,7 +74,7 @@ func (c *Config) Set(key string, value interface{}) (string, error) {
 
 	ok, expectedValue := c.settingsByName[key].validationFn(castValue)
 	if !ok {
-		return "", fmt.Errorf(invalidProp, castValue, key, expectedValue)
+		return "", fmt.Errorf(invalidProp, value, key, expectedValue)
 	}
 
 	if err := c.storage.Set(key, castValue); err != nil {


### PR DESCRIPTION
invalidprop variable is used to create the error message and it respect
the strings instead of casted value. if casted value is used then following
msg shown to user which is not a good ux.

```
$ crc config set cpus 2
Value '%!!(MISSING)s(int=2)' for configuration property 'cpus' is invalid, reason: requires CPUs >= 4
```