### PR TITLE
Upping client,server timeouts to prevent EOFs

### DIFF
--- a/docs/source/topics/proc_setting-up-remote-server.adoc
+++ b/docs/source/topics/proc_setting-up-remote-server.adoc
@@ -69,8 +69,8 @@ defaults
     log global
     mode http
     timeout connect 5000
-    timeout client 5000
-    timeout server 5000
+    timeout client 500000
+    timeout server 500000
 
 frontend apps
     bind 0.0.0.0:80


### PR DESCRIPTION
While tailing logs of pods via accessing CRC remotely, the default
HAProxy config cuts connections by sending:

```
error: unexpected EOFs
```

Raising these timeouts eleviates the problem.