### PR TITLE
Adding the ability to build CRC with an embedded OKD bundle.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,16 @@
 SHELL := /bin/bash
 
+
 BUNDLE_VERSION = 4.6.3
 BUNDLE_EXTENSION = crcbundle
 CRC_VERSION = 1.19.0
 COMMIT_SHA=$(shell git rev-parse --short HEAD)
 CONTAINER_RUNTIME ?= podman
+
+ifdef OKD_VERSION
+    BUNDLE_VERSION = $(OKD_VERSION)
+    CRC_VERSION := $(CRC_VERSION)-OKD
+endif
 
 # Go and compilation related variables
 BUILD_DIR ?= out
@@ -46,6 +52,10 @@ __check_defined = \
 VERSION_VARIABLES := -X $(REPOPATH)/pkg/crc/version.crcVersion=$(CRC_VERSION) \
     -X $(REPOPATH)/pkg/crc/version.bundleVersion=$(BUNDLE_VERSION) \
 	-X $(REPOPATH)/pkg/crc/version.commitSha=$(COMMIT_SHA)
+
+ifdef OKD_VERSION
+	VERSION_VARIABLES := $(VERSION_VARIABLES) -X $(REPOPATH)/pkg/crc/version.okdBuild=true
+endif
 
 # https://golang.org/cmd/link/
 LDFLAGS := $(VERSION_VARIABLES) -extldflags='-static' -s -w

--- a/cmd/crc/cmd/start_test.go
+++ b/cmd/crc/cmd/start_test.go
@@ -24,13 +24,16 @@ func TestRenderActionPlainSuccess(t *testing.T) {
 			},
 		},
 	}, out, ""))
-	assert.Equal(t, `Started the OpenShift cluster
+	assert.Equal(t, `
 
-To access the cluster, first set up your environment by following 'crc oc-env' instructions.
-Then you can access it by running 'oc login -u developer -p developer https://api.crc.testing:6443'.
-To login as an admin, run 'oc login -u kubeadmin -p secret https://api.crc.testing:6443'.
+Started the OpenShift cluster
 
-You can now run 'crc console' and use these credentials to access the OpenShift web console.
+To access the cluster, first set up your environment by following the instructions returned by executing 'crc oc-env'.
+Then you can access your cluster by running 'oc login -u developer -p developer https://api.crc.testing:6443'.
+To login as a cluster admin, run 'oc login -u kubeadmin -p secret https://api.crc.testing:6443'.
+
+You can also run 'crc console' and use the above credentials to access the OpenShift web console.
+The console will open in your default browser.
 `, out.String())
 }
 

--- a/pkg/crc/constants/constants.go
+++ b/pkg/crc/constants/constants.go
@@ -21,15 +21,13 @@ const (
 
 	CrcEnvPrefix = "CRC"
 
-	DefaultWebConsoleURL = "https://console-openshift-console.apps-crc.testing"
-	DefaultAPIURL        = "https://api.crc.testing:6443"
-	DefaultLogLevel      = "info"
-	ConfigFile           = "crc.json"
-	LogFile              = "crc.log"
-	DaemonLogFile        = "crcd.log"
-	CrcLandingPageURL    = "https://cloud.redhat.com/openshift/install/crc/installer-provisioned" // #nosec G101
-
-	DefaultOcURLBase          = "https://mirror.openshift.com/pub/openshift-v4/clients/ocp"
+	DefaultWebConsoleURL      = "https://console-openshift-console.apps-crc.testing"
+	DefaultAPIURL             = "https://api.crc.testing:6443"
+	DefaultLogLevel           = "info"
+	ConfigFile                = "crc.json"
+	LogFile                   = "crc.log"
+	DaemonLogFile             = "crcd.log"
+	CrcLandingPageURL         = "https://cloud.redhat.com/openshift/install/crc/installer-provisioned" // #nosec G101
 	DefaultPodmanURLBase      = "https://storage.googleapis.com/libpod-master-releases"
 	DefaultGoodhostsCliBase   = "https://github.com/code-ready/goodhosts-cli/releases/download/v1.0.0"
 	CRCMacTrayDownloadURL     = "https://github.com/code-ready/tray-macos/releases/download/v%s/crc-tray-macos.tar.gz"
@@ -38,6 +36,8 @@ const (
 
 	VSockGateway = "192.168.127.1"
 	VsockSSHPort = 2222
+
+	OkdPullSecret = `{"auths":{"fake":{"auth": "Zm9vOmJhcgo="}}}` // #nosec G101
 )
 
 var podmanURLForOs = map[string]string{

--- a/pkg/crc/version/version.go
+++ b/pkg/crc/version/version.go
@@ -20,6 +20,8 @@ var (
 
 	// Bundle version which used for the release.
 	bundleVersion = "0.0.0-unset"
+
+	okdBuild = "false"
 )
 
 const (
@@ -46,6 +48,10 @@ func GetCommitSha() string {
 
 func GetBundleVersion() string {
 	return bundleVersion
+}
+
+func IsOkdBuild() bool {
+	return okdBuild == "true"
 }
 
 func GetCRCMacTrayVersion() string {


### PR DESCRIPTION
## Proposed changes

1. The Makefile checks for `OKD_VERSION` to be set.  If set, then it
overrides `CRC_VERSION`, and `BUNDLE_VERSION`.  It also sets `pkg/crc/version.okdBuild=true`
2. `start.go` has been modified to use an embedded fake pull secret if
`version.okdBuild` is true.  The pull secret is in `constants.go`
3. Modified the text output in `start.go`
    Changed some of the sentence structure and added text for OKD if an OKD bundle is used.
4. Removed an unneeded reference to: `DefaultOcURLBase` in `constants.go`

## Testing

Successfully tested with an OKD 4.5 bundle.  Needs to be tested with OCP.
