### PR TITLE
Additional improvements around disk resizing, mostly for macos

### DIFF
--- a/pkg/crc/machine/driver.go
+++ b/pkg/crc/machine/driver.go
@@ -6,37 +6,53 @@ import (
 	"github.com/code-ready/machine/libmachine/host"
 )
 
-type valueSetter func(driver *libmachine.VMDriver)
+type valueSetter func(driver *libmachine.VMDriver) bool
 
 func updateDriverValue(host *host.Host, setDriverValue valueSetter) error {
 	driver, err := loadDriverConfig(host)
 	if err != nil {
 		return err
 	}
-	setDriverValue(driver.VMDriver)
+	valueChanged := setDriverValue(driver.VMDriver)
+	if !valueChanged {
+		return nil
+	}
 
 	return updateDriverConfig(host, driver)
 }
 
 func setMemory(host *host.Host, memorySize int) error {
-	memorySetter := func(driver *libmachine.VMDriver) {
+	memorySetter := func(driver *libmachine.VMDriver) bool {
+		if driver.Memory == memorySize {
+			return false
+		}
 		driver.Memory = memorySize
+		return true
 	}
 
 	return updateDriverValue(host, memorySetter)
 }
 
 func setVcpus(host *host.Host, vcpus int) error {
-	vcpuSetter := func(driver *libmachine.VMDriver) {
+	vcpuSetter := func(driver *libmachine.VMDriver) bool {
+		if driver.CPU == vcpus {
+			return false
+		}
 		driver.CPU = vcpus
+		return true
 	}
 
 	return updateDriverValue(host, vcpuSetter)
 }
 
 func setDiskSize(host *host.Host, diskSizeGiB int) error {
-	diskSizeSetter := func(driver *libmachine.VMDriver) {
-		driver.DiskCapacity = config.ConvertGiBToBytes(diskSizeGiB)
+	diskSizeSetter := func(driver *libmachine.VMDriver) bool {
+		capacity := config.ConvertGiBToBytes(diskSizeGiB)
+		if driver.DiskCapacity == capacity {
+			return false
+		}
+		driver.DiskCapacity = capacity
+		return true
 	}
 
 	return updateDriverValue(host, diskSizeSetter)

--- a/pkg/crc/validation/validation.go
+++ b/pkg/crc/validation/validation.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/code-ready/crc/pkg/crc/constants"
@@ -35,6 +36,11 @@ func ValidateDiskSize(value int) error {
 	if value < constants.DefaultDiskSize {
 		return fmt.Errorf("requires disk size in GiB >= %d", constants.DefaultDiskSize)
 	}
+	// https://github.com/code-ready/machine-driver-hyperkit/issues/18
+	if runtime.GOOS == "darwin" && value > constants.DefaultDiskSize {
+		return fmt.Errorf("Disk resizing is not supported on macOS")
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
This PR adds an explicit error when the user tries disk resizing on macos.
It also removes annoying warnings when using `crc start` on this platform.

## Testing

2 main changes:
- `crc start --disk-size 32` fails on macos
- `crc start && crc stop && crc start` no longer shows warnings on macos

Checking that disk resizing/memory/vcpu changes did not regress could be useful as well.