### PR TITLE
Handle SIGTERM in crc daemon

### DIFF
--- a/cmd/crc/cmd/daemon.go
+++ b/cmd/crc/cmd/daemon.go
@@ -5,9 +5,11 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"os/signal"
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"syscall"
 	"time"
 
 	"github.com/code-ready/crc/pkg/crc/api"
@@ -130,7 +132,15 @@ func run(configuration *types.Configuration, endpoints []string) error {
 			}
 		}()
 	}
-	return <-errCh
+
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
+	select {
+	case <-c:
+		return nil
+	case err := <-errCh:
+		return err
+	}
 }
 
 func newConfig() (crcConfig.Storage, error) {

--- a/cmd/crc/cmd/daemon.go
+++ b/cmd/crc/cmd/daemon.go
@@ -151,9 +151,9 @@ func newConfig() (crcConfig.Storage, error) {
 func runDaemon() {
 	// Remove if an old socket is present
 	os.Remove(constants.DaemonSocketPath)
-	crcAPIServer, err := api.CreateAPIServer(constants.DaemonSocketPath, newConfig, newMachineWithConfig)
+	apiServer, err := api.CreateServer(constants.DaemonSocketPath, newConfig, newMachineWithConfig)
 	if err != nil {
 		logging.Fatal("Failed to launch daemon", err)
 	}
-	crcAPIServer.Serve()
+	apiServer.Serve()
 }

--- a/pkg/crc/api/api.go
+++ b/pkg/crc/api/api.go
@@ -36,7 +36,7 @@ func createServerWithListener(listener net.Listener, config newConfigFunc, machi
 	return apiServer, nil
 }
 
-func (api Server) Serve() {
+func (api Server) Serve() error {
 	go api.handleClusterOperations() // go routine that handles start, stop and delete calls
 	for {
 		conn, err := api.listener.Accept()

--- a/pkg/crc/api/api_test.go
+++ b/pkg/crc/api/api_test.go
@@ -11,13 +11,13 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/code-ready/crc/pkg/crc/machine"
-
 	cmdConfig "github.com/code-ready/crc/cmd/crc/cmd/config"
 	"github.com/code-ready/crc/pkg/crc/config"
+	"github.com/code-ready/crc/pkg/crc/machine"
 	"github.com/code-ready/crc/pkg/crc/machine/fakemachine"
 	"github.com/code-ready/crc/pkg/crc/preflight"
 	"github.com/code-ready/crc/pkg/crc/version"
+	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -36,7 +36,11 @@ func TestApi(t *testing.T) {
 		return client
 	})
 	require.NoError(t, err)
-	go api.Serve()
+	go func() {
+		if err := api.Serve(); err != nil {
+			log.Error(err)
+		}
+	}()
 
 	tt := []struct {
 		command       string
@@ -221,7 +225,11 @@ func setupAPIServer(t *testing.T) (string, func()) {
 		return client
 	})
 	require.NoError(t, err)
-	go api.Serve()
+	go func() {
+		if err := api.Serve(); err != nil {
+			log.Error(err)
+		}
+	}()
 
 	return socket, func() { os.RemoveAll(dir) }
 }

--- a/pkg/crc/api/api_test.go
+++ b/pkg/crc/api/api_test.go
@@ -32,7 +32,7 @@ func TestApi(t *testing.T) {
 	require.NoError(t, err)
 
 	client := fakemachine.NewClient()
-	api, err := createAPIServerWithListener(listener, setupNewInMemoryConfig, func(_ config.Storage) machine.Client {
+	api, err := createServerWithListener(listener, setupNewInMemoryConfig, func(_ config.Storage) machine.Client {
 		return client
 	})
 	require.NoError(t, err)
@@ -217,7 +217,7 @@ func setupAPIServer(t *testing.T) (string, func()) {
 	require.NoError(t, err)
 
 	client := fakemachine.NewClient()
-	api, err := createAPIServerWithListener(listener, setupNewInMemoryConfig, func(_ config.Storage) machine.Client {
+	api, err := createServerWithListener(listener, setupNewInMemoryConfig, func(_ config.Storage) machine.Client {
 		return client
 	})
 	require.NoError(t, err)

--- a/pkg/crc/api/types.go
+++ b/pkg/crc/api/types.go
@@ -16,7 +16,7 @@ type commandError struct {
 	Err string
 }
 
-type CrcAPIServer struct {
+type Server struct {
 	handlerFactory         newHandlerFunc
 	listener               net.Listener
 	clusterOpsRequestsChan chan clusterOpsRequest


### PR DESCRIPTION
* Catch SIGTERM so that crc daemon ends like other commands (by sending a message to segment)
* runDaemon() can now return an error if it can't listen the unix socket (instead of panic)
* couple of refactorings.