### PR TITLE
Status check

### DIFF
--- a/test/integration/features/basic.feature
+++ b/test/integration/features/basic.feature
@@ -92,8 +92,7 @@ Feature: Basic test
 
     @darwin @linux @windows
     Scenario: CRC status and disk space check
-        When with up to "15" retries with wait period of "1m" command "crc status --log-level debug" output should not contain "Stopped"
-        And stdout should contain "Running"
+        When checking that CRC is running
         And stdout should match ".*Disk Usage: *\d+\.\d+GB of 32.\d+GB.*"
 
     @darwin @linux @windows
@@ -119,13 +118,11 @@ Feature: Basic test
 
     @darwin @linux @windows
     Scenario: CRC status check
-        When with up to "2" retries with wait period of "1m" command "crc status --log-level debug" output should not contain "Running"
-        And stdout should contain "Stopped"
+        When checking that CRC is stopped
+        And stdout should not contain "Running"
 
     @darwin @linux @windows
     Scenario: CRC console check
-        Given executing "crc status" succeeds
-        And stdout contains "Stopped"
         When executing "crc console"
         Then stderr should contain "The OpenShift cluster is not running, cannot open the OpenShift Web Console"
 

--- a/test/integration/features/basic.feature
+++ b/test/integration/features/basic.feature
@@ -1,6 +1,8 @@
 @basic
 Feature: Basic test
-    Checks whether CRC top-level commands behave correctly.
+
+    User explores some of the top-level CRC commands while going
+    through the lifecycle of CRC.
 
     @darwin @linux @windows
     Scenario: CRC version

--- a/test/integration/features/basic.feature
+++ b/test/integration/features/basic.feature
@@ -23,7 +23,7 @@ Feature: Basic test
         And stdout should contain "delete"
         And stdout should contain "status"
         And stdout should contain "Flags:"
-        And stdout should contain 
+        And stdout should contain
             """
             Use "crc [command] --help" for more information about a command.
             """
@@ -31,10 +31,10 @@ Feature: Basic test
     @darwin @linux @windows
     Scenario: CRC status
         When executing "crc status" fails
-        Then stderr should contain 
-        """
-        Machine 'crc' does not exist. Use 'crc start' to create it
-        """
+        Then stderr should contain
+            """
+            Machine 'crc' does not exist. Use 'crc start' to create it
+            """
 
     @linux
     Scenario: CRC setup on Linux
@@ -57,8 +57,8 @@ Feature: Basic test
         And stderr should contain "Will use root access: executing systemctl daemon-reload command"
         And stderr should contain "Will use root access: executing systemctl reload NetworkManager"
         And stderr should contain "Checking if /etc/NetworkManager/dnsmasq.d/crc.conf exists"
-	And stderr should contain "Writing dnsmasq config for crc"
-	And stderr should contain "Will use root access: write NetworkManager configuration to /etc/NetworkManager/dnsmasq.d/crc.conf"
+        And stderr should contain "Writing dnsmasq config for crc"
+        And stderr should contain "Will use root access: write NetworkManager configuration to /etc/NetworkManager/dnsmasq.d/crc.conf"
         And stderr should contain "Will use root access: executing systemctl daemon-reload command"
         And stderr should contain "Will use root access: executing systemctl reload NetworkManager"
         And stdout should contain "Setup is complete, you can now run 'crc start -b $bundlename' to start the OpenShift cluster" if bundle is not embedded
@@ -149,7 +149,7 @@ Feature: Basic test
         When executing "crc cleanup" succeeds
         Then stderr should contain "Removing the crc VM if exists"
         And stderr should contain "Removing /etc/NetworkManager/dnsmasq.d/crc.conf file"
-	And stderr should contain "Will use root access: removing NetworkManager configuration file in /etc/NetworkManager/dnsmasq.d/crc.conf"
+        And stderr should contain "Will use root access: removing NetworkManager configuration file in /etc/NetworkManager/dnsmasq.d/crc.conf"
         And stderr should contain "Will use root access: executing systemctl daemon-reload command"
         And stderr should contain "Will use root access: executing systemctl reload NetworkManager"
         And stderr should contain "Removing /etc/NetworkManager/conf.d/crc-nm-dnsmasq.conf file"

