### PR TITLE
preflight: Rename dispatcher file config option

### DIFF
--- a/pkg/crc/preflight/preflight_checks_network_linux.go
+++ b/pkg/crc/preflight/preflight_checks_network_linux.go
@@ -102,7 +102,7 @@ var systemdResolvedPreflightChecks = [...]Check{
 		flags:            NoFix,
 	},
 	{
-		configKeySuffix:    "check-crc-nm-dispatcher-file",
+		configKeySuffix:    "check-network-manager-dispatcher-file",
 		checkDescription:   fmt.Sprintf("Checking if %s exists", crcNetworkManagerDispatcherPath),
 		check:              checkCrcNetworkManagerDispatcherFile,
 		fixDescription:     "Writing NetworkManager dispatcher file for crc",


### PR DESCRIPTION
All other configuration options use "network-manager", not just "nm".
Since this was not part of a release yet, it's still time to rename
check-crc-nm-dispatcher-file to a better name.