### PR TITLE
Use a separate fd for libmachine logging

### DIFF
--- a/pkg/crc/logging/logging.go
+++ b/pkg/crc/logging/logging.go
@@ -21,19 +21,15 @@ func OpenLogFile(path string) (*os.File, error) {
 	if err != nil {
 		return nil, err
 	}
-	logfile, err = os.OpenFile(path, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0600)
+	logFile, err := os.OpenFile(path, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0600)
 	if err != nil {
 		return nil, err
 	}
-	return logfile, nil
-}
-
-func CloseLogFile() {
-	logfile.Close()
+	return logFile, nil
 }
 
 func CloseLogging() {
-	CloseLogFile()
+	logfile.Close()
 	logrus.StandardLogger().ReplaceHooks(make(logrus.LevelHooks))
 }
 

--- a/pkg/crc/machine/ip.go
+++ b/pkg/crc/machine/ip.go
@@ -3,11 +3,6 @@ package machine
 import "github.com/pkg/errors"
 
 func (client *client) IP() (string, error) {
-	err := setMachineLogging(client.debug)
-	if err != nil {
-		return "", errors.Wrap(err, "Cannot initialize logging")
-	}
-
 	libMachineAPIClient, cleanup, err := createLibMachineClient(client.debug)
 	defer cleanup()
 	if err != nil {

--- a/pkg/crc/machine/stop.go
+++ b/pkg/crc/machine/stop.go
@@ -7,14 +7,6 @@ import (
 )
 
 func (client *client) Stop() (state.State, error) {
-	defer unsetMachineLogging()
-
-	// Set libmachine logging
-	err := setMachineLogging(client.debug)
-	if err != nil {
-		return state.None, errors.Wrap(err, "Cannot initialize logging")
-	}
-
 	libMachineAPIClient, cleanup, err := createLibMachineClient(client.debug)
 	defer cleanup()
 	if err != nil {


### PR DESCRIPTION
logging.OpenLogFile called in machine was overriding the fd stored at package-level in logging.
Now machine uses its own fd and close it before the log rotation happens

on macOS, the issue was:
```
$ crc status --log-level debug
DEBU operator-lifecycle-manager-packageserver operator is still progressing, Reason:  
Failed to write to log, write /Users/guillaumerose/.crc/crc.log: file already closed
DEBU service-ca operator is still progressing, Reason: _ManagedDeploymentsAvailable 
Failed to write to log, write /Users/guillaumerose/.crc/crc.log: file already closed
CRC VM:          Running
OpenShift:       Starting (v4.6.9)
Disk Usage:      10.59GB of 32.72GB (Inside the CRC VM)
Cache Usage:     10.72GB
Cache Directory: /Users/guillaumerose/.crc/cache
DEBU Running 'sw_vers -productVersion'            
Failed to write to log, write /Users/guillaumerose/.crc/crc.log: file already closed
Collapse

$ crc delete
Do you want to delete the OpenShift cluster? [y/N]: y
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x13f0f96]
goroutine 1 [running]:
os.(*File).Name(...)
    /Users/guillaumerose/.gvm/gos/go1.14/src/os/file.go:54
github.com/code-ready/crc/pkg/crc/logging.BackupLogFile()
    /Users/guillaumerose/gomod/crc/pkg/crc/logging/logging.go:41 +0x36
```