### PR TITLE
Integration: Add check for enabled monitoring stack

### DIFF
--- a/test/integration/features/basic.feature
+++ b/test/integration/features/basic.feature
@@ -85,6 +85,14 @@ Feature: Basic test
         Then stderr should contain "Checking if the Hyper-V virtual switch exist"
 
     @darwin @linux @windows
+    Scenario: Request start with monitoring stack
+        When setting config property "enable-cluster-monitoring" to value "true" succeeds
+        And setting config property "memory" to value "14000" succeeds
+        Then starting CRC with default bundle fails
+        And stderr should contain "Too little memory"
+        And setting config property "memory" to value "16000" succeeds
+
+    @darwin @linux @windows
     Scenario: CRC start
         When starting CRC with default bundle succeeds
         Then stdout should contain "Started the OpenShift cluster"
@@ -112,6 +120,16 @@ Feature: Basic test
         When executing "crc console --credentials" succeeds
         Then stdout should contain "To login as a regular user, run 'oc login -u developer -p developer"
         And stdout should contain "To login as an admin, run 'oc login -u kubeadmin -p "
+
+    @darwin @linux @windows
+    Scenario: Monitoring stack check
+        Given checking that CRC is running
+        When executing "eval $(crc oc-env)" succeeds
+        And login to the oc cluster succeeds
+        And executing "oc get pods -n openshift-monitoring" succeeds
+        Then stdout matches ".*cluster-monitoring-operator-\w+-\w+\ *2/2\ *Running.*"
+        And unsetting config property "enable-cluster-monitoring" succeeds
+        And unsetting config property "memory" succeeds
 
     @darwin @linux @windows
     Scenario: CRC forcible stop


### PR DESCRIPTION
**Relates to:** PR #1774, PR #1787 and [this comment](https://github.com/code-ready/crc/pull/1774#issuecomment-744272906).

## Proposed changes

Add two scenarios to `basic.feature` (`enable-openshift-monitoring` in config settings; check if related pods are running). The check happens after `crc status` which waits for the cluster monitoring operator to come up.

This test belongs in this feature (imo) because the `enable-monitoring` functionality is "basic" in the sense that it's default on OCP and by default turned off in CRC. Plus, `basic.feature` does not deploy other resource using apps/operators/etc. So there's no worry of interfering. 

## Testing

1. `make integration` with a `@basic` tag 'on'. Expect a pass.
