### PR TITLE
Issue #1724: Do not use Dockerhub centos images

### DIFF
--- a/images/openshift-ci/Dockerfile
+++ b/images/openshift-ci/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /go/src/github.com/code-ready/crc
 COPY . .
 RUN make cross
 
-FROM centos:7
+FROM registry.centos.org/centos/centos:7
 COPY --from=builder /go/src/github.com/code-ready/crc /opt/crc
 COPY --from=builder /go/src/github.com/code-ready/crc/out/linux-amd64/crc /bin/crc
 COPY --from=builder /go/src/github.com/code-ready/crc/images/openshift-ci/mock-nss.sh /bin/mock-nss.sh

--- a/images/squid/Dockerfile
+++ b/images/squid/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:centos8
+FROM registry.centos.org/centos/centos:centos8
 MAINTAINER CodeReady Container <devtools-cdk@redhat.com>
 
 ENV SQUID_CACHE_DIR=/var/spool/squid \

--- a/test/testdata/Dockerfile
+++ b/test/testdata/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:latest
+FROM registry.centos.org/centos/centos:latest
 
 RUN groupadd -r crcek -g 1234 && useradd -u 1234 -r -g crcek -m -d /crcek -s /sbin/nologin -c "CRC user" crcek && chmod 755 /crcek
 


### PR DESCRIPTION
**Fixes:** Issue #1724 

## Solution

Modify the Dockerfile to pull specifically from quay.io. The image we're pulling is a mirror of the upstream CentOS repository (probably along the lines of: https://www.openshift.com/blog/mitigate-impact-of-docker-hub-pull-request-limits). 

## Testing

1. The restriction of integration tests to `story_registry` feature should pass OK.