### PR TITLE
[WIP] extract embed bundle directly from crc, remove intermediate bundle on disk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL := /bin/bash
 
-BUNDLE_VERSION = 4.6.3
+BUNDLE_VERSION = 4.6.1
 BUNDLE_EXTENSION = crcbundle
 CRC_VERSION = 1.19.0
 COMMIT_SHA=$(shell git rev-parse --short HEAD)

--- a/go.mod
+++ b/go.mod
@@ -84,3 +84,5 @@ replace (
 replace vbom.ml/util => github.com/fvbommel/util v0.0.2
 
 replace golang.org/x/sys => golang.org/x/sys v0.0.0-20200826173525-f9321e4c35a6
+
+replace github.com/YourFin/binappend => github.com/guillaumerose/binappend v0.0.0-20201123104445-14e342367bb5

--- a/go.sum
+++ b/go.sum
@@ -64,8 +64,6 @@ github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWX
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
 github.com/VividCortex/ewma v1.1.1 h1:MnEK4VOv6n0RSY4vtRe3h11qjxL3+t0B8yOL8iMXdcM=
 github.com/VividCortex/ewma v1.1.1/go.mod h1:2Tkkvm3sRDVXaiyucHiACn4cqf7DpdyLvmxzcbUokwA=
-github.com/YourFin/binappend v0.0.0-20181105185800-0add4bf0b9ad h1:OUogh+sUEo6yRwGEkqifcr3MfXNi0AtdCSwh7H8yTUM=
-github.com/YourFin/binappend v0.0.0-20181105185800-0add4bf0b9ad/go.mod h1:QhzJSct0NZ/q7HOtQrw867061u93HYPWa4KTotzdzls=
 github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4RqaHDIsdSBg7lM=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
@@ -438,6 +436,8 @@ github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgf
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/grpc-ecosystem/grpc-gateway v1.9.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/grpc-ecosystem/grpc-health-probe v0.2.1-0.20181220223928-2bf0a5b182db/go.mod h1:uBKkC2RbarFsvS5jMJHpVhTLvGlGQj9JJwkaePE3FWI=
+github.com/guillaumerose/binappend v0.0.0-20201123104445-14e342367bb5 h1:yLap1tltSqPGHNLkJu3xf2n8EPPQh/ykaj5rhPRp5wU=
+github.com/guillaumerose/binappend v0.0.0-20201123104445-14e342367bb5/go.mod h1:attM+rMy3Pu6UTCOlvVeWD49M77+LJbRRlZbGYfkVoY=
 github.com/h2non/filetype v1.1.0 h1:Or/gjocJrJRNK/Cri/TDEKFjAR+cfG6eK65NGYB6gBA=
 github.com/h2non/filetype v1.1.0/go.mod h1:319b3zT68BvV+WRj7cwy856M2ehB3HqNOt6sy1HndBY=
 github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed/go.mod h1:tMWxXQ9wFIaZeTI9F+hmhFiGpFmhOHzyShyFUhRm0H4=

--- a/pkg/crc/machine/bundle/metadata.go
+++ b/pkg/crc/machine/bundle/metadata.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/code-ready/crc/pkg/crc/constants"
+	"github.com/code-ready/crc/pkg/embed"
 	"github.com/code-ready/crc/pkg/extract"
 	crcos "github.com/code-ready/crc/pkg/os"
 )
