### PR TITLE
Use only config object and don't recreate it for each api request

### DIFF
--- a/cmd/crc/cmd/daemon.go
+++ b/cmd/crc/cmd/daemon.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/code-ready/crc/pkg/crc/api"
-	crcConfig "github.com/code-ready/crc/pkg/crc/config"
 	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/code-ready/gvisor-tap-vsock/pkg/transport"
 	"github.com/code-ready/gvisor-tap-vsock/pkg/types"
@@ -142,15 +141,10 @@ func run(configuration *types.Configuration, endpoints []string) error {
 	}
 }
 
-func newConfig() (crcConfig.Storage, error) {
-	config, _, err := newViperConfig()
-	return config, err
-}
-
 func runDaemon() error {
 	// Remove if an old socket is present
 	os.Remove(constants.DaemonSocketPath)
-	apiServer, err := api.CreateServer(constants.DaemonSocketPath, newConfig, newMachineWithConfig)
+	apiServer, err := api.CreateServer(constants.DaemonSocketPath, config, newMachine())
 	if err != nil {
 		return err
 	}

--- a/cmd/crc/cmd/root.go
+++ b/cmd/crc/cmd/root.go
@@ -164,13 +164,7 @@ func newViperConfig() (*crcConfig.Config, *crcConfig.ViperStorage, error) {
 }
 
 func newMachine() machine.Client {
-	return newMachineWithConfig(config)
-}
-
-func newMachineWithConfig(config crcConfig.Storage) machine.Client {
-	networkMode := network.ParseMode(config.Get(cmdConfig.NetworkMode).AsString())
-	enableMonitoring := config.Get(cmdConfig.EnableClusterMonitoring).AsBool()
-	return machine.NewClient(constants.DefaultName, networkMode, enableMonitoring)
+	return machine.NewClient(constants.DefaultName, isDebugLog(), config)
 }
 
 func addForceFlag(cmd *cobra.Command) {

--- a/pkg/crc/api/api_test.go
+++ b/pkg/crc/api/api_test.go
@@ -13,7 +13,6 @@ import (
 
 	cmdConfig "github.com/code-ready/crc/cmd/crc/cmd/config"
 	"github.com/code-ready/crc/pkg/crc/config"
-	"github.com/code-ready/crc/pkg/crc/machine"
 	"github.com/code-ready/crc/pkg/crc/machine/fakemachine"
 	"github.com/code-ready/crc/pkg/crc/preflight"
 	"github.com/code-ready/crc/pkg/crc/version"
@@ -32,9 +31,7 @@ func TestApi(t *testing.T) {
 	require.NoError(t, err)
 
 	client := fakemachine.NewClient()
-	api, err := createServerWithListener(listener, setupNewInMemoryConfig, func(_ config.Storage) machine.Client {
-		return client
-	})
+	api, err := createServerWithListener(listener, setupNewInMemoryConfig(), client)
 	require.NoError(t, err)
 	go func() {
 		if err := api.Serve(); err != nil {
@@ -201,7 +198,7 @@ func TestGetconfigApi(t *testing.T) {
 	}, getconfigRes)
 }
 
-func setupNewInMemoryConfig() (config.Storage, error) {
+func setupNewInMemoryConfig() config.Storage {
 	storage := config.NewEmptyInMemoryStorage()
 	cfg := config.New(&skipPreflights{
 		storage: storage,
@@ -209,7 +206,7 @@ func setupNewInMemoryConfig() (config.Storage, error) {
 	cmdConfig.RegisterSettings(cfg)
 	preflight.RegisterSettings(cfg)
 
-	return cfg, nil
+	return cfg
 }
 
 func setupAPIServer(t *testing.T) (string, func()) {
@@ -221,9 +218,7 @@ func setupAPIServer(t *testing.T) (string, func()) {
 	require.NoError(t, err)
 
 	client := fakemachine.NewClient()
-	api, err := createServerWithListener(listener, setupNewInMemoryConfig, func(_ config.Storage) machine.Client {
-		return client
-	})
+	api, err := createServerWithListener(listener, setupNewInMemoryConfig(), client)
 	require.NoError(t, err)
 	go func() {
 		if err := api.Serve(); err != nil {

--- a/pkg/crc/api/types.go
+++ b/pkg/crc/api/types.go
@@ -3,21 +3,14 @@ package api
 import (
 	"encoding/json"
 	"net"
-
-	"github.com/code-ready/crc/pkg/crc/config"
-	"github.com/code-ready/crc/pkg/crc/machine"
 )
-
-type newHandlerFunc func() (RequestHandler, error)
-type newConfigFunc func() (config.Storage, error)
-type newMachineFunc func(config.Storage) machine.Client
 
 type commandError struct {
 	Err string
 }
 
 type Server struct {
-	handlerFactory         newHandlerFunc
+	handler                RequestHandler
 	listener               net.Listener
 	clusterOpsRequestsChan chan clusterOpsRequest
 }

--- a/pkg/crc/config/viper_config_test.go
+++ b/pkg/crc/config/viper_config_test.go
@@ -256,8 +256,8 @@ func TestTwoInstancesSharingSameConfiguration(t *testing.T) {
 	assert.JSONEq(t, `{"cpus":5}`, string(bin))
 
 	assert.Equal(t, SettingValue{
-		Value:     4, // wrong
-		IsDefault: true,
+		Value:     5,
+		IsDefault: false,
 	}, config2.Get(CPUs))
 	assert.Equal(t, SettingValue{
 		Value:     5,
@@ -285,13 +285,13 @@ func TestTwoInstancesWriteSameConfiguration(t *testing.T) {
 
 	bin, err := ioutil.ReadFile(configFile)
 	assert.NoError(t, err)
-	assert.JSONEq(t, `{"nameservers":"1.1.1.1"}`, string(bin)) // cpus missing
+	assert.JSONEq(t, `{"cpus":5, "nameservers":"1.1.1.1"}`, string(bin))
 
-	assert.Equal(t, 4, config2.Get(CPUs).Value) // wrong
+	assert.Equal(t, 5, config2.Get(CPUs).Value)
 	assert.Equal(t, 5, config1.Get(CPUs).Value)
 
 	assert.Equal(t, "1.1.1.1", config2.Get(NameServer).Value)
-	assert.Equal(t, "", config1.Get(NameServer).Value) // wrong
+	assert.Equal(t, "1.1.1.1", config1.Get(NameServer).Value)
 }
 
 func TestTwoInstancesSetAndUnsetSameConfiguration(t *testing.T) {
@@ -317,5 +317,5 @@ func TestTwoInstancesSetAndUnsetSameConfiguration(t *testing.T) {
 	assert.JSONEq(t, `{}`, string(bin))
 
 	assert.Equal(t, 4, config2.Get(CPUs).Value)
-	assert.Equal(t, 5, config1.Get(CPUs).Value) // wrong
+	assert.Equal(t, 4, config1.Get(CPUs).Value)
 }

--- a/pkg/crc/machine/client.go
+++ b/pkg/crc/machine/client.go
@@ -1,6 +1,8 @@
 package machine
 
 import (
+	cmdConfig "github.com/code-ready/crc/cmd/crc/cmd/config"
+	crcConfig "github.com/code-ready/crc/pkg/crc/config"
 	"github.com/code-ready/crc/pkg/crc/network"
 	"github.com/code-ready/machine/libmachine/state"
 )
@@ -20,16 +22,16 @@ type Client interface {
 }
 
 type client struct {
-	name              string
-	networkMode       network.Mode
-	monitoringEnabled bool
+	name   string
+	debug  bool
+	config crcConfig.Storage
 }
 
-func NewClient(name string, networkMode network.Mode, monitoringEnabled bool) Client {
+func NewClient(name string, debug bool, config crcConfig.Storage) Client {
 	return &client{
-		name:              name,
-		networkMode:       networkMode,
-		monitoringEnabled: monitoringEnabled,
+		name:   name,
+		debug:  debug,
+		config: config,
 	}
 }
 
@@ -38,5 +40,13 @@ func (client *client) GetName() string {
 }
 
 func (client *client) useVSock() bool {
-	return client.networkMode == network.VSockMode
+	return client.networkMode() == network.VSockMode
+}
+
+func (client *client) networkMode() network.Mode {
+	return network.ParseMode(client.config.Get(cmdConfig.NetworkMode).AsString())
+}
+
+func (client *client) monitoringEnabled() bool {
+	return client.config.Get(cmdConfig.EnableClusterMonitoring).AsBool()
 }

--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -116,7 +116,7 @@ func (client *client) Start(startConfig StartConfig) (*StartResult, error) {
 			CPUs:        startConfig.CPUs,
 			Memory:      startConfig.Memory,
 			DiskSize:    startConfig.DiskSize,
-			NetworkMode: client.networkMode,
+			NetworkMode: client.networkMode(),
 		}
 
 		crcBundleMetadata, err = getCrcBundleInfo(startConfig.BundlePath)
@@ -261,7 +261,7 @@ func (client *client) Start(startConfig StartConfig) (*StartResult, error) {
 		IP:        instanceIP,
 		// TODO: should be more finegrained
 		BundleMetadata: *crcBundleMetadata,
-		NetworkMode:    client.networkMode,
+		NetworkMode:    client.networkMode(),
 	}
 
 	// Run the DNS server inside the VM
@@ -335,7 +335,7 @@ func (client *client) Start(startConfig StartConfig) (*StartResult, error) {
 		return nil, errors.Wrap(err, "Failed to update cluster ID")
 	}
 
-	if client.monitoringEnabled {
+	if client.monitoringEnabled() {
 		logging.Info("Enabling cluster monitoring operator...")
 		if err := cluster.StartMonitoring(ocConfig); err != nil {
 			return nil, errors.Wrap(err, "Cannot start monitoring stack")
@@ -406,7 +406,7 @@ func (client *client) IsRunning() (bool, error) {
 }
 
 func (client *client) validateStartConfig(startConfig StartConfig) error {
-	if client.monitoringEnabled && startConfig.Memory < minimumMemoryForMonitoring {
+	if client.monitoringEnabled() && startConfig.Memory < minimumMemoryForMonitoring {
 		return fmt.Errorf("Too little memory (%s) allocated to the virtual machine to start the monitoring stack, %s is the minimum",
 			units.BytesSize(float64(startConfig.Memory)*1024*1024),
 			units.BytesSize(minimumMemoryForMonitoring*1024*1024))

--- a/pkg/crc/machine/status.go
+++ b/pkg/crc/machine/status.go
@@ -61,7 +61,7 @@ func (client *client) Status() (*ClusterStatusResult, error) {
 	}
 	return &ClusterStatusResult{
 		CrcStatus:        state.Running,
-		OpenshiftStatus:  getOpenShiftStatus(sshRunner, client.monitoringEnabled),
+		OpenshiftStatus:  getOpenShiftStatus(sshRunner, client.monitoringEnabled()),
 		OpenshiftVersion: crcBundleMetadata.GetOpenshiftVersion(),
 		DiskUse:          diskUse,
 		DiskSize:         diskSize,

--- a/test/e2e/crcsuite/collect.go
+++ b/test/e2e/crcsuite/collect.go
@@ -13,10 +13,10 @@ import (
 	"sync"
 	"time"
 
+	crcConfig "github.com/code-ready/crc/pkg/crc/config"
 	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/code-ready/crc/pkg/crc/logging"
 	"github.com/code-ready/crc/pkg/crc/machine"
-	"github.com/code-ready/crc/pkg/crc/network"
 	"github.com/code-ready/crc/pkg/crc/ssh"
 	"github.com/pkg/errors"
 	"golang.org/x/sync/semaphore"
@@ -177,7 +177,7 @@ type VMCommandCollector struct {
 }
 
 func (collector *VMCommandCollector) Collect(w Writer) error {
-	client := machine.NewClient(constants.DefaultName, network.DefaultMode, false)
+	client := machine.NewClient(constants.DefaultName, true, crcConfig.New(crcConfig.NewEmptyInMemoryStorage()))
 	ip, err := client.IP()
 	if err != nil {
 		return err
@@ -198,7 +198,7 @@ type ContainerLogCollector struct {
 }
 
 func (collector *ContainerLogCollector) Collect(w Writer) error {
-	client := machine.NewClient(constants.DefaultName, network.DefaultMode, false)
+	client := machine.NewClient(constants.DefaultName, true, crcConfig.New(crcConfig.NewEmptyInMemoryStorage()))
 	ip, err := client.IP()
 	if err != nil {
 		return err


### PR DESCRIPTION
Follow-up of https://github.com/code-ready/crc/pull/1558

Since #1558 we recreate the config object each time. This is painful and implies to reconstruct the API handler for each request. 
This PR fixes that by only using viper for reading configuration. Writing is done manually. 

* Get() is now called every time.
* 2 processes can now share the same configuration without reloading

The intention of this is to simplify the API in a future PR.