### PR TITLE
Allow to resize disk when machine is created

### DIFF
--- a/pkg/crc/machine/config/config.go
+++ b/pkg/crc/machine/config/config.go
@@ -10,6 +10,7 @@ type MachineConfig struct {
 	Name            string
 	Memory          int
 	CPUs            int
+	DiskSize        int
 	ImageSourcePath string
 	ImageFormat     string
 	SSHKeyPath      string

--- a/pkg/crc/machine/config/driver.go
+++ b/pkg/crc/machine/config/driver.go
@@ -4,9 +4,14 @@ import (
 	"github.com/code-ready/machine/libmachine/drivers"
 )
 
+func ConvertGiBToBytes(gib int) uint64 {
+	return uint64(gib) * 1024 * 1024 * 1024
+}
+
 func InitVMDriverFromMachineConfig(machineConfig MachineConfig, driver *drivers.VMDriver) {
 	driver.CPU = machineConfig.CPUs
 	driver.Memory = machineConfig.Memory
+	driver.DiskCapacity = ConvertGiBToBytes(machineConfig.DiskSize)
 	driver.BundleName = machineConfig.BundleName
 	driver.ImageSourcePath = machineConfig.ImageSourcePath
 	driver.ImageFormat = machineConfig.ImageFormat

--- a/pkg/crc/machine/driver.go
+++ b/pkg/crc/machine/driver.go
@@ -1,6 +1,7 @@
 package machine
 
 import (
+	"github.com/code-ready/crc/pkg/crc/machine/config"
 	libmachine "github.com/code-ready/machine/libmachine/drivers"
 	"github.com/code-ready/machine/libmachine/host"
 )
@@ -33,13 +34,9 @@ func setVcpus(host *host.Host, vcpus int) error {
 	return updateDriverValue(host, vcpuSetter)
 }
 
-func convertGiBToBytes(gib int) uint64 {
-	return uint64(gib) * 1024 * 1024 * 1024
-}
-
 func setDiskSize(host *host.Host, diskSizeGiB int) error {
 	diskSizeSetter := func(driver *libmachine.VMDriver) {
-		driver.DiskCapacity = convertGiBToBytes(diskSizeGiB)
+		driver.DiskCapacity = config.ConvertGiBToBytes(diskSizeGiB)
 	}
 
 	return updateDriverValue(host, diskSizeSetter)

--- a/pkg/crc/machine/machine.go
+++ b/pkg/crc/machine/machine.go
@@ -171,6 +171,7 @@ func (client *client) Start(startConfig StartConfig) (*StartResult, error) {
 			BundleName:  filepath.Base(startConfig.BundlePath),
 			CPUs:        startConfig.CPUs,
 			Memory:      startConfig.Memory,
+			DiskSize:    startConfig.DiskSize,
 			NetworkMode: client.networkMode,
 		}
 


### PR DESCRIPTION
For some reason, during initial implementation of disk resizing, setting
the disk size when the VM is initially created was missing. This commit
adds this, but this also needs a change in the libvirt machine driver.



## Testing

What is the _bottom-line_ functionality that needs testing? Describe in pseudo-code or in English. Use verifiable statements that tie your changes to existing functionality.

1. `start --disk-size 40` succeeds first time after `setup` succeeded
2. `df -h` inside the VM, or `virsh -c qemu:///system vol-info crc.qcow2 crc` confirm that the image was resized to 40GiB