### PR TITLE
Issue #1490: Better recognize disk usage by regex

### DIFF
--- a/test/integration/features/basic.feature
+++ b/test/integration/features/basic.feature
@@ -95,7 +95,7 @@ Feature: Basic test
     @darwin @linux @windows
     Scenario: CRC status and disk space check
         When checking that CRC is running
-        And stdout should match ".*Disk Usage: *\d+\.\d+GB of 32.\d+GB.*"
+        And stdout should match ".*Disk Usage: *\d+[\.\d]*GB of 32.\d+GB.*"
 
     @darwin @linux @windows
     Scenario: CRC IP check


### PR DESCRIPTION
**Fixes:** Issue #1490 

Only found 1 instance in `basic.feature`. 

## Testing

Try to get your disk usage to be an integer, then run the `basic.feature` and hope it's still an integer when the check happens :). Or, here's a [go playground](https://play.golang.org/p/u0tFvgJlcT1) where the new regex recognizes both cases. 