### PR TITLE
Use admin-helper instead of goodhosts

### DIFF
--- a/cmd/crc-embedder/cmd/embed.go
+++ b/cmd/crc-embedder/cmd/embed.go
@@ -90,14 +90,14 @@ var (
 			hyperkit.MachineDriverDownloadURL,
 			hyperkit.HyperKitDownloadURL,
 			constants.GetCRCMacTrayDownloadURL(),
-			constants.GetGoodhostsURLForOs("darwin"),
+			constants.GetAdminHelperURLForOs("darwin"),
 		},
 		"linux": {
 			libvirt.MachineDriverDownloadURL,
-			constants.GetGoodhostsURLForOs("linux"),
+			constants.GetAdminHelperURLForOs("linux"),
 		},
 		"windows": {
-			constants.GetGoodhostsURLForOs("windows"),
+			constants.GetAdminHelperURLForOs("windows"),
 			constants.GetCRCWindowsTrayDownloadURL(),
 		},
 	}

--- a/pkg/crc/adminhelper/hosts.go
+++ b/pkg/crc/adminhelper/hosts.go
@@ -32,3 +32,7 @@ func RemoveFromHostsFile(instanceIP string, hostnames ...string) error {
 	}
 	return execute(append([]string{"rm"}, hostnames...)...)
 }
+
+func CleanHostsFile() error {
+	return execute([]string{"clean", constants.ClusterDomain, constants.AppsDomain}...)
+}

