### PR TITLE
Add explicit order to all preflight checks

### DIFF
--- a/pkg/crc/preflight/preflight.go
+++ b/pkg/crc/preflight/preflight.go
@@ -2,6 +2,7 @@ package preflight
 
 import (
 	"fmt"
+	gosort "sort"
 
 	cmdConfig "github.com/code-ready/crc/cmd/crc/cmd/config"
 	"github.com/code-ready/crc/pkg/crc/config"
@@ -24,6 +25,7 @@ type FixFunc func() error
 type CleanUpFunc func() error
 
 type Check struct {
+	order              int
 	configKeySuffix    string
 	checkDescription   string
 	check              CheckFunc
@@ -101,6 +103,18 @@ func (check *Check) doCleanUp() error {
 	logging.Infof("%s", check.cleanupDescription)
 
 	return check.cleanup()
+}
+
+func sort(checks []Check) {
+	gosort.Slice(checks, func(i, j int) bool {
+		if checks[i].order < checks[j].order {
+			return true
+		}
+		if checks[i].order > checks[j].order {
+			return false
+		}
+		return checks[i].configKeySuffix < checks[j].configKeySuffix
+	})
 }
 
 func doPreflightChecks(config config.Storage, checks []Check) error {

--- a/pkg/crc/preflight/preflight_checks_common.go
+++ b/pkg/crc/preflight/preflight_checks_common.go
@@ -16,6 +16,7 @@ import (
 
 var genericPreflightChecks = [...]Check{
 	{
+		order:            100,
 		configKeySuffix:  "check-oc-cached",
 		checkDescription: "Checking if oc executable is cached",
 		check:            checkOcExecutableCached,
@@ -23,6 +24,7 @@ var genericPreflightChecks = [...]Check{
 		fix:              fixOcExecutableCached,
 	},
 	{
+		order:            100,
 		configKeySuffix:  "check-podman-cached",
 		checkDescription: "Checking if podman remote executable is cached",
 		check:            checkPodmanExecutableCached,
@@ -30,6 +32,7 @@ var genericPreflightChecks = [...]Check{
 		fix:              fixPodmanExecutableCached,
 	},
 	{
+		order:            100,
 		configKeySuffix:  "check-goodhosts-cached",
 		checkDescription: "Checking if goodhosts executable is cached",
 		check:            checkGoodhostsExecutableCached,
@@ -37,6 +40,7 @@ var genericPreflightChecks = [...]Check{
 		fix:              fixGoodhostsExecutableCached,
 	},
 	{
+		order:            100,
 		configKeySuffix:  "check-bundle-cached",
 		checkDescription: "Checking if CRC bundle is cached in '$HOME/.crc'",
 		check:            checkBundleCached,
@@ -45,6 +49,7 @@ var genericPreflightChecks = [...]Check{
 		flags:            SetupOnly,
 	},
 	{
+		order:            10,
 		configKeySuffix:  "check-ram",
 		checkDescription: "Checking minimum RAM requirements",
 		check: func() error {

--- a/pkg/crc/preflight/preflight_checks_nonwin.go
+++ b/pkg/crc/preflight/preflight_checks_nonwin.go
@@ -13,6 +13,7 @@ import (
 
 var nonWinPreflightChecks = [...]Check{
 	{
+		order:            0,
 		configKeySuffix:  "check-root-user",
 		checkDescription: "Checking if running as non-root",
 		check:            checkIfRunningAsNormalUser,

--- a/pkg/crc/preflight/preflight_darwin.go
+++ b/pkg/crc/preflight/preflight_darwin.go
@@ -7,6 +7,7 @@ import (
 // SetupHost performs the prerequisite checks and setups the host to run the cluster
 var hyperkitPreflightChecks = [...]Check{
 	{
+		order:            30,
 		configKeySuffix:  "check-hyperkit-installed",
 		checkDescription: "Checking if HyperKit is installed",
 		check:            checkHyperKitInstalled,
@@ -14,6 +15,7 @@ var hyperkitPreflightChecks = [...]Check{
 		fix:              fixHyperKitInstallation,
 	},
 	{
+		order:            30,
 		configKeySuffix:  "check-hyperkit-driver",
 		checkDescription: "Checking if crc-driver-hyperkit is installed",
 		check:            checkMachineDriverHyperKitInstalled,
@@ -24,6 +26,7 @@ var hyperkitPreflightChecks = [...]Check{
 
 var dnsPreflightChecks = [...]Check{
 	{
+		order:            40,
 		configKeySuffix:  "check-hosts-file-permissions",
 		checkDescription: fmt.Sprintf("Checking file permissions for %s", hostsFile),
 		check:            checkEtcHostsFilePermissions,
@@ -31,6 +34,7 @@ var dnsPreflightChecks = [...]Check{
 		fix:              fixEtcHostsFilePermissions,
 	},
 	{
+		order:              40,
 		configKeySuffix:    "check-resolver-file-permissions",
 		checkDescription:   fmt.Sprintf("Checking file permissions for %s", resolverFile),
 		check:              checkResolverFilePermissions,
@@ -43,6 +47,7 @@ var dnsPreflightChecks = [...]Check{
 
 var traySetupChecks = [...]Check{
 	{
+		order:            200,
 		checkDescription: "Checking if tray executable is installed",
 		check:            checkTrayExecutablePresent,
 		fixDescription:   "Installing and setting up tray",
@@ -50,6 +55,7 @@ var traySetupChecks = [...]Check{
 		flags:            SetupOnly,
 	},
 	{
+		order:              201,
 		checkDescription:   "Checking if launchd configuration for daemon exists",
 		check:              checkIfDaemonPlistFileExists,
 		fixDescription:     "Creating launchd configuration for daemon",
@@ -59,6 +65,7 @@ var traySetupChecks = [...]Check{
 		cleanup:            removeDaemonPlistFile,
 	},
 	{
+		order:              202,
 		checkDescription:   "Checking if launchd configuration for tray exists",
 		check:              checkIfTrayPlistFileExists,
 		fixDescription:     "Creating launchd configuration for tray",
@@ -68,6 +75,7 @@ var traySetupChecks = [...]Check{
 		cleanup:            removeTrayPlistFile,
 	},
 	{
+		order:            203,
 		checkDescription: "Checking installed tray version",
 		check:            checkTrayVersion,
 		fixDescription:   "Installing and setting up tray app",
@@ -75,6 +83,7 @@ var traySetupChecks = [...]Check{
 		flags:            SetupOnly,
 	},
 	{
+		order:              204,
 		checkDescription:   "Checking if CodeReady Containers daemon is running",
 		check:              checkIfDaemonAgentRunning,
 		fixDescription:     "Starting CodeReady Containers daemon",
@@ -84,6 +93,7 @@ var traySetupChecks = [...]Check{
 		cleanup:            unLoadDaemonAgent,
 	},
 	{
+		order:              205,
 		checkDescription:   "Check if CodeReady Containers tray is running",
 		check:              checkIfTrayAgentRunning,
 		fixDescription:     "Starting CodeReady Containers tray",
@@ -107,5 +117,6 @@ func getPreflightChecks(experimentalFeatures bool) []Check {
 		checks = append(checks, traySetupChecks[:]...)
 	}
 
+	sort(checks)
 	return checks
 }

--- a/pkg/crc/preflight/preflight_linux.go
+++ b/pkg/crc/preflight/preflight_linux.go
@@ -2,6 +2,7 @@ package preflight
 
 var libvirtPreflightChecks = [...]Check{
 	{
+		order:            10,
 		configKeySuffix:  "check-virt-enabled",
 		checkDescription: "Checking if Virtualization is enabled",
 		check:            checkVirtualizationEnabled,
@@ -9,6 +10,7 @@ var libvirtPreflightChecks = [...]Check{
 		fix:              fixVirtualizationEnabled,
 	},
 	{
+		order:            11,
 		configKeySuffix:  "check-kvm-enabled",
 		checkDescription: "Checking if KVM is enabled",
 		check:            checkKvmEnabled,
@@ -16,6 +18,7 @@ var libvirtPreflightChecks = [...]Check{
 		fix:              fixKvmEnabled,
 	},
 	{
+		order:            20,
 		configKeySuffix:  "check-libvirt-installed",
 		checkDescription: "Checking if libvirt is installed",
 		check:            checkLibvirtInstalled,
@@ -23,6 +26,7 @@ var libvirtPreflightChecks = [...]Check{
 		fix:              fixLibvirtInstalled,
 	},
 	{
+		order:            21,
 		configKeySuffix:  "check-user-in-libvirt-group",
 		checkDescription: "Checking if user is part of libvirt group",
 		check:            checkUserPartOfLibvirtGroup,
@@ -30,6 +34,7 @@ var libvirtPreflightChecks = [...]Check{
 		fix:              fixUserPartOfLibvirtGroup,
 	},
 	{
+		order:            22,
 		configKeySuffix:  "check-libvirt-running",
 		checkDescription: "Checking if libvirt daemon is running",
 		check:            checkLibvirtServiceRunning,
@@ -37,6 +42,7 @@ var libvirtPreflightChecks = [...]Check{
 		fix:              fixLibvirtServiceRunning,
 	},
 	{
+		order:            23,
 		configKeySuffix:  "check-libvirt-version",
 		checkDescription: "Checking if a supported libvirt version is installed",
 		check:            checkLibvirtVersion,
@@ -44,6 +50,7 @@ var libvirtPreflightChecks = [...]Check{
 		fix:              fixLibvirtVersion,
 	},
 	{
+		order:            30,
 		configKeySuffix:  "check-libvirt-driver",
 		checkDescription: "Checking if crc-driver-libvirt is installed",
 		check:            checkMachineDriverLibvirtInstalled,
@@ -51,6 +58,7 @@ var libvirtPreflightChecks = [...]Check{
 		fix:              fixMachineDriverLibvirtInstalled,
 	},
 	{
+		order:            31,
 		configKeySuffix:  "check-obsolete-libvirt-driver",
 		checkDescription: "Checking for obsolete crc-driver-libvirt",
 		check:            checkOldMachineDriverLibvirtInstalled,
@@ -59,6 +67,7 @@ var libvirtPreflightChecks = [...]Check{
 		flags:            SetupOnly,
 	},
 	{
+		order:              24,
 		configKeySuffix:    "check-crc-network",
 		checkDescription:   "Checking if libvirt 'crc' network is available",
 		check:              checkLibvirtCrcNetworkAvailable,
@@ -68,6 +77,7 @@ var libvirtPreflightChecks = [...]Check{
 		cleanup:            removeLibvirtCrcNetwork,
 	},
 	{
+		order:            25,
 		configKeySuffix:  "check-crc-network-active",
 		checkDescription: "Checking if libvirt 'crc' network is active",
 		check:            checkLibvirtCrcNetworkActive,
@@ -75,6 +85,7 @@ var libvirtPreflightChecks = [...]Check{
 		fix:              fixLibvirtCrcNetworkActive,
 	},
 	{
+		order:            40,
 		configKeySuffix:  "check-network-manager-installed",
 		checkDescription: "Checking if NetworkManager is installed",
 		check:            checkNetworkManagerInstalled,
@@ -82,6 +93,7 @@ var libvirtPreflightChecks = [...]Check{
 		fix:              fixNetworkManagerInstalled,
 	},
 	{
+		order:            41,
 		configKeySuffix:  "check-network-manager-running",
 		checkDescription: "Checking if NetworkManager service is running",
 		check:            checkNetworkManagerIsRunning,
@@ -89,6 +101,7 @@ var libvirtPreflightChecks = [...]Check{
 		fix:              fixNetworkManagerIsRunning,
 	},
 	{
+		order:              42,
 		configKeySuffix:    "check-network-manager-config",
 		checkDescription:   "Checking if /etc/NetworkManager/conf.d/crc-nm-dnsmasq.conf exists",
 		check:              checkCrcNetworkManagerConfig,
@@ -98,6 +111,7 @@ var libvirtPreflightChecks = [...]Check{
 		cleanup:            removeCrcNetworkManagerConfig,
 	},
 	{
+		order:              43,
 		configKeySuffix:    "check-crc-dnsmasq-file",
 		checkDescription:   "Checking if /etc/NetworkManager/dnsmasq.d/crc.conf exists",
 		check:              checkCrcDnsmasqConfigFile,
@@ -107,6 +121,7 @@ var libvirtPreflightChecks = [...]Check{
 		cleanup:            removeCrcDnsmasqConfigFile,
 	},
 	{
+		order:              1000,
 		cleanupDescription: "Removing the crc VM if exists",
 		cleanup:            removeCrcVM,
 		flags:              CleanUpOnly,
@@ -119,5 +134,6 @@ func getPreflightChecks(experimentalFeatures bool) []Check {
 	checks = append(checks, nonWinPreflightChecks[:]...)
 	checks = append(checks, libvirtPreflightChecks[:]...)
 
+	sort(checks)
 	return checks
 }

--- a/pkg/crc/preflight/preflight_windows.go
+++ b/pkg/crc/preflight/preflight_windows.go
@@ -2,6 +2,7 @@ package preflight
 
 var hypervPreflightChecks = [...]Check{
 	{
+		order:            0,
 		configKeySuffix:  "check-administrator-user",
 		checkDescription: "Checking if running as normal user",
 		check:            checkIfRunningAsNormalUser,
@@ -9,6 +10,7 @@ var hypervPreflightChecks = [...]Check{
 		flags:            NoFix,
 	},
 	{
+		order:            10,
 		configKeySuffix:  "check-windows-version",
 		checkDescription: "Checking Windows 10 release",
 		check:            checkVersionOfWindowsUpdate,
@@ -16,6 +18,7 @@ var hypervPreflightChecks = [...]Check{
 		flags:            NoFix,
 	},
 	{
+		order:            11,
 		configKeySuffix:  "check-windows-edition",
 		checkDescription: "Checking Windows edition",
 		check:            checkWindowsEdition,
@@ -23,6 +26,7 @@ var hypervPreflightChecks = [...]Check{
 		flags:            NoFix,
 	},
 	{
+		order:            20,
 		configKeySuffix:  "check-hyperv-installed",
 		checkDescription: "Checking if Hyper-V is installed and operational",
 		check:            checkHyperVInstalled,
@@ -30,6 +34,7 @@ var hypervPreflightChecks = [...]Check{
 		fix:              fixHyperVInstalled,
 	},
 	{
+		order:            21,
 		configKeySuffix:  "check-user-in-hyperv-group",
 		checkDescription: "Checking if user is a member of the Hyper-V Administrators group",
 		check:            checkIfUserPartOfHyperVAdmins,
@@ -37,6 +42,7 @@ var hypervPreflightChecks = [...]Check{
 		fix:              fixUserPartOfHyperVAdmins,
 	},
 	{
+		order:            21,
 		configKeySuffix:  "check-hyperv-service-running",
 		checkDescription: "Checking if Hyper-V service is enabled",
 		check:            checkHyperVServiceRunning,
@@ -44,6 +50,7 @@ var hypervPreflightChecks = [...]Check{
 		fix:              fixHyperVServiceRunning,
 	},
 	{
+		order:            21,
 		configKeySuffix:  "check-hyperv-switch",
 		checkDescription: "Checking if the Hyper-V virtual switch exist",
 		check:            checkIfHyperVVirtualSwitchExists,
@@ -51,11 +58,13 @@ var hypervPreflightChecks = [...]Check{
 		flags:            NoFix,
 	},
 	{
+		order:              1000,
 		cleanupDescription: "Removing dns server from interface",
 		cleanup:            removeDNSServerAddress,
 		flags:              CleanUpOnly,
 	},
 	{
+		order:              1000,
 		cleanupDescription: "Removing the crc VM if exists",
 		cleanup:            removeCrcVM,
 		flags:              CleanUpOnly,
@@ -64,6 +73,7 @@ var hypervPreflightChecks = [...]Check{
 
 var traySetupChecks = [...]Check{
 	{
+		order:            200,
 		checkDescription: "Checking if tray executable is present",
 		check:            checkTrayExecutableExists,
 		fixDescription:   "Caching tray executable",
@@ -71,6 +81,7 @@ var traySetupChecks = [...]Check{
 		flags:            SetupOnly,
 	},
 	{
+		order:              200,
 		checkDescription:   "Checking if tray is installed",
 		check:              checkIfTrayInstalled,
 		fixDescription:     "Installing CodeReady Containers tray",
@@ -91,5 +102,6 @@ func getPreflightChecks(experimentalFeatures bool) []Check {
 		checks = append(checks, traySetupChecks[:]...)
 	}
 
+	sort(checks)
 	return checks
 }


### PR DESCRIPTION
This ensures the order is always what we want. For instance, root check
is always the first check performed now.

Before:
```
INFO Checking if oc executable is cached          
INFO Checking if podman remote executable is cached 
INFO Checking if goodhosts executable is cached   
INFO Checking if CRC bundle is cached in '$HOME/.crc' 
INFO Checking minimum RAM requirements            
INFO Checking if running as non-root              
INFO Checking if Virtualization is enabled        
INFO Checking if KVM is enabled                   
INFO Checking if libvirt is installed             
INFO Checking if user is part of libvirt group    
INFO Checking if libvirt daemon is running        
INFO Checking if a supported libvirt version is installed 
INFO Checking if crc-driver-libvirt is installed  
INFO Checking for obsolete crc-driver-libvirt     
INFO Checking if libvirt 'crc' network is available 
INFO Checking if libvirt 'crc' network is active  
INFO Checking if NetworkManager is installed      
INFO Checking if NetworkManager service is running 
INFO Checking if /etc/NetworkManager/conf.d/crc-nm-dnsmasq.conf exists 
INFO Checking if /etc/NetworkManager/dnsmasq.d/crc.conf exists 
```

After:
``` 
INFO Checking if running as non-root              
INFO Checking minimum RAM requirements            
INFO Checking if Virtualization is enabled        
INFO Checking if KVM is enabled                   
INFO Checking if libvirt is installed             
INFO Checking if user is part of libvirt group    
INFO Checking if libvirt daemon is running        
INFO Checking if a supported libvirt version is installed 
INFO Checking if libvirt 'crc' network is available 
INFO Checking if libvirt 'crc' network is active  
INFO Checking if crc-driver-libvirt is installed  
INFO Checking for obsolete crc-driver-libvirt     
INFO Checking if NetworkManager is installed      
INFO Checking if NetworkManager service is running 
INFO Checking if /etc/NetworkManager/conf.d/crc-nm-dnsmasq.conf exists 
INFO Checking if /etc/NetworkManager/dnsmasq.d/crc.conf exists 
INFO Checking if CRC bundle is cached in '$HOME/.crc' 
INFO Checking if goodhosts executable is cached   
INFO Checking if oc executable is cached          
INFO Checking if podman remote executable is cached 

``` 

With this + https://github.com/code-ready/crc/pull/1630, I would like to make the bundle extraction to be the last item of the list (because it is the longest).