### PR TITLE
Remove BeforeFeature function from crc integration test suite

### DIFF
--- a/test/integration/crcsuite/crcsuite.go
+++ b/test/integration/crcsuite/crcsuite.go
@@ -122,21 +122,21 @@ func FeatureContext(s *godog.Suite) {
 		}
 
 		if !bundleEmbedded {
-			if _, err := os.Stat(bundleName); err != nil {
+			if _, err := os.Stat(bundleLocation); err != nil {
 				if !os.IsNotExist(err) {
-					fmt.Printf("Unexpected error obtaining the bundle %v.\n", bundleName)
+					fmt.Printf("Unexpected error obtaining the bundle %v.\n", bundleLocation)
 					os.Exit(1)
 				}
 				// Obtain the bundle to current dir
 				fmt.Println("Obtaining bundle...")
-				bundle, err := DownloadBundle(bundleLocation, ".")
+				bundleLocation, err = DownloadBundle(bundleLocation, ".")
 				if err != nil {
 					fmt.Printf("Failed to obtain CRC bundle, %v\n", err)
 					os.Exit(1)
 				}
-				fmt.Println("Using bundle:", bundle)
+				fmt.Println("Using bundle:", bundleLocation)
 			} else {
-				fmt.Println("Using existing bundle:", bundleName)
+				fmt.Println("Using existing bundle:", bundleLocation)
 			}
 		}
 	})
@@ -376,7 +376,7 @@ func StartCRCWithDefaultBundleSucceedsOrFails(expected string) error {
 	var extraBundleArgs string
 
 	if !bundleEmbedded {
-		extraBundleArgs = fmt.Sprintf("-b %s", bundleName)
+		extraBundleArgs = fmt.Sprintf("-b %s", bundleLocation)
 	}
 	cmd = fmt.Sprintf("crc start -p '%s' %s --log-level debug", pullSecretFile, extraBundleArgs)
 	err := clicumber.ExecuteCommandSucceedsOrFails(cmd, expected)
@@ -390,7 +390,7 @@ func StartCRCWithDefaultBundleWithStopNetworkTimeSynchronizationSucceedsOrFails(
 	var extraBundleArgs string
 
 	if !bundleEmbedded {
-		extraBundleArgs = fmt.Sprintf("-b %s", bundleName)
+		extraBundleArgs = fmt.Sprintf("-b %s", bundleLocation)
 	}
 	cmd = fmt.Sprintf("CRC_DEBUG_ENABLE_STOP_NTP=true crc start -p '%s' %s --log-level debug", pullSecretFile, extraBundleArgs)
 	err := clicumber.ExecuteCommandSucceedsOrFails(cmd, expected)
@@ -402,7 +402,7 @@ func StartCRCWithDefaultBundleAndNameServerSucceedsOrFails(nameserver string, ex
 
 	var extraBundleArgs string
 	if !bundleEmbedded {
-		extraBundleArgs = fmt.Sprintf("-b %s", bundleName)
+		extraBundleArgs = fmt.Sprintf("-b %s", bundleLocation)
 	}
 
 	cmd := fmt.Sprintf("crc start -n %s -p '%s' %s --log-level debug", nameserver, pullSecretFile, extraBundleArgs)
@@ -430,7 +430,7 @@ func SetConfigPropertyToValueSucceedsOrFails(property string, value string, expe
 		if bundleEmbedded {
 			value = filepath.Join(CRCHome, "cache", bundleName)
 		} else {
-			value = bundleName
+			value = bundleLocation
 		}
 	}
 

--- a/test/integration/crcsuite/crcsuite.go
+++ b/test/integration/crcsuite/crcsuite.go
@@ -114,27 +114,9 @@ func FeatureContext(s *godog.Suite) {
 			fmt.Println(err)
 			os.Exit(1)
 		}
-	})
 
-	s.AfterScenario(func(pickle *messages.Pickle, err error) {
-		if err != nil {
-			if err := runDiagnose(filepath.Join("..", "test-results")); err != nil {
-				fmt.Printf("Failed to collect diagnostic: %v\n", err)
-			}
-		}
-	})
-
-	s.AfterSuite(func() {
-		err := DeleteCRC()
-		if err != nil {
-			fmt.Printf("Could not delete CRC VM: %s.", err)
-		}
-	})
-
-	// nolint:staticcheck
-	s.BeforeFeature(func(this *messages.GherkinDocument) {
 		// copy data/config files to test dir
-		err := CopyFilesToTestDir()
+		err = CopyFilesToTestDir()
 		if err != nil {
 			os.Exit(1)
 		}
@@ -156,6 +138,21 @@ func FeatureContext(s *godog.Suite) {
 			} else {
 				fmt.Println("Using existing bundle:", bundleName)
 			}
+		}
+	})
+
+	s.AfterScenario(func(pickle *messages.Pickle, err error) {
+		if err != nil {
+			if err := runDiagnose(filepath.Join("..", "test-results")); err != nil {
+				fmt.Printf("Failed to collect diagnostic: %v\n", err)
+			}
+		}
+	})
+
+	s.AfterSuite(func() {
+		err := DeleteCRC()
+		if err != nil {
+			fmt.Printf("Could not delete CRC VM: %s.", err)
 		}
 	})
 }

