### PR TITLE
telemetry: send additional data (cpus, memory, network mode) 

### DIFF
--- a/cmd/crc/cmd/config/get.go
+++ b/cmd/crc/cmd/config/get.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/code-ready/crc/pkg/crc/config"
+	"github.com/code-ready/crc/pkg/crc/telemetry"
 	"github.com/spf13/cobra"
 )
 
@@ -18,15 +19,19 @@ func configGetCmd(config config.Storage) *cobra.Command {
 				return errors.New("Please provide a configuration property to get")
 			}
 			key := args[0]
+
 			v := config.Get(key)
-			switch {
-			case v.Invalid:
+			if v.Invalid {
 				return fmt.Errorf("Configuration property '%s' does not exist", key)
-			case v.IsDefault:
-				return fmt.Errorf("Configuration property '%s' is not set. Default value is '%s'", key, v.AsString())
-			default:
-				fmt.Println(key, ":", v.AsString())
 			}
+
+			telemetry.SetContextProperty(cmd.Context(), "key", args[0])
+
+			if v.IsDefault {
+				return fmt.Errorf("Configuration property '%s' is not set. Default value is '%s'", key, v.AsString())
+
+			}
+			fmt.Println(key, ":", v.AsString())
 			return nil
 		},
 	}

--- a/cmd/crc/cmd/config/set.go
+++ b/cmd/crc/cmd/config/set.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/code-ready/crc/pkg/crc/config"
+	"github.com/code-ready/crc/pkg/crc/telemetry"
 	"github.com/spf13/cobra"
 )
 
@@ -21,6 +22,8 @@ func configSetCmd(config config.Storage) *cobra.Command {
 			if err != nil {
 				return err
 			}
+
+			telemetry.SetContextProperty(cmd.Context(), "key", args[0])
 
 			if setMessage != "" {
 				fmt.Println(setMessage)

--- a/cmd/crc/cmd/config/unset.go
+++ b/cmd/crc/cmd/config/unset.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/code-ready/crc/pkg/crc/config"
+	"github.com/code-ready/crc/pkg/crc/telemetry"
 	"github.com/spf13/cobra"
 )
 
@@ -21,6 +22,9 @@ func configUnsetCmd(config config.Storage) *cobra.Command {
 			if err != nil {
 				return err
 			}
+
+			telemetry.SetContextProperty(cmd.Context(), "key", args[0])
+
 			if unsetMessage != "" {
 				fmt.Println(unsetMessage)
 			}

--- a/pkg/crc/segment/segment_test.go
+++ b/pkg/crc/segment/segment_test.go
@@ -26,7 +26,8 @@ type segmentResponse struct {
 		AnonymousID string `json:"anonymousId"`
 		MessageID   string `json:"messageId"`
 		Traits      struct {
-			OS string `json:"os"`
+			OS                   string `json:"os"`
+			ExperimentalFeatures bool   `json:"enable-experimental-features"`
 		} `json:"traits"`
 		Properties struct {
 			Error   string `json:"error"`
@@ -62,6 +63,9 @@ func newTestConfig(value string) (*crcConfig.Config, error) {
 	if _, err := config.Set(cmdConfig.ConsentTelemetry, value); err != nil {
 		return nil, err
 	}
+	if _, err := config.Set(cmdConfig.ExperimentalFeatures, true); err != nil {
+		return nil, err
+	}
 	return config, nil
 }
 
@@ -89,6 +93,7 @@ func TestClientUploadWithConsent(t *testing.T) {
 		require.NoError(t, json.Unmarshal(x, &s))
 		require.Equal(t, s.Batch[0].Type, "identify")
 		require.Equal(t, s.Batch[0].Traits.OS, runtime.GOOS)
+		require.Equal(t, s.Batch[0].Traits.ExperimentalFeatures, true)
 		require.Equal(t, s.Batch[1].Type, "track")
 		require.Equal(t, s.Batch[1].Properties.Error, "an error occurred")
 		require.Equal(t, s.Batch[1].Properties.Version, version.GetCRCVersion())

--- a/pkg/crc/telemetry/telemetry.go
+++ b/pkg/crc/telemetry/telemetry.go
@@ -1,0 +1,58 @@
+package telemetry
+
+import (
+	"context"
+	"sync"
+)
+
+type contextKey struct{}
+
+var key = contextKey{}
+
+type Properties struct {
+	lock    sync.Mutex
+	storage map[string]interface{}
+}
+
+func (p *Properties) set(name string, value interface{}) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	p.storage[name] = value
+}
+
+func (p *Properties) values() map[string]interface{} {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	ret := make(map[string]interface{})
+	for k, v := range p.storage {
+		ret[k] = v
+	}
+	return ret
+}
+
+func propertiesFromContext(ctx context.Context) *Properties {
+	value := ctx.Value(key)
+	if cast, ok := value.(*Properties); ok {
+		return cast
+	}
+	return nil
+}
+
+func NewContext(ctx context.Context) context.Context {
+	return context.WithValue(ctx, key, &Properties{storage: make(map[string]interface{})})
+}
+
+func GetContextProperties(ctx context.Context) map[string]interface{} {
+	properties := propertiesFromContext(ctx)
+	if properties == nil {
+		return make(map[string]interface{})
+	}
+	return properties.values()
+}
+
+func SetContextProperty(ctx context.Context, key string, value interface{}) {
+	properties := propertiesFromContext(ctx)
+	if properties != nil {
+		properties.set(key, value)
+	}
+}


### PR DESCRIPTION
This uses context to pass the data. This is required as we cannot easily extend or change the signature of cobra.Command RunE.