### PR TITLE
[WIP] Add toggle to not start the OpenShift cluster

### DIFF
--- a/cmd/crc/cmd/config/config.go
+++ b/cmd/crc/cmd/config/config.go
@@ -26,6 +26,7 @@ const (
 	ProxyCAFile             = "proxy-ca-file"
 	ConsentTelemetry        = "consent-telemetry"
 	EnableClusterMonitoring = "enable-cluster-monitoring"
+	StartOpenShift          = "start-openshift"
 )
 
 func RegisterSettings(cfg *config.Config) {
@@ -49,6 +50,9 @@ func RegisterSettings(cfg *config.Config) {
 
 	// Telemeter Configuration
 	cfg.AddSetting(ConsentTelemetry, "", config.ValidateYesNo, config.SuccessfullyApplied)
+
+	// Change startup behaviour
+	cfg.AddSetting(StartOpenShift, true, config.ValidateYesNo, config.SuccessfullyApplied)
 }
 
 func isPreflightKey(key string) bool {

--- a/pkg/crc/machine/config/config.go
+++ b/pkg/crc/machine/config/config.go
@@ -22,4 +22,7 @@ type MachineConfig struct {
 
 	// Experimental features
 	NetworkMode network.Mode
+
+	// Changes start behaviour of the cluster
+	StartOpenShift bool
 }

--- a/pkg/crc/machine/types.go
+++ b/pkg/crc/machine/types.go
@@ -20,6 +20,9 @@ type StartConfig struct {
 
 	// User Pull secret
 	PullSecret *cluster.PullSecret
+
+	// Change startup behaviour
+	StartOpenShift bool
 }
 
 type ClusterConfig struct {


### PR DESCRIPTION
Signed-off-by: Gerard Braad <me@gbraad.nl>

This adds a toggle to prevent starting the kubelet service for use with a podman-only target
However, some side-effects remains:

  * a running VM will report `KubeletStarted` (restart)
  * etc.

For a podman-only VM, you can start with `crc start --start-openshift=false`