### PR TITLE
doc: Add notice and procedures for usage data collection

### DIFF
--- a/docs/source/topics/proc_setting-up-codeready-containers.adoc
+++ b/docs/source/topics/proc_setting-up-codeready-containers.adoc
@@ -25,3 +25,24 @@ Always run the [command]`{bin}` executable with your user account.
 ----
 $ {bin} setup
 ----
+
+.Consent for telemetry data collection
+
+The `{bin} setup` command prompts you for optional, anonymous usage data collection to assist with development.
+No personally identifiable information is collected.
+
+* To manually enable telemetry, run the following command:
++
+[subs="+quotes,attributes"]
+----
+$ {bin} config set consent-telemetry yes
+----
+
+* To manually disable telemetry, run the following command:
++
+[subs="+quotes,attributes"]
+----
+$ {bin} config set consent-telemetry no
+----
+
+For more information about collected data, see the Red{nbsp}Hat link:https://developers.redhat.com/article/tool-data-collection[Telemetry data collection notice].


### PR DESCRIPTION
## Solution/Idea

Add relevant information regarding telemetry to the documentation for the `crc setup` command.

The documentation includes minor information about the data collection itself, how to skip the prompt, how to manually enable/disable telemetry, and a link to the relevant Red Hat privacy statement.

## Proposed changes

For now, add information about usage data collection to the documentation for the `crc setup` command. In the future, we are going to create a dedicated section for this information so that it's more readily findable.