### PR TITLE
Add crc setup instruction if start fail in preflight

### DIFF
--- a/cmd/crc/cmd/start.go
+++ b/cmd/crc/cmd/start.go
@@ -129,6 +129,10 @@ type startResult struct {
 
 func (s *startResult) prettyPrintTo(writer io.Writer) error {
 	if s.Error != nil {
+		var e *crcErrors.PreflightError
+		if errors.As(s.Error, &e) {
+			logging.Warn("Preflight checks failed during `crc start`, please try to run `crc setup` first in case you haven't done so yet")
+		}
 		return s.Error
 	}
 	if s.ClusterConfig == nil {

--- a/pkg/crc/errors/multierror.go
+++ b/pkg/crc/errors/multierror.go
@@ -16,6 +16,18 @@ func (v vmNotExist) Error() string {
 
 const VMNotExist vmNotExist = "Machine does not exist. Use 'crc start' to create it"
 
+type PreflightError struct {
+	Err error
+}
+
+func (p *PreflightError) Error() string {
+	return p.Err.Error()
+}
+
+func (p *PreflightError) Unwrap() error {
+	return p.Err
+}
+
 type MultiError struct {
 	Errors []error
 }

--- a/pkg/crc/preflight/preflight.go
+++ b/pkg/crc/preflight/preflight.go
@@ -153,7 +153,10 @@ func doRegisterSettings(cfg config.Schema, checks []Check) {
 func StartPreflightChecks(config config.Storage) error {
 	experimentalFeatures := config.Get(cmdConfig.ExperimentalFeatures).AsBool()
 	mode := network.ParseMode(config.Get(cmdConfig.NetworkMode).AsString())
-	return doPreflightChecks(config, getPreflightChecks(experimentalFeatures, mode))
+	if err := doPreflightChecks(config, getPreflightChecks(experimentalFeatures, mode)); err != nil {
+		return &errors.PreflightError{Err: err}
+	}
+	return nil
 }
 
 // SetupHost performs the prerequisite checks and setups the host to run the cluster


### PR DESCRIPTION
**Fixes:** Issue #1876 

## Solution/Idea
In case of error during preflight, better to advice the user to
run crc setup once if user directly started executed `crc start`.

