### PR TITLE
Connect ssh only once, and reuse the same connection

### DIFF
--- a/pkg/crc/machine/machine.go
+++ b/pkg/crc/machine/machine.go
@@ -269,7 +269,10 @@ func (client *client) Start(startConfig StartConfig) (*StartResult, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "Error getting the IP")
 	}
-	sshRunner := crcssh.CreateRunner(instanceIP, getSSHPort(client.useVSock()), crcBundleMetadata.GetSSHKeyPath(), constants.GetPrivateKeyPath())
+	sshRunner, err := crcssh.CreateRunner(instanceIP, getSSHPort(client.useVSock()), crcBundleMetadata.GetSSHKeyPath(), constants.GetPrivateKeyPath())
+	if err != nil {
+		return nil, errors.Wrap(err, "Error creating the ssh client")
+	}
 
 	logging.Debug("Waiting until ssh is available")
 	if err := cluster.WaitForSSH(sshRunner); err != nil {
@@ -602,7 +605,10 @@ func (client *client) Status() (*ClusterStatusResult, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "Error getting ip")
 	}
-	sshRunner := crcssh.CreateRunner(ip, getSSHPort(client.useVSock()), constants.GetPrivateKeyPath())
+	sshRunner, err := crcssh.CreateRunner(ip, getSSHPort(client.useVSock()), constants.GetPrivateKeyPath())
+	if err != nil {
+		return nil, errors.Wrap(err, "Error creating the ssh client")
+	}
 	// check if all the clusteroperators are running
 	diskSize, diskUse, err := cluster.GetRootPartitionUsage(sshRunner)
 	if err != nil {

--- a/pkg/crc/machine/machine.go
+++ b/pkg/crc/machine/machine.go
@@ -273,6 +273,7 @@ func (client *client) Start(startConfig StartConfig) (*StartResult, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "Error creating the ssh client")
 	}
+	defer sshRunner.Close()
 
 	logging.Debug("Waiting until ssh is available")
 	if err := cluster.WaitForSSH(sshRunner); err != nil {
@@ -609,6 +610,7 @@ func (client *client) Status() (*ClusterStatusResult, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "Error creating the ssh client")
 	}
+	defer sshRunner.Close()
 	// check if all the clusteroperators are running
 	diskSize, diskUse, err := cluster.GetRootPartitionUsage(sshRunner)
 	if err != nil {

--- a/pkg/crc/ssh/ssh.go
+++ b/pkg/crc/ssh/ssh.go
@@ -17,9 +17,7 @@ type Runner struct {
 }
 
 func CreateRunner(ip string, port int, privateKeys ...string) (*Runner, error) {
-	client, err := NewClient(constants.DefaultSSHUser, ip, port, &Auth{
-		Keys: privateKeys,
-	})
+	client, err := NewClient(constants.DefaultSSHUser, ip, port, privateKeys...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/crc/ssh/ssh.go
+++ b/pkg/crc/ssh/ssh.go
@@ -28,6 +28,10 @@ func CreateRunner(ip string, port int, privateKeys ...string) (*Runner, error) {
 	}, nil
 }
 
+func (runner *Runner) Close() {
+	runner.client.Close()
+}
+
 // Create a host using the driver's config
 func (runner *Runner) Run(command string) (string, error) {
 	return runner.runSSHCommandFromDriver(command, false)

--- a/pkg/crc/ssh/ssh_test.go
+++ b/pkg/crc/ssh/ssh_test.go
@@ -48,7 +48,8 @@ func TestRunner(t *testing.T) {
 	})
 
 	addr := listener.Addr().String()
-	runner := CreateRunner(ipFor(addr), portFor(addr), clientKeyFile)
+	runner, err := CreateRunner(ipFor(addr), portFor(addr), clientKeyFile)
+	assert.NoError(t, err)
 
 	bin, err := runner.Run("echo hello")
 	assert.NoError(t, err)

--- a/test/integration/crcsuite/collect.go
+++ b/test/integration/crcsuite/collect.go
@@ -182,9 +182,7 @@ func (collector *VMCommandCollector) Collect(w Writer) error {
 	if err != nil {
 		return err
 	}
-	ssh, err := ssh.NewClient(constants.DefaultSSHUser, ip, 22, &ssh.Auth{
-		Keys: []string{constants.GetPrivateKeyPath()},
-	})
+	ssh, err := ssh.NewClient(constants.DefaultSSHUser, ip, 22, constants.GetPrivateKeyPath())
 	if err != nil {
 		return err
 	}
@@ -205,9 +203,7 @@ func (collector *ContainerLogCollector) Collect(w Writer) error {
 	if err != nil {
 		return err
 	}
-	ssh, err := ssh.NewClient(constants.DefaultSSHUser, ip, 22, &ssh.Auth{
-		Keys: []string{constants.GetPrivateKeyPath()},
-	})
+	ssh, err := ssh.NewClient(constants.DefaultSSHUser, ip, 22, constants.GetPrivateKeyPath())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
It removes plenty of ssh handshakes and should improve the startup time.
    
When crc change the private key, the connection with the previous key is
kept opened and still works.
