### PR TITLE
Fixes for daemon service in windows

### DIFF
--- a/pkg/crc/preflight/preflight_checks_tray_windows.go
+++ b/pkg/crc/preflight/preflight_checks_tray_windows.go
@@ -91,7 +91,10 @@ func fixTrayInstalled() error {
 	if _, err = goos.Stat(filepath.Join(tempDir, "success")); goos.IsNotExist(err) {
 		return fmt.Errorf("Installation script didn't execute successfully: %v", err)
 	}
-	return nil
+
+	// start the tray process
+	_, _, err = powershell.Execute("Start-Process", constants.TrayExecutablePath)
+	return err
 }
 
 func escapeWindowsPassword(password string) string {

--- a/pkg/crc/preflight/preflight_checks_tray_windows.go
+++ b/pkg/crc/preflight/preflight_checks_tray_windows.go
@@ -61,8 +61,10 @@ func fixTrayInstalled() error {
 
 	// sanitize password
 	password = escapeWindowsPassword(password)
+	username := goos.Getenv("USERNAME")
 
 	psScriptContent := genTrayInstallScript(
+		username,
 		password,
 		tempDir,
 		binPathWithArgs,
@@ -121,7 +123,9 @@ func removeTray() error {
 		_ = goos.RemoveAll(tempDir)
 	}()
 
+	username := goos.Getenv("USERNAME")
 	psScriptContent := genTrayRemovalScript(
+		username,
 		trayProcessName,
 		constants.TrayShortcutName,
 		constants.DaemonServiceName,

--- a/pkg/crc/preflight/preflight_checks_tray_windows.go
+++ b/pkg/crc/preflight/preflight_checks_tray_windows.go
@@ -51,7 +51,6 @@ func fixTrayInstalled() error {
 	if err != nil {
 		return fmt.Errorf("Unable to find the current executables location: %v", err)
 	}
-	binPathWithArgs := fmt.Sprintf("%s daemon", strings.TrimSpace(binPath))
 
 	// get the password from user
 	password, err := input.PromptUserForSecret("Enter account login password for service installation", "This is the login password of your current account, needed to install the daemon service")
@@ -67,7 +66,7 @@ func fixTrayInstalled() error {
 		username,
 		password,
 		tempDir,
-		binPathWithArgs,
+		binPath,
 		constants.TrayExecutablePath,
 		constants.TrayShortcutName,
 		constants.DaemonServiceName,

--- a/pkg/crc/preflight/preflight_tray_powershell_windows.go
+++ b/pkg/crc/preflight/preflight_tray_powershell_windows.go
@@ -82,7 +82,6 @@ var (
 
 		`$ErrorActionPreference = "Stop"`,
 		`New-Item -ItemType SymbolicLink -Path "$startUpFolder" -Name "$traySymlinkName" -Value "$trayExecutablePath"`,
-		`Start-Process -FilePath "$trayExecutablePath"`,
 		`New-Item -ItemType File -Path "$tempDir" -Name "success"`,
 		`Set-Content -Path $tempDir\success "blah blah"`,
 	}

--- a/pkg/crc/preflight/preflight_tray_powershell_windows.go
+++ b/pkg/crc/preflight/preflight_tray_powershell_windows.go
@@ -56,7 +56,7 @@ var (
 		`	$creds = New-Object pscredential ("$env:USERDOMAIN\$env:USERNAME", $secPass)`,
 		`	$params = @{`,
 		`		Name = "$serviceName"`,
-		`		ExecutablePathName = "$crcExecutablePath daemon"`,
+		`		BinaryPathName = "$crcExecutablePath daemon"`,
 		`		DisplayName = "$serviceName"`,
 		`		StartupType = "Automatic"`,
 		`		Description = "CodeReady Containers Daemon service for System Tray."`,


### PR DESCRIPTION
This partially fixes #1637, in case the user is using a standard user account then, this will install the daemon service with the standard user as the logon user and everything should work fine (starting the cluster through the daemon is possible and doesn't fail the "is-root" check)

If the user is using an Administrator user account then the "is-root" check still fails and daemon can't complete the start.