### PR TITLE
Add the command name in the log file

### DIFF
--- a/cmd/crc/cmd/root.go
+++ b/cmd/crc/cmd/root.go
@@ -177,7 +177,7 @@ func executeWithLogging(fullCmd string, input func(cmd *cobra.Command, args []st
 		logging.Debugf("Running '%s'", fullCmd)
 		if err := input(cmd, args); err != nil {
 			if serr := segmentClient.Upload(fullCmd, err); serr != nil {
-				fmt.Println(serr.Error())
+				logging.Debugf("Cannot send data to telemetry: %v", serr)
 			}
 			return err
 		}

--- a/cmd/crc/cmd/root.go
+++ b/cmd/crc/cmd/root.go
@@ -174,6 +174,7 @@ func addForceFlag(cmd *cobra.Command) {
 
 func executeWithLogging(fullCmd string, input func(cmd *cobra.Command, args []string) error) func(cmd *cobra.Command, args []string) error {
 	return func(cmd *cobra.Command, args []string) error {
+		logging.Debugf("Running '%s'", fullCmd)
 		if err := input(cmd, args); err != nil {
 			if serr := segmentClient.Upload(fullCmd, err); serr != nil {
 				fmt.Println(serr.Error())

--- a/pkg/os/linux/release_info.go
+++ b/pkg/os/linux/release_info.go
@@ -92,9 +92,7 @@ func UnmarshalOsRelease(osReleaseContents []byte, release *OsRelease) error {
 			logging.Warnf("Warning: got an invalid line error parsing /etc/os-release: %s", err)
 			continue
 		}
-		if err := release.setIfPossible(key, val); err != nil {
-			logging.Debug(err)
-		}
+		_ = release.setIfPossible(key, val)
 	}
 	return nil
 }


### PR DESCRIPTION
Now in the log:
```
time="2021-01-05T15:28:19+01:00" level=debug msg="CodeReady Containers version: 1.20.0+fb533810\n"
time="2021-01-05T15:28:19+01:00" level=debug msg="OpenShift version: 4.6.9 (not embedded in executable)\n"
time="2021-01-05T15:28:19+01:00" level=debug msg="Command 'crc version' started"
time="2021-01-05T15:31:05+01:00" level=debug msg="CodeReady Containers version: 1.20.0+169c3220\n"
time="2021-01-05T15:31:05+01:00" level=debug msg="OpenShift version: 4.6.9 (not embedded in executable)\n"
time="2021-01-05T15:31:05+01:00" level=debug msg="Running 'crc config view'"
...
```
