### PR TITLE
Implement serializable error to use with render

### DIFF
--- a/cmd/crc/cmd/cleanup.go
+++ b/cmd/crc/cmd/cleanup.go
@@ -1,11 +1,11 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"os"
 
+	crcErrors "github.com/code-ready/crc/pkg/crc/errors"
 	"github.com/code-ready/crc/pkg/crc/preflight"
 	"github.com/spf13/cobra"
 )
@@ -28,18 +28,18 @@ func runCleanup() error {
 	err := preflight.CleanUpHost()
 	return render(&cleanupResult{
 		Success: err == nil,
-		Error:   errorMessage(err),
+		Error:   crcErrors.ToSerializableError(err),
 	}, os.Stdout, outputFormat)
 }
 
 type cleanupResult struct {
-	Success bool   `json:"success"`
-	Error   string `json:"error,omitempty"`
+	Success bool                         `json:"success"`
+	Error   *crcErrors.SerializableError `json:"error,omitempty"`
 }
 
 func (s *cleanupResult) prettyPrintTo(writer io.Writer) error {
-	if s.Error != "" {
-		return errors.New(s.Error)
+	if s.Error != nil {
+		return s.Error
 	}
 	_, err := fmt.Fprintln(writer, "Cleanup finished")
 	return err

--- a/cmd/crc/cmd/setup.go
+++ b/cmd/crc/cmd/setup.go
@@ -1,12 +1,12 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"os"
 
 	cmdConfig "github.com/code-ready/crc/cmd/crc/cmd/config"
+	crcErrors "github.com/code-ready/crc/pkg/crc/errors"
 	"github.com/code-ready/crc/pkg/crc/input"
 	"github.com/code-ready/crc/pkg/crc/preflight"
 	pkgversion "github.com/code-ready/crc/pkg/crc/version"
@@ -50,18 +50,18 @@ func runSetup(arguments []string) error {
 	err := preflight.SetupHost(config)
 	return render(&setupResult{
 		Success: err == nil,
-		Error:   errorMessage(err),
+		Error:   crcErrors.ToSerializableError(err),
 	}, os.Stdout, outputFormat)
 }
 
 type setupResult struct {
-	Success bool   `json:"success"`
-	Error   string `json:"error,omitempty"`
+	Success bool                         `json:"success"`
+	Error   *crcErrors.SerializableError `json:"error,omitempty"`
 }
 
 func (s *setupResult) prettyPrintTo(writer io.Writer) error {
-	if s.Error != "" {
-		return errors.New(s.Error)
+	if s.Error != nil {
+		return s.Error
 	}
 	_, err := fmt.Fprintf(writer, "Setup is complete, you can now run 'crc start%s' to start the OpenShift cluster\n", extraArguments())
 	return err

--- a/cmd/crc/cmd/setup_test.go
+++ b/cmd/crc/cmd/setup_test.go
@@ -2,8 +2,10 @@ package cmd
 
 import (
 	"bytes"
+	"errors"
 	"testing"
 
+	crcErrors "github.com/code-ready/crc/pkg/crc/errors"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -17,9 +19,10 @@ func TestSetupRenderActionPlainSuccess(t *testing.T) {
 
 func TestSetupRenderActionPlainFailure(t *testing.T) {
 	out := new(bytes.Buffer)
+	err := errors.New("broken")
 	assert.EqualError(t, render(&setupResult{
 		Success: false,
-		Error:   "broken",
+		Error:   crcErrors.ToSerializableError(err),
 	}, out, ""), "broken")
 	assert.Equal(t, "", out.String())
 }
@@ -36,7 +39,7 @@ func TestSetupRenderActionJSONFailure(t *testing.T) {
 	out := new(bytes.Buffer)
 	assert.NoError(t, render(&setupResult{
 		Success: false,
-		Error:   "broken",
+		Error:   crcErrors.ToSerializableError(errors.New("broken")),
 	}, out, jsonFormat))
 	assert.JSONEq(t, `{"success": false, "error": "broken"}`, out.String())
 }

--- a/cmd/crc/cmd/start.go
+++ b/cmd/crc/cmd/start.go
@@ -106,13 +106,6 @@ func toClusterConfig(result *machine.StartResult) *clusterConfig {
 	}
 }
 
-func errorMessage(err error) string {
-	if err != nil {
-		return err.Error()
-	}
-	return ""
-}
-
 type clusterConfig struct {
 	ClusterCACert        string      `json:"cacert"`
 	WebConsoleURL        string      `json:"webConsoleUrl"`

--- a/cmd/crc/cmd/start_test.go
+++ b/cmd/crc/cmd/start_test.go
@@ -2,9 +2,11 @@ package cmd
 
 import (
 	"bytes"
+	"errors"
 	"testing"
 
 	"github.com/code-ready/crc/pkg/crc/constants"
+	crcErrors "github.com/code-ready/crc/pkg/crc/errors"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -39,9 +41,10 @@ The console will open in your default browser.
 
 func TestRenderActionPlainFailure(t *testing.T) {
 	out := new(bytes.Buffer)
+	err := errors.New("broken")
 	assert.EqualError(t, render(&startResult{
 		Success: false,
-		Error:   "broken",
+		Error:   crcErrors.ToSerializableError(err),
 	}, out, ""), "broken")
 	assert.Equal(t, "", out.String())
 }
@@ -86,7 +89,7 @@ func TestRenderActionJSONFailure(t *testing.T) {
 	out := new(bytes.Buffer)
 	assert.NoError(t, render(&startResult{
 		Success: false,
-		Error:   "broken",
+		Error:   crcErrors.ToSerializableError(errors.New("broken")),
 	}, out, jsonFormat))
 	assert.JSONEq(t, `{"success": false, "error": "broken"}`, out.String())
 }

--- a/cmd/crc/cmd/stop.go
+++ b/cmd/crc/cmd/stop.go
@@ -1,11 +1,11 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"os"
 
+	crcErrors "github.com/code-ready/crc/pkg/crc/errors"
 	"github.com/code-ready/crc/pkg/crc/input"
 	"github.com/code-ready/crc/pkg/crc/machine"
 	"github.com/code-ready/machine/libmachine/state"
@@ -59,19 +59,19 @@ func runStop(writer io.Writer, client machine.Client, interactive, force bool, o
 	return render(&stopResult{
 		Success: err == nil,
 		Forced:  forced,
-		Error:   errorMessage(err),
+		Error:   crcErrors.ToSerializableError(err),
 	}, writer, outputFormat)
 }
 
 type stopResult struct {
-	Success bool   `json:"success"`
-	Forced  bool   `json:"forced"`
-	Error   string `json:"error,omitempty"`
+	Success bool                         `json:"success"`
+	Forced  bool                         `json:"forced"`
+	Error   *crcErrors.SerializableError `json:"error,omitempty"`
 }
 
 func (s *stopResult) prettyPrintTo(writer io.Writer) error {
-	if s.Error != "" {
-		return errors.New(s.Error)
+	if s.Error != nil {
+		return s.Error
 	}
 	if s.Forced {
 		_, err := fmt.Fprintln(writer, "Forcibly stopped the OpenShift cluster")

--- a/pkg/crc/errors/serialerror.go
+++ b/pkg/crc/errors/serialerror.go
@@ -1,0 +1,22 @@
+package errors
+
+import "encoding/json"
+
+func ToSerializableError(err error) *SerializableError {
+	if err == nil {
+		return nil
+	}
+	return &SerializableError{err}
+}
+
+type SerializableError struct {
+	error
+}
+
+func (e *SerializableError) MarshalJSON() ([]byte, error) {
+	return json.Marshal(e.Error())
+}
+
+func (e *SerializableError) UnWrap() error {
+	return e.error
+}


### PR DESCRIPTION
Right now, errors which are occurred in the pkg level and passed to
cmd are rendered and lose it's error chain. Following is happening
for most of the commands where error is passed as string and then
it again converted to new error using `errors.New`.

```
func (s *deleteResult) prettyPrintTo(writer io.Writer) error {
	if s.Error != "" {
		return errors.New(s.Error)
	}
...
```

This patch will try to have error chain back to cmd level when render
happen and output format is not json one.
