### PR TITLE
Improve os.MkdirAll use

### DIFF
--- a/pkg/crc/cache/cache.go
+++ b/pkg/crc/cache/cache.go
@@ -121,7 +121,7 @@ func (c *Cache) CacheExecutable() error {
 
 	// Copy the requested asset into its final destination
 	err = os.MkdirAll(c.destDir, 0750)
-	if err != nil && !os.IsExist(err) {
+	if err != nil {
 		return errors.Wrap(err, "Cannot create the target directory.")
 	}
 

--- a/pkg/crc/constants/constants.go
+++ b/pkg/crc/constants/constants.go
@@ -116,17 +116,9 @@ func GetHomeDir() string {
 	return os.Getenv("HOME")
 }
 
-// EnsureBaseDirectoriesExist create the ~/.crc and ~/.crc/oc dirs if they are not present
+// EnsureBaseDirectoryExists create the ~/.crc directory if it is not present
 func EnsureBaseDirectoriesExist() error {
-	if _, err := os.Stat(CrcBaseDir); err != nil {
-		if !os.IsNotExist(err) {
-			return err
-		}
-		if err := os.Mkdir(CrcBaseDir, 0750); err != nil {
-			return err
-		}
-	}
-	return nil
+	return os.MkdirAll(CrcBaseDir, 0750)
 }
 
 // IsBundleEmbedded returns true if the executable was compiled to contain the bundle

--- a/pkg/crc/machine/bundle/metadata.go
+++ b/pkg/crc/machine/bundle/metadata.go
@@ -98,13 +98,8 @@ func GetCachedBundleInfo(bundleName string) (*CrcBundleInfo, error) {
 func (bundle *CrcBundleInfo) installSymlinkOrCopy() error {
 	ocInBundle := filepath.Join(bundle.cachedPath, constants.OcExecutableName)
 	ocInBinDir := filepath.Join(constants.CrcOcBinDir, constants.OcExecutableName)
-	if _, err := os.Stat(constants.CrcOcBinDir); err != nil {
-		if !os.IsNotExist(err) {
-			return err
-		}
-		if err := os.MkdirAll(constants.CrcOcBinDir, 0750); err != nil {
-			return err
-		}
+	if err := os.MkdirAll(constants.CrcOcBinDir, 0750); err != nil {
+		return err
 	}
 	_ = os.Remove(ocInBinDir)
 	if runtime.GOOS == "windows" {

--- a/pkg/crc/preflight/preflight_checks_tray_darwin.go
+++ b/pkg/crc/preflight/preflight_checks_tray_darwin.go
@@ -207,7 +207,7 @@ func downloadOrExtractTrayApp() error {
 	archivePath := filepath.Join(tmpArchivePath, filepath.Base(constants.GetCRCMacTrayDownloadURL()))
 	outputPath := constants.CrcBinDir
 	err = goos.MkdirAll(outputPath, 0750)
-	if err != nil && !goos.IsExist(err) {
+	if err != nil {
 		return errors.Wrap(err, "Cannot create the target directory.")
 	}
 	_, err = extract.Uncompress(archivePath, outputPath, false)

--- a/pkg/extract/extract.go
+++ b/pkg/extract/extract.go
@@ -115,10 +115,8 @@ func untar(reader io.Reader, targetDir string, fileFilter func(string) bool, sho
 
 		// if its a dir and it doesn't exist create it
 		case tar.TypeDir:
-			if _, err := os.Stat(path); err != nil {
-				if err := os.MkdirAll(path, header.FileInfo().Mode()); err != nil {
-					return nil, err
-				}
+			if err := os.MkdirAll(path, header.FileInfo().Mode()); err != nil {
+				return nil, err
 			}
 
 		// if it's a file create it


### PR DESCRIPTION
`os.MkdirAll()` returns `nil` when the directory already exists,
so we don't need to explicitly check errors for `os.IsExists()`.

## Testing

There should be no user-visible changes. The mkdir calls which are changed are the one related to system tray and oc installation, bundle unpacking, and creation of ~/.crc and ~/.crc/cache.
They should still be created as before.