### PR TITLE
Consistency on integration test for nameserver configuration

### DIFF
--- a/test/integration/features/story_health.feature
+++ b/test/integration/features/story_health.feature
@@ -10,7 +10,7 @@ Feature: End-to-end health check
     Scenario: Start CRC
         Given executing "crc setup" succeeds
         When setting config property "memory" to value "12000" succeeds
-        When starting CRC with default bundle succeeds
+        When starting CRC with default bundle and nameserver "10.75.5.25" succeeds
         Then stdout should contain "Started the OpenShift cluster"
         And executing "eval $(crc oc-env)" succeeds
         When checking that CRC is running

--- a/test/integration/features/story_health.feature
+++ b/test/integration/features/story_health.feature
@@ -59,7 +59,7 @@ Feature: End-to-end health check
         Given with up to "2" retries with wait period of "60s" http response from "http://httpd-example-testproj.apps-crc.testing" has status code "200"
         When executing "crc stop -f" succeeds
         Then checking that CRC is stopped
-        When starting CRC with default bundle succeeds
+        When starting CRC with default bundle and nameserver "10.75.5.25" succeeds
         Then checking that CRC is running
         And with up to "2" retries with wait period of "1m" http response from "http://httpd-example-testproj.apps-crc.testing" has status code "200"
 


### PR DESCRIPTION
The test start the crc cluster with a nameserver for windows environment. (This is required due to some known issues with windows dns resolutions). 

During the test the cluster is stopped and then started again. The second start does not configure any nameserver. This change will add the nameserver to this second start. Also to make it consistent across all plarforms the namesever is also configured for the first crc start on linux and macos.