### PR TITLE
Several fixes for proxy configuration

### DIFF
--- a/pkg/crc/cluster/cluster.go
+++ b/pkg/crc/cluster/cluster.go
@@ -236,7 +236,7 @@ func AddProxyToKubeletAndCriO(sshRunner *ssh.Runner, proxy *network.ProxyConfig)
 	proxyTemplate := `[Service]
 Environment=HTTP_PROXY=%s
 Environment=HTTPS_PROXY=%s
-Environment=NO_PROXY=.cluster.local,.svc,10.128.0.0/14,172.30.0.0/16,%s`
+Environment=NO_PROXY=.cluster.local,.svc,10.116.0.0/14,172.25.0.0/16,192.168.126.0/24,%s`
 	p := fmt.Sprintf(proxyTemplate, proxy.HTTPProxy, proxy.HTTPSProxy, proxy.GetNoProxyString())
 	// This will create a systemd drop-in configuration for proxy (both for kubelet and crio services) on the VM.
 	err := sshRunner.CopyData([]byte(p), "/etc/systemd/system/crio.service.d/10-default-env.conf", 0644)

--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -378,12 +378,12 @@ func (client *client) Start(startConfig StartConfig) (*StartResult, error) {
 
 	time.Sleep(time.Minute * 3)
 
+	waitForProxyPropagation(ocConfig, proxyConfig)
+
 	logging.Info("Updating kubeconfig")
 	if err := eventuallyWriteKubeconfig(ocConfig, instanceIP, clusterConfig); err != nil {
 		log.Warnf("Cannot update kubeconfig: %v", err)
 	}
-
-	waitForProxyPropagation(ocConfig, proxyConfig)
 
 	logging.Warn("The cluster might report a degraded or error state. This is expected since several operators have been disabled to lower the resource usage. For more information, please consult the documentation")
 	return &StartResult{

--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -27,7 +27,6 @@ import (
 	"github.com/code-ready/machine/libmachine"
 	"github.com/code-ready/machine/libmachine/drivers"
 	"github.com/code-ready/machine/libmachine/host"
-	"github.com/code-ready/machine/libmachine/log"
 	"github.com/code-ready/machine/libmachine/state"
 	"github.com/docker/go-units"
 	"github.com/pkg/errors"
@@ -382,7 +381,7 @@ func (client *client) Start(startConfig StartConfig) (*StartResult, error) {
 
 	logging.Info("Updating kubeconfig")
 	if err := eventuallyWriteKubeconfig(ocConfig, instanceIP, clusterConfig); err != nil {
-		log.Warnf("Cannot update kubeconfig: %v", err)
+		logging.Warnf("Cannot update kubeconfig: %v", err)
 	}
 
 	logging.Warn("The cluster might report a degraded or error state. This is expected since several operators have been disabled to lower the resource usage. For more information, please consult the documentation")

--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -546,7 +546,7 @@ func waitForProxyPropagation(ocConfig oc.Config, proxyConfig *network.ProxyConfi
 		return nil
 	}
 
-	if err := crcerrors.RetryAfter(60*time.Second, checkProxySettingsForOperator, 2*time.Second); err != nil {
+	if err := crcerrors.RetryAfter(300*time.Second, checkProxySettingsForOperator, 2*time.Second); err != nil {
 		logging.Debug("Failed to propagate proxy settings to cluster")
 	}
 }

--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -534,7 +534,7 @@ func configProxyForCluster(ocConfig oc.Config, sshRunner *crcssh.Runner, sd *sys
 
 func waitForProxyPropagation(ocConfig oc.Config, proxyConfig *network.ProxyConfig) {
 	checkProxySettingsForOperator := func() error {
-		proxySet, err := cluster.CheckProxySettingsForOperator(ocConfig, proxyConfig, "redhat-operators", "openshift-marketplace")
+		proxySet, err := cluster.CheckProxySettingsForOperator(ocConfig, proxyConfig, "marketplace-operator", "openshift-marketplace")
 		if err != nil {
 			logging.Debugf("Error getting proxy setting for openshift-marketplace operator %v", err)
 			return &crcerrors.RetriableError{Err: err}


### PR DESCRIPTION
While working with mitmproxy and crc, I've found couple of issues.

* the deployment we watched no longer exist. I updated it.
* 60s is not enough clearly. 
* I removed the restart of kubelet/crio. I only needed to change the configuration of kubelet/crio before the start of kubelet.
* default service ip range changed.