### PR TITLE
Switch go.mod to 1.14

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
     macos:
       xcode: "10.0.0"
     environment:
-      GOVERSION: "1.13.4"
+      GOVERSION: "1.14.13"
 
 ## Build crc
     steps:
@@ -41,7 +41,7 @@ jobs:
     machine:
       image: ubuntu-1604:202007-01
     environment:
-      GOVERSION: "1.13.4"
+      GOVERSION: "1.14.13"
       CONTAINER_RUNTIME: "docker"
     steps:
       - checkout

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,12 @@
 dist: bionic
-
 language: go
-
 go:
-- 1.13.4
-
+  - 1.14.13
 before_script:
   - echo "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_18.04 /" | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
   - curl -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_18.04/Release.key | sudo apt-key add -
   - sudo apt-get update -qq
   - sudo apt-get -qq -y install podman
-
 script:
-- make check
-- make BUNDLE_DIR=/tmp MOCK_BUNDLE=true release
+  - make check
+  - make BUNDLE_DIR=/tmp MOCK_BUNDLE=true release

--- a/Makefile
+++ b/Makefile
@@ -206,3 +206,11 @@ embed_bundle: clean cross $(HOST_BUILD_DIR)/crc-embedder check_bundledir $(HYPER
 	$(HOST_BUILD_DIR)/crc-embedder embed --log-level debug --goos=darwin --bundle-dir=$(BUNDLE_DIR) $(BUILD_DIR)/macos-amd64/crc
 	$(HOST_BUILD_DIR)/crc-embedder embed --log-level debug --goos=linux --bundle-dir=$(BUNDLE_DIR) $(BUILD_DIR)/linux-amd64/crc
 	$(HOST_BUILD_DIR)/crc-embedder embed --log-level debug --goos=windows --bundle-dir=$(BUNDLE_DIR) $(BUILD_DIR)/windows-amd64/crc.exe
+
+.PHONY: update-go-version
+update-go-version:
+	./update-go-version.sh 1.14
+
+.PHONY: goversioncheck
+goversioncheck:
+	./verify-go-version.sh

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,15 +1,10 @@
 build: off
-
 clone_folder: c:\gopath\src\github.com\code-ready\crc
-
 environment:
   GOPATH: c:\gopath
-
 stack: go 1.14
-
 before_test:
   - choco install make
   - make cross
-
 test_script:
   - make test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ clone_folder: c:\gopath\src\github.com\code-ready\crc
 environment:
   GOPATH: c:\gopath
 
-stack: go 1.13
+stack: go 1.14
 
 before_test:
   - choco install make

--- a/centos_ci.sh
+++ b/centos_ci.sh
@@ -3,7 +3,7 @@
 # bundle location
 BUNDLE_VERSION=4.6.6
 BUNDLE=crc_libvirt_$BUNDLE_VERSION.crcbundle
-GO_VERSION=1.13.4
+GO_VERSION=1.14.13
 
 # Output command before executing
 set -x

--- a/centos_ci.sh
+++ b/centos_ci.sh
@@ -54,7 +54,6 @@ function install_required_packages() {
 		 libcurl-devel \
 		 glib2-devel \
 		 openssl-devel \
-		 asciidoc \
 		 unzip \
 		 podman
 

--- a/centos_ci.sh
+++ b/centos_ci.sh
@@ -51,9 +51,6 @@ function install_required_packages() {
                  libvirt-devel \
                  jq \
                  gcc \
-		 libcurl-devel \
-		 glib2-devel \
-		 openssl-devel \
 		 unzip \
 		 podman
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/code-ready/crc
 
-go 1.13
+go 1.14
 
 require (
 	github.com/Masterminds/semver v1.5.0

--- a/images/openshift-ci/Dockerfile
+++ b/images/openshift-ci/Dockerfile
@@ -1,7 +1,7 @@
 # This Dockerfile is used by openshift CI
 # It builds an image containing crc and nss-wrapper for remote deployments, as well as the google cloud-sdk for nested GCE environments.
 
-FROM registry.svc.ci.openshift.org/openshift/release:golang-1.13 AS builder
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.14 AS builder
 WORKDIR /go/src/github.com/code-ready/crc
 COPY . .
 RUN make cross

--- a/update-go-version.sh
+++ b/update-go-version.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Updates our various build files, CI configs, ... to the latest released go
+# version in a given minor release stream (1.x)
+# This requires yq and jq in addition to fairly standard shell tools (curl, grep, sed, ...)
+
+golang_base_version=$1
+latest_version=$(curl --silent  'https://golang.org/dl/?mode=json&include=all' | jq -r '.[].files[].version'  |uniq | sed -e 's/go//' |sort -V |grep ${golang_base_version}|tail -1)
+echo "Updating golang version to $latest_version"
+
+go mod edit -go ${golang_base_version}
+sed -i "s,^FROM registry.svc.ci.openshift.org/openshift/release:golang-1\... AS builder\$,FROM registry.svc.ci.openshift.org/openshift/release:golang-${golang_base_version} AS builder," images/openshift-ci/Dockerfile
+sed -i "s/GOVERSION: .*\$/GOVERSION: \"${latest_version}\"/" .circleci/config.yml
+sed -i "s/^GO_VERSION=.*$/GO_VERSION=${latest_version}/" centos_ci.sh
+yq write --inplace ./appveyor.yml  stack "go ${golang_base_version}"
+yq write --inplace ./.travis.yml go[0] ${latest_version}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -2,12 +2,14 @@
 github.com/Azure/go-ansiterm
 github.com/Azure/go-ansiterm/winterm
 # github.com/Masterminds/semver v1.5.0
+## explicit
 github.com/Masterminds/semver
 # github.com/RangelReale/osincli v0.0.0-20160924135400-fababb0555f2
 github.com/RangelReale/osincli
 # github.com/VividCortex/ewma v1.1.1
 github.com/VividCortex/ewma
 # github.com/YourFin/binappend v0.0.0-20181105185800-0add4bf0b9ad
+## explicit
 github.com/YourFin/binappend
 # github.com/alexbrainman/sspi v0.0.0-20180613141037-e580b900e9f5
 github.com/alexbrainman/sspi
@@ -17,16 +19,21 @@ github.com/apcera/gssapi
 # github.com/apparentlymart/go-cidr v1.1.0
 github.com/apparentlymart/go-cidr/cidr
 # github.com/asaskevich/govalidator v0.0.0-20200907205600-7a23bdc65eef
+## explicit
 github.com/asaskevich/govalidator
 # github.com/cavaliercoder/grab v2.0.0+incompatible
+## explicit
 github.com/cavaliercoder/grab
 # github.com/cheggaaa/pb/v3 v3.0.5
+## explicit
 github.com/cheggaaa/pb/v3
 github.com/cheggaaa/pb/v3/termutil
 # github.com/code-ready/clicumber v0.0.0-20200728062640-1203dda97f67
+## explicit
 github.com/code-ready/clicumber/testsuite
 github.com/code-ready/clicumber/util
 # github.com/code-ready/gvisor-tap-vsock v0.0.0-20201105131011-9258bacc7a6c
+## explicit
 github.com/code-ready/gvisor-tap-vsock/pkg/services/dns
 github.com/code-ready/gvisor-tap-vsock/pkg/services/forwarder
 github.com/code-ready/gvisor-tap-vsock/pkg/tap
@@ -34,6 +41,7 @@ github.com/code-ready/gvisor-tap-vsock/pkg/transport
 github.com/code-ready/gvisor-tap-vsock/pkg/types
 github.com/code-ready/gvisor-tap-vsock/pkg/virtualnetwork
 # github.com/code-ready/machine v0.0.0-20201202090222-9558ae8c05b9
+## explicit
 github.com/code-ready/machine/drivers/hyperkit
 github.com/code-ready/machine/drivers/hyperv
 github.com/code-ready/machine/drivers/libvirt
@@ -52,21 +60,26 @@ github.com/code-ready/machine/libmachine/version
 # github.com/cucumber/gherkin-go/v11 v11.0.0
 github.com/cucumber/gherkin-go/v11
 # github.com/cucumber/godog v0.9.0
+## explicit
 github.com/cucumber/godog
 github.com/cucumber/godog/colors
 # github.com/cucumber/messages-go/v10 v10.0.3
+## explicit
 github.com/cucumber/messages-go/v10
 # github.com/davecgh/go-spew v1.1.1
 github.com/davecgh/go-spew/spew
 # github.com/docker/docker v1.13.1 => github.com/docker/docker v1.4.2-0.20191121165722-d1d5f6476656
+## explicit
 github.com/docker/docker/pkg/term
 github.com/docker/docker/pkg/term/windows
 # github.com/docker/go-units v0.4.0
+## explicit
 github.com/docker/go-units
 # github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96
 github.com/docker/spdystream
 github.com/docker/spdystream/spdy
 # github.com/fatih/color v1.10.0
+## explicit
 github.com/fatih/color
 # github.com/fsnotify/fsnotify v1.4.9
 github.com/fsnotify/fsnotify
@@ -79,9 +92,12 @@ github.com/gogo/protobuf/io
 github.com/gogo/protobuf/proto
 github.com/gogo/protobuf/sortkeys
 # github.com/golang/protobuf v1.4.3
+## explicit
 github.com/golang/protobuf/proto
 # github.com/google/btree v1.0.0
 github.com/google/btree
+# github.com/google/go-cmp v0.5.4
+## explicit
 # github.com/google/gofuzz v1.1.0
 github.com/google/gofuzz
 # github.com/google/gopacket v1.1.16
@@ -90,8 +106,10 @@ github.com/google/gopacket/layers
 # github.com/google/tcpproxy v0.0.0-20200125044825-b6bb9b5b8252
 github.com/google/tcpproxy
 # github.com/google/uuid v1.1.2
+## explicit
 github.com/google/uuid
 # github.com/h2non/filetype v1.1.0
+## explicit
 github.com/h2non/filetype
 github.com/h2non/filetype/matchers
 github.com/h2non/filetype/matchers/isobmff
@@ -108,9 +126,11 @@ github.com/hashicorp/hcl/json/parser
 github.com/hashicorp/hcl/json/scanner
 github.com/hashicorp/hcl/json/token
 # github.com/hectane/go-acl v0.0.0-20190604041725-da78bae5fc95
+## explicit
 github.com/hectane/go-acl
 github.com/hectane/go-acl/api
 # github.com/imdario/mergo v0.3.11
+## explicit
 github.com/imdario/mergo
 # github.com/inconshreveable/mousetrap v1.0.0
 github.com/inconshreveable/mousetrap
@@ -119,26 +139,32 @@ github.com/json-iterator/go
 # github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 github.com/kballard/go-shellquote
 # github.com/libvirt/libvirt-go-xml v6.10.0+incompatible
+## explicit
 github.com/libvirt/libvirt-go-xml
 # github.com/linuxkit/virtsock v0.0.0-20180830132707-8e79449dea07
 github.com/linuxkit/virtsock/pkg/hvsock
 # github.com/magiconair/properties v1.8.4
+## explicit
 github.com/magiconair/properties
 # github.com/mattn/go-colorable v0.1.8
+## explicit
 github.com/mattn/go-colorable
 # github.com/mattn/go-isatty v0.0.12
 github.com/mattn/go-isatty
 # github.com/mattn/go-runewidth v0.0.9
+## explicit
 github.com/mattn/go-runewidth
 # github.com/mdlayher/vsock v0.0.0-20200508120832-7ad3638b3fbc
 github.com/mdlayher/vsock
 # github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d
+## explicit
 github.com/mgutz/ansi
 # github.com/miekg/dns v1.1.35
 github.com/miekg/dns
 # github.com/mitchellh/go-wordwrap v1.0.0
 github.com/mitchellh/go-wordwrap
 # github.com/mitchellh/mapstructure v1.4.0
+## explicit
 github.com/mitchellh/mapstructure
 # github.com/moby/term v0.0.0-20200312100748-672ec06f55cd
 github.com/moby/term
@@ -148,47 +174,63 @@ github.com/modern-go/concurrent
 # github.com/modern-go/reflect2 v1.0.1
 github.com/modern-go/reflect2
 # github.com/openshift/api v0.0.0-20200930075302-db52bc4ef99f
+## explicit
 github.com/openshift/api/config/v1
 # github.com/openshift/library-go v0.0.0-20201007105531-fcceeb075980
 github.com/openshift/library-go/pkg/oauth/oauthdiscovery
 # github.com/openshift/oc v0.0.0-alpha.0.0.20201126035554-299b6af535d1
+## explicit
 github.com/openshift/oc/pkg/helpers/term
 github.com/openshift/oc/pkg/helpers/tokencmd
 # github.com/pbnjay/memory v0.0.0-20201129165224-b12e5d931931
+## explicit
 github.com/pbnjay/memory
 # github.com/pborman/uuid v1.2.1
+## explicit
 github.com/pborman/uuid
 # github.com/pelletier/go-toml v1.8.1
+## explicit
 github.com/pelletier/go-toml
 # github.com/pkg/browser v0.0.0-20201207095918-0426ae3fba23
+## explicit
 github.com/pkg/browser
 # github.com/pkg/errors v0.9.1
+## explicit
 github.com/pkg/errors
 # github.com/pmezard/go-difflib v1.0.0
 github.com/pmezard/go-difflib/difflib
 # github.com/sirupsen/logrus v1.7.0
+## explicit
 github.com/sirupsen/logrus
 # github.com/spf13/afero v1.4.1
+## explicit
 github.com/spf13/afero
 github.com/spf13/afero/mem
 # github.com/spf13/cast v1.3.1
+## explicit
 github.com/spf13/cast
 # github.com/spf13/cobra v1.1.1
+## explicit
 github.com/spf13/cobra
 # github.com/spf13/jwalterweatherman v1.1.0
 github.com/spf13/jwalterweatherman
 # github.com/spf13/pflag v1.0.5
+## explicit
 github.com/spf13/pflag
 # github.com/spf13/viper v1.7.1
+## explicit
 github.com/spf13/viper
 # github.com/stretchr/testify v1.6.1
+## explicit
 github.com/stretchr/testify/assert
 github.com/stretchr/testify/require
 # github.com/subosito/gotenv v1.2.0
 github.com/subosito/gotenv
 # github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8
+## explicit
 github.com/xi2/xz
 # golang.org/x/crypto v0.0.0-20201203163018-be400aefbc4c
+## explicit
 golang.org/x/crypto/blowfish
 golang.org/x/crypto/chacha20
 golang.org/x/crypto/curve25519
@@ -200,6 +242,7 @@ golang.org/x/crypto/ssh
 golang.org/x/crypto/ssh/internal/bcrypt_pbkdf
 golang.org/x/crypto/ssh/terminal
 # golang.org/x/net v0.0.0-20201202161906-c7110b5ffcbb
+## explicit
 golang.org/x/net/bpf
 golang.org/x/net/context
 golang.org/x/net/context/ctxhttp
@@ -212,11 +255,14 @@ golang.org/x/net/internal/socket
 golang.org/x/net/ipv4
 golang.org/x/net/ipv6
 # golang.org/x/oauth2 v0.0.0-20201203001011-0b49973bad19
+## explicit
 golang.org/x/oauth2
 golang.org/x/oauth2/internal
 # golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
+## explicit
 golang.org/x/sync/semaphore
 # golang.org/x/sys v0.0.0-20201204225414-ed752295db88
+## explicit
 golang.org/x/sys/cpu
 golang.org/x/sys/internal/unsafeheader
 golang.org/x/sys/plan9
@@ -227,8 +273,10 @@ golang.org/x/sys/windows/svc
 golang.org/x/sys/windows/svc/debug
 golang.org/x/sys/windows/svc/eventlog
 # golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1
+## explicit
 golang.org/x/term
 # golang.org/x/text v0.3.4
+## explicit
 golang.org/x/text/encoding
 golang.org/x/text/encoding/internal
 golang.org/x/text/encoding/internal/identifier
@@ -240,8 +288,10 @@ golang.org/x/text/transform
 golang.org/x/text/unicode/bidi
 golang.org/x/text/unicode/norm
 # golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e
+## explicit
 golang.org/x/time/rate
 # google.golang.org/appengine v1.6.7
+## explicit
 google.golang.org/appengine/internal
 google.golang.org/appengine/internal/base
 google.golang.org/appengine/internal/datastore
@@ -276,14 +326,17 @@ google.golang.org/protobuf/reflect/protoregistry
 google.golang.org/protobuf/runtime/protoiface
 google.golang.org/protobuf/runtime/protoimpl
 # gopkg.in/AlecAivazis/survey.v1 v1.8.8
+## explicit
 gopkg.in/AlecAivazis/survey.v1
 gopkg.in/AlecAivazis/survey.v1/core
 gopkg.in/AlecAivazis/survey.v1/terminal
 # gopkg.in/inf.v0 v0.9.1
 gopkg.in/inf.v0
 # gopkg.in/ini.v1 v1.62.0
+## explicit
 gopkg.in/ini.v1
 # gopkg.in/yaml.v2 v2.4.0
+## explicit
 gopkg.in/yaml.v2
 # gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c
 gopkg.in/yaml.v3
@@ -319,8 +372,10 @@ gvisor.dev/gvisor/pkg/tcpip/transport/tcpconntrack
 gvisor.dev/gvisor/pkg/tcpip/transport/udp
 gvisor.dev/gvisor/pkg/waiter
 # howett.net/plist v0.0.0-20201203080718-1454fab16a06
+## explicit
 howett.net/plist
 # k8s.io/api v0.19.0 => k8s.io/api v0.19.0
+## explicit
 k8s.io/api/certificates/v1beta1
 k8s.io/api/core/v1
 # k8s.io/apimachinery v0.19.0 => github.com/openshift/kubernetes-apimachinery v0.0.0-20200831185207-c0eb43ac4a3e
@@ -363,6 +418,7 @@ k8s.io/apimachinery/pkg/watch
 k8s.io/apimachinery/third_party/forked/golang/netutil
 k8s.io/apimachinery/third_party/forked/golang/reflect
 # k8s.io/client-go v0.19.0 => github.com/openshift/kubernetes-client-go v0.0.0-20200908071752-9409de4c95e0
+## explicit
 k8s.io/client-go/pkg/apis/clientauthentication
 k8s.io/client-go/pkg/apis/clientauthentication/v1alpha1
 k8s.io/client-go/pkg/apis/clientauthentication/v1beta1
@@ -397,3 +453,32 @@ k8s.io/utils/integer
 sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.2.0
 sigs.k8s.io/yaml
+# github.com/Microsoft/hcsshim => github.com/Microsoft/hcsshim v0.8.10
+# github.com/apcera/gssapi => github.com/openshift/gssapi v0.0.0-20161010215902-5fb4217df13b
+# github.com/containers/image => github.com/openshift/containers-image v0.0.0-20190130162819-76de87591e9d
+# github.com/docker/docker => github.com/docker/docker v1.4.2-0.20191121165722-d1d5f6476656
+# k8s.io/api => k8s.io/api v0.19.0
+# k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.19.0
+# k8s.io/apimachinery => github.com/openshift/kubernetes-apimachinery v0.0.0-20200831185207-c0eb43ac4a3e
+# k8s.io/apiserver => k8s.io/apiserver v0.19.0
+# k8s.io/cli-runtime => github.com/openshift/kubernetes-cli-runtime v0.0.0-20200831185531-852eec47b608
+# k8s.io/client-go => github.com/openshift/kubernetes-client-go v0.0.0-20200908071752-9409de4c95e0
+# k8s.io/cloud-provider => k8s.io/cloud-provider v0.19.0
+# k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.19.0
+# k8s.io/code-generator => k8s.io/code-generator v0.19.0
+# k8s.io/component-base => k8s.io/component-base v0.19.0
+# k8s.io/cri-api => k8s.io/cri-api v0.19.0
+# k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.19.0
+# k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.19.0
+# k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.19.0
+# k8s.io/kube-proxy => k8s.io/kube-proxy v0.19.0
+# k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.19.0
+# k8s.io/kubectl => github.com/openshift/kubernetes-kubectl v0.0.0-20200922135455-1f5b2cd472a9
+# k8s.io/kubelet => k8s.io/kubelet v0.19.0
+# k8s.io/kubernetes => github.com/openshift/kubernetes v1.20.0-alpha.0.0.20200922142336-4700daee7399
+# k8s.io/legacy-cloud-providers => k8s.io/legacy-cloud-providers v0.19.0
+# k8s.io/metrics => k8s.io/metrics v0.19.0
+# k8s.io/node-api => k8s.io/node-api v0.19.0
+# k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.19.0
+# k8s.io/sample-cli-plugin => k8s.io/sample-cli-plugin v0.19.0
+# k8s.io/sample-controller => k8s.io/sample-controller v0.19.0

--- a/verify-go-version.sh
+++ b/verify-go-version.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+export GO111MODULE=on
+
+readonly REPO_ROOT_DIR="$(git rev-parse --show-toplevel 2> /dev/null)"
+readonly TMP_DIFFROOT="$(mktemp -d "${REPO_ROOT_DIR}"/tmpdiffroot.XXXXXX)"
+
+cleanup() {
+  rm -rf "${TMP_DIFFROOT}"
+}
+
+trap "cleanup" EXIT SIGINT
+
+cleanup
+
+git clone "${REPO_ROOT_DIR}" "${TMP_DIFFROOT}"
+
+make -C "${TMP_DIFFROOT}" update-go-version
+
+echo "Diffing ${REPO_ROOT_DIR} against tree with freshly updated golang version"
+ret=0
+git --no-pager -C ${TMP_DIFFROOT} diff --exit-code 2>&1 >/dev/null || ret=1
+#diff -Naupr "${REPO_ROOT_DIR}/vendor" "${TMP_DIFFROOT}/vendor" || ret=1
+
+if [[ $ret -eq 0 ]]
+then
+  echo "${REPO_ROOT_DIR} up to date."
+else
+  echo "${REPO_ROOT_DIR} is out of date. Please run make update-go-version"
+  exit 1
+fi


### PR DESCRIPTION
This makes go automatically add -mod=vendor when needed so that
our vendor/ directory is used.
This fixes https://github.com/code-ready/crc/issues/1767

Some openshift components have already switched to 1.14 or newer in 4.6,
rhel8.3 has a new enough golang, so I think this can be done now without
waiting for 4.7