### PR TITLE
Pull Secret UX: keep asking it in case of error and better wording

### DIFF
--- a/cmd/crc/cmd/start.go
+++ b/cmd/crc/cmd/start.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -12,7 +11,6 @@ import (
 	"github.com/code-ready/crc/pkg/crc/cluster"
 	"github.com/code-ready/crc/pkg/crc/constants"
 	crcErrors "github.com/code-ready/crc/pkg/crc/errors"
-	"github.com/code-ready/crc/pkg/crc/input"
 	"github.com/code-ready/crc/pkg/crc/logging"
 	"github.com/code-ready/crc/pkg/crc/machine"
 	"github.com/code-ready/crc/pkg/crc/preflight"
@@ -70,9 +68,7 @@ func runStart(arguments []string) (*machine.StartResult, error) {
 		DiskSize:   config.Get(cmdConfig.DiskSize).AsInt(),
 		CPUs:       config.Get(cmdConfig.CPUs).AsInt(),
 		NameServer: config.Get(cmdConfig.NameServer).AsString(),
-		PullSecret: &cluster.PullSecret{
-			Getter: getPullSecretFileContent,
-		},
+		PullSecret: cluster.NewInteractivePullSecretLoader(config),
 	}
 
 	client := newMachine()
@@ -177,40 +173,6 @@ func validateStartFlags() error {
 		}
 	}
 	return nil
