### PR TITLE
Check for race conditions when running go test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ cross: $(BUILD_DIR)/macos-amd64/crc $(BUILD_DIR)/linux-amd64/crc $(BUILD_DIR)/wi
 
 .PHONY: test
 test:
-	go test --tags build -v -ldflags="$(VERSION_VARIABLES)" ./pkg/... ./cmd/...
+	go test -race --tags build -v -ldflags="$(VERSION_VARIABLES)" ./pkg/... ./cmd/...
 
 .PHONY: build_docs
 build_docs:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,7 @@ environment:
   GOPATH: c:\gopath
 stack: go 1.14
 before_test:
+  - choco install mingw
   - choco install make
   - make cross
 test_script:


### PR DESCRIPTION
`viper.WatchConfig` is full of race and having this race check will prevent us (and esp. me in https://github.com/code-ready/crc/pull/1837) to add it again. 