### PR TITLE
Delete the VM directly without stopping it in most integration tests

### DIFF
--- a/test/integration/features/story_health.feature
+++ b/test/integration/features/story_health.feature
@@ -66,6 +66,5 @@ Feature: End-to-end health check
     @darwin @linux @windows
     Scenario: Switch off CRC
         When executing "oc delete project testproj" succeeds
-        Then executing "crc stop -f" succeeds
         And executing "crc delete -f" succeeds
         And executing "crc cleanup" succeeds

--- a/test/integration/features/story_marketplace.feature
+++ b/test/integration/features/story_marketplace.feature
@@ -72,8 +72,6 @@ Feature: Operator from marketplace
         
     @darwin @linux @windows
     Scenario: Clean up
-        When executing "crc stop -f" succeeds
-        Then stdout should match "(.*)[Ss]topped the OpenShift cluster"
         When executing "crc delete -f" succeeds
         Then stdout should contain "Deleted the OpenShift cluster"
         When executing "crc cleanup" succeeds

--- a/test/integration/features/story_registry.feature
+++ b/test/integration/features/story_registry.feature
@@ -38,8 +38,6 @@ Feature: Local image to image-registry
         When stdout contains "localhost/hello"
         Then executing "sudo podman image rm localhost/hello:test" succeeds
         And executing "oc delete project testproj-img" succeeds
-        When executing "crc stop -f" succeeds
-        Then stdout should match "(.*)[Ss]topped the OpenShift cluster"
         And executing "crc delete -f" succeeds
         Then stdout should contain "Deleted the OpenShift cluster"
         When executing "crc cleanup" succeeds


### PR DESCRIPTION
`crc stop` takes too much time esp. when we delete the VM just after. Delete it directly and avoid a graceful shutdown. 

`crc stop` is still tested in basic (check the console is here after a restart) and health (check user app is still here after restart) integration tests.