### PR TITLE
Add wait for apiserver function

### DIFF
--- a/pkg/crc/cluster/cluster.go
+++ b/pkg/crc/cluster/cluster.go
@@ -307,6 +307,20 @@ func WaitForRequestHeaderClientCaFile(sshRunner *ssh.Runner) error {
 	return errors.RetryAfter(8*time.Minute, lookupRequestHeaderClientCa, 2*time.Second)
 }
 
+func WaitForAPIServer(ocConfig oc.Config) error {
+	logging.Debugf("Waiting for apiserver availability")
+	waitForAPIServer := func() error {
+		stdout, stderr, err := ocConfig.RunOcCommand("get", "nodes")
+		if err != nil {
+			logging.Debug(stderr)
+			return &errors.RetriableError{Err: err}
+		}
+		logging.Debug(stdout)
+		return nil
+	}
+	return errors.RetryAfter(2*time.Minute, waitForAPIServer, time.Second)
+}
+
 func DeleteOpenshiftAPIServerPods(ocConfig oc.Config) error {
 	if err := WaitForOpenshiftResource(ocConfig, "pod"); err != nil {
 		return err

--- a/pkg/crc/machine/machine.go
+++ b/pkg/crc/machine/machine.go
@@ -375,6 +375,10 @@ func (client *client) Start(startConfig StartConfig) (*StartResult, error) {
 		return nil, errors.Wrap(err, "Failed to renew TLS certificates: please check if a newer CodeReady Containers release is available")
 	}
 
+	if err := cluster.WaitForAPIServer(ocConfig); err != nil {
+		return nil, errors.Wrap(err, "Error waiting for apiserver")
+	}
+
 	if !exists {
 		logging.Info("Configuring cluster for first start")
 		if err := configProxyForCluster(ocConfig, sshRunner, sd, proxyConfig, instanceIP); err != nil {


### PR DESCRIPTION
With current scenario, we start the kubelet and then check for secret resource
(80 sec wait+retry), most of the time during this retry the apiserver come up
and start serving the requests.

Recently we found out that during openshift dev cycle the cert rotation is set for
12 hours and our generated bundles are not able to modify those to 30 days one. This
change affect the serving and aggregator certs. With this patch we are trying to add
another waiting ~2 mins with (retry) to provide time for apisever to start serving to
the incoming requests.

- https://bugzilla.redhat.com/show_bug.cgi?id=1906290
- https://bugzilla.redhat.com/show_bug.cgi?id=1883790

As per test it takes around ~100sec before apiserver become responsive.
```
oc get nodes --context admin --cluster crc --kubeconfig /opt/kubeconfig
DEBU SSH command results: err: Process exited with status 1, output:
DEBU Unable to connect to the server: x509: certificate has expired or is not yet valid: current time 2020-12-15T12:12:49Z is
after 2020-12-07T20:40:59Z
DEBU error: Temporary error: ssh command error:
command : oc get nodes --context admin --cluster crc --kubeconfig /opt/kubeconfig
err     : Process exited with status 1
output  :  - sleeping 1s
DEBU retry loop: attempt 56
DEBU About to run SSH command:
oc get nodes --context admin --cluster crc --kubeconfig /opt/kubeconfig
DEBU SSH command results: err: <nil>, output: NAME                 STATUS   ROLES           AGE   VERSION
crc-qcmcx-master-0   Ready    master,worker   9d    v1.19.2+ad738ba
DEBU NAME                 STATUS   ROLES           AGE   VERSION
crc-qcmcx-master-0   Ready    master,worker   9d    v1.19.2+ad738ba
```


