### PR TITLE
Remove warn flags from the config

### DIFF
--- a/cmd/crc/cmd/config/config.go
+++ b/cmd/crc/cmd/config/config.go
@@ -52,22 +52,15 @@ func RegisterSettings(cfg *config.Config) {
 }
 
 func isPreflightKey(key string) bool {
-	return strings.HasPrefix(key, "skip-") || strings.HasPrefix(key, "warn-")
+	return strings.HasPrefix(key, "skip-")
 }
 
 // less is used to sort the config keys. We want to sort first the regular keys, and
-// then the keys related to preflight starting with a skip- or warn- prefix. We want
-// these preflight keys to be grouped by pair: 'skip-bar', 'warn-bar', 'skip-foo', 'warn-foo'
-// would be sorted in that order.
+// then the keys related to preflight starting with a skip- prefix.
 func less(lhsKey, rhsKey string) bool {
 	if isPreflightKey(lhsKey) {
 		if isPreflightKey(rhsKey) {
-			// lhs is preflight, rhs is preflight
-			if lhsKey[4:] == rhsKey[4:] {
-				// we want skip-foo before warn-foo
-				return lhsKey < rhsKey
-			}
-			// ignore skip-/warn- prefix
+			// ignore skip prefix
 			return lhsKey[4:] < rhsKey[4:]
 		}
 		// lhs is preflight, rhs is not preflight

--- a/docs/source/topics/con_about-codeready-containers-configuration.adoc
+++ b/docs/source/topics/con_about-codeready-containers-configuration.adoc
@@ -9,4 +9,4 @@ Run the [command]`{bin} config --help` command to list the available properties.
 
 You can also use the [command]`{bin} config` command to configure the behavior of the startup checks for the [command]`{bin} start` and [command]`{bin} setup` commands.
 By default, startup checks report an error and stop execution when their conditions are not met.
-Set the value of a property starting with `skip-check` or `warn-check` to `true` to skip the check or report a warning rather than an error, respectively.
+Set the value of a property starting with `skip-check` to `true` to skip the check.

--- a/pkg/crc/preflight/preflight_darwin_test.go
+++ b/pkg/crc/preflight/preflight_darwin_test.go
@@ -12,7 +12,7 @@ import (
 func TestCountConfigurationOptions(t *testing.T) {
 	cfg := config.New(config.NewEmptyInMemoryStorage())
 	RegisterSettings(cfg)
-	assert.Len(t, cfg.AllConfigs(), 18)
+	assert.Len(t, cfg.AllConfigs(), 9)
 }
 
 func TestCountPreflights(t *testing.T) {

--- a/pkg/crc/preflight/preflight_linux_test.go
+++ b/pkg/crc/preflight/preflight_linux_test.go
@@ -21,7 +21,7 @@ func TestCountConfigurationOptions(t *testing.T) {
 	var preflightChecksCount int
 	for _, check := range getAllPreflightChecks() {
 		if check.configKeySuffix != "" {
-			preflightChecksCount += 2
+			preflightChecksCount++
 		}
 	}
 	assert.True(t, options == preflightChecksCount, "Unexpected number of preflight configuration flags, got %d, expected %d", options, preflightChecksCount)

--- a/pkg/crc/preflight/preflight_test.go
+++ b/pkg/crc/preflight/preflight_test.go
@@ -39,18 +39,6 @@ func TestFixPreflight(t *testing.T) {
 	assert.True(t, calls.fixed)
 }
 
-func TestWarnPreflight(t *testing.T) {
-	check, calls := sampleCheck(errors.New("check failed"), errors.New("fix failed"))
-	cfg := config.New(config.NewEmptyInMemoryStorage())
-	doRegisterSettings(cfg, []Check{*check})
-	_, err := cfg.Set("warn-sample", true)
-	assert.NoError(t, err)
-
-	assert.NoError(t, doFixPreflightChecks(cfg, []Check{*check}))
-	assert.True(t, calls.checked)
-	assert.True(t, calls.fixed)
-}
-
 func sampleCheck(checkErr, fixErr error) (*Check, *status) {
 	status := &status{}
 	return &Check{

--- a/pkg/crc/preflight/preflight_windows_test.go
+++ b/pkg/crc/preflight/preflight_windows_test.go
@@ -11,7 +11,7 @@ import (
 func TestCountConfigurationOptions(t *testing.T) {
 	cfg := config.New(config.NewEmptyInMemoryStorage())
 	RegisterSettings(cfg)
-	assert.Len(t, cfg.AllConfigs(), 24)
+	assert.Len(t, cfg.AllConfigs(), 12)
 }
 
 func TestCountPreflights(t *testing.T) {

--- a/test/integration/features/config.feature
+++ b/test/integration/features/config.feature
@@ -56,55 +56,6 @@ Feature: Test configuration settings
         When unsetting config property "disable-update-check" succeeds
         Then "JSON" config file "crc.json" in CRC home folder does not contain key "disable-update-check"
 
-    # WARNINGS
-
-    Scenario Outline: CRC config checks (warnings)
-        When setting config property "<property>" to value "<value1>" succeeds
-        Then "JSON" config file "crc.json" in CRC home folder contains key "<property>" with value matching "<value1>"
-        When setting config property "<property>" to value "<value2>" succeeds
-        Then "JSON" config file "crc.json" in CRC home folder contains key "<property>" with value matching "<value2>"
-        When unsetting config property "<property>" succeeds
-        Then "JSON" config file "crc.json" in CRC home folder does not contain key "<property>"
-
-        @darwin
-        Examples: Config warnings on Mac
-            | property                             | value1 | value2 |
-            | warn-check-bundle-extracted          | true   | false  |
-            | warn-check-hosts-file-permissions    | true   | false  |
-            | warn-check-hyperkit-driver           | true   | false  |
-            | warn-check-hyperkit-installed        | true   | false  |
-            | warn-check-resolver-file-permissions | true   | false  |
-            | warn-check-root-user                 | true   | false  |
-
-        @linux
-        Examples: Config warnings on Linux
-            | property                             | value1 | value2 |
-            | warn-check-bundle-extracted          | true   | false  |
-            | warn-check-crc-dnsmasq-file          | true   | false  |
-            | warn-check-crc-network               | true   | false  |
-            | warn-check-crc-network-active        | true   | false  |
-            | warn-check-kvm-enabled               | true   | false  |
-            | warn-check-libvirt-driver            | true   | false  |
-            | warn-check-libvirt-installed         | true   | false  |
-            | warn-check-libvirt-running           | true   | false  |
-            | warn-check-libvirt-version           | true   | false  |
-            | warn-check-network-manager-config    | true   | false  |
-            | warn-check-network-manager-installed | true   | false  |
-            | warn-check-network-manager-running   | true   | false  |
-            | warn-check-root-user                 | true   | false  |
-            | warn-check-user-in-libvirt-group     | true   | false  |
-            | warn-check-virt-enabled              | true   | false  |
-
-        @windows
-        Examples: Config warnings on Windows
-            | property                        | value1 | value2 |
-            | warn-check-administrator-user   | true   | false  |
-            | warn-check-bundle-extracted     | true   | false  |
-            | warn-check-hyperv-installed     | true   | false  |
-            | warn-check-hyperv-switch        | true   | false  |
-            | warn-check-user-in-hyperv-group | true   | false  |
-            | warn-check-windows-version      | true   | false  |
-
     # SKIP
 
     Scenario Outline: CRC config checks (skips)


### PR DESCRIPTION
`warn-<preflight-check>` is not used in crc context because we
are already capturing the checks data as part of debug logs. `skip`
is there to skip a check if a user don't want to run a check.