### PR TITLE
Add vm not exist error type 

### DIFF
--- a/cmd/crc/cmd/root.go
+++ b/cmd/crc/cmd/root.go
@@ -13,6 +13,7 @@ import (
 	cmdConfig "github.com/code-ready/crc/cmd/crc/cmd/config"
 	crcConfig "github.com/code-ready/crc/pkg/crc/config"
 	"github.com/code-ready/crc/pkg/crc/constants"
+	crcErr "github.com/code-ready/crc/pkg/crc/errors"
 	"github.com/code-ready/crc/pkg/crc/logging"
 	"github.com/code-ready/crc/pkg/crc/machine"
 	"github.com/code-ready/crc/pkg/crc/network"
@@ -102,7 +103,7 @@ func checkIfMachineMissing(client machine.Client) error {
 		return err
 	}
 	if !exists {
-		return fmt.Errorf("Machine '%s' does not exist. Use 'crc start' to create it", client.GetName())
+		return crcErr.VMNotExist
 	}
 	return nil
 }

--- a/pkg/crc/errors/multierror.go
+++ b/pkg/crc/errors/multierror.go
@@ -8,6 +8,14 @@ import (
 	"github.com/code-ready/crc/pkg/crc/logging"
 )
 
+type vmNotExist string
+
+func (v vmNotExist) Error() string {
+	return string(v)
+}
+
+const VMNotExist vmNotExist = "Machine does not exist. Use 'crc start' to create it"
+
 type MultiError struct {
 	Errors []error
 }

--- a/pkg/crc/errors/serialerror.go
+++ b/pkg/crc/errors/serialerror.go
@@ -17,6 +17,6 @@ func (e *SerializableError) MarshalJSON() ([]byte, error) {
 	return json.Marshal(e.Error())
 }
 
-func (e *SerializableError) UnWrap() error {
+func (e *SerializableError) Unwrap() error {
 	return e.error
 }

--- a/test/e2e/features/basic.feature
+++ b/test/e2e/features/basic.feature
@@ -33,7 +33,7 @@ Feature: Basic test
         When executing "crc status" fails
         Then stderr should contain
             """
-            Machine 'crc' does not exist. Use 'crc start' to create it
+            Machine does not exist. Use 'crc start' to create it
             """
 
     @linux


### PR DESCRIPTION
With recent data collection side, lots of error message is for the
crc vm is not exist and user need to start it. With this patch
`VMNotExist` error type introduce for such case so in segment side
it can be tracked and ignored.