--- a/test/integration/features/cert_rotation.feature
+++ b/test/integration/features/cert_rotation.feature
@@ -14,7 +14,7 @@ Feature: Check the cert is rotation happen after it expire
       When starting CRC with default bundle along with stopped network time synchronization succeeds
       Then stdout should contain "Started the OpenShift cluster"
       And executing "eval $(crc oc-env)" succeeds
-      When with up to "4" retries with wait period of "2m" command "crc status --log-level debug" output matches ".*Running \(v\d+\.\d+\.\d+.*\).*"
+      When checking that CRC is running
       Then login to the oc cluster succeeds
 
     Scenario: Set clock back to original time

--- a/test/integration/features/cert_rotation.feature
+++ b/test/integration/features/cert_rotation.feature
@@ -1,11 +1,11 @@
 @cert_rotation @linux
-Feature: Check the cert is rotation happen after it expire
+Feature: Certificate rotation test
 
-    The user try to use crc after one month. he/she expect the
-    cert rotation happen successfully and able to deploy the app and check its
-    accessibility.
+    User starts CRC more than one month after the release. They expect
+    certificate rotation to happen successfully and to be able to deploy
+    an app and check its accessibility.
 
-    Scenario: Set clock to 3 month ahead on the host
+    Scenario: Set clock to 3 months ahead on the host
       Given executing "sudo timedatectl set-ntp off" succeeds
       Then executing "sudo date -s '3 month'" succeeds
 
@@ -17,7 +17,7 @@ Feature: Check the cert is rotation happen after it expire
       When checking that CRC is running
       Then login to the oc cluster succeeds
 
-    Scenario: Set clock back to original time
+    Scenario: Set clock back to the original time
       When executing "sudo date -s '-3 month'" succeeds
       And executing "sudo timedatectl set-ntp on" succeeds
 

--- a/test/integration/features/cert_rotation.feature
+++ b/test/integration/features/cert_rotation.feature
@@ -6,22 +6,22 @@ Feature: Certificate rotation test
     an app and check its accessibility.
 
     Scenario: Set clock to 3 months ahead on the host
-      Given executing "sudo timedatectl set-ntp off" succeeds
-      Then executing "sudo date -s '3 month'" succeeds
+        Given executing "sudo timedatectl set-ntp off" succeeds
+        Then executing "sudo date -s '3 month'" succeeds
 
     Scenario: Start CRC
-      Given executing "crc setup" succeeds
-      When starting CRC with default bundle along with stopped network time synchronization succeeds
-      Then stdout should contain "Started the OpenShift cluster"
-      And executing "eval $(crc oc-env)" succeeds
-      When checking that CRC is running
-      Then login to the oc cluster succeeds
+        Given executing "crc setup" succeeds
+        When starting CRC with default bundle along with stopped network time synchronization succeeds
+        Then stdout should contain "Started the OpenShift cluster"
+        And executing "eval $(crc oc-env)" succeeds
+        When checking that CRC is running
+        Then login to the oc cluster succeeds
 
     Scenario: Set clock back to the original time
-      When executing "sudo date -s '-3 month'" succeeds
-      And executing "sudo timedatectl set-ntp on" succeeds
+        When executing "sudo date -s '-3 month'" succeeds
+        And executing "sudo timedatectl set-ntp on" succeeds
 
     Scenario: CRC delete and cleanup
-      When executing "crc delete -f" succeeds
-      Then stdout should contain "Deleted the OpenShift cluster"
-      When executing "crc cleanup" succeeds
+        When executing "crc delete -f" succeeds
+        Then stdout should contain "Deleted the OpenShift cluster"
+        When executing "crc cleanup" succeeds

--- a/test/integration/features/config.feature
+++ b/test/integration/features/config.feature
@@ -4,7 +4,7 @@ Feature: Test configuration settings
     User checks whether CRC `config set` command works as expected 
     in conjunction with `crc setup` and `crc start` commands.
 
-# SETTINGS
+    # SETTINGS
 
     Scenario Outline: CRC config checks (settings)
         When setting config property "<property>" to value "<value1>" succeeds
