### PR TITLE
Make behaviour releases installed from macos package closer to the previous embedded behaviour

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,8 +35,6 @@ RELEASE_INFO := release-info.json
 
 MOCK_BUNDLE ?= false
 
-SEGMENT_WRITE_KEY := "cvpHsNcmGCJqVzf6YxrSnVlwFSAZaYtp"
-
 # Check that given variables are set and all have non-empty values,
 # die with an error otherwise.
 #
@@ -54,6 +52,8 @@ __check_defined = \
 VERSION_VARIABLES := -X $(REPOPATH)/pkg/crc/version.crcVersion=$(CRC_VERSION) \
 	-X $(REPOPATH)/pkg/crc/version.bundleVersion=$(BUNDLE_VERSION) \
 	-X $(REPOPATH)/pkg/crc/version.commitSha=$(COMMIT_SHA)
+RELEASE_VERSION_VARIABLES := -X $(REPOPATH)/pkg/crc/segment.WriteKey=cvpHsNcmGCJqVzf6YxrSnVlwFSAZaYtp \
+	-X $(REPOPATH)/pkg/crc/version.isRelease=true
 
 ifdef OKD_VERSION
 	VERSION_VARIABLES := $(VERSION_VARIABLES) -X $(REPOPATH)/pkg/crc/version.okdBuild=true
@@ -181,7 +181,7 @@ gen_release_info:
 	@sed -i s/@OPENSHIFT_VERSION@/\"$(BUNDLE_VERSION)\"/ $(RELEASE_INFO)
 
 .PHONY: release
-release: LDFLAGS += -X $(REPOPATH)/pkg/crc/segment.WriteKey=$(SEGMENT_WRITE_KEY)
+release: LDFLAGS += $(RELEASE_VERSION_VARIABLES)
 release: cross-lint embed_bundle build_docs_pdf gen_release_info
 	mkdir $(RELEASE_DIR)
 	
@@ -225,7 +225,7 @@ update-go-version:
 goversioncheck:
 	./verify-go-version.sh
 
-package: LDFLAGS+= -X '$(REPOPATH)/pkg/crc/version.macosInstallPath=$(MACOS_INSTALL_PATH)' -X $(REPOPATH)/pkg/crc/segment.WriteKey=$(SEGMENT_WRITE_KEY)
+package: LDFLAGS+= -X '$(REPOPATH)/pkg/crc/version.macosInstallPath=$(MACOS_INSTALL_PATH)' $(RELEASE_VERSION_VARIABLES)
 package: clean check_bundledir $(BUILD_DIR)/macos-amd64/crc $(HOST_BUILD_DIR)/crc-embedder
 	sed -e 's/__VERSION__/'$(CRC_VERSION)'/g' -e 's@__INSTALL_PATH__@$(MACOS_INSTALL_PATH)@g' packaging/darwin/Distribution.in >packaging/darwin/Distribution
 	sed -e 's/__VERSION__/'$(CRC_VERSION)'/g' -e 's@__INSTALL_PATH__@$(MACOS_INSTALL_PATH)@g' packaging/darwin/welcome.html.in >packaging/darwin/Resources/welcome.html

--- a/cmd/crc/cmd/setup.go
+++ b/cmd/crc/cmd/setup.go
@@ -7,9 +7,9 @@ import (
 	"os"
 
 	cmdConfig "github.com/code-ready/crc/cmd/crc/cmd/config"
-	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/code-ready/crc/pkg/crc/input"
 	"github.com/code-ready/crc/pkg/crc/preflight"
+	pkgversion "github.com/code-ready/crc/pkg/crc/version"
 	"github.com/spf13/cobra"
 )
 
