### PR TITLE
Fix for crc stop -f

### DIFF
--- a/pkg/crc/machine/machine.go
+++ b/pkg/crc/machine/machine.go
@@ -438,13 +438,11 @@ func (client *client) Stop() (state.State, error) {
 		return state.None, errors.Wrap(err, "Cannot load machine")
 	}
 
-	// FIXME: Why is the state fetched before calling host.Stop() ? We will return state.Running most of the time instead of state.Stopped
-	vmState, _ := host.Driver.GetState()
 	logging.Info("Stopping the OpenShift cluster, this may take a few minutes...")
 	if err := host.Stop(); err != nil {
 		return state.None, errors.Wrap(err, "Cannot stop machine")
 	}
-	return vmState, nil
+	return host.Driver.GetState()
 }
 
 func (client *client) PowerOff() error {

--- a/pkg/crc/machine/machine.go
+++ b/pkg/crc/machine/machine.go
@@ -440,7 +440,11 @@ func (client *client) Stop() (state.State, error) {
 
 	logging.Info("Stopping the OpenShift cluster, this may take a few minutes...")
 	if err := host.Stop(); err != nil {
-		return state.None, errors.Wrap(err, "Cannot stop machine")
+		status, err := host.Driver.GetState()
+		if err != nil {
+			logging.Debugf("Cannot get VM status after stopping it: %v", err)
+		}
+		return status, errors.Wrap(err, "Cannot stop machine")
 	}
 	return host.Driver.GetState()
 }


### PR DESCRIPTION
If the driver can't stop the VM, return a fresh status instead of None

If we return None here, the CLI will not try to kill the VM. It only
tries to kill it if the return status is Running.

``` 
   Scenario: Clean up                                                # features/story_marketplace.feature:73
    When executing "crc stop -f" succeeds                           # shell.go:234 -> github.com/code-ready/clicumber/testsuite.ExecuteCommandSucceedsOrFails
    command 'crc stop -f', expected to succeed, exited with exit code: 1
Command stdout: 
Command stderr: level=info msg="Stopping the OpenShift cluster, this may take a few minutes..."
Cannot stop machine: VM Failed to gracefully shutdown, try the kill command 
```