-}
-
-func getPullSecretFileContent() (string, error) {
-	var (
-		pullsecret string
-		err        error
-	)
-
-	// If crc is built from an OKD bundle, then use the fake pull secret in contants.
-	if crcversion.IsOkdBuild() {
-		pullsecret = constants.OkdPullSecret
-		return pullsecret, nil
-	}
-	// In case user doesn't provide a file in start command or in config then ask for it.
-	if config.Get(cmdConfig.PullSecretFile).AsString() == "" {
-		pullsecret, err = input.PromptUserForSecret("Image pull secret", fmt.Sprintf("Copy it from %s", constants.CrcLandingPageURL))
-		// This is just to provide a new line after user enter the pull secret.
-		fmt.Println()
-		if err != nil {
-			return "", errors.New(err.Error())
-		}
-	} else {
-		// Read the file content
-		data, err := ioutil.ReadFile(config.Get(cmdConfig.PullSecretFile).AsString())
-		if err != nil {
-			return "", errors.New(err.Error())
-		}
-		pullsecret = string(data)
-	}
-	if err := validation.ImagePullSecret(pullsecret); err != nil {
-		return "", errors.New(err.Error())
-	}
-
-	return pullsecret, nil
 }
 
 func checkIfNewVersionAvailable(noUpdateCheck bool) {

--- a/pkg/crc/api/handlers.go
+++ b/pkg/crc/api/handlers.go
@@ -67,18 +67,13 @@ func parseStartArgs(args json.RawMessage) (startArgs, error) {
 }
 
 func getStartConfig(cfg crcConfig.Storage, args startArgs) machine.StartConfig {
-	startConfig := machine.StartConfig{
+	return machine.StartConfig{
 		BundlePath: cfg.Get(config.Bundle).AsString(),
 		Memory:     cfg.Get(config.Memory).AsInt(),
 		CPUs:       cfg.Get(config.CPUs).AsInt(),
 		NameServer: cfg.Get(config.NameServer).AsString(),
+		PullSecret: cluster.NewNonInteractivePullSecretLoader(cfg, args.PullSecretFile),
 	}
-	pullSecretFile := args.PullSecretFile
-	if pullSecretFile == "" {
-		pullSecretFile = cfg.Get(config.PullSecretFile).AsString()
-	}
-	startConfig.PullSecret = cluster.NewNonInteractivePullSecretLoader(pullSecretFile)
-	return startConfig
 }
 
 type VersionResult struct {

--- a/pkg/crc/cluster/pullsecret.go
+++ b/pkg/crc/cluster/pullsecret.go
@@ -41,7 +41,7 @@ func (loader *interactivePullSecretLoader) Value() (string, error) {
 		return fromNonInteractive, nil
 	}
 
-	return promptUserForSecret("Image pull secret", fmt.Sprintf("Copy it from %s", constants.CrcLandingPageURL))
+	return promptUserForSecret()
 }
 
 type nonInteractivePullSecretLoader struct {
@@ -91,17 +91,21 @@ func loadFile(path string) (string, error) {
 	return pullsecret, validation.ImagePullSecret(pullsecret)
 }
 
+const helpMessage = `CodeReady Containers requires a pull secret to download content from Red Hat.
+You can copy it from the Pull Secret section of %s.
+`
+
 // promptUserForSecret can be used for any kind of secret like image pull
 // secret or for password.
-func promptUserForSecret(message string, help string) (string, error) {
+func promptUserForSecret() (string, error) {
 	if !terminal.IsTerminal(int(os.Stdin.Fd())) {
 		return "", errors.New("cannot ask for secret, crc not launched by a terminal")
 	}
 
+	fmt.Printf(helpMessage, constants.CrcLandingPageURL)
 	var secret string
 	prompt := &survey.Password{
-		Message: message,
-		Help:    help,
+		Message: "Please enter the pull secret",
 	}
 	if err := survey.AskOne(prompt, &secret, func(ans interface{}) error {
 		return validation.ImagePullSecret(ans.(string))

--- a/pkg/crc/cluster/pullsecret.go
+++ b/pkg/crc/cluster/pullsecret.go
@@ -1,0 +1,87 @@
+package cluster
+
+import (
+	"fmt"
+	"io/ioutil"
+
+	cmdConfig "github.com/code-ready/crc/cmd/crc/cmd/config"
+	crcConfig "github.com/code-ready/crc/pkg/crc/config"
+	"github.com/code-ready/crc/pkg/crc/constants"
+	"github.com/code-ready/crc/pkg/crc/input"
+	"github.com/code-ready/crc/pkg/crc/validation"
+	crcversion "github.com/code-ready/crc/pkg/crc/version"
+)
+
+type PullSecretLoader interface {
+	Value() (string, error)
+}
+
+type interactivePullSecretLoader struct {
+	config *crcConfig.Config
+}
+
+func NewInteractivePullSecretLoader(config *crcConfig.Config) PullSecretLoader {
+	return &PullSecretMemoizer{
+		Getter: &interactivePullSecretLoader{
+			config: config,
+		},
+	}
+}
+
+func (loader *interactivePullSecretLoader) Value() (string, error) {
+	var (
+		pullsecret string
+		err        error
+	)
+
+	// If crc is built from an OKD bundle, then use the fake pull secret in contants.
+	if crcversion.IsOkdBuild() {
+		pullsecret = constants.OkdPullSecret
+		return pullsecret, nil
+	}
+	// In case user doesn't provide a file in start command or in config then ask for it.
+	if loader.config.Get(cmdConfig.PullSecretFile).AsString() == "" {
+		pullsecret, err = input.PromptUserForSecret("Image pull secret", fmt.Sprintf("Copy it from %s", constants.CrcLandingPageURL))
+		// This is just to provide a new line after user enter the pull secret.
+		fmt.Println()
+		if err != nil {
+			return "", err
+		}
+	} else {
+		// Read the file content
+		data, err := ioutil.ReadFile(loader.config.Get(cmdConfig.PullSecretFile).AsString())
+		if err != nil {
+			return "", err
+		}
+		pullsecret = string(data)
+	}
+	if err := validation.ImagePullSecret(pullsecret); err != nil {
+		return "", err
+	}
+
+	return pullsecret, nil
+}
+
+type nonInteractivePullSecretLoader struct {
+	path string
+}
+
+func NewNonInteractivePullSecretLoader(path string) PullSecretLoader {
+	return &PullSecretMemoizer{
+		Getter: &nonInteractivePullSecretLoader{
+			path: path,
+		},
+	}
+}
+
+func (loader *nonInteractivePullSecretLoader) Value() (string, error) {
+	data, err := ioutil.ReadFile(loader.path)
+	if err != nil {
+		return "", err
+	}
+	pullsecret := string(data)
+	if err := validation.ImagePullSecret(pullsecret); err != nil {
+		return "", err
+	}
+	return pullsecret, nil
+}

--- a/pkg/crc/cluster/pullsecret.go
+++ b/pkg/crc/cluster/pullsecret.go
@@ -36,8 +36,7 @@ func (loader *interactivePullSecretLoader) Value() (string, error) {
 
 	// If crc is built from an OKD bundle, then use the fake pull secret in contants.
 	if crcversion.IsOkdBuild() {
-		pullsecret = constants.OkdPullSecret
-		return pullsecret, nil
+		return constants.OkdPullSecret, nil
 	}
 	// In case user doesn't provide a file in start command or in config then ask for it.
 	if loader.config.Get(cmdConfig.PullSecretFile).AsString() == "" {
@@ -75,6 +74,11 @@ func NewNonInteractivePullSecretLoader(path string) PullSecretLoader {
 }
 
 func (loader *nonInteractivePullSecretLoader) Value() (string, error) {
+	// If crc is built from an OKD bundle, then use the fake pull secret in contants.
+	if crcversion.IsOkdBuild() {
+		return constants.OkdPullSecret, nil
+	}
+
 	data, err := ioutil.ReadFile(loader.path)
 	if err != nil {
 		return "", err

--- a/pkg/crc/cluster/pullsecret.go
+++ b/pkg/crc/cluster/pullsecret.go
@@ -41,16 +41,7 @@ func (loader *interactivePullSecretLoader) Value() (string, error) {
 		return fromNonInteractive, nil
 	}
 
-	fromUser, err := promptUserForSecret("Image pull secret", fmt.Sprintf("Copy it from %s", constants.CrcLandingPageURL))
-	// This is just to provide a new line after user enter the pull secret.
-	fmt.Println()
-	if err != nil {
-		return "", err
-	}
-	if err := validation.ImagePullSecret(fromUser); err != nil {
-		return "", err
-	}
-	return fromUser, nil
+	return promptUserForSecret("Image pull secret", fmt.Sprintf("Copy it from %s", constants.CrcLandingPageURL))
 }
 
 type nonInteractivePullSecretLoader struct {
@@ -112,7 +103,9 @@ func promptUserForSecret(message string, help string) (string, error) {
 		Message: message,
 		Help:    help,
 	}
-	if err := survey.AskOne(prompt, &secret, nil); err != nil {
+	if err := survey.AskOne(prompt, &secret, func(ans interface{}) error {
+		return validation.ImagePullSecret(ans.(string))
+	}); err != nil {
 		return "", err
 	}
 	return secret, nil

--- a/pkg/crc/cluster/pullsecret.go
+++ b/pkg/crc/cluster/pullsecret.go
@@ -1,13 +1,16 @@
 package cluster
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
+	"strings"
 
 	cmdConfig "github.com/code-ready/crc/cmd/crc/cmd/config"
 	crcConfig "github.com/code-ready/crc/pkg/crc/config"
 	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/code-ready/crc/pkg/crc/input"
+	"github.com/code-ready/crc/pkg/crc/logging"
 	"github.com/code-ready/crc/pkg/crc/validation"
 	crcversion "github.com/code-ready/crc/pkg/crc/version"
 )
@@ -17,58 +20,47 @@ type PullSecretLoader interface {
 }
 
 type interactivePullSecretLoader struct {
-	config *crcConfig.Config
+	nonInteractivePullSecretLoader *nonInteractivePullSecretLoader
 }
 
-func NewInteractivePullSecretLoader(config *crcConfig.Config) PullSecretLoader {
+func NewInteractivePullSecretLoader(config crcConfig.Storage) PullSecretLoader {
 	return &PullSecretMemoizer{
 		Getter: &interactivePullSecretLoader{
-			config: config,
+			nonInteractivePullSecretLoader: &nonInteractivePullSecretLoader{
+				config: config,
+			},
 		},
 	}
 }
 
 func (loader *interactivePullSecretLoader) Value() (string, error) {
-	var (
-		pullsecret string
-		err        error
-	)
+	fromNonInteractive, err := loader.nonInteractivePullSecretLoader.Value()
+	if err == nil {
+		return fromNonInteractive, nil
+	}
 
-	// If crc is built from an OKD bundle, then use the fake pull secret in contants.
-	if crcversion.IsOkdBuild() {
-		return constants.OkdPullSecret, nil
-	}
-	// In case user doesn't provide a file in start command or in config then ask for it.
-	if loader.config.Get(cmdConfig.PullSecretFile).AsString() == "" {
-		pullsecret, err = input.PromptUserForSecret("Image pull secret", fmt.Sprintf("Copy it from %s", constants.CrcLandingPageURL))
-		// This is just to provide a new line after user enter the pull secret.
-		fmt.Println()
-		if err != nil {
-			return "", err
-		}
-	} else {
-		// Read the file content
-		data, err := ioutil.ReadFile(loader.config.Get(cmdConfig.PullSecretFile).AsString())
-		if err != nil {
-			return "", err
-		}
-		pullsecret = string(data)
-	}
-	if err := validation.ImagePullSecret(pullsecret); err != nil {
+	fromUser, err := input.PromptUserForSecret("Image pull secret", fmt.Sprintf("Copy it from %s", constants.CrcLandingPageURL))
+	// This is just to provide a new line after user enter the pull secret.
+	fmt.Println()
+	if err != nil {
 		return "", err
 	}
-
-	return pullsecret, nil
+	if err := validation.ImagePullSecret(fromUser); err != nil {
+		return "", err
+	}
+	return fromUser, nil
 }
 
 type nonInteractivePullSecretLoader struct {
-	path string
+	config crcConfig.Storage
+	path   string
 }
 
-func NewNonInteractivePullSecretLoader(path string) PullSecretLoader {
+func NewNonInteractivePullSecretLoader(config crcConfig.Storage, path string) PullSecretLoader {
 	return &PullSecretMemoizer{
 		Getter: &nonInteractivePullSecretLoader{
-			path: path,
+			config: config,
+			path:   path,
 		},
 	}
 }
@@ -79,13 +71,29 @@ func (loader *nonInteractivePullSecretLoader) Value() (string, error) {
 		return constants.OkdPullSecret, nil
 	}
 
-	data, err := ioutil.ReadFile(loader.path)
+	if loader.path != "" {
+		fromPath, err := loadFile(loader.path)
+		if err == nil {
+			return fromPath, nil
+		}
+		logging.Debugf("Cannot load secret from path %q: %v", loader.path, err)
+	}
+	fromConfig, err := loadFile(loader.config.Get(cmdConfig.PullSecretFile).AsString())
+	if err == nil {
+		return fromConfig, nil
+	}
+	logging.Debugf("Cannot load secret from configuration: %v", err)
+	return "", fmt.Errorf("unable to load pull secret from path %q or from configuration", loader.path)
+}
+
+func loadFile(path string) (string, error) {
+	if path == "" {
+		return "", errors.New("empty path")
+	}
+	data, err := ioutil.ReadFile(path)
 	if err != nil {
 		return "", err
 	}
-	pullsecret := string(data)
-	if err := validation.ImagePullSecret(pullsecret); err != nil {
-		return "", err
-	}
-	return pullsecret, nil
+	pullsecret := strings.TrimSpace(string(data))
+	return pullsecret, validation.ImagePullSecret(pullsecret)
 }

--- a/pkg/crc/cluster/pullsecret_test.go
+++ b/pkg/crc/cluster/pullsecret_test.go
@@ -1,0 +1,48 @@
+package cluster
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	cmdConfig "github.com/code-ready/crc/cmd/crc/cmd/config"
+	"github.com/code-ready/crc/pkg/crc/config"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	secret1 = `{"auths":{"quay.io":{"auth":"secret1"}}}` // #nosec G101
+	secret2 = `{"auths":{"quay.io":{"auth":"secret2"}}}` // #nosec G101
+)
+
+func TestLoadPullSecret(t *testing.T) {
+	dir, err := ioutil.TempDir("", "pull-secret")
+	assert.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	cfg := config.New(config.NewEmptyInMemoryStorage())
+	cmdConfig.RegisterSettings(cfg)
+
+	loader := &nonInteractivePullSecretLoader{
+		config: cfg,
+		path:   filepath.Join(dir, "file1"),
+	}
+
+	_, err = loader.Value()
+	assert.Error(t, err)
+
+	assert.NoError(t, ioutil.WriteFile(filepath.Join(dir, "file2"), []byte(secret2), 0600))
+	_, err = cfg.Set(cmdConfig.PullSecretFile, filepath.Join(dir, "file2"))
+	assert.NoError(t, err)
+
+	val, err := loader.Value()
+	assert.NoError(t, err)
+	assert.Equal(t, secret2, val)
+
+	assert.NoError(t, ioutil.WriteFile(filepath.Join(dir, "file2"), []byte(secret1), 0600))
+
+	val, err = loader.Value()
+	assert.NoError(t, err)
+	assert.Equal(t, secret1, val)
+}

--- a/pkg/crc/input/input.go
+++ b/pkg/crc/input/input.go
@@ -1,13 +1,11 @@
 package input
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"strings"
 
 	terminal "golang.org/x/term"
-	survey "gopkg.in/AlecAivazis/survey.v1"
 )
 
 func PromptUserForYesOrNo(message string, force bool) bool {
@@ -22,22 +20,4 @@ func PromptUserForYesOrNo(message string, force bool) bool {
 	fmt.Scanf("%s", &response)
 
 	return strings.ToLower(response) == "y"
-}
-
-// PromptUserForSecret can be used for any kind of secret like image pull
-// secret or for password.
-func PromptUserForSecret(message string, help string) (string, error) {
-	if !terminal.IsTerminal(int(os.Stdin.Fd())) {
-		return "", errors.New("cannot ask for secret, crc not launched by a terminal")
-	}
-
-	var secret string
-	prompt := &survey.Password{
-		Message: message,
-		Help:    help,
-	}
-	if err := survey.AskOne(prompt, &secret, nil); err != nil {
-		return "", err
-	}
-	return secret, nil
 }

--- a/pkg/crc/machine/types.go
+++ b/pkg/crc/machine/types.go
@@ -19,7 +19,7 @@ type StartConfig struct {
 	NameServer string
 
 	// User Pull secret
-	PullSecret *cluster.PullSecret
+	PullSecret cluster.PullSecretLoader
 }
 
 type ClusterConfig struct {

--- a/pkg/crc/validation/validation.go
+++ b/pkg/crc/validation/validation.go
@@ -2,6 +2,7 @@ package validation
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -101,6 +102,9 @@ type imagePullSecret struct {
 
 // ImagePullSecret checks if the given string is a valid image pull secret and returns an error if not.
 func ImagePullSecret(secret string) error {
+	if secret == "" {
+		return errors.New("empty pull secret")
+	}
 	var s imagePullSecret
 	err := json.Unmarshal([]byte(secret), &s)
 	if err != nil {


### PR DESCRIPTION
Related to #1892 

Couple of UX changes:
* `crc start` now keep asking for the pull secret until a valid one is passed. 
* directly print how to get the pull secret before asking for it. No more indirection with [? for help].
* make the daemon and the cli call almost the same code for the pull secret

```
$ crc start
INFO Checking if running as non-root              
...
INFO Checking if libvirt 'crc' network is active  
CodeReady Containers requires a pull secret to download content from Red Hat.
You can copy it from the Pull Secret section of https://cloud.redhat.com/openshift/install/crc/installer-provisioned.
? Please enter the pull secret 
X Sorry, your reply was invalid: empty pull secret
X Sorry, your reply was invalid: invalid pull secret: missing 'auths' JSON-object field
X Sorry, your reply was invalid: invalid pull secret: invalid character 'b' looking for beginning of value
X Sorry, your reply was invalid: invalid pull secret: invalid character '?' looking for beginning of value
? Please enter the pull secret ************************
INFO Loading bundle: crc_libvirt_4.6.9.crcbundle ... 
INFO Verifying bundle crc_libvirt_4.6.9.crcbundle ... 
INFO Creating CodeReady Containers VM for OpenShift 4.6.9... 
..

```