@@ -56,7 +56,7 @@ Feature: Test configuration settings
         When unsetting config property "disable-update-check" succeeds
         Then "JSON" config file "crc.json" in CRC home folder does not contain key "disable-update-check"
 
-# WARNINGS
+    # WARNINGS
 
     Scenario Outline: CRC config checks (warnings)
         When setting config property "<property>" to value "<value1>" succeeds
@@ -105,7 +105,7 @@ Feature: Test configuration settings
             | warn-check-user-in-hyperv-group | true   | false  |
             | warn-check-windows-version      | true   | false  |
 
-# SKIP
+    # SKIP
 
     Scenario Outline: CRC config checks (skips)
         When setting config property "<property>" to value "<value1>" succeeds
@@ -158,44 +158,44 @@ Feature: Test configuration settings
             | skip-check-user-in-hyperv-group | true   | false  |
             | skip-check-windows-version      | true   | false  |
 
-# --------------------------------------
-# Linux-specific Scenarios
+    # --------------------------------------
+    # Linux-specific Scenarios
 
-   @linux
-   Scenario: Check network setup and destroy it, then check again
-       When removing file "crc.json" from CRC home folder succeeds
-       And executing "crc setup" succeeds
-       And executing "sudo virsh net-list --name" succeeds
-       Then stdout contains "crc"
-       When executing "sudo virsh net-undefine crc && sudo virsh net-destroy crc" succeeds
-       And executing "sudo virsh net-list --name" succeeds
-       Then stdout should not contain "crc"
+    @linux
+    Scenario: Check network setup and destroy it, then check again
+        When removing file "crc.json" from CRC home folder succeeds
+        And executing "crc setup" succeeds
+        And executing "sudo virsh net-list --name" succeeds
+        Then stdout contains "crc"
+        When executing "sudo virsh net-undefine crc && sudo virsh net-destroy crc" succeeds
+        And executing "sudo virsh net-list --name" succeeds
+        Then stdout should not contain "crc"
 
-   @linux
-   Scenario: Running `crc setup` with checks enabled restores destroyed network
-       When executing "crc config set skip-check-crc-network false" succeeds
-       And executing "crc config set skip-check-crc-network-active false" succeeds
-       Then executing "crc setup" succeeds
-       And executing "sudo virsh net-list --name" succeeds
-       And stdout contains "crc"
+    @linux
+    Scenario: Running `crc setup` with checks enabled restores destroyed network
+        When executing "crc config set skip-check-crc-network false" succeeds
+        And executing "crc config set skip-check-crc-network-active false" succeeds
+        Then executing "crc setup" succeeds
+        And executing "sudo virsh net-list --name" succeeds
+        And stdout contains "crc"
 
-   @linux
-   Scenario: Running `crc start` without `crc setup` and with checks disabled fails when network destroyed
-       # Destroy network again
-       When executing "sudo virsh net-undefine crc && sudo virsh net-destroy crc" succeeds
-       And executing "sudo virsh net-list --name" succeeds
-       Then stdout should not contain "crc"
-       # Disable checks
-       When executing "crc config set skip-check-crc-network true" succeeds
-       And executing "crc config set skip-check-crc-network-active true" succeeds
-       # Start CRC
-       Then starting CRC with default bundle fails
-       And stderr contains "Network not found: no network with matching name 'crc'"
+    @linux
+    Scenario: Running `crc start` without `crc setup` and with checks disabled fails when network destroyed
+        # Destroy network again
+        When executing "sudo virsh net-undefine crc && sudo virsh net-destroy crc" succeeds
+        And executing "sudo virsh net-list --name" succeeds
+        Then stdout should not contain "crc"
+        # Disable checks
+        When executing "crc config set skip-check-crc-network true" succeeds
+        And executing "crc config set skip-check-crc-network-active true" succeeds
+        # Start CRC
+        Then starting CRC with default bundle fails
+        And stderr contains "Network not found: no network with matching name 'crc'"
 
