### PR TITLE
Use .bak as backup file for sed to make it work in mac

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -168,8 +168,8 @@ cross-lint: $(GOPATH)/bin/golangci-lint
 .PHONY: gen_release_info
 gen_release_info:
 	@cat release-info.json.sample | sed s/@CRC_VERSION@/\"$(CRC_VERSION)\"/ > $(RELEASE_INFO)
-	@sed -i s/@GIT_COMMIT_SHA@/\"$(COMMIT_SHA)\"/ $(RELEASE_INFO)
-	@sed -i s/@OPENSHIFT_VERSION@/\"$(BUNDLE_VERSION)\"/ $(RELEASE_INFO)
+	@sed -i '.bak' s/@GIT_COMMIT_SHA@/\"$(COMMIT_SHA)\"/ $(RELEASE_INFO)
+	@sed -i '.bak' s/@OPENSHIFT_VERSION@/\"$(BUNDLE_VERSION)\"/ $(RELEASE_INFO)
 
 .PHONY: release
 release: cross-lint embed_bundle build_docs_pdf gen_release_info


### PR DESCRIPTION
Mac OS X uses the BSD version of sed, which treats the -i option slightly differently.
In BSD sed, the argument to -i is required, to make it portable with linux and mac
it is better to use `.bak` for backup file.


