### PR TITLE
Use ID_LIKE for most preflights checks

### DIFF
--- a/pkg/crc/preflight/preflight_checks_linux.go
+++ b/pkg/crc/preflight/preflight_checks_linux.go
@@ -144,10 +144,10 @@ func fixLibvirtInstalled(distro *linux.OsRelease) func() error {
 
 func installLibvirtCommand(distro *linux.OsRelease) string {
 	yumCommand := "yum install -y libvirt libvirt-daemon-kvm qemu-kvm"
-	switch distroID(distro) {
-	case linux.Ubuntu:
+	switch {
+	case distroIsLike(distro, linux.Ubuntu):
 		return "apt-get update && apt-get install -y libvirt-daemon libvirt-daemon-system libvirt-clients"
-	case linux.RHEL, linux.CentOS, linux.Fedora:
+	case distroIsLike(distro, linux.Fedora):
 		return yumCommand
 	default:
 		logging.Warnf("unsupported distribution %s, trying to install libvirt with yum", distro)

--- a/pkg/crc/preflight/preflight_linux.go
+++ b/pkg/crc/preflight/preflight_linux.go
@@ -180,7 +180,7 @@ func getNetworkChecksForDistro(distro *linux.OsRelease, networkMode network.Mode
 
 	switch {
 	default:
-		logging.Warnf("distribution-specific preflight checks are not implemented for '%s'", distroID(distro))
+		logging.Warnf("distribution-specific preflight checks are not implemented for '%s'", distro.ID)
 		fallthrough
 	case distroIsLike(distro, linux.Ubuntu), distroIsLike(distro, linux.Fedora):
 		checks = append(checks, nmPreflightChecks[:]...)
@@ -216,14 +216,6 @@ func usesSystemdResolved(distro *linux.OsRelease) bool {
 	default:
 		return false
 	}
-}
-
-func distroID(osRelease *linux.OsRelease) linux.OsType {
-	if osRelease == nil {
-		return "unknown"
-	}
-	// FIXME: should also use IDLike
-	return osRelease.ID
 }
 
 func distroIsLike(osRelease *linux.OsRelease, osType linux.OsType) bool {

--- a/pkg/crc/preflight/preflight_linux.go
+++ b/pkg/crc/preflight/preflight_linux.go
@@ -246,8 +246,10 @@ func distroIsLike(osRelease *linux.OsRelease, osType linux.OsType) bool {
 func distro() *linux.OsRelease {
 	distro, err := linux.GetOsRelease()
 	if err != nil {
-		logging.Warnf("cannot get distribution name: %v", err)
-		return nil
+		logging.Errorf("cannot get distribution name: %v", err)
+		return &linux.OsRelease{
+			ID: "unknown",
+		}
 	}
 	return distro
 }

--- a/pkg/crc/preflight/preflight_linux.go
+++ b/pkg/crc/preflight/preflight_linux.go
@@ -207,12 +207,12 @@ func getPreflightChecksForDistro(distro *linux.OsRelease, networkMode network.Mo
 	return checks
 }
 
-func usesSystemdResolved(osRelease *linux.OsRelease) bool {
-	switch distroID(osRelease) {
-	case linux.Ubuntu:
+func usesSystemdResolved(distro *linux.OsRelease) bool {
+	switch {
+	case distroIsLike(distro, linux.Ubuntu):
 		return true
-	case linux.Fedora:
-		return osRelease.VersionID >= "33"
+	case distro.ID == linux.Fedora:
+		return distro.VersionID >= "33"
 	default:
 		return false
 	}

--- a/pkg/crc/preflight/preflight_linux.go
+++ b/pkg/crc/preflight/preflight_linux.go
@@ -71,7 +71,7 @@ func libvirtPreflightChecks(distro *linux.OsRelease) []Check {
 			flags:              CleanUpOnly,
 		},
 	}
-	if distroID(distro) == linux.Ubuntu {
+	if distroIsLike(distro, linux.Ubuntu) {
 		checks = append(checks, ubuntuPreflightChecks...)
 	}
 	return checks

--- a/pkg/os/linux/release_info.go
+++ b/pkg/os/linux/release_info.go
@@ -102,7 +102,7 @@ func UnmarshalOsRelease(osReleaseContents []byte, release *OsRelease) error {
 func GetOsRelease() (*OsRelease, error) {
 	// Check if release file exist
 	if _, err := os.Stat(releaseFile); os.IsNotExist(err) {
-		return nil, fmt.Errorf("%s not exist", releaseFile)
+		return nil, fmt.Errorf("%s doesn't exist", releaseFile)
 	}
 	content, err := ioutil.ReadFile(releaseFile)
 	if err != nil {


### PR DESCRIPTION
This should fix some derivative distros of Ubuntu (popos, linux mint).