### PR TITLE
Remove network manager and dnsmasq config in case systemd-resolved active

### DIFF
--- a/pkg/crc/preflight/preflight_checks_network_linux.go
+++ b/pkg/crc/preflight/preflight_checks_network_linux.go
@@ -95,6 +95,13 @@ exit 0
 
 var systemdResolvedPreflightChecks = [...]Check{
 	{
+		configKeySuffix:  "check-dnsmasq-network-manager-config",
+		checkDescription: "Checking if dnsmasq configurations file exist for NetworkManager",
+		check:            checkCrcDnsmasqAndNetworkManagerConfigFile,
+		fixDescription:   "Removing dnsmasq configuration file for NetworkManager",
+		fix:              fixCrcDnsmasqAndNetworkManagerConfigFile,
+	},
+	{
 		configKeySuffix:  "check-systemd-resolved-running",
 		checkDescription: "Checking if the systemd-resolved service is running",
 		check:            checkSystemdResolvedIsRunning,
@@ -270,4 +277,27 @@ func fixCrcNetworkManagerDispatcherFile() error {
 
 func removeCrcNetworkManagerDispatcherFile() error {
 	return removeNetworkManagerConfigFile(crcNetworkManagerDispatcherPath)
+}
+
+func checkCrcDnsmasqAndNetworkManagerConfigFile() error {
+	// IF check return nil, which means file
+	if _, err := os.Stat(crcDnsmasqConfigPath); !os.IsNotExist(err) {
+		return fmt.Errorf("%s file exists", crcDnsmasqConfigPath)
+	}
+	if _, err := os.Stat(crcNetworkManagerConfigPath); !os.IsNotExist(err) {
+		return fmt.Errorf("%s file exists", crcNetworkManagerConfigPath)
+	}
+	return nil
+}
+
+func fixCrcDnsmasqAndNetworkManagerConfigFile() error {
+	// In case user upgrades from f-32 to f-33 the dnsmasq config for NM still
+	// exists and needs to be removed.
+	if err := removeCrcNetworkManagerConfig(); err != nil {
+		logging.Debugf("%s: not present.", crcNetworkManagerConfigPath)
+	}
+	if err := removeCrcDnsmasqConfigFile(); err != nil {
+		logging.Debugf("%s: not present.", crcDnsmasqConfigPath)
+	}
+	return nil
 }


### PR DESCRIPTION
User who upgraded from fedora-32 to 33 and also used crc on 32 then
the networkmanager and dnsmasq configuration will be present and need
to be removed before adding the dispatcher file.