-   @linux
-   Scenario: Clean-up
-       # Remove the config file
-       When removing file "crc.json" from CRC home folder succeeds
-       And executing "crc setup" succeeds
-       Then stderr should not contain "Skipping above check"
+    @linux
+    Scenario: Clean-up
+        # Remove the config file
+        When removing file "crc.json" from CRC home folder succeeds
+        And executing "crc setup" succeeds
+        Then stderr should not contain "Skipping above check"
        

--- a/test/integration/features/config.feature
+++ b/test/integration/features/config.feature
@@ -1,6 +1,8 @@
 @config
 Feature: Test configuration settings
-Checks whether CRC `config set` command works as expected in conjunction with `crc setup` and `crc start`.
+
+    User checks whether CRC `config set` command works as expected 
+    in conjunction with `crc setup` and `crc start` commands.
 
 # SETTINGS
 

--- a/test/integration/features/proxy.feature
+++ b/test/integration/features/proxy.feature
@@ -15,7 +15,7 @@ Feature: Test the proxy
     When starting CRC with default bundle succeeds
     Then stdout should contain "Started the OpenShift cluster"
     And executing "eval $(crc oc-env)" succeeds
-    When with up to "4" retries with wait period of "2m" command "crc status --log-level debug" output matches ".*Running \(v\d+\.\d+\.\d+.*\).*"
+    When checking that CRC is running
     Then login to the oc cluster succeeds
 
   Scenario: Remove the proxy container and host proxy env (which set because of oc-env)

--- a/test/integration/features/proxy.feature
+++ b/test/integration/features/proxy.feature
@@ -4,29 +4,28 @@ Feature: Behind proxy test
     User starts CRC behind a proxy. They expect a successful start 
     and to be able to deploy an app and check its accessibility.
 
-  Scenario: Setup the proxy container using podman
-    Given executing "sudo podman run --name squid -d -p 3128:3128 quay.io/crcont/squid" succeeds
+    Scenario: Setup the proxy container using podman
+        Given executing "sudo podman run --name squid -d -p 3128:3128 quay.io/crcont/squid" succeeds
 
-  Scenario: Start CRC
-    Given executing "crc setup" succeeds
-    And  executing "crc config set http-proxy http://192.168.130.1:3128" succeeds
-    Then executing "crc config set https-proxy http://192.168.130.1:3128" succeeds
-    When starting CRC with default bundle succeeds
-    Then stdout should contain "Started the OpenShift cluster"
-    And executing "eval $(crc oc-env)" succeeds
-    When checking that CRC is running
-    Then login to the oc cluster succeeds
+    Scenario: Start CRC
+        Given executing "crc setup" succeeds
+        And  executing "crc config set http-proxy http://192.168.130.1:3128" succeeds
+        Then executing "crc config set https-proxy http://192.168.130.1:3128" succeeds
+        When starting CRC with default bundle succeeds
+        Then stdout should contain "Started the OpenShift cluster"
+        And executing "eval $(crc oc-env)" succeeds
+        When checking that CRC is running
+        Then login to the oc cluster succeeds
 
-  Scenario: Remove the proxy container and host proxy env (which set because of oc-env)
-    Given executing "sudo podman stop squid" succeeds
-    And executing "sudo podman rm squid" succeeds
-    And executing "unset HTTP_PROXY HTTPS_PROXY NO_PROXY" succeeds
+    Scenario: Remove the proxy container and host proxy env (which set because of oc-env)
+        Given executing "sudo podman stop squid" succeeds
+        And executing "sudo podman rm squid" succeeds
+        And executing "unset HTTP_PROXY HTTPS_PROXY NO_PROXY" succeeds
 
-
-  Scenario: CRC delete and remove proxy settings from config
-    When executing "crc delete -f" succeeds
-    Then stdout should contain "Deleted the OpenShift cluster"
-    And  executing "crc config unset http-proxy" succeeds
-    And executing "crc config unset https-proxy" succeeds
-    And executing "crc cleanup" succeeds
+    Scenario: CRC delete and remove proxy settings from config
+        When executing "crc delete -f" succeeds
+        Then stdout should contain "Deleted the OpenShift cluster"
+        And  executing "crc config unset http-proxy" succeeds
+        And executing "crc config unset https-proxy" succeeds
+        And executing "crc cleanup" succeeds
 

