### PR TITLE
Issue #1690 cert_recovery: put time back manually

### DIFF
--- a/test/integration/features/cert_rotation.feature
+++ b/test/integration/features/cert_rotation.feature
@@ -18,7 +18,8 @@ Feature: Check the cert is rotation happen after it expire
       Then login to the oc cluster succeeds
 
     Scenario: Set clock back to original time
-      Given executing "sudo timedatectl set-ntp on" succeeds
+      When executing "sudo date -s '-3 month'" succeeds
+      And executing "sudo timedatectl set-ntp on" succeeds
 
     Scenario: CRC delete and cleanup
       When executing "crc delete -f" succeeds


### PR DESCRIPTION
**Fixes:** Issue #1690 

## Solution/Idea

It sometimes takes too long for the time to sync back to current time after being 3 months in the future. The idea @cfergeau had was to put it back manually to within a small neighborhood of the true time. Then the sync might be faster *and* we also don't care much if sync is slow because we're very close to real time anyway.

## Proposed changes

1. Precede the `timedatectl set-ntp on` command with `sudo date -s '-3 month'`.

## Testing

Immediatelly after running `cert_recovery.feature`, time on the host should be not be noticeably off.