### PR TITLE
Use oc executable embedded in the bundle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,6 @@
 SHELL := /bin/bash
 
 BUNDLE_VERSION = 4.6.1
-# OC_VERSION and BUNDLE_VERSION are going to same for release artifacts but
-# different for nightly and CI bits where bundle version would be any random
-# string or dd-mm-yyyy format.
-OC_VERSION ?= ${BUNDLE_VERSION}
 BUNDLE_EXTENSION = crcbundle
 CRC_VERSION = 1.18.0
 COMMIT_SHA=$(shell git rev-parse --short HEAD)
@@ -49,7 +45,6 @@ __check_defined = \
 # Linker flags
 VERSION_VARIABLES := -X $(REPOPATH)/pkg/crc/version.crcVersion=$(CRC_VERSION) \
     -X $(REPOPATH)/pkg/crc/version.bundleVersion=$(BUNDLE_VERSION) \
-    -X $(REPOPATH)/pkg/crc/version.ocVersion=$(OC_VERSION) \
 	-X $(REPOPATH)/pkg/crc/version.commitSha=$(COMMIT_SHA)
 
 # https://golang.org/cmd/link/

--- a/cmd/crc-embedder/cmd/embed.go
+++ b/cmd/crc-embedder/cmd/embed.go
@@ -89,17 +89,14 @@ var (
 		"darwin": {
 			hyperkit.MachineDriverDownloadURL,
 			hyperkit.HyperKitDownloadURL,
-			constants.GetOcURLForOs("darwin"),
 			constants.GetCRCMacTrayDownloadURL(),
 			constants.GetGoodhostsURLForOs("darwin"),
 		},
 		"linux": {
 			libvirt.MachineDriverDownloadURL,
-			constants.GetOcURLForOs("linux"),
 			constants.GetGoodhostsURLForOs("linux"),
 		},
 		"windows": {
-			constants.GetOcURLForOs("windows"),
 			constants.GetGoodhostsURLForOs("windows"),
 			constants.GetCRCWindowsTrayDownloadURL(),
 		},

--- a/cmd/crc/cmd/root.go
+++ b/cmd/crc/cmd/root.go
@@ -40,7 +40,7 @@ var (
 )
 
 func init() {
-	if err := constants.EnsureBaseDirExists(); err != nil {
+	if err := constants.EnsureBaseDirectoriesExist(); err != nil {
 		logging.Fatal(err.Error())
 	}
 	var err error

--- a/pkg/crc/cache/cache.go
+++ b/pkg/crc/cache/cache.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/code-ready/crc/pkg/crc/logging"
-	"github.com/code-ready/crc/pkg/crc/version"
 	"github.com/code-ready/crc/pkg/download"
 	"github.com/code-ready/crc/pkg/embed"
 	"github.com/code-ready/crc/pkg/extract"
@@ -39,10 +38,6 @@ func New(executableName string, archiveURL string, destDir string, version strin
 	return &Cache{executableName: executableName, archiveURL: archiveURL, destDir: destDir, version: version, getVersion: getVersion}
 }
 
-func getCurrentOcVersion(executablePath string) (string, error) {
-	return getVersionGeneric(executablePath, "version", "--client")
-}
-
 func (c *Cache) GetExecutablePath() string {
 	return filepath.Join(c.destDir, c.executableName)
 }
@@ -57,17 +52,13 @@ func (c *Cache) GetExecutableName() string {
  *
  * It returns <version> as a string
  */
-func getVersionGeneric(executablePath string, args ...string) (string, error) {
+func getVersionGeneric(executablePath string, args ...string) (string, error) { //nolint:deadcode,unused
 	stdOut, _, err := crcos.RunWithDefaultLocale(executablePath, args...)
 	parsedOutput := strings.Split(stdOut, ":")
 	if len(parsedOutput) < 2 {
 		return "", fmt.Errorf("Unable to parse the version information of %s", executablePath)
 	}
 	return strings.TrimSpace(parsedOutput[1]), err
-}
-
-func NewOcCache() *Cache {
-	return New(constants.OcExecutableName, constants.GetOcURL(), constants.CrcOcBinDir, version.GetOcVersion(), getCurrentOcVersion)
 }
 
 func NewPodmanCache() *Cache {

--- a/pkg/crc/constants/constants.go
+++ b/pkg/crc/constants/constants.go
@@ -37,20 +37,6 @@ const (
 	DefaultContext            = "admin"
 )
 
-var ocURLForOs = map[string]string{
-	"darwin":  fmt.Sprintf("%s/%s/%s", DefaultOcURLBase, version.GetOcVersion(), "openshift-client-mac.tar.gz"),
-	"linux":   fmt.Sprintf("%s/%s/%s", DefaultOcURLBase, version.GetOcVersion(), "openshift-client-linux.tar.gz"),
-	"windows": fmt.Sprintf("%s/%s/%s", DefaultOcURLBase, version.GetOcVersion(), "openshift-client-windows.zip"),
-}
-
-func GetOcURLForOs(os string) string {
-	return ocURLForOs[os]
-}
-
-func GetOcURL() string {
-	return GetOcURLForOs(runtime.GOOS)
-}
-
 var podmanURLForOs = map[string]string{
 	"darwin":  fmt.Sprintf("%s/%s", DefaultPodmanURLBase, "podman-remote-latest-master-darwin-amd64.zip"),
 	"linux":   fmt.Sprintf("%s/%s", DefaultPodmanURLBase, "podman-remote-latest-master-linux---amd64.zip"),
@@ -126,11 +112,15 @@ func GetHomeDir() string {
 	return os.Getenv("HOME")
 }
 
-// EnsureBaseDirExists create the ~/.crc dir if its not there
-func EnsureBaseDirExists() error {
-	_, err := os.Stat(CrcBaseDir)
-	if err != nil {
-		return os.Mkdir(CrcBaseDir, 0750)
+// EnsureBaseDirectoriesExist create the ~/.crc and ~/.crc/oc dirs if they are not present
+func EnsureBaseDirectoriesExist() error {
+	if _, err := os.Stat(CrcBaseDir); err != nil {
+		if !os.IsNotExist(err) {
+			return err
+		}
+		if err := os.Mkdir(CrcBaseDir, 0750); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/pkg/crc/logging/logging.go
+++ b/pkg/crc/logging/logging.go
@@ -15,7 +15,7 @@ var (
 )
 
 func OpenLogFile(path string) (*os.File, error) {
-	err := constants.EnsureBaseDirExists()
+	err := constants.EnsureBaseDirectoriesExist()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/crc/machine/machine.go
+++ b/pkg/crc/machine/machine.go
@@ -69,6 +69,7 @@ func getCrcBundleInfo(bundlePath string) (*bundle.CrcBundleInfo, error) {
 		logging.Infof("Loading bundle: %s ...", bundleName)
 		return bundleInfo, nil
 	}
+	logging.Debugf("Failed to load bundle %s: %v", bundleName, err)
 	logging.Infof("Extracting bundle: %s ...", bundleName)
 	return bundle.Extract(bundlePath)
 }

--- a/pkg/crc/preflight/preflight_checks_common.go
+++ b/pkg/crc/preflight/preflight_checks_common.go
@@ -16,13 +16,6 @@ import (
 
 var genericPreflightChecks = [...]Check{
 	{
-		configKeySuffix:  "check-oc-cached",
-		checkDescription: "Checking if oc executable is cached",
-		check:            checkOcExecutableCached,
-		fixDescription:   "Caching oc executable",
-		fix:              fixOcExecutableCached,
-	},
-	{
 		configKeySuffix:  "check-podman-cached",
 		checkDescription: "Checking if podman remote executable is cached",
 		check:            checkPodmanExecutableCached,
@@ -82,32 +75,6 @@ func fixBundleCached() error {
 		return embed.Extract(filepath.Base(constants.DefaultBundlePath), constants.DefaultBundlePath)
 	}
 	return fmt.Errorf("CRC bundle is not embedded in the executable")
-}
-
-// Check if oc executable is cached or not
-func checkOcExecutableCached() error {
-	// Remove oc executable from older location and ignore the error
-	// We should remove this code after 3-4 releases. (after 2020-07-10)
-	os.Remove(filepath.Join(constants.CrcBinDir, "oc"))
-
-	oc := cache.NewOcCache()
-	if !oc.IsCached() {
-		return errors.New("oc executable is not cached")
-	}
-	if err := oc.CheckVersion(); err != nil {
-		return err
-	}
-	logging.Debug("oc executable already cached")
-	return nil
-}
-
-func fixOcExecutableCached() error {
-	oc := cache.NewOcCache()
-	if err := oc.EnsureIsCached(); err != nil {
-		return fmt.Errorf("Unable to download oc %v", err)
-	}
-	logging.Debug("oc executable cached")
-	return nil
 }
 
 // Check if podman executable is cached or not

--- a/pkg/crc/preflight/preflight_darwin_test.go
+++ b/pkg/crc/preflight/preflight_darwin_test.go
@@ -10,10 +10,10 @@ import (
 func TestCountConfigurationOptions(t *testing.T) {
 	cfg := config.New(config.NewEmptyInMemoryStorage())
 	RegisterSettings(cfg)
-	assert.Len(t, cfg.AllConfigs(), 20)
+	assert.Len(t, cfg.AllConfigs(), 18)
 }
 
 func TestCountPreflights(t *testing.T) {
-	assert.Len(t, getPreflightChecks(false), 10)
-	assert.Len(t, getPreflightChecks(true), 16)
+	assert.Len(t, getPreflightChecks(false), 9)
+	assert.Len(t, getPreflightChecks(true), 15)
 }

--- a/pkg/crc/preflight/preflight_linux_test.go
+++ b/pkg/crc/preflight/preflight_linux_test.go
@@ -12,16 +12,16 @@ func TestCountConfigurationOptions(t *testing.T) {
 	cfg := config.New(config.NewEmptyInMemoryStorage())
 	RegisterSettings(cfg)
 	options := len(cfg.AllConfigs())
-	assert.True(t, options == 40 || options == 32)
+	assert.True(t, options == 38 || options == 30)
 }
 
 func TestCountPreflights(t *testing.T) {
-	assert.Len(t, getPreflightChecksForDistro(crcos.RHEL, false), 21)
-	assert.Len(t, getPreflightChecksForDistro(crcos.RHEL, true), 21)
+	assert.Len(t, getPreflightChecksForDistro(crcos.RHEL, false), 20)
+	assert.Len(t, getPreflightChecksForDistro(crcos.RHEL, true), 20)
 
-	assert.Len(t, getPreflightChecksForDistro("unexpected", false), 21)
-	assert.Len(t, getPreflightChecksForDistro("unexpected", true), 21)
+	assert.Len(t, getPreflightChecksForDistro("unexpected", false), 20)
+	assert.Len(t, getPreflightChecksForDistro("unexpected", true), 20)
 
-	assert.Len(t, getPreflightChecksForDistro(crcos.Ubuntu, false), 17)
-	assert.Len(t, getPreflightChecksForDistro(crcos.Ubuntu, true), 17)
+	assert.Len(t, getPreflightChecksForDistro(crcos.Ubuntu, false), 16)
+	assert.Len(t, getPreflightChecksForDistro(crcos.Ubuntu, true), 16)
 }

--- a/pkg/crc/preflight/preflight_windows_test.go
+++ b/pkg/crc/preflight/preflight_windows_test.go
@@ -10,10 +10,10 @@ import (
 func TestCountConfigurationOptions(t *testing.T) {
 	cfg := config.New(config.NewEmptyInMemoryStorage())
 	RegisterSettings(cfg)
-	assert.Len(t, cfg.AllConfigs(), 24)
+	assert.Len(t, cfg.AllConfigs(), 22)
 }
 
 func TestCountPreflights(t *testing.T) {
-	assert.Len(t, getPreflightChecks(false), 14)
-	assert.Len(t, getPreflightChecks(true), 16)
+	assert.Len(t, getPreflightChecks(false), 13)
+	assert.Len(t, getPreflightChecks(true), 15)
 }

--- a/pkg/crc/version/version.go
+++ b/pkg/crc/version/version.go
@@ -20,9 +20,6 @@ var (
 
 	// Bundle version which used for the release.
 	bundleVersion = "0.0.0-unset"
-
-	// OC version which should be used.
-	ocVersion = "0.0.0-unset"
 )
 
 const (
@@ -49,10 +46,6 @@ func GetCommitSha() string {
 
 func GetBundleVersion() string {
 	return bundleVersion
-}
-
-func GetOcVersion() string {
-	return ocVersion
 }
 
 func GetCRCMacTrayVersion() string {

--- a/test/integration/features/basic.feature
+++ b/test/integration/features/basic.feature
@@ -37,7 +37,6 @@ Feature: Basic test
     @linux
     Scenario: CRC setup on Linux
         When executing "crc setup" succeeds
-        Then stderr should contain "Caching oc executable"
         And stderr should contain "Checking if CRC bundle is cached in '$HOME/.crc'"
         And stderr should contain "Checking if running as non-root"
         And stderr should contain "Checking if Virtualization is enabled"
@@ -67,7 +66,6 @@ Feature: Basic test
     @darwin
     Scenario: CRC setup on Mac
         When executing "crc setup" succeeds
-        Then stderr should contain "Caching oc executable"
         And stderr should contain "Checking if running as non-root"
         And stderr should contain "Checking if HyperKit is installed"
         And stderr should contain "Checking if crc-driver-hyperkit is installed"
@@ -79,7 +77,6 @@ Feature: Basic test
     @windows
     Scenario: CRC setup on Windows
         When executing "crc setup" succeeds
-        Then stderr should contain "Caching oc executable"
         Then stderr should contain "Unpacking bundle from the CRC executable" if bundle is embedded
         Then stderr should contain "Checking Windows 10 release"
         Then stderr should contain "Checking if Hyper-V is installed"


### PR DESCRIPTION
oc executable is now in the bundle. This removes the hard link between
an openshift/snc release and a crc release. A crc release can use any
bundle compatible: for instance an okd bundle.

---

oc is not available after crc setup now. The bundle needs to be extracted first (with crc start).
still need to double check on Windows