--- a/test/integration/features/proxy.feature
+++ b/test/integration/features/proxy.feature
@@ -1,9 +1,8 @@
 @proxy @linux
-Feature: Test the proxy
+Feature: Behind proxy test
 
-  The user tries to use crc behind proxy. he/she expects the
-  crc start happen successfully and able to deploy the app and check its
-  accessibility.
+    User starts CRC behind a proxy. They expect a successful start 
+    and to be able to deploy an app and check its accessibility.
 
   Scenario: Setup the proxy container using podman
     Given executing "sudo podman run --name squid -d -p 3128:3128 quay.io/crcont/squid" succeeds

--- a/test/integration/features/story_health.feature
+++ b/test/integration/features/story_health.feature
@@ -26,10 +26,10 @@ Feature: End-to-end health check
         When checking that CRC is running
         Then login to the oc cluster succeeds
 
-    @linux @darwin @windows    
+    @linux @darwin @windows
     Scenario: Check cluster health
         When executing "oc get nodes"
-        Then stdout contains "Ready" 
+        Then stdout contains "Ready"
         And stdout does not contain "Not ready"
         # next line checks similar things as `crc status` except gives more informative output
         And with up to "5" retries with wait period of "1m" all cluster operators are running
@@ -62,7 +62,6 @@ Feature: End-to-end health check
         When starting CRC with default bundle succeeds
         Then checking that CRC is running
         And with up to "2" retries with wait period of "1m" http response from "http://httpd-example-testproj.apps-crc.testing" has status code "200"
-
 
     @darwin @linux @windows
     Scenario: Switch off CRC

--- a/test/integration/features/story_health.feature
+++ b/test/integration/features/story_health.feature
@@ -11,7 +11,7 @@ Feature:
         When starting CRC with default bundle succeeds
         Then stdout should contain "Started the OpenShift cluster"
         And executing "eval $(crc oc-env)" succeeds
-        When with up to "4" retries with wait period of "2m" command "crc status --log-level debug" output matches ".*Running \(v\d+\.\d+\.\d+.*\).*"
+        When checking that CRC is running
         Then login to the oc cluster succeeds
 
     @windows
@@ -21,13 +21,11 @@ Feature:
         When starting CRC with default bundle and nameserver "10.75.5.25" succeeds
         Then stdout should contain "Started the OpenShift cluster"
         And executing "crc oc-env | Invoke-Expression" succeeds
-        When with up to "4" retries with wait period of "2m" command "crc status --log-level debug" output matches ".*Running \(v\d+\.\d+\.\d+.*\).*"
+        When checking that CRC is running
         Then login to the oc cluster succeeds
 
     @linux @darwin @windows    
     Scenario: Check cluster health
-        Given executing "crc status" succeeds
-        And stdout should match ".*Running \(v\d+\.\d+\.\d+.*\).*"
         When executing "oc get nodes"
         Then stdout contains "Ready" 
         And stdout does not contain "Not ready"
@@ -58,10 +56,10 @@ Feature:
     Scenario: Stop and start CRC, then check app still runs
         Given with up to "2" retries with wait period of "60s" http response from "http://httpd-example-testproj.apps-crc.testing" has status code "200"
         When executing "crc stop -f" succeeds
-        Then with up to "4" retries with wait period of "2m" command "crc status" output should contain "Stopped"
+        Then checking that CRC is stopped
         When starting CRC with default bundle succeeds
-        Then with up to "4" retries with wait period of "2m" command "crc status" output should match ".*Running \(v\d+\.\d+\.\d+.*\).*"
-        And with up to "2" retries with wait period of "60s" http response from "http://httpd-example-testproj.apps-crc.testing" has status code "200"
+        Then checking that CRC is running
+        And with up to "2" retries with wait period of "1m" http response from "http://httpd-example-testproj.apps-crc.testing" has status code "200"
 
 
     @darwin @linux @windows

--- a/test/integration/features/story_health.feature
+++ b/test/integration/features/story_health.feature
@@ -1,8 +1,10 @@
 @story_health
