### PR TITLE
Unpack the tray in the macOS pkg directly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -233,12 +233,20 @@ package: clean check_bundledir $(BUILD_DIR)/macos-amd64/crc $(HOST_BUILD_DIR)/cr
 	chmod 755 packaging/darwin/scripts/postinstall
 	mkdir -p packaging/root/"$(MACOS_INSTALL_PATH)"/$(CRC_VERSION)/
 	$(HOST_BUILD_DIR)/crc-embedder download packaging/root/"$(MACOS_INSTALL_PATH)"/$(CRC_VERSION)/
+
+	tar -C packaging/root/"$(MACOS_INSTALL_PATH)"/$(CRC_VERSION)/ -xvzf packaging/root/"$(MACOS_INSTALL_PATH)"/$(CRC_VERSION)/crc-tray-macos.tar.gz
+	rm packaging/root/"$(MACOS_INSTALL_PATH)"/$(CRC_VERSION)/crc-tray-macos.tar.gz
+
 	cp $(HYPERKIT_BUNDLENAME) packaging/root/"$(MACOS_INSTALL_PATH)"/$(CRC_VERSION)/
 	cp $(BUILD_DIR)/macos-amd64/crc packaging/root/"$(MACOS_INSTALL_PATH)"/$(CRC_VERSION)/
 	cp LICENSE packaging/darwin/Resources/LICENSE.txt
+	pkgbuild --analyze --root packaging/root packaging/components.plist
+	plutil -replace BundleIsRelocatable -bool NO packaging/components.plist
 	pkgbuild --identifier com.redhat.crc.$(CRC_VERSION) --version $(CRC_VERSION) \
 		--scripts packaging/darwin/scripts \
 		--root packaging/root \
+		--install-location / \
+		--component-plist packaging/components.plist \
 		$(BUILD_DIR)/macos-amd64/crc.pkg
 	productbuild --distribution packaging/darwin/Distribution \
 		--resources packaging/darwin/Resources \

--- a/packaging/.gitignore
+++ b/packaging/.gitignore
@@ -1,1 +1,2 @@
 root/
+/components.plist

--- a/packaging/.gitignore
+++ b/packaging/.gitignore
@@ -1,2 +1,6 @@
 root/
 /components.plist
+/darwin/Distribution
+/darwin/Resources/LICENSE.txt
+/darwin/Resources/welcome.html
+/darwin/scripts/postinstall

--- a/pkg/crc/constants/constants_darwin.go
+++ b/pkg/crc/constants/constants_darwin.go
@@ -1,6 +1,11 @@
 package constants
 
-import "path/filepath"
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/code-ready/crc/pkg/crc/version"
+)
 
 const (
 	OcExecutableName          = "oc"
@@ -10,6 +15,16 @@ const (
 )
 
 var (
-	TrayAppBundlePath  = filepath.Join(CrcBinDir, TrayExecutableName)
+	TrayAppBundlePath  = trayAppBundlePath()
 	TrayExecutablePath = filepath.Join(TrayAppBundlePath, "Contents", "MacOS", "CodeReady Containers")
 )
+
+func trayAppBundlePath() string {
+	if version.IsMacosInstallPathSet() {
+		path := filepath.Join(version.GetMacosInstallPath(), version.GetCRCVersion(), TrayExecutableName)
+		if _, err := os.Stat(path); err == nil {
+			return path
+		}
+	}
+	return filepath.Join(CrcBinDir, TrayExecutableName)
+}


### PR DESCRIPTION
Notarization forces us to untar everything in the package. For an app,
it's slightly more complicated: the plist needs to be changed otherwise
the app is not installed at all.
    
Reference: https://scriptingosx.com/2017/05/relocatable-package-installers-and-quickpkg-update/