### PR TITLE
Remove OcBinDir if it's a file

### DIFF
--- a/pkg/crc/machine/bundle/repository.go
+++ b/pkg/crc/machine/bundle/repository.go
@@ -83,6 +83,14 @@ func (repo *Repository) Use(bundleName string) (*CrcBundleInfo, error) {
 func (bundle *CrcBundleInfo) createSymlinkOrCopyOpenShiftClient(ocBinDir string) error {
 	ocInBundle := bundle.resolvePath(constants.OcExecutableName)
 	ocInBinDir := filepath.Join(ocBinDir, constants.OcExecutableName)
+
+	// this is needed when upgrading from crc versions anterior to commit 1.11.0~5
+	if info, err := os.Stat(ocBinDir); err == nil && !info.IsDir() {
+		if err := os.Remove(ocBinDir); err != nil {
+			return err
+		}
+	}
+
 	if err := os.MkdirAll(ocBinDir, 0750); err != nil {
 		return err
 	}

--- a/pkg/crc/machine/bundle/repository_test.go
+++ b/pkg/crc/machine/bundle/repository_test.go
@@ -21,9 +21,7 @@ func TestUse(t *testing.T) {
 	assert.NoError(t, err)
 	defer os.RemoveAll(ocBinDir)
 
-	assert.NoError(t, os.Mkdir(filepath.Join(dir, "crc_libvirt_4.6.1"), 0755))
-	writeMetadata(t, filepath.Join(dir, "crc_libvirt_4.6.1"), reference)
-	assert.NoError(t, ioutil.WriteFile(filepath.Join(dir, "crc_libvirt_4.6.1", constants.OcExecutableName), []byte("openshift-client"), 0600))
+	addBundle(t, dir, "crc_libvirt_4.6.1")
 
 	repo := &Repository{
 		CacheDir: dir,
@@ -37,6 +35,27 @@ func TestUse(t *testing.T) {
 	bin, err := ioutil.ReadFile(filepath.Join(ocBinDir, constants.OcExecutableName))
 	assert.NoError(t, err)
 	assert.Equal(t, "openshift-client", string(bin))
+}
+
+func TestUseWithOCFile(t *testing.T) {
+	dir, err := ioutil.TempDir("", "repo")
+	assert.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	fd, err := ioutil.TempFile("", "oc-bin-dir")
+	assert.NoError(t, err)
+	fd.Close()
+	defer os.RemoveAll(fd.Name())
+
+	addBundle(t, dir, "crc_libvirt_4.6.1")
+
+	repo := &Repository{
+		CacheDir: dir,
+		OcBinDir: fd.Name(),
+	}
+
+	_, err = repo.Use("crc_libvirt_4.6.1.crcbundle")
+	assert.NoError(t, err)
 }
 
 func TestExtract(t *testing.T) {
@@ -104,4 +123,10 @@ func TestVersionCheck(t *testing.T) {
 
 func writeMetadata(t *testing.T, dir string, s string) bool {
 	return assert.NoError(t, ioutil.WriteFile(filepath.Join(dir, metadataFilename), []byte(s), 0600))
+}
+
+func addBundle(t *testing.T, dir, name string) {
+	assert.NoError(t, os.Mkdir(filepath.Join(dir, name), 0755))
+	writeMetadata(t, filepath.Join(dir, name), reference)
+	assert.NoError(t, ioutil.WriteFile(filepath.Join(dir, name, constants.OcExecutableName), []byte("openshift-client"), 0600))
 }


### PR DESCRIPTION
Apparently, we removed this code too quickly. Some users still need it.
They hit the error: mkdir /Users/name/.crc/bin/oc: not a directory

Found with telemetry.