--- a/test/integration/crcsuite/crcsuite.go
+++ b/test/integration/crcsuite/crcsuite.go
@@ -115,12 +115,6 @@ func FeatureContext(s *godog.Suite) {
 			os.Exit(1)
 		}
 
-		// copy data/config files to test dir
-		err = CopyFilesToTestDir()
-		if err != nil {
-			os.Exit(1)
-		}
-
 		if !bundleEmbedded {
 			if _, err := os.Stat(bundleLocation); err != nil {
 				if !os.IsNotExist(err) {
@@ -138,6 +132,14 @@ func FeatureContext(s *godog.Suite) {
 			} else {
 				fmt.Println("Using existing bundle:", bundleLocation)
 			}
+		}
+	})
+
+	s.BeforeScenario(func(pickle *messages.Pickle) {
+		// copy data/config files to test dir
+		err := CopyFilesToTestDir()
+		if err != nil {
+			os.Exit(1)
 		}
 	})
 

--- a/test/integration/features/proxy.feature
+++ b/test/integration/features/proxy.feature
@@ -5,7 +5,7 @@ Feature: Behind proxy test
     and to be able to deploy an app and check its accessibility.
 
     Scenario: Setup the proxy container using podman
-        Given executing "sudo podman run --name squid -d -p 3128:3128 quay.io/crcont/squid" succeeds
+        Given executing "podman run --name squid -d -p 3128:3128 quay.io/crcont/squid" succeeds
 
     Scenario: Start CRC
         Given executing "crc setup" succeeds
@@ -18,8 +18,8 @@ Feature: Behind proxy test
         Then login to the oc cluster succeeds
 
     Scenario: Remove the proxy container and host proxy env (which set because of oc-env)
-        Given executing "sudo podman stop squid" succeeds
-        And executing "sudo podman rm squid" succeeds
+        Given executing "podman stop squid" succeeds
+        And executing "podman rm squid" succeeds
         And executing "unset HTTP_PROXY HTTPS_PROXY NO_PROXY" succeeds
 
     Scenario: CRC delete and remove proxy settings from config

--- a/test/integration/features/story_registry.feature
+++ b/test/integration/features/story_registry.feature
@@ -14,15 +14,15 @@ Feature: Local image to image-registry
         And login to the oc cluster succeeds
 
     Scenario: Create local image
-        Given executing "sudo podman build -t hello:test -f Dockerfile" succeeds
-        When executing "sudo podman images" succeeds
+        Given executing "podman build -t hello:test -f Dockerfile" succeeds
+        When executing "podman images" succeeds
         Then stdout should contain "localhost/hello"
         
     Scenario: Push local image to OpenShift image registry
         Given executing "oc new-project testproj-img" succeeds
-        When executing "sudo podman login -u kubeadmin -p $(oc whoami -t) default-route-openshift-image-registry.apps-crc.testing --tls-verify=false" succeeds
+        When executing "podman login -u kubeadmin -p $(oc whoami -t) default-route-openshift-image-registry.apps-crc.testing --tls-verify=false" succeeds
         Then stdout should contain "Login Succeeded!"
-        When executing "sudo podman push hello:test default-route-openshift-image-registry.apps-crc.testing/testproj-img/hello:test --tls-verify=false" succeeds
+        When executing "podman push hello:test default-route-openshift-image-registry.apps-crc.testing/testproj-img/hello:test --tls-verify=false" succeeds
 
     Scenario: Deploy the image
         Given executing "oc new-app testproj-img/hello:test" succeeds
@@ -34,9 +34,9 @@ Feature: Local image to image-registry
         Then stdout should contain "Hello, it works!"
 
     Scenario: Clean up
-        Given executing "sudo podman images" succeeds
+        Given executing "podman images" succeeds
         When stdout contains "localhost/hello"
-        Then executing "sudo podman image rm localhost/hello:test" succeeds
+        Then executing "podman image rm localhost/hello:test" succeeds
         And executing "oc delete project testproj-img" succeeds
         And executing "crc delete -f" succeeds
         Then stdout should contain "Deleted the OpenShift cluster"


### PR DESCRIPTION
In BeforeFeature, bundle is downloaded and testdata file is moved
to the test run directory. Both can be part of BeforeSuite.
