### PR TITLE
Docs: separate port 80 and 443 remote haproxy sections

### DIFF
--- a/docs/source/topics/proc_setting-up-remote-server.adoc
+++ b/docs/source/topics/proc_setting-up-remote-server.adoc
@@ -74,12 +74,22 @@ defaults
 
 frontend apps
     bind 0.0.0.0:80
-    bind 0.0.0.0:443
     option tcplog
     mode tcp
     default_backend apps
 
+frontend apps_ssl
+    bind 0.0.0.0:443
+    option tcplog
+    mode tcp
+    default_backend apps_ssl
+
 backend apps
+    mode tcp
+    balance roundrobin
+    server webserver1 $CRC_IP:80 check
+
+backend apps_ssl
     mode tcp
     balance roundrobin
     option ssl-hello-chk


### PR DESCRIPTION
**Relates to:** #705

## Solution/Idea

Prior to this change, HAproxy would send all remote incoming traffic (both HTTP and HTTPS) to port 443 on the CRC VM. Remote HTTPS connections worked, but remote HTTP connections failed.

## Proposed changes

Split the `apps` configuration into two separate sections: `apps` and `apps_ssl`. Each section will handle traffic on TCP 80 or TCP 443.

## Testing

1. Follow the [existing instructions for setting up CRC on a remote server](https://access.redhat.com/documentation/en-us/red_hat_codeready_containers/1.18/html/getting_started_guide/networking_gsg#connecting-to-remote-instance_gsg)
2. Connect to the instance with HTTP (port 80), note that HAproxy closes the connection prematurely
3. Reconfigure HAproxy according to this pull request
4. Connect to the instance with HTTP and HTTPS, note that HAproxy handles both types of connections now