### PR TITLE
[WIP] Issue #1707: Integration: Add Scenario enabling monitoring operator

### DIFF
--- a/test/integration/crcsuite/prepare.go
+++ b/test/integration/crcsuite/prepare.go
@@ -13,7 +13,7 @@ import (
 	"github.com/code-ready/crc/pkg/download"
 )
 
-// Download bundle for testing
+// DownloadBundle retrieves the bundle for testing
 func DownloadBundle(bundleLocation string, bundleDestination string) (string, error) {
 
 	if bundleLocation[:4] != "http" {
@@ -57,6 +57,7 @@ func DownloadBundle(bundleLocation string, bundleDestination string) (string, er
 	return filename, nil
 }
 
+// CopyFilesToTestDir moves files required by tests to test folder
 func CopyFilesToTestDir() error {
 
 	cwd, err := os.Getwd()
@@ -118,6 +119,7 @@ func CopyFilesToTestDir() error {
 	return nil
 }
 
+// ParseFlags accepts command line arguments to godog
 func ParseFlags() {
 
 	flag.StringVar(&bundleURL, "bundle-location", "embedded", "Path to the bundle to be used in tests")

--- a/test/integration/crcsuite/util.go
+++ b/test/integration/crcsuite/util.go
@@ -8,7 +8,7 @@ import (
 	clicumber "github.com/code-ready/clicumber/testsuite"
 )
 
-// Delete CRC instance
+// DeleteCRC deletes CRC instance
 func DeleteCRC() error {
 
 	command := "crc delete"
@@ -18,7 +18,7 @@ func DeleteCRC() error {
 	return nil
 }
 
-// Remove CRC home folder ~/.crc
+// RemoveCRCHome removes CRC home folder ~/.crc
 func RemoveCRCHome() error {
 
 	keepFile := filepath.Join(CRCHome, ".keep")


### PR DESCRIPTION
_Needs testing on Windows_. MacOS/Linux work OK.

**Fixes:** Issue #1707 

## Solution

Instead of adding a Feature file, I added 1 Scenario into `story_health`. This utilizes a running cluster at the end of a test which only creates an app (i.e. after deleting the project, the cluster should be usable for enabling `cluster-monitoring-operator`).

## Testing

1. Run `make integration` with only `story_health` feature. It should pass OK.
