### PR TITLE
Use public registry for ubi

### DIFF
--- a/images/dnsmasq/Dockerfile
+++ b/images/dnsmasq/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/ubi8/ubi
+FROM registry.access.redhat.com/ubi8/ubi
 MAINTAINER CodeReady Container <devtools-cdk@redhat.com>
 
 RUN yum -y install dnsmasq && \

--- a/images/docs-builder/Dockerfile
+++ b/images/docs-builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/ubi8
+FROM registry.access.redhat.com/ubi8/ubi
 MAINTAINER CodeReady Containers <devtools-cdk@redhat.com>
 
 RUN yum update -y && \


### PR DESCRIPTION
registry.redhat.io requires authentication, registry.access.redhat.com
does not as described on https://access.redhat.com/RegistryAuthentication

Since both have the image that we need, we can use the public one to
make builds easier.