@@ -68,7 +68,7 @@ func (s *setupResult) prettyPrintTo(writer io.Writer) error {
 
 func extraArguments() string {
 	var bundle string
-	if !constants.BundleEmbedded() {
+	if !pkgversion.IsRelease() {
 		bundle = " -b $bundlename"
 	}
 	return bundle

--- a/pkg/crc/preflight/preflight_checks_common.go
+++ b/pkg/crc/preflight/preflight_checks_common.go
@@ -10,6 +10,7 @@ import (
 	"github.com/code-ready/crc/pkg/crc/logging"
 	"github.com/code-ready/crc/pkg/crc/machine/bundle"
 	"github.com/code-ready/crc/pkg/crc/validation"
+	"github.com/code-ready/crc/pkg/crc/version"
 	"github.com/code-ready/crc/pkg/embed"
 	"github.com/docker/go-units"
 	"github.com/pkg/errors"
@@ -60,7 +61,7 @@ var genericPreflightChecks = [...]Check{
 }
 
 func checkBundleExtracted() error {
-	if !constants.BundleEmbedded() {
+	if !version.IsRelease() {
 		return nil
 	}
 	if _, err := os.Stat(constants.DefaultBundlePath); os.IsNotExist(err) {
@@ -76,7 +77,7 @@ func fixBundleExtracted() error {
 	if err := os.Chmod(constants.MachineCacheDir, 0775); err != nil {
 		logging.Debugf("Error changing %s permissions to 0775", constants.MachineCacheDir)
 	}
-	if constants.BundleEmbedded() {
+	if version.IsRelease() {
 		bundleDir := filepath.Dir(constants.DefaultBundlePath)
 		if err := os.MkdirAll(bundleDir, 0775); err != nil {
 			return fmt.Errorf("Cannot create directory %s: %v", bundleDir, err)

--- a/pkg/crc/validation/validation.go
+++ b/pkg/crc/validation/validation.go
@@ -63,7 +63,7 @@ func ValidateBundle(bundle string) error {
 		if constants.BundleEmbedded() {
 			return fmt.Errorf("Run 'crc setup' to unpack the bundle to disk")
 		}
-		return fmt.Errorf("Please provide the path to a valid bundle using the -b option")
+		return fmt.Errorf("%s not found, please provide the path to a valid bundle using the -b option", bundle)
 	}
 	// Check if the version of the bundle provided by user is same as what is released with crc.
 	releaseBundleVersion := version.GetBundleVersion()
@@ -73,7 +73,7 @@ func ValidateBundle(bundle string) error {
 			logging.Warnf("Using unsupported bundle %s", userProvidedBundleVersion)
 			return nil
 		}
-		return fmt.Errorf("%s bundle is not supported by this crc executable, please use %s", userProvidedBundleVersion, constants.GetDefaultBundle())
+		return fmt.Errorf("%s is not supported by this crc executable, please use %s", userProvidedBundleVersion, constants.GetDefaultBundle())
 	}
 	return nil
 }

--- a/pkg/crc/validation/validation.go
+++ b/pkg/crc/validation/validation.go
@@ -69,7 +69,7 @@ func ValidateBundle(bundle string) error {
 	releaseBundleVersion := version.GetBundleVersion()
 	userProvidedBundleVersion := filepath.Base(bundle)
 	if !strings.Contains(userProvidedBundleVersion, fmt.Sprintf("%s.crcbundle", releaseBundleVersion)) {
-		if !constants.BundleEmbedded() {
+		if !version.IsRelease() {
 			logging.Warnf("Using unsupported bundle %s", userProvidedBundleVersion)
 			return nil
 		}

--- a/pkg/crc/version/version.go
+++ b/pkg/crc/version/version.go
@@ -24,6 +24,8 @@ var (
 	okdBuild = "false"
 
 	macosInstallPath = "/unset"
+
+	isRelease = "false"
 )
 
 const (
@@ -54,6 +56,10 @@ func GetBundleVersion() string {
 
 func IsOkdBuild() bool {
 	return okdBuild == "true"
+}
+
+func IsRelease() bool {
+	return isRelease == "true"
 }
 
 func GetCRCMacTrayVersion() string {


### PR DESCRIPTION
This readds 2 things when using a binary built with 'make package':
- `crc setup` no longer instructs to use `-b $bundlename` since the bundle can be located automatically
- `crc start -b $bundlename` requires the openshift version which was set at build time