### PR TITLE
Unit for memory sizes are is MB, not MiB

### DIFF
--- a/cmd/crc/cmd/start.go
+++ b/cmd/crc/cmd/start.go
@@ -30,7 +30,7 @@ func init() {
 	flagSet.StringP(cmdConfig.Bundle, "b", constants.DefaultBundlePath, "The system bundle used for deployment of the OpenShift cluster")
 	flagSet.StringP(cmdConfig.PullSecretFile, "p", "", fmt.Sprintf("File path of image pull secret (download from %s)", constants.CrcLandingPageURL))
 	flagSet.IntP(cmdConfig.CPUs, "c", constants.DefaultCPUs, "Number of CPU cores to allocate to the OpenShift cluster")
-	flagSet.IntP(cmdConfig.Memory, "m", constants.DefaultMemory, "MiB of memory to allocate to the OpenShift cluster")
+	flagSet.IntP(cmdConfig.Memory, "m", constants.DefaultMemory, "MB of memory to allocate to the OpenShift cluster")
 	flagSet.UintP(cmdConfig.DiskSize, "d", constants.DefaultDiskSize, "Total size in GiB of the disk used by the OpenShift cluster")
 	flagSet.StringP(cmdConfig.NameServer, "n", "", "IPv4 address of nameserver to use for the OpenShift cluster")
 	flagSet.Bool(cmdConfig.DisableUpdateCheck, false, "Don't check for update")

--- a/docs/source/topics/proc_configuring-the-virtual-machine.adoc
+++ b/docs/source/topics/proc_configuring-the-virtual-machine.adoc
@@ -39,8 +39,8 @@ $ {bin} config set memory __<number-in-mib>__
 +
 [NOTE]
 ====
-Values for available memory are set in mebibytes (MiB).
-One gibibyte (GiB) of memory is equal to 1024 MiB.
+Values for available memory are set in megabytes (MB).
+One gigabyte (GB) of memory is equal to 1000 MB.
 ====
 +
 The default value for the `memory` property is `9216`.

--- a/pkg/crc/config/validations.go
+++ b/pkg/crc/config/validations.go
@@ -48,7 +48,7 @@ func ValidateCPUs(value interface{}) (bool, string) {
 func ValidateMemory(value interface{}) (bool, string) {
 	v, err := cast.ToIntE(value)
 	if err != nil {
-		return false, fmt.Sprintf("requires integer value in MiB >= %d", constants.DefaultMemory)
+		return false, fmt.Sprintf("requires integer value in MB >= %d", constants.DefaultMemory)
 	}
 	if err := validation.ValidateMemory(v); err != nil {
 		return false, err.Error()

--- a/pkg/crc/machine/types.go
+++ b/pkg/crc/machine/types.go
@@ -11,7 +11,7 @@ type StartConfig struct {
 	BundlePath string
 
 	// Hypervisor
-	Memory   int // Memory size in MiB
+	Memory   int // Memory size in MB
 	CPUs     int
 	DiskSize int // Disk size in GiB
 

--- a/pkg/crc/preflight/preflight_checks_common.go
+++ b/pkg/crc/preflight/preflight_checks_common.go
@@ -44,7 +44,7 @@ var genericPreflightChecks = [...]Check{
 		check: func() error {
 			return validation.ValidateEnoughMemory(constants.DefaultMemory)
 		},
-		fixDescription: fmt.Sprintf("crc requires at least %s to run", units.HumanSize(float64(constants.DefaultMemory*1024*1024))),
+		fixDescription: fmt.Sprintf("crc requires at least %s to run", units.HumanSize(float64(constants.DefaultMemory*1000*1000))),
 		flags:          NoFix,
 	},
 	{

--- a/pkg/crc/validation/validation.go
+++ b/pkg/crc/validation/validation.go
@@ -27,7 +27,7 @@ func ValidateCPUs(value int) error {
 // ValidateMemory checks if provided Memory count is valid
 func ValidateMemory(value int) error {
 	if value < constants.DefaultMemory {
-		return fmt.Errorf("requires memory in MiB >= %d", constants.DefaultMemory)
+		return fmt.Errorf("requires memory in MB >= %d", constants.DefaultMemory)
 	}
 	return ValidateEnoughMemory(value)
 }
@@ -48,7 +48,7 @@ func ValidateDiskSize(value int) error {
 func ValidateEnoughMemory(value int) error {
 	totalMemory := memory.TotalMemory()
 	logging.Debugf("Total memory of system is %d bytes", totalMemory)
-	valueBytes := value * 1024 * 1024
+	valueBytes := value * 1000 * 1000
 	if totalMemory < uint64(valueBytes) {
 		return fmt.Errorf("only %s of memory found (%s required)",
 			units.HumanSize(float64(totalMemory)),


### PR DESCRIPTION
The libvirt machine driver expects memory sizes to be in MB (megabytes,
1000*1000 bytes), while crc documents memory sizes to be in MiB.
The difference is not too bad, if X MB is enough, X MiB will most likely
be enough, and vice versa.
Let's fix this though to avoid potential confusion.

https://github.com/code-ready/machine-driver-libvirt/blob/29905467a281ab60c40cc00a38957919fbdd1f00/pkg/libvirt/libvirt.go#L118-L122
https://github.com/code-ready/machine-driver-libvirt/blob/29905467a281ab60c40cc00a38957919fbdd1f00/pkg/libvirt/domain.go#L13-L16