### PR TITLE
Update story_marketplace with etcdcluster init container image from quay.io 

### DIFF
--- a/test/testdata/etcd-cluster3.yaml
+++ b/test/testdata/etcd-cluster3.yaml
@@ -8,3 +8,5 @@ metadata:
 spec:
   size: 3
   version: 3.2.13
+  pod:
+    busyboxImage: quay.io/libpod/alpine:3.10.2

--- a/test/testdata/etcd-cluster5.yaml
+++ b/test/testdata/etcd-cluster5.yaml
@@ -8,3 +8,5 @@ metadata:
 spec:
   size: 5
   version: 3.2.13
+  pod:
+    busyboxImage: quay.io/libpod/alpine:3.10.2


### PR DESCRIPTION
Remove docherhub dependecy on story marketplace 

**Fixes:** Issue #1753

## Solution/Idea

etcd operator uses as init container busybox:1.28.0-glibc, the idea is to use an equivalent image hosted at quay.io registry.

## Proposed changes

EtcdCluster allows to specify the image used for init container, the default image is busybox, as so the name on the spec is referring to it but any other small image which can be execute the init functionality  is suitable. Alpine from libpod was tested sucessfully.

Define the cluster with alpine as init container:

```bash
apiVersion: etcd.database.coreos.com/v1beta2
kind: EtcdCluster
metadata:
  name: example
  annotations:
    etcd.database.coreos.com/scope: clusterwide
  namespace: default
spec:
  size: 3
  version: 3.2.13
  pod:
    busyboxImage: quay.io/libpod/alpine:3.10.2
```

## Testing

Run e2e story_marketplace feature
