### PR TITLE
Docs: Disable automatic URL for the OpenShift console

### DIFF
--- a/docs/source/topics/proc_connecting-to-remote-instance.adoc
+++ b/docs/source/topics/proc_connecting-to-remote-instance.adoc
@@ -63,4 +63,4 @@ $ sudo systemctl reload NetworkManager
 $ oc login -u developer -p developer https://api.crc.testing:6443
 ----
 +
-The remote OpenShift Web Console is available at https://console-openshift-console.apps-crc.testing.
+The remote OpenShift Web Console is available at \https://console-openshift-console.apps-crc.testing.


### PR DESCRIPTION
Disable automatic link generation for the OpenShift console URL (`console-openshift-console.apps-crc.testing`), as this is most likely a broken link.