### PR TITLE
Fix destination file for win/mac tray

### DIFF
--- a/pkg/crc/preflight/preflight_checks_tray_darwin.go
+++ b/pkg/crc/preflight/preflight_checks_tray_darwin.go
@@ -195,7 +195,9 @@ func downloadOrExtractTrayApp() error {
 	}()
 
 	logging.Debug("Trying to extract tray from crc executable")
-	err = embed.Extract(filepath.Base(constants.GetCRCMacTrayDownloadURL()), tmpArchivePath)
+	trayFileName := filepath.Base(constants.GetCRCMacTrayDownloadURL())
+	trayDestFileName := filepath.Join(tmpArchivePath, trayFileName)
+	err = embed.Extract(trayFileName, trayDestFileName)
 	if err != nil {
 		logging.Debug("Could not extract tray from crc executable", err)
 		logging.Debug("Downloading crc tray")
@@ -204,15 +206,14 @@ func downloadOrExtractTrayApp() error {
 			return err
 		}
 	}
-	archivePath := filepath.Join(tmpArchivePath, filepath.Base(constants.GetCRCMacTrayDownloadURL()))
 	outputPath := constants.CrcBinDir
 	err = goos.MkdirAll(outputPath, 0750)
 	if err != nil {
 		return errors.Wrap(err, "Cannot create the target directory.")
 	}
-	_, err = extract.Uncompress(archivePath, outputPath, false)
+	_, err = extract.Uncompress(trayDestFileName, outputPath, false)
 	if err != nil {
-		return errors.Wrapf(err, "Cannot uncompress '%s'", archivePath)
+		return errors.Wrapf(err, "Cannot uncompress '%s'", trayDestFileName)
 	}
 	return nil
 }

--- a/pkg/crc/preflight/preflight_checks_tray_windows.go
+++ b/pkg/crc/preflight/preflight_checks_tray_windows.go
@@ -161,7 +161,9 @@ func fixTrayExecutableExists() error {
 	}()
 
 	logging.Debug("Trying to extract tray from crc executable")
-	err = embed.Extract(filepath.Base(constants.GetCRCWindowsTrayDownloadURL()), tmpArchivePath)
+	trayFileName := filepath.Base(constants.GetCRCWindowsTrayDownloadURL())
+	trayDestFileName := filepath.Join(tmpArchivePath, trayFileName)
+	err = embed.Extract(trayFileName, trayDestFileName)
 	if err != nil {
 		logging.Debug("Could not extract tray from crc executable", err)
 		logging.Debug("Downloading crc tray")
@@ -170,10 +172,9 @@ func fixTrayExecutableExists() error {
 			return err
 		}
 	}
-	archivePath := filepath.Join(tmpArchivePath, filepath.Base(constants.GetCRCWindowsTrayDownloadURL()))
-	_, err = extract.Uncompress(archivePath, constants.TrayExecutableDir, false)
+	_, err = extract.Uncompress(trayDestFileName, constants.TrayExecutableDir, false)
 	if err != nil {
-		return fmt.Errorf("Cannot uncompress '%s': %v", archivePath, err)
+		return fmt.Errorf("Cannot uncompress '%s': %v", trayDestFileName, err)
 	}
 
 	return nil


### PR DESCRIPTION
Extract function take embedded file name and destination filename to
extract the file from the binary to destination file. We had bug till
now in tray side where we are passing the destination folder instead
destination file and extration fails.

```
DEBU Could not extract tray from crc executableCould not create '/var/folders/6q/9mnplh5s6wg__rrvzdv9nkp80000gn/T/crc094171414': open /var/folders/6q/9mnplh5s6wg__rrvzdv9nkp80000gn/T/crc094171414: is a directory
```