### PR TITLE
cmd/start: Remove duplicate message

### DIFF
--- a/cmd/crc/cmd/start.go
+++ b/cmd/crc/cmd/start.go
@@ -145,7 +145,6 @@ func (s *startResult) prettyPrintTo(writer io.Writer) error {
 		"To access the cluster, first set up your environment by following 'crc oc-env' instructions.",
 		fmt.Sprintf("Then you can access it by running 'oc login -u %s -p %s %s'.", s.ClusterConfig.DeveloperCredentials.Username, s.ClusterConfig.DeveloperCredentials.Password, s.ClusterConfig.URL),
 		fmt.Sprintf("To login as an admin, run 'oc login -u %s -p %s %s'.", s.ClusterConfig.AdminCredentials.Username, s.ClusterConfig.AdminCredentials.Password, s.ClusterConfig.URL),
-		"To access the cluster, first set up your environment by following 'crc oc-env' instructions.",
 		"",
 		"You can now run 'crc console' and use these credentials to access the OpenShift web console.",
 	}, "\n"))

--- a/cmd/crc/cmd/start_test.go
+++ b/cmd/crc/cmd/start_test.go
@@ -29,7 +29,6 @@ func TestRenderActionPlainSuccess(t *testing.T) {
 To access the cluster, first set up your environment by following 'crc oc-env' instructions.
 Then you can access it by running 'oc login -u developer -p developer https://api.crc.testing:6443'.
 To login as an admin, run 'oc login -u kubeadmin -p secret https://api.crc.testing:6443'.
-To access the cluster, first set up your environment by following 'crc oc-env' instructions.
 
 You can now run 'crc console' and use these credentials to access the OpenShift web console.
 `, out.String())


### PR DESCRIPTION
At the end of a successful crc start, crc prints this message twice:
"To access the cluster, first set up your environment by following 'crc
oc-env' instructions."

This commit removes the second occurrence.

This fixes https://github.com/code-ready/crc/issues/1657