### PR TITLE
delete: Fix message when user refuses cluster deletion

### DIFF
--- a/cmd/crc/cmd/delete_test.go
+++ b/cmd/crc/cmd/delete_test.go
@@ -24,6 +24,19 @@ func TestPlainDelete(t *testing.T) {
 	assert.True(t, os.IsNotExist(err))
 }
 
+func TestNonForceDelete(t *testing.T) {
+	cacheDir, err := ioutil.TempDir("", "cache")
+	require.NoError(t, err)
+	defer os.RemoveAll(cacheDir)
+
+	out := new(bytes.Buffer)
+	assert.NoError(t, runDelete(out, fakemachine.NewClient(), true, cacheDir, true, false, ""))
+	assert.Equal(t, "", out.String())
+
+	_, err = os.Stat(cacheDir)
+	assert.NoError(t, err)
+}
+
 func TestJSONDelete(t *testing.T) {
 	cacheDir, err := ioutil.TempDir("", "cache")
 	require.NoError(t, err)


### PR DESCRIPTION
Currently, after `crc delete`, the user is asked
"Do you want to delete the OpenShift cluster [y/N]?"
If they answer 'no', or just press enter, `crc` will still display
"Deleted the OpenShift cluster" even if the cluster was not actually
deleted.
This commit ensures this is only displayed when `client.Delete()` was
called.



## Testing

What is the _bottom-line_ functionality that needs testing? Describe in pseudo-code or in English. Use verifiable statements that tie your changes to existing functionality.

1. make sure you have a cluster created
2. run `crc delete`
3. press 'N' or 'enter'
4. "Deleted the OpenShift cluster is not displayed"