--- a/pkg/crc/adminhelper/hosts.go
+++ b/pkg/crc/adminhelper/hosts.go
@@ -1,4 +1,4 @@
-package goodhosts
+package adminhelper
 
 import (
 	"path/filepath"
@@ -7,7 +7,7 @@ import (
 )
 
 var (
-	goodhostPath = filepath.Join(constants.CrcBinDir, constants.GoodhostsExecutableName)
+	goodhostPath = filepath.Join(constants.CrcBinDir, constants.AdminHelperExecutableName)
 )
 
 // UpdateHostsFile updates the host's /etc/hosts file with Instance IP.

--- a/pkg/crc/adminhelper/hosts_nowin.go
+++ b/pkg/crc/adminhelper/hosts_nowin.go
@@ -1,6 +1,6 @@
 // +build !windows
 
-package goodhosts
+package adminhelper
 
 import (
 	crcos "github.com/code-ready/crc/pkg/os"

--- a/pkg/crc/adminhelper/hosts_windows.go
+++ b/pkg/crc/adminhelper/hosts_windows.go
@@ -1,4 +1,4 @@
-package goodhosts
+package adminhelper
 
 import (
 	"strings"

--- a/pkg/crc/cache/cache.go
+++ b/pkg/crc/cache/cache.go
@@ -54,11 +54,14 @@ func (c *Cache) GetExecutableName() string {
  */
 func getVersionGeneric(executablePath string, args ...string) (string, error) { //nolint:deadcode,unused
 	stdOut, _, err := crcos.RunWithDefaultLocale(executablePath, args...)
+	if err != nil {
+		return "", err
+	}
 	parsedOutput := strings.Split(stdOut, ":")
 	if len(parsedOutput) < 2 {
 		return "", fmt.Errorf("Unable to parse the version information of %s", executablePath)
 	}
-	return strings.TrimSpace(parsedOutput[1]), err
+	return strings.TrimSpace(parsedOutput[1]), nil
 }
 
 func NewPodmanCache() *Cache {

--- a/pkg/crc/constants/constants.go
+++ b/pkg/crc/constants/constants.go
@@ -38,6 +38,9 @@ const (
 	VsockSSHPort = 2222
 
 	OkdPullSecret = `{"auths":{"fake":{"auth": "Zm9vOmJhcgo="}}}` // #nosec G101
+
+	ClusterDomain = ".crc.testing"
+	AppsDomain    = ".apps-crc.testing"
 )
 
 var podmanURLForOs = map[string]string{

--- a/pkg/crc/constants/constants.go
+++ b/pkg/crc/constants/constants.go
@@ -29,7 +29,7 @@ const (
 	DaemonLogFile             = "crcd.log"
 	CrcLandingPageURL         = "https://cloud.redhat.com/openshift/install/crc/installer-provisioned" // #nosec G101
 	DefaultPodmanURLBase      = "https://storage.googleapis.com/libpod-master-releases"
-	DefaultGoodhostsCliBase   = "https://github.com/code-ready/goodhosts-cli/releases/download/v1.0.0"
+	DefaultAdminHelperCliBase = "https://github.com/code-ready/admin-helper/releases/download/0.0.1"
 	CRCMacTrayDownloadURL     = "https://github.com/code-ready/tray-macos/releases/download/v%s/crc-tray-macos.tar.gz"
 	CRCWindowsTrayDownloadURL = "https://github.com/code-ready/tray-windows/releases/download/v%s/crc-tray-windows.zip"
 	DefaultContext            = "admin"
@@ -54,18 +54,18 @@ func GetPodmanURL() string {
 	return podmanURLForOs[runtime.GOOS]
 }
 
-var goodhostsURLForOs = map[string]string{
-	"darwin":  fmt.Sprintf("%s/%s", DefaultGoodhostsCliBase, "goodhosts-cli-macos-amd64.tar.xz"),
-	"linux":   fmt.Sprintf("%s/%s", DefaultGoodhostsCliBase, "goodhosts-cli-linux-amd64.tar.xz"),
-	"windows": fmt.Sprintf("%s/%s", DefaultGoodhostsCliBase, "goodhosts-cli-windows-amd64.tar.xz"),
+var adminHelperURLForOs = map[string]string{
+	"darwin":  fmt.Sprintf("%s/%s", DefaultAdminHelperCliBase, "admin-helper-macos-amd64.tar.xz"),
+	"linux":   fmt.Sprintf("%s/%s", DefaultAdminHelperCliBase, "admin-helper-linux-amd64.tar.xz"),
+	"windows": fmt.Sprintf("%s/%s", DefaultAdminHelperCliBase, "admin-helper-windows-amd64.tar.xz"),
 }
 
-func GetGoodhostsURLForOs(os string) string {
-	return goodhostsURLForOs[os]
+func GetAdminHelperURLForOs(os string) string {
+	return adminHelperURLForOs[os]
 }
 
-func GetGoodhostsURL() string {
-	return goodhostsURLForOs[runtime.GOOS]
+func GetAdminHelperURL() string {
+	return adminHelperURLForOs[runtime.GOOS]
 }
 
 var defaultBundleForOs = map[string]string{

--- a/pkg/crc/constants/constants_darwin.go
+++ b/pkg/crc/constants/constants_darwin.go
@@ -3,10 +3,10 @@ package constants
 import "path/filepath"
 
 const (
-	OcExecutableName        = "oc"
-	PodmanExecutableName    = "podman"
-	TrayExecutableName      = "CodeReady Containers.app"
-	GoodhostsExecutableName = "goodhosts"
+	OcExecutableName          = "oc"
+	PodmanExecutableName      = "podman"
+	TrayExecutableName        = "CodeReady Containers.app"
+	AdminHelperExecutableName = "admin-helper"
 )
 
 var (

--- a/pkg/crc/constants/constants_linux.go
+++ b/pkg/crc/constants/constants_linux.go
@@ -1,7 +1,7 @@
 package constants
 
 const (
-	OcExecutableName        = "oc"
-	PodmanExecutableName    = "podman"
-	GoodhostsExecutableName = "goodhosts"
+	OcExecutableName          = "oc"
+	PodmanExecutableName      = "podman"
+	AdminHelperExecutableName = "admin-helper"
 )

--- a/pkg/crc/constants/constants_windows.go
+++ b/pkg/crc/constants/constants_windows.go
@@ -3,12 +3,12 @@ package constants
 import "path/filepath"
 
 const (
-	OcExecutableName        = "oc.exe"
-	PodmanExecutableName    = "podman.exe"
-	GoodhostsExecutableName = "goodhosts.exe"
-	TrayExecutableName      = "tray-windows.exe"
-	DaemonServiceName       = "CodeReady Containers"
-	TrayShortcutName        = "tray-windows.lnk"
+	OcExecutableName          = "oc.exe"
+	PodmanExecutableName      = "podman.exe"
+	AdminHelperExecutableName = "admin-helper.exe"
+	TrayExecutableName        = "tray-windows.exe"
+	DaemonServiceName         = "CodeReady Containers"
+	TrayShortcutName          = "tray-windows.lnk"
 )
 
 var (

--- a/pkg/crc/machine/bundle/repository.go
+++ b/pkg/crc/machine/bundle/repository.go
@@ -68,6 +68,12 @@ func (repo *Repository) Use(bundleName string) (*CrcBundleInfo, error) {
 	if err != nil {
 		return nil, err
 	}
+	if fmt.Sprintf(".%s", bundleInfo.ClusterInfo.AppsDomain) != constants.AppsDomain {
+		return nil, fmt.Errorf("unexpected bundle, it must have %s apps domain", constants.AppsDomain)
+	}
+	if bundleInfo.GetAPIHostname() != fmt.Sprintf("api%s", constants.ClusterDomain) {
+		return nil, fmt.Errorf("unexpected bundle, it must have %s base domain", constants.ClusterDomain)
+	}
 	if err := bundleInfo.createSymlinkOrCopyOpenShiftClient(repo.OcBinDir); err != nil {
 		return nil, err
 	}

--- a/pkg/crc/preflight/preflight_checks_nonwin.go
+++ b/pkg/crc/preflight/preflight_checks_nonwin.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"syscall"
 
+	"github.com/code-ready/crc/pkg/crc/adminhelper"
 	"github.com/code-ready/crc/pkg/crc/logging"
 	crcos "github.com/code-ready/crc/pkg/os"
 )
@@ -18,6 +19,11 @@ var nonWinPreflightChecks = [...]Check{
 		check:            checkIfRunningAsNormalUser,
 		fixDescription:   "crc should be ran as a normal user",
 		flags:            NoFix,
+	},
+	{
+		cleanupDescription: "Removing hosts file records added by CRC",
+		cleanup:            adminhelper.CleanHostsFile,
+		flags:              CleanUpOnly,
 	},
 }
 

--- a/pkg/crc/preflight/preflight_darwin_test.go
+++ b/pkg/crc/preflight/preflight_darwin_test.go
@@ -16,9 +16,9 @@ func TestCountConfigurationOptions(t *testing.T) {
 }
 
 func TestCountPreflights(t *testing.T) {
-	assert.Len(t, getPreflightChecks(false, network.DefaultMode), 11)
-	assert.Len(t, getPreflightChecks(true, network.DefaultMode), 17)
+	assert.Len(t, getPreflightChecks(false, network.DefaultMode), 12)
+	assert.Len(t, getPreflightChecks(true, network.DefaultMode), 18)
 
-	assert.Len(t, getPreflightChecks(false, network.VSockMode), 10)
-	assert.Len(t, getPreflightChecks(true, network.VSockMode), 16)
+	assert.Len(t, getPreflightChecks(false, network.VSockMode), 11)
+	assert.Len(t, getPreflightChecks(true, network.VSockMode), 17)
 }

--- a/pkg/crc/preflight/preflight_linux_test.go
+++ b/pkg/crc/preflight/preflight_linux_test.go
@@ -5,6 +5,8 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/code-ready/crc/pkg/crc/adminhelper"
+
 	"github.com/code-ready/crc/pkg/crc/config"
 	"github.com/code-ready/crc/pkg/crc/network"
 	crcos "github.com/code-ready/crc/pkg/os/linux"
@@ -60,11 +62,12 @@ var checkListForDistros = []checkListForDistro{
 		networkMode: network.DefaultMode,
 		checks: []Check{
 			{check: checkPodmanExecutableCached},
-			{check: checkGoodhostsExecutableCached},
+			{check: checkAdminHelperExecutableCached},
 			{check: checkBundleExtracted},
 			{configKeySuffix: "check-ram"},
 			{cleanup: removeCRCMachinesDir},
 			{check: checkIfRunningAsNormalUser},
+			{cleanup: adminhelper.CleanHostsFile},
 			{check: checkVirtualizationEnabled},
 			{check: checkKvmEnabled},
 			{check: checkLibvirtInstalled},
@@ -88,11 +91,12 @@ var checkListForDistros = []checkListForDistro{
 		networkMode: network.VSockMode,
 		checks: []Check{
 			{check: checkPodmanExecutableCached},
-			{check: checkGoodhostsExecutableCached},
+			{check: checkAdminHelperExecutableCached},
 			{check: checkBundleExtracted},
 			{configKeySuffix: "check-ram"},
 			{cleanup: removeCRCMachinesDir},
 			{check: checkIfRunningAsNormalUser},
+			{cleanup: adminhelper.CleanHostsFile},
 			{check: checkVirtualizationEnabled},
 			{check: checkKvmEnabled},
 			{check: checkLibvirtInstalled},
@@ -109,11 +113,12 @@ var checkListForDistros = []checkListForDistro{
 		networkMode: network.DefaultMode,
 		checks: []Check{
 			{check: checkPodmanExecutableCached},
-			{check: checkGoodhostsExecutableCached},
+			{check: checkAdminHelperExecutableCached},
 			{check: checkBundleExtracted},
 			{configKeySuffix: "check-ram"},
 			{cleanup: removeCRCMachinesDir},
 			{check: checkIfRunningAsNormalUser},
+			{cleanup: adminhelper.CleanHostsFile},
 			{check: checkVirtualizationEnabled},
 			{check: checkKvmEnabled},
 			{check: checkLibvirtInstalled},
@@ -136,11 +141,12 @@ var checkListForDistros = []checkListForDistro{
 		networkMode: network.VSockMode,
 		checks: []Check{
 			{check: checkPodmanExecutableCached},
-			{check: checkGoodhostsExecutableCached},
+			{check: checkAdminHelperExecutableCached},
 			{check: checkBundleExtracted},
 			{configKeySuffix: "check-ram"},
 			{cleanup: removeCRCMachinesDir},
 			{check: checkIfRunningAsNormalUser},
+			{cleanup: adminhelper.CleanHostsFile},
 			{check: checkVirtualizationEnabled},
 			{check: checkKvmEnabled},
 			{check: checkLibvirtInstalled},
@@ -157,11 +163,12 @@ var checkListForDistros = []checkListForDistro{
 		networkMode: network.DefaultMode,
 		checks: []Check{
 			{check: checkPodmanExecutableCached},
-			{check: checkGoodhostsExecutableCached},
+			{check: checkAdminHelperExecutableCached},
 			{check: checkBundleExtracted},
 			{configKeySuffix: "check-ram"},
 			{cleanup: removeCRCMachinesDir},
 			{check: checkIfRunningAsNormalUser},
+			{cleanup: adminhelper.CleanHostsFile},
 			{check: checkVirtualizationEnabled},
 			{check: checkKvmEnabled},
 			{check: checkLibvirtInstalled},
@@ -184,11 +191,12 @@ var checkListForDistros = []checkListForDistro{
 		networkMode: network.VSockMode,
 		checks: []Check{
 			{check: checkPodmanExecutableCached},
-			{check: checkGoodhostsExecutableCached},
+			{check: checkAdminHelperExecutableCached},
 			{check: checkBundleExtracted},
 			{configKeySuffix: "check-ram"},
 			{cleanup: removeCRCMachinesDir},
 			{check: checkIfRunningAsNormalUser},
+			{cleanup: adminhelper.CleanHostsFile},
 			{check: checkVirtualizationEnabled},
 			{check: checkKvmEnabled},
 			{check: checkLibvirtInstalled},
@@ -205,11 +213,12 @@ var checkListForDistros = []checkListForDistro{
 		networkMode: network.DefaultMode,
 		checks: []Check{
 			{check: checkPodmanExecutableCached},
-			{check: checkGoodhostsExecutableCached},
+			{check: checkAdminHelperExecutableCached},
 			{check: checkBundleExtracted},
 			{configKeySuffix: "check-ram"},
 			{cleanup: removeCRCMachinesDir},
 			{check: checkIfRunningAsNormalUser},
+			{cleanup: adminhelper.CleanHostsFile},
 			{check: checkVirtualizationEnabled},
 			{check: checkKvmEnabled},
 			{check: checkLibvirtInstalled},
@@ -234,11 +243,12 @@ var checkListForDistros = []checkListForDistro{
 		networkMode: network.VSockMode,
 		checks: []Check{
 			{check: checkPodmanExecutableCached},
-			{check: checkGoodhostsExecutableCached},
+			{check: checkAdminHelperExecutableCached},
 			{check: checkBundleExtracted},
 			{configKeySuffix: "check-ram"},
 			{cleanup: removeCRCMachinesDir},
 			{check: checkIfRunningAsNormalUser},
+			{cleanup: adminhelper.CleanHostsFile},
 			{check: checkVirtualizationEnabled},
 			{check: checkKvmEnabled},
 			{check: checkLibvirtInstalled},

--- a/pkg/crc/preflight/preflight_ubuntu_linux_test.go
+++ b/pkg/crc/preflight/preflight_ubuntu_linux_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/code-ready/crc/pkg/crc/constants"
-
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/crc/services/dns/dns.go
+++ b/pkg/crc/services/dns/dns.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/code-ready/crc/pkg/crc/adminhelper"
 	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/code-ready/crc/pkg/crc/errors"
-	"github.com/code-ready/crc/pkg/crc/goodhosts"
 	"github.com/code-ready/crc/pkg/crc/network"
 	"github.com/code-ready/crc/pkg/crc/services"
 )
@@ -121,7 +121,7 @@ func CheckCRCPublicDNSReachable(serviceConfig services.ServicePostStartConfig) (
 }
 
 func addOpenShiftHosts(serviceConfig services.ServicePostStartConfig) error {
-	return goodhosts.UpdateHostsFile(serviceConfig.IP, serviceConfig.BundleMetadata.GetAPIHostname(),
+	return adminhelper.UpdateHostsFile(serviceConfig.IP, serviceConfig.BundleMetadata.GetAPIHostname(),
 		serviceConfig.BundleMetadata.GetAppHostname("oauth-openshift"),
 		serviceConfig.BundleMetadata.GetAppHostname("console-openshift-console"),
 		serviceConfig.BundleMetadata.GetAppHostname("default-route-openshift-image-registry"))


### PR DESCRIPTION
**Fixes:** Issue #1328

It uses https://github.com/code-ready/admin-helper instead of goodhosts CLI.
I introduced a new command called clean that remove all entries by a domain suffix. It is enough to clean up what was added by crc.