### PR TITLE
Add a missing newline to console command

### DIFF
--- a/cmd/crc/cmd/console.go
+++ b/cmd/crc/cmd/console.go
@@ -94,7 +94,7 @@ func (s *consoleResult) prettyPrintTo(writer io.Writer) error {
 		return errors.New("The OpenShift cluster is not running, cannot open the OpenShift Web Console")
 	}
 
-	if _, err := fmt.Fprint(writer, "Opening the OpenShift Web Console in the default browser..."); err != nil {
+	if _, err := fmt.Fprintln(writer, "Opening the OpenShift Web Console in the default browser..."); err != nil {
 		return err
 	}
 	if err := browser.OpenURL(s.ClusterConfig.WebConsoleURL); err != nil {


### PR DESCRIPTION
## Solution/Idea

The console command:
```
deboer-mac:crc-macos-1.20.0-amd64 deboer$ ./crc console
Opening the OpenShift Web Console in the default browser...deboer-mac:crc-macos-1.20.0-amd64 deboer$ ./crc console
```
is missing a newline, and it gets annoying that the command prompt changes position.

## Proposed changes

Literally just added 'ln'.

## Testing

Absolutely none. I don't know Golang, so please verify this is as minor as it seems. :)