### PR TITLE
cleanup: Don't error out when hyperkit is not running

### DIFF
--- a/pkg/crc/preflight/preflight_checks_darwin.go
+++ b/pkg/crc/preflight/preflight_checks_darwin.go
@@ -189,11 +189,9 @@ func addFileWritePermissionToUser(filename string) error {
 func stopCRCHyperkitProcess() error {
 	path, err := exec.LookPath("pkill")
 	if err != nil {
-		logging.Debugf("Could not find 'pkill'. %v", err)
 		return fmt.Errorf("Could not find 'pkill'. %w", err)
 	}
 	if _, _, err := crcos.RunWithDefaultLocale(path, "-f", filepath.Join(constants.CrcBinDir, "hyperkit")); err != nil {
-		logging.Debugf("Failed to kill 'hyperkit' process. %v", err)
 		return fmt.Errorf("Failed to kill 'hyperkit' process. %w", err)
 	}
 	return nil


### PR DESCRIPTION
When running `crc cleanup` on macOS while no hyperkit processes are
running, crc cleanup ends with:

$ crc cleanup --log-level debug
DEBU CodeReady Containers version: 1.19.0+d4ad56f
DEBU OpenShift version: 4.6.6 (not embedded in executable)
INFO Unload CodeReady Containers tray
INFO Unload CodeReady Containers daemon
INFO Removing launchd configuration for tray
INFO Removing launchd configuration for daemon
INFO Removing /etc/resolver/testing file
DEBU Removing /etc/resolver/testing file
INFO Will use root access: Remove file /etc/resolver/testing
DEBU Running '/usr/bin/sudo rm -f /etc/resolver/testing'
INFO Stopping CRC Hyperkit process
DEBU Running '/usr/bin/pkill -f /Users/crcqe/.crc/bin/hyperkit'
DEBU Command failed: exit status 1
DEBU stdout:
DEBU stderr:
DEBU Failed to kill 'hyperkit' process. exit status 1
DEBU Failed to kill 'hyperkit' process. exit status 1
INFO Removing CRC Machine Instance directory
DEBU Deleting machines directory
Failed to kill 'hyperkit' process. exit status 1

No hyperkit processes running should not be an error. This commit fixes
this by running pgrep first, and checking its exit code to detect if
a hyperkit process was found.

This fixes https://github.com/code-ready/crc/issues/1749



**Fixes:** Issue #N

**Relates to:** Issue #N, PR #N, ...

## Solution/Idea

Describe in plain English what you solved and how. For instance, _Added `start` command to CRC so the user can create a VM and set-up a single-node OpenShift cluster on it with one command. It requires blablabla..._

## Proposed changes

List main as well as consequential changes you introduced or had to introduce.

1. Add `start` command.
2. Add `setup` as prerequisite to `start`.
3. ...

## Testing

What is the _bottom-line_ functionality that needs testing? Describe in pseudo-code or in English. Use verifiable statements that tie your changes to existing functionality.

1. `start` succeeds first time after `setup` succeeded
2. stdout contains ... if `start` succeeded
3. stderr contains ... after `start` failed
4. `status` returns ... if `start` succeeded
5. `status` returns ... if `start` failed
6. `start` fails after `start` succeeded or after `status` says CRC is `Running`
7. ...