### PR TITLE
Check if the user is root must be the first check and for all commands

### DIFF
--- a/cmd/crc/cmd/root.go
+++ b/cmd/crc/cmd/root.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"io/ioutil"
+	"os"
 	"strings"
 
 	cmdConfig "github.com/code-ready/crc/cmd/crc/cmd/config"
@@ -40,6 +41,9 @@ var (
 )
 
 func init() {
+	if err := checkIfRunningAsNormalUser(); err != nil {
+		logging.Fatal(err.Error())
+	}
 	if err := constants.EnsureBaseDirectoriesExist(); err != nil {
 		logging.Fatal(err.Error())
 	}
@@ -147,4 +151,12 @@ func newMachine() machine.Client {
 
 func newMachineWithConfig(config crcConfig.Storage) machine.Client {
 	return machine.NewClient(constants.DefaultName, isDebugLog(), network.ParseMode(config.Get(cmdConfig.NetworkMode).AsString()))
+}
+
+func checkIfRunningAsNormalUser() error {
+	if os.Geteuid() != 0 {
+		return nil
+	}
+	logging.Debug("Ran as root")
+	return fmt.Errorf("crc should be ran as a normal user")
 }

--- a/pkg/crc/preflight/preflight_checks_nonwin.go
+++ b/pkg/crc/preflight/preflight_checks_nonwin.go
@@ -11,24 +11,6 @@ import (
 	crcos "github.com/code-ready/crc/pkg/os"
 )
 
-var nonWinPreflightChecks = [...]Check{
-	{
-		configKeySuffix:  "check-root-user",
-		checkDescription: "Checking if running as non-root",
-		check:            checkIfRunningAsNormalUser,
-		fixDescription:   "crc should be ran as a normal user",
-		flags:            NoFix,
-	},
-}
-
-func checkIfRunningAsNormalUser() error {
-	if os.Geteuid() != 0 {
-		return nil
-	}
-	logging.Debug("Ran as root")
-	return fmt.Errorf("crc should be ran as a normal user")
-}
-
 func setSuid(path string) error {
 	logging.Debugf("Making %s suid", path)
 

--- a/pkg/crc/preflight/preflight_darwin.go
+++ b/pkg/crc/preflight/preflight_darwin.go
@@ -109,7 +109,6 @@ func getPreflightChecks(experimentalFeatures bool, mode network.Mode) []Check {
 	checks := []Check{}
 
 	checks = append(checks, genericPreflightChecks[:]...)
-	checks = append(checks, nonWinPreflightChecks[:]...)
 	checks = append(checks, hyperkitPreflightChecks(mode)...)
 	checks = append(checks, dnsPreflightChecks[:]...)
 

--- a/pkg/crc/preflight/preflight_darwin_test.go
+++ b/pkg/crc/preflight/preflight_darwin_test.go
@@ -12,13 +12,13 @@ import (
 func TestCountConfigurationOptions(t *testing.T) {
 	cfg := config.New(config.NewEmptyInMemoryStorage())
 	RegisterSettings(cfg)
-	assert.Len(t, cfg.AllConfigs(), 18)
+	assert.Len(t, cfg.AllConfigs(), 16)
 }
 
 func TestCountPreflights(t *testing.T) {
-	assert.Len(t, getPreflightChecks(false, network.DefaultMode), 9)
-	assert.Len(t, getPreflightChecks(true, network.DefaultMode), 15)
+	assert.Len(t, getPreflightChecks(false, network.DefaultMode), 8)
+	assert.Len(t, getPreflightChecks(true, network.DefaultMode), 14)
 
-	assert.Len(t, getPreflightChecks(false, network.VSockMode), 8)
-	assert.Len(t, getPreflightChecks(true, network.VSockMode), 14)
+	assert.Len(t, getPreflightChecks(false, network.VSockMode), 7)
+	assert.Len(t, getPreflightChecks(true, network.VSockMode), 13)
 }

--- a/pkg/crc/preflight/preflight_linux.go
+++ b/pkg/crc/preflight/preflight_linux.go
@@ -196,7 +196,6 @@ func getPreflightChecksForDistro(distro linux.OsType, networkMode network.Mode) 
 func commonChecks() []Check {
 	var checks []Check
 	checks = append(checks, genericPreflightChecks[:]...)
-	checks = append(checks, nonWinPreflightChecks[:]...)
 	checks = append(checks, libvirtPreflightChecks[:]...)
 	return checks
 }

--- a/pkg/crc/preflight/preflight_linux_test.go
+++ b/pkg/crc/preflight/preflight_linux_test.go
@@ -13,16 +13,16 @@ func TestCountConfigurationOptions(t *testing.T) {
 	cfg := config.New(config.NewEmptyInMemoryStorage())
 	RegisterSettings(cfg)
 	options := len(cfg.AllConfigs())
-	assert.True(t, options == 40 || options == 32)
+	assert.True(t, options == 38 || options == 30)
 }
 
 func TestCountPreflights(t *testing.T) {
-	assert.Len(t, getPreflightChecksForDistro(crcos.RHEL, network.DefaultMode), 20)
-	assert.Len(t, getPreflightChecksForDistro(crcos.RHEL, network.VSockMode), 17)
+	assert.Len(t, getPreflightChecksForDistro(crcos.RHEL, network.DefaultMode), 19)
+	assert.Len(t, getPreflightChecksForDistro(crcos.RHEL, network.VSockMode), 16)
 
-	assert.Len(t, getPreflightChecksForDistro("unexpected", network.DefaultMode), 20)
-	assert.Len(t, getPreflightChecksForDistro("unexpected", network.VSockMode), 17)
+	assert.Len(t, getPreflightChecksForDistro("unexpected", network.DefaultMode), 19)
+	assert.Len(t, getPreflightChecksForDistro("unexpected", network.VSockMode), 16)
 
-	assert.Len(t, getPreflightChecksForDistro(crcos.Ubuntu, network.DefaultMode), 16)
-	assert.Len(t, getPreflightChecksForDistro(crcos.Ubuntu, network.VSockMode), 17)
+	assert.Len(t, getPreflightChecksForDistro(crcos.Ubuntu, network.DefaultMode), 15)
+	assert.Len(t, getPreflightChecksForDistro(crcos.Ubuntu, network.VSockMode), 16)
 }

--- a/test/integration/features/basic.feature
+++ b/test/integration/features/basic.feature
@@ -38,7 +38,6 @@ Feature: Basic test
     Scenario: CRC setup on Linux
         When executing "crc setup" succeeds
         And stderr should contain "Checking if CRC bundle is extracted in '$HOME/.crc'"
-        And stderr should contain "Checking if running as non-root"
         And stderr should contain "Checking if Virtualization is enabled"
         And stderr should contain "Checking if KVM is enabled"
         And stderr should contain "Checking if libvirt is installed"
@@ -66,7 +65,6 @@ Feature: Basic test
     @darwin
     Scenario: CRC setup on Mac
         When executing "crc setup" succeeds
-        And stderr should contain "Checking if running as non-root"
         And stderr should contain "Checking if HyperKit is installed"
         And stderr should contain "Checking if crc-driver-hyperkit is installed"
         And stderr should contain "Installing crc-machine-hyperkit"

--- a/test/integration/features/config.feature
+++ b/test/integration/features/config.feature
@@ -72,7 +72,6 @@ Checks whether CRC `config set` command works as expected in conjunction with `c
             | warn-check-hyperkit-driver           | true   | false  |
             | warn-check-hyperkit-installed        | true   | false  |
             | warn-check-resolver-file-permissions | true   | false  |
-            | warn-check-root-user                 | true   | false  |
 
         @linux
         Examples: Config warnings on Linux
@@ -89,7 +88,6 @@ Checks whether CRC `config set` command works as expected in conjunction with `c
             | warn-check-network-manager-config    | true   | false  |
             | warn-check-network-manager-installed | true   | false  |
             | warn-check-network-manager-running   | true   | false  |
-            | warn-check-root-user                 | true   | false  |
             | warn-check-user-in-libvirt-group     | true   | false  |
             | warn-check-virt-enabled              | true   | false  |
 
@@ -125,7 +123,6 @@ Checks whether CRC `config set` command works as expected in conjunction with `c
             | skip-check-hyperkit-driver           | true   | false  |
             | skip-check-hyperkit-installed        | true   | false  |
             | skip-check-resolver-file-permissions | true   | false  |
-            | skip-check-root-user                 | true   | false  |
 
         @linux
         Examples:
@@ -142,7 +139,6 @@ Checks whether CRC `config set` command works as expected in conjunction with `c
             | skip-check-network-manager-config    | true   | false  |
             | skip-check-network-manager-installed | true   | false  |
             | skip-check-network-manager-running   | true   | false  |
-            | skip-check-root-user                 | true   | false  |
             | skip-check-user-in-libvirt-group     | true   | false  |
             | skip-check-virt-enabled              | true   | false  |
 


### PR DESCRIPTION
It needs to be done before anything (esp. creating the base directory).
`crc daemon`, `crc config`, etc. must be run as user.