-Feature: 
-    End-to-end health check. Set-up and start CRC. Then create a
-    project and deploy an app. Check on the app and delete the
-    project. Stop and delete CRC.
+Feature: End-to-end health check
+
+    User goes through a "day in the life of" CRC. They set up
+    and start CRC. They then create a project and deploy an app.
+    They check on the app and delete the project. They stop CRC
+    and delete the CRC VM.
 
     @linux @darwin
     Scenario: Start CRC

--- a/test/integration/features/story_marketplace.feature
+++ b/test/integration/features/story_marketplace.feature
@@ -4,7 +4,6 @@ Feature: Operator from marketplace
     User installs an OpenShift operator from OperatorHub and uses
     it to manage admin tasks.
 
-
     @linux @darwin
     Scenario: Start CRC and login to cluster
         Given executing "crc setup" succeeds

--- a/test/integration/features/story_marketplace.feature
+++ b/test/integration/features/story_marketplace.feature
@@ -8,7 +8,7 @@ Feature:
         Given executing "crc setup" succeeds
         When starting CRC with default bundle succeeds
         Then stdout should contain "Started the OpenShift cluster"
-        When with up to "8" retries with wait period of "2m" command "crc status" output matches ".*Running \(v\d+\.\d+\.\d+.*\).*"
+        When checking that CRC is running
         Then executing "eval $(crc oc-env)" succeeds
         And login to the oc cluster succeeds
 
@@ -18,7 +18,7 @@ Feature:
         When starting CRC with default bundle and nameserver "10.75.5.25" succeeds
         Then stdout should contain "Started the OpenShift cluster"
         And executing "crc oc-env | Invoke-Expression" succeeds
-        When with up to "4" retries with wait period of "2m" command "crc status --log-level debug" output matches ".*Running \(v\d+\.\d+\.\d+.*\).*"
+        When checking that CRC is running
         Then login to the oc cluster succeeds
 
     @darwin @linux @windows

--- a/test/integration/features/story_marketplace.feature
+++ b/test/integration/features/story_marketplace.feature
@@ -1,7 +1,9 @@
 @story_marketplace
-Feature: 
-    Install OpenShift operator from OperatorHub and use it to manage
-    admin tasks.
+Feature: Operator from marketplace
+
+    User installs an OpenShift operator from OperatorHub and uses
+    it to manage admin tasks.
+
 
     @linux @darwin
     Scenario: Start CRC and login to cluster

--- a/test/integration/features/story_registry.feature
+++ b/test/integration/features/story_registry.feature
@@ -10,7 +10,7 @@ Feature: Local image to image-registry to deployment
         Given executing "crc setup" succeeds
         When starting CRC with default bundle succeeds
         Then stdout should contain "Started the OpenShift cluster"
-        When with up to "8" retries with wait period of "2m" command "crc status" output matches ".*Running \(v\d+\.\d+\.\d+.*\).*"
+        When checking that CRC is running
         Then executing "eval $(crc oc-env)" succeeds
         And login to the oc cluster succeeds
 

--- a/test/integration/features/story_registry.feature
+++ b/test/integration/features/story_registry.feature
@@ -1,10 +1,9 @@
 @story_registry @linux
-Feature: Local image to image-registry to deployment
+Feature: Local image to image-registry
 
-    The user creates a local container image with an app. They then
-    push it to the openshift image-registry in their
-    project/namespace. They deploy and expose the app and check its
-    accessibility.
+    User creates a local container image with an app inside it. They then
+    push it to the OpenShift image-registry in their project/namespace.
+    They deploy and expose the app and check its accessibility.
 
     Scenario: Start CRC and login to cluster
         Given executing "crc setup" succeeds


### PR DESCRIPTION
**Fixes:** Issue #1737 

## Solution

The entire `crc status` check is hidden in one function. If looking for `Stopped` status, then exit with success as soon as status returns `Stopped` for the first time. If looking for `Running` status, then exit with success only if 3 consecutive probes (at 1min intervals) return `Running` cluster status. The probing is set to 15x1min.

Second commit updates the language in Feature files.

## Testing

1. `make integration` succeeds
