### PR TITLE
Add flag to crc start to automatically turn on monitoring stack

### DIFF
--- a/cmd/crc/cmd/config/config.go
+++ b/cmd/crc/cmd/config/config.go
@@ -24,6 +24,7 @@ const (
 	HTTPSProxy           = "https-proxy"
 	NoProxy              = "no-proxy"
 	ProxyCAFile          = "proxy-ca-file"
+	EnableMonitoring     = "enable-monitoring"
 )
 
 func RegisterSettings(cfg *config.Config) {
@@ -42,6 +43,8 @@ func RegisterSettings(cfg *config.Config) {
 	cfg.AddSetting(HTTPSProxy, "", config.ValidateURI, config.SuccessfullyApplied)
 	cfg.AddSetting(NoProxy, "", config.ValidateNoProxy, config.SuccessfullyApplied)
 	cfg.AddSetting(ProxyCAFile, "", config.ValidatePath, config.SuccessfullyApplied)
+
+	cfg.AddSetting(EnableMonitoring, false, config.ValidateBool, config.SuccessfullyApplied)
 }
 
 func isPreflightKey(key string) bool {

--- a/cmd/crc/cmd/start.go
+++ b/cmd/crc/cmd/start.go
@@ -34,6 +34,7 @@ func init() {
 	flagSet.UintP(cmdConfig.DiskSize, "d", constants.DefaultDiskSize, "Total size in GiB of the disk used by the OpenShift cluster")
 	flagSet.StringP(cmdConfig.NameServer, "n", "", "IPv4 address of nameserver to use for the OpenShift cluster")
 	flagSet.Bool(cmdConfig.DisableUpdateCheck, false, "Don't check for update")
+	flagSet.Bool(cmdConfig.EnableMonitoring, false, "Enable monitoring stack")
 
 	startCmd.Flags().AddFlagSet(flagSet)
 }
@@ -72,6 +73,7 @@ func runStart(arguments []string) (*machine.StartResult, error) {
 		PullSecret: &cluster.PullSecret{
 			Getter: getPullSecretFileContent,
 		},
+		EnableMonitoring: config.Get(cmdConfig.EnableMonitoring).AsBool(),
 	}
 
 	client := newMachine()

--- a/pkg/crc/cluster/monitoring.go
+++ b/pkg/crc/cluster/monitoring.go
@@ -1,0 +1,39 @@
+package cluster
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/code-ready/crc/pkg/crc/oc"
+	v1 "github.com/openshift/api/config/v1"
+	log "github.com/sirupsen/logrus"
+)
+
+func StartMonitoring(ocConfig oc.Config) error {
+	data, _, err := ocConfig.RunOcCommand("get", "clusterversion/version", "-o", "json")
+	if err != nil {
+		return err
+	}
+
+	var cv v1.ClusterVersion
+	if err := json.Unmarshal([]byte(data), &cv); err != nil {
+		return err
+	}
+
+	pos := -1
+	for i, override := range cv.Spec.Overrides {
+		if override.Name == "cluster-monitoring-operator" {
+			pos = i
+			break
+		}
+	}
+	if pos == -1 {
+		log.Debug("monitoring operator not found in cluster version overrides")
+		return nil
+	}
+
+	_, _, err = ocConfig.RunOcCommand("patch", "clusterversion/version",
+		"--type", "json",
+		"--patch", fmt.Sprintf(`'[{"op":"remove", "path":"/spec/overrides/%d"}]'`, pos))
+	return err
+}

--- a/pkg/crc/machine/types.go
+++ b/pkg/crc/machine/types.go
@@ -20,6 +20,8 @@ type StartConfig struct {
 
 	// User Pull secret
 	PullSecret *cluster.PullSecret
+
+	EnableMonitoring bool
 }
 
 type ClusterConfig struct {


### PR DESCRIPTION
User can now use `enable-monitoring` flag with `crc start` and in
`crc config set`.

---

It can be improved by waiting for the cluster operator to be ready.