### PR TITLE
Use latest hyperkit driver 

### DIFF
--- a/pkg/crc/machine/hyperkit/constants.go
+++ b/pkg/crc/machine/hyperkit/constants.go
@@ -6,7 +6,7 @@ import "fmt"
 
 const (
 	MachineDriverCommand = "crc-driver-hyperkit"
-	MachineDriverVersion = "0.12.9"
+	MachineDriverVersion = "0.12.10-beta1"
 	HyperKitCommand      = "hyperkit"
 	HyperKitVersion      = "v0.20200224-44-gb54460"
 )

--- a/pkg/crc/machine/hyperkit/driver_darwin.go
+++ b/pkg/crc/machine/hyperkit/driver_darwin.go
@@ -18,6 +18,7 @@ func CreateHost(machineConfig config.MachineConfig) *hyperkit.Driver {
 	hyperkitDriver.VmlinuzPath = machineConfig.Kernel
 	hyperkitDriver.InitrdPath = machineConfig.Initramfs
 	hyperkitDriver.HyperKitPath = filepath.Join(constants.CrcBinDir, "hyperkit")
+	hyperkitDriver.VMNet = true
 
 	return hyperkitDriver
 }


### PR DESCRIPTION
I merged the vsock changes and it requires for the default and current use case to set VMNet = true.