### PR TITLE
Improve/fix systemd state parsing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,5 @@ before_script:
   - sudo apt-get -qq -y install podman
 
 script:
-- make
-- make vendorcheck
-- make cross-lint
-- make cross
-- make test
-- make build_integration
+- make check
 - make BUNDLE_DIR=/tmp MOCK_BUNDLE=true release

--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,9 @@ vendor:
 vendorcheck:
 	./verify-vendor.sh
 
+.PHONY: check
+check: cross build_integration $(HOST_BUILD_DIR)/crc-embedder test cross-lint vendorcheck
+
 # Start of the actual build targets
 
 .PHONY: install

--- a/pkg/crc/cluster/cluster.go
+++ b/pkg/crc/cluster/cluster.go
@@ -22,7 +22,7 @@ const vmPullSecretPath = "/var/lib/kubelet/config.json"
 
 func WaitForSSH(sshRunner *ssh.Runner) error {
 	checkSSHConnectivity := func() error {
-		_, err := sshRunner.Run("exit 0")
+		_, _, err := sshRunner.Run("exit 0")
 		if err != nil {
 			return &errors.RetriableError{Err: err}
 		}
@@ -52,7 +52,7 @@ func CheckCertsValidity(sshRunner *ssh.Runner) (bool, bool, error) {
 }
 
 func checkCertValidity(sshRunner *ssh.Runner, cert string) (bool, error) {
-	output, err := sshRunner.Run(fmt.Sprintf(`date --date="$(sudo openssl x509 -in %s -noout -enddate | cut -d= -f 2)" --iso-8601=seconds`, cert))
+	output, _, err := sshRunner.Run(fmt.Sprintf(`date --date="$(sudo openssl x509 -in %s -noout -enddate | cut -d= -f 2)" --iso-8601=seconds`, cert))
 	if err != nil {
 		return false, err
 	}
@@ -71,7 +71,7 @@ func checkCertValidity(sshRunner *ssh.Runner, cert string) (bool, error) {
 func GetRootPartitionUsage(sshRunner *ssh.Runner) (int64, int64, error) {
 	cmd := "df -B1 --output=size,used,target /sysroot | tail -1"
 
-	out, err := sshRunner.Run(cmd)
+	out, _, err := sshRunner.Run(cmd)
 
 	if err != nil {
 		return 0, 0, err
@@ -257,7 +257,7 @@ func addProxyCACertToInstance(sshRunner *ssh.Runner, proxy *network.ProxyConfig)
 	if err := sshRunner.CopyData([]byte(proxy.ProxyCACert), "/etc/pki/ca-trust/source/anchors/openshift-config-user-ca-bundle.crt", 0600); err != nil {
 		return err
 	}
-	if _, err := sshRunner.Run("sudo update-ca-trust"); err != nil {
+	if _, _, err := sshRunner.Run("sudo update-ca-trust"); err != nil {
 		return err
 	}
 	return nil
@@ -280,7 +280,7 @@ func (p *PullSecret) Value() (string, error) {
 }
 
 func EnsurePullSecretPresentOnInstanceDisk(sshRunner *ssh.Runner, pullSecret *PullSecret) error {
-	if _, err := sshRunner.Run(fmt.Sprintf("test -e %s", vmPullSecretPath)); err == nil {
+	if _, _, err := sshRunner.Run(fmt.Sprintf("test -e %s", vmPullSecretPath)); err == nil {
 		return nil
 	}
 	logging.Info("Adding user's pull secret to instance disk...")

--- a/pkg/crc/machine/machine.go
+++ b/pkg/crc/machine/machine.go
@@ -288,14 +288,14 @@ func (client *client) Start(startConfig StartConfig) (*StartResult, error) {
 	}
 
 	// Trigger disk resize, this will be a no-op if no disk size change is needed
-	if _, err = sshRunner.Run("sudo xfs_growfs / >/dev/null"); err != nil {
+	if _, _, err = sshRunner.Run("sudo xfs_growfs / >/dev/null"); err != nil {
 		return nil, errors.Wrap(err, "Error updating filesystem size")
 	}
 
 	// Start network time synchronization if `CRC_DEBUG_ENABLE_STOP_NTP` is not set
 	if stopNtp, _ := strconv.ParseBool(os.Getenv("CRC_DEBUG_ENABLE_STOP_NTP")); !stopNtp {
 		logging.Info("Starting network time synchronization in CodeReady Containers VM")
-		if _, err := sshRunner.Run("sudo timedatectl set-ntp on"); err != nil {
+		if _, _, err := sshRunner.Run("sudo timedatectl set-ntp on"); err != nil {
 			return nil, errors.Wrap(err, "Failed to start network time synchronization")
 		}
 	}
@@ -755,14 +755,14 @@ func updateSSHKeyPair(sshRunner *crcssh.Runner) error {
 		return err
 	}
 
-	authorizedKeys, err := sshRunner.Run("cat /home/core/.ssh/authorized_keys")
+	authorizedKeys, _, err := sshRunner.Run("cat /home/core/.ssh/authorized_keys")
 	if err == nil && strings.TrimSpace(authorizedKeys) == strings.TrimSpace(string(publicKey)) {
 		return nil
 	}
 
 	logging.Info("Updating authorized keys ...")
 	cmd := fmt.Sprintf("echo '%s' > /home/core/.ssh/authorized_keys; chmod 644 /home/core/.ssh/authorized_keys", publicKey)
-	_, err = sshRunner.Run(cmd)
+	_, _, err = sshRunner.Run(cmd)
 	if err != nil {
 		return err
 	}

--- a/pkg/crc/network/nameservers.go
+++ b/pkg/crc/network/nameservers.go
@@ -11,7 +11,7 @@ import (
 // HasGivenNameserversConfigured returns true if the instance uses a provided nameserver.
 func HasGivenNameserversConfigured(sshRunner *ssh.Runner, nameserver NameServer) (bool, error) {
 	cmd := "cat /etc/resolv.conf"
-	out, err := sshRunner.Run(cmd)
+	out, _, err := sshRunner.Run(cmd)
 
 	if err != nil {
 		return false, err
@@ -22,7 +22,7 @@ func HasGivenNameserversConfigured(sshRunner *ssh.Runner, nameserver NameServer)
 
 func GetResolvValuesFromInstance(sshRunner *ssh.Runner) (*ResolvFileValues, error) {
 	cmd := "cat /etc/resolv.conf"
-	out, err := sshRunner.Run(cmd)
+	out, _, err := sshRunner.Run(cmd)
 
 	if err != nil {
 		return nil, err
@@ -54,7 +54,7 @@ func AddNameserversToInstance(sshRunner *ssh.Runner, nameservers []NameServer) e
 
 // writes nameserver to the /etc/resolv.conf inside the instance
 func addNameserverToInstance(sshRunner *ssh.Runner, nameserver NameServer) error {
-	_, err := sshRunner.Run(fmt.Sprintf("NS=%s; cat /etc/resolv.conf |grep -i \"^nameserver $NS\" || echo \"nameserver $NS\" | sudo tee -a /etc/resolv.conf", nameserver.IPAddress))
+	_, _, err := sshRunner.Run(fmt.Sprintf("NS=%s; cat /etc/resolv.conf |grep -i \"^nameserver $NS\" || echo \"nameserver $NS\" | sudo tee -a /etc/resolv.conf", nameserver.IPAddress))
 	if err != nil {
 		return fmt.Errorf("%s: %s", "Error adding nameserver", err.Error())
 	}

--- a/pkg/crc/oc/oc.go
+++ b/pkg/crc/oc/oc.go
@@ -59,7 +59,7 @@ type SSHRunner struct {
 
 func UseOCWithSSH(sshRunner *ssh.Runner) Config {
 	return Config{
-		Runner:           ssh.NewRemoteCommandRunner(sshRunner),
+		Runner:           sshRunner,
 		OcExecutablePath: "oc",
 		KubeconfigPath:   "/opt/kubeconfig",
 		Context:          constants.DefaultContext,

--- a/pkg/crc/preflight/preflight_checks_linux.go
+++ b/pkg/crc/preflight/preflight_checks_linux.go
@@ -223,12 +223,19 @@ func checkLibvirtServiceRunning() error {
 	libvirtSystemdUnits := []string{"virtqemud.socket", "libvirtd.socket", "virtqemud.service", "libvirtd.service"}
 	for _, unit := range libvirtSystemdUnits {
 		status, err := sd.Status(unit)
-		if err == nil && status == states.Running {
-			logging.Debugf("%s is running", unit)
-			return nil
+		if err == nil {
+			switch status {
+			case states.Running:
+				logging.Debugf("%s is running", unit)
+				return nil
+			case states.Listening:
+				logging.Debugf("%s is listening", unit)
+				return nil
+			default:
+				logging.Debugf("%s is neither running nor listening", unit)
+			}
 		}
 
-		logging.Debugf("%s is not running", unit)
 	}
 
 	logging.Warnf("No active (running) libvirtd systemd unit could be found - make sure one of libvirt systemd units is enabled so that it's autostarted at boot time.")

--- a/pkg/crc/ssh/ssh_test.go
+++ b/pkg/crc/ssh/ssh_test.go
@@ -52,16 +52,10 @@ func TestRunner(t *testing.T) {
 	assert.NoError(t, err)
 	defer runner.Close()
 
-	bin, err := runner.Run("echo hello")
+	bin, _, err := runner.Run("echo hello")
 	assert.NoError(t, err)
 	assert.Equal(t, "hello", bin)
 	assert.NoError(t, runner.CopyData([]byte(`hello world`), "/hello", 0644))
-
-	cmdRunner := NewRemoteCommandRunner(runner)
-	stdout, stderr, err := cmdRunner.Run("echo", "hello")
-	assert.NoError(t, err)
-	assert.Equal(t, "hello", stdout)
-	assert.Empty(t, stderr)
 
 	assert.Equal(t, 1, *totalConn)
 }

--- a/pkg/crc/systemd/states/state.go
+++ b/pkg/crc/systemd/states/state.go
@@ -9,6 +9,7 @@ type State int
 const (
 	Unknown State = iota
 	Running
+	Listening
 	Stopped
 	NotFound
 	Error
@@ -17,6 +18,7 @@ const (
 var states = []string{
 	"unknown",
 	"active (running)",
+	"active (listening)",
 	"inactive (dead)",
 	"could not be found",
 	"error",
@@ -32,6 +34,9 @@ func (s State) String() string {
 func Compare(input string) State {
 	if strings.Contains(input, states[Running]) {
 		return Running
+	}
+	if strings.Contains(input, states[Listening]) {
+		return Listening
 	}
 	if strings.Contains(input, states[Stopped]) {
 		return Stopped

--- a/pkg/crc/systemd/systemd.go
+++ b/pkg/crc/systemd/systemd.go
@@ -15,7 +15,7 @@ type Commander struct {
 
 func NewInstanceSystemdCommander(sshRunner *ssh.Runner) *Commander {
 	return &Commander{
-		commandRunner: ssh.NewRemoteCommandRunner(sshRunner),
+		commandRunner: sshRunner,
 	}
 }
 

--- a/pkg/crc/systemd/systemd.go
+++ b/pkg/crc/systemd/systemd.go
@@ -78,6 +78,15 @@ func (c Commander) service(name string, action actions.Action) (states.State, er
 	}
 
 	if err != nil {
+		state := states.Compare(stdOut)
+		if state != states.Unknown {
+			return state, nil
+		}
+		state = states.Compare(stdErr)
+		if state == states.NotFound {
+			return state, nil
+		}
+
 		return states.Error, fmt.Errorf("Executing systemctl action failed: %s %v: %s", stdOut, err, stdErr)
 	}
 

--- a/pkg/crc/systemd/systemd_linux_test.go
+++ b/pkg/crc/systemd/systemd_linux_test.go
@@ -1,6 +1,7 @@
 package systemd
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
@@ -34,6 +35,26 @@ func TestSystemd(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestSystemdStatuses(t *testing.T) {
+	systemctl, _ := newMockCommander(t)
+
+	status, err := systemctl.Status("running.service")
+	assert.NoError(t, err)
+	assert.Equal(t, states.Running.String(), status.String())
+
+	status, err = systemctl.Status("listening.socket")
+	assert.NoError(t, err)
+	assert.Equal(t, states.Listening.String(), status.String())
+
+	status, err = systemctl.Status("stopped.service")
+	assert.NoError(t, err)
+	assert.Equal(t, states.Stopped.String(), status.String())
+
+	status, err = systemctl.Status("notfound.service")
+	assert.NoError(t, err)
+	assert.Equal(t, states.NotFound.String(), status.String())
+}
+
 type mockSystemdRunner struct {
 	test    *testing.T
 	failing bool
@@ -41,7 +62,21 @@ type mockSystemdRunner struct {
 
 func (r *mockSystemdRunner) Run(command string, args ...string) (string, string, error) {
 	assertSystemCtlCommand(r.test, "status", command, args)
-	return r.status(states.Running)
+	assert.GreaterOrEqual(r.test, len(args), 2)
+
+	unitName := args[1]
+	switch unitName {
+	case "running.service":
+		return r.status(states.Running)
+	case "listening.socket":
+		return r.status(states.Listening)
+	case "stopped.service":
+		return r.status(states.Stopped)
+	case "notfound.service":
+		return r.status(states.NotFound)
+	default:
+		return r.status(states.Running)
+	}
 }
 
 func (r *mockSystemdRunner) RunPrivate(command string, args ...string) (string, string, error) {
@@ -69,20 +104,69 @@ func (r *mockSystemdRunner) setFailing(failing bool) {
 	r.failing = failing
 }
 
+const (
+	statusRunning string = `● running.service - running service
+     Loaded: loaded (/usr/lib/systemd/system/running.service; enabled; vendor preset: enabled)
+     Active: active (running) since Tue 2020-11-24 14:52:20 CET; 15s ago
+TriggeredBy: ● listening.socket
+       Docs: man:running(8)
+             https://running.example.com
+   Main PID: 224516 (running)
+      Tasks: 19 (limit: 32768)
+     Memory: 36.9M
+        CPU: 414ms
+     CGroup: /system.slice/running.service
+             ├─ 19588 /usr/sbin/true
+             ├─ 19589 /usr/sbin/true
+             └─224516 /usr/sbin/running
+`
+	statusListening string = `● listening.socket - listening socket
+     Loaded: loaded (/usr/lib/systemd/system/listening.socket; enabled; vendor preset: disabled)
+     Active: active (listening) since Mon 2020-11-16 17:02:29 CET; 1 weeks 0 days ago
+   Triggers: ● running.service
+     Listen: /run/listening/listening-sock (Stream)
+      Tasks: 0 (limit: 38160)
+     Memory: 0B
+        CPU: 0
+     CGroup: /system.slice/listening.socket
+`
+	statusStopped string = `● stopped.service - stopped service
+     Loaded: loaded (/usr/lib/systemd/system/stopped.service; enabled; vendor preset: enabled)
+     Active: inactive (dead) since Tue 2020-11-17 12:22:15 CET; 1 weeks 0 days ago
+TriggeredBy: ● listening.socket
+       Docs: man:stopped(8)
+             https://stopped.example.com
+    Process: 64922 ExecStart=/usr/sbin/true (code=exited, status=0/SUCCESS)
+   Main PID: 64922 (code=exited, status=0/SUCCESS)
+        CPU: 327ms
+`
+	statusNotFound string = "Unit notfound.service could not be found."
+)
+
 func (r *mockSystemdRunner) status(s states.State) (string, string, error) {
 	var (
 		err    error
 		stdout string
+		stderr string
 	)
 
 	if r.failing {
-		stdout = "error"
-		err = fmt.Errorf("Failed to run systemd command")
-	} else {
-		stdout = s.String()
+		return "error", "", fmt.Errorf("Failed to run systemd command")
+	}
+	switch s {
+	case states.Running:
+		stdout = statusRunning
+	case states.Listening:
+		stdout = statusListening
+	case states.Stopped:
+		stdout = statusStopped
+		err = errors.New("exit code: 3 - see EXIT STATUS in man systemctl")
+	case states.NotFound:
+		stderr = statusNotFound
+		err = errors.New("exit code: 4 - see EXIT STATUS in man systemctl")
 	}
 
-	return stdout, "", err
+	return stdout, stderr, err
 }
 
 func assertSystemCtlCommands(t *testing.T, systemctlCommands []string, cmd string, args []string) {

--- a/test/integration/crcsuite/collect.go
+++ b/test/integration/crcsuite/collect.go
@@ -186,7 +186,7 @@ func (collector *VMCommandCollector) Collect(w Writer) error {
 	if err != nil {
 		return err
 	}
-	out, err := ssh.Output(collector.Command)
+	out, _, err := ssh.Run(collector.Command)
 	if err != nil {
 		return errors.Wrapf(err, "collecting %s", collector.Target)
 	}
@@ -207,12 +207,12 @@ func (collector *ContainerLogCollector) Collect(w Writer) error {
 	if err != nil {
 		return err
 	}
-	out, err := ssh.Output(fmt.Sprintf("sudo %s ps -a -q", collector.Process))
+	out, _, err := ssh.Run(fmt.Sprintf("sudo %s ps -a -q", collector.Process))
 	if err != nil {
 		return err
 	}
-	for _, id := range strings.Split(strings.TrimSpace(out), "\n") {
-		inspect, err := ssh.Output(fmt.Sprintf("sudo %s inspect %s", collector.Process, id))
+	for _, id := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		inspect, _, err := ssh.Run(fmt.Sprintf("sudo %s inspect %s", collector.Process, id))
 		if err != nil {
 			logging.Errorf("error while inspecting %s: %v", id, err)
 			continue
@@ -221,7 +221,7 @@ func (collector *ContainerLogCollector) Collect(w Writer) error {
 			logging.Errorf("error while inspecting %s: %v", id, err)
 			continue
 		}
-		logs, err := ssh.Output(fmt.Sprintf("sudo %s logs --tail 200 %s", collector.Process, id))
+		logs, _, err := ssh.Run(fmt.Sprintf("sudo %s logs --tail 200 %s", collector.Process, id))
 		if err != nil {
 			logging.Errorf("error while getting logs %s: %v", id, err)
 			continue


### PR DESCRIPTION
The current code does not handle correctly stopped/not found units, and it also does not support systemd socket units.
This PR will fix this. It starts with preparatory work so that local command runners and ssh command runners behave the same
(separate stdout and stderr), since at the moment local command runners use separate output streams, while ssh command runners
combine stdout and stderr.

**Fixes:** Issue #1705

## Solution/Idea

This fixes the 'libvirtd is running' preflight check on systems using socket activation for libvirtd (libvirtd.socket is `active (listening`) and libvirtd.service is stopped after a few minutes of inactivity).

## Testing

This should be testable on rhel 8.3 by enabling/starting libvirtd.socket, stopping libvirtd.service, and running `crc setup`, the 'check-libvirt-running' test should succeed without any attempt at fixing it up.