@@ -115,6 +116,19 @@ func (bundle *CrcBundleInfo) installSymlinkOrCopy() error {
 
 func (bundle *CrcBundleInfo) resolvePath(filename string) string {
 	return filepath.Join(bundle.cachedPath, filename)
+}
+
+func ExtractFromExecutable(sourcepath string) (*CrcBundleInfo, error) {
+	reader, err := embed.Open(filepath.Base(constants.DefaultBundlePath))
+	if err != nil {
+		return nil, err
+	}
+	_, err = extract.UncompressReader(reader, reader.Size(), constants.MachineCacheDir, true)
+	if err != nil {
+		return nil, err
+	}
+
+	return GetCachedBundleInfo(filepath.Base(sourcepath))
 }
 
 func Extract(sourcepath string) (*CrcBundleInfo, error) {

--- a/pkg/crc/preflight/preflight_checks_common.go
+++ b/pkg/crc/preflight/preflight_checks_common.go
@@ -56,7 +56,7 @@ func checkBundleExtracted() error {
 	if err != nil {
 		return err
 	}
-	return found.CheckDiskImageSize()
+	return found.Verify()
 }
 
 func fixBundleExtracted() error {

--- a/pkg/crc/preflight/preflight_checks_common.go
+++ b/pkg/crc/preflight/preflight_checks_common.go
@@ -47,7 +47,6 @@ var bundleExtractionCheck = Check{
 	check:            checkBundleExtracted,
 	fixDescription:   "Extracting bundle from the CRC executable",
 	fix:              fixBundleExtracted,
-	flags:            SetupOnly,
 }
 
 func checkBundleExtracted() error {

--- a/pkg/crc/preflight/preflight_checks_common.go
+++ b/pkg/crc/preflight/preflight_checks_common.go
@@ -11,7 +11,6 @@ import (
 	"github.com/code-ready/crc/pkg/crc/logging"
 	"github.com/code-ready/crc/pkg/crc/machine/bundle"
 	"github.com/code-ready/crc/pkg/crc/validation"
-	"github.com/code-ready/crc/pkg/embed"
 	"github.com/docker/go-units"
 )
 
@@ -53,10 +52,11 @@ func checkBundleExtracted() error {
 	if !constants.BundleEmbedded() {
 		return nil
 	}
-	if _, err := os.Stat(constants.DefaultBundlePath); os.IsNotExist(err) {
+	found, err := bundle.GetCachedBundleInfo(filepath.Base(constants.DefaultBundlePath))
+	if err != nil {
 		return err
 	}
-	return nil
+	return found.CheckDiskImageSize()
 }
 
 func fixBundleExtracted() error {
@@ -72,10 +72,7 @@ func fixBundleExtracted() error {
 			return fmt.Errorf("Cannot create directory %s: %v", bundleDir, err)
 		}
 
-		if err := embed.Extract(filepath.Base(constants.DefaultBundlePath), constants.DefaultBundlePath); err != nil {
-			return err
-		}
-		_, err := bundle.Extract(constants.DefaultBundlePath)
+		_, err := bundle.ExtractFromExecutable(filepath.Base(constants.DefaultBundlePath))
 		return err
 	}
 	return fmt.Errorf("CRC bundle is not embedded in the executable")

--- a/pkg/crc/preflight/preflight_checks_common.go
+++ b/pkg/crc/preflight/preflight_checks_common.go
@@ -31,14 +31,6 @@ var genericPreflightChecks = [...]Check{
 		fix:              fixGoodhostsExecutableCached,
 	},
 	{
-		configKeySuffix:  "check-bundle-extracted",
-		checkDescription: "Checking if CRC bundle is extracted in '$HOME/.crc'",
-		check:            checkBundleExtracted,
-		fixDescription:   "Extracting bundle from the CRC executable",
-		fix:              fixBundleExtracted,
-		flags:            SetupOnly,
-	},
-	{
 		configKeySuffix:  "check-ram",
 		checkDescription: "Checking minimum RAM requirements",
 		check: func() error {
@@ -47,6 +39,15 @@ var genericPreflightChecks = [...]Check{
 		fixDescription: fmt.Sprintf("crc requires at least %s to run", units.HumanSize(float64(constants.DefaultMemory*1024*1024))),
 		flags:          NoFix,
 	},
+}
+
+var bundleExtractionCheck = Check{
+	configKeySuffix:  "check-bundle-extracted",
+	checkDescription: "Checking if CRC bundle is extracted in '$HOME/.crc'",
+	check:            checkBundleExtracted,
+	fixDescription:   "Extracting bundle from the CRC executable",
+	fix:              fixBundleExtracted,
+	flags:            SetupOnly,
 }
 
 func checkBundleExtracted() error {

--- a/pkg/crc/preflight/preflight_darwin.go
+++ b/pkg/crc/preflight/preflight_darwin.go
@@ -116,6 +116,9 @@ func getPreflightChecks(experimentalFeatures bool, mode network.Mode) []Check {
 	if mode == network.DefaultMode {
 		checks = append(checks, resolverPreflightChecks[:]...)
 	}
+
+	checks = append(checks, bundleExtractionCheck)
+
 	// Experimental feature
 	if experimentalFeatures {
 		checks = append(checks, traySetupChecks[:]...)

--- a/pkg/crc/preflight/preflight_linux.go
+++ b/pkg/crc/preflight/preflight_linux.go
@@ -190,7 +190,7 @@ func getPreflightChecksForDistro(distro linux.OsType, networkMode network.Mode) 
 		}
 	}
 
-	return checks
+	return append(checks, bundleExtractionCheck)
 }
 
 func commonChecks() []Check {

--- a/pkg/crc/preflight/preflight_windows.go
+++ b/pkg/crc/preflight/preflight_windows.go
@@ -141,6 +141,8 @@ func getPreflightChecks(experimentalFeatures bool, networkMode network.Mode) []C
 		checks = append(checks, vsockChecks[:]...)
 	}
 
+	checks = append(checks, bundleExtractionCheck)
+
 	// Experimental feature
 	if experimentalFeatures {
 		checks = append(checks, traySetupChecks[:]...)

--- a/pkg/embed/embed.go
+++ b/pkg/embed/embed.go
@@ -10,7 +10,7 @@ import (
 	"github.com/YourFin/binappend"
 )
 
-func openEmbeddedFile(executablePath, embedName string) (*binappend.Reader, error) {
+func openFromExecutable(executablePath, embedName string) (*binappend.Reader, error) {
 	extractor, err := binappend.MakeExtractor(executablePath)
 	if err != nil {
 		return nil, fmt.Errorf("Could not data embedded in %s: %v", executablePath, err)
@@ -20,6 +20,14 @@ func openEmbeddedFile(executablePath, embedName string) (*binappend.Reader, erro
 		return nil, fmt.Errorf("Could not open embedded '%s' in %s: %v", embedName, executablePath, err)
 	}
 	return reader, nil
+}
+
+func Open(embedName string) (*binappend.Reader, error) {
+	executablePath, err := os.Executable()
+	if err != nil {
+		return nil, err
+	}
+	return openFromExecutable(executablePath, embedName)
 }
 
 func Extract(embedName, destFile string) error {
@@ -32,7 +40,7 @@ func Extract(embedName, destFile string) error {
 
 func ExtractFromExecutable(executablePath, embedName, destFile string) error {
 	logging.Debugf("Extracting embedded '%s' from %s to %s", embedName, executablePath, destFile)
-	reader, err := openEmbeddedFile(executablePath, embedName)
+	reader, err := openFromExecutable(executablePath, embedName)
 	if err != nil {
 		return err
 	}

--- a/pkg/extract/extract.go
+++ b/pkg/extract/extract.go
@@ -36,6 +36,10 @@ func UncompressWithFilter(tarball, targetDir string, showProgress bool, fileFilt
 	return uncompress(file, stat.Size(), targetDir, fileFilter, showProgress && terminal.IsTerminal(int(os.Stdout.Fd())))
 }
 
+func UncompressReader(tarball io.ReaderAt, size int64, targetDir string, showProgress bool) ([]string, error) {
+	return uncompress(tarball, size, targetDir, nil, showProgress)
+}
+
 func Uncompress(tarball, targetDir string, showProgress bool) ([]string, error) {
 	return UncompressWithFilter(tarball, targetDir, showProgress, nil)
 }

--- a/pkg/extract/extract.go
+++ b/pkg/extract/extract.go
@@ -25,7 +25,7 @@ func UncompressWithFilter(tarball, targetDir string, showProgress bool, fileFilt
 }
 
 func Uncompress(tarball, targetDir string, showProgress bool) ([]string, error) {
-	return uncompress(tarball, targetDir, nil, showProgress && terminal.IsTerminal(int(os.Stdout.Fd())))
+	return UncompressWithFilter(tarball, targetDir, showProgress, nil)
 }
 
 func uncompress(tarball, targetDir string, fileFilter func(string) bool, showProgress bool) ([]string, error) {

--- a/vendor/github.com/YourFin/binappend/.gitignore
+++ b/vendor/github.com/YourFin/binappend/.gitignore
@@ -10,3 +10,6 @@
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+
+# Go vendoring
+vendor/

--- a/vendor/github.com/YourFin/binappend/go.mod
+++ b/vendor/github.com/YourFin/binappend/go.mod
@@ -1,0 +1,5 @@
+module github.com/YourFin/binappend
+
+go 1.14
+
+require github.com/pkg/errors v0.9.1

--- a/vendor/github.com/YourFin/binappend/go.sum
+++ b/vendor/github.com/YourFin/binappend/go.sum
@@ -1,0 +1,2 @@
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -7,7 +7,7 @@ github.com/Masterminds/semver
 github.com/RangelReale/osincli
 # github.com/VividCortex/ewma v1.1.1
 github.com/VividCortex/ewma
-# github.com/YourFin/binappend v0.0.0-20181105185800-0add4bf0b9ad
+# github.com/YourFin/binappend v0.0.0-20181105185800-0add4bf0b9ad => github.com/guillaumerose/binappend v0.0.0-20201123104445-14e342367bb5
 github.com/YourFin/binappend
 # github.com/alexbrainman/sspi v0.0.0-20180613141037-e580b900e9f5
 github.com/alexbrainman/sspi


### PR DESCRIPTION
It saves ~2GB of disk space for the end user.

Requires https://github.com/YourFin/binappend/pull/1 - this is only to not break the compatibility with an eventual zip bundle.