### PR TITLE
Fix status command for json output

### DIFF
--- a/cmd/crc/cmd/delete.go
+++ b/cmd/crc/cmd/delete.go
@@ -33,11 +33,10 @@ var deleteCmd = &cobra.Command{
 }
 
 func deleteMachine(client machine.Client, clearCache bool, cacheDir string, interactive, force bool) (bool, error) {
-	if !interactive && !force {
-		return false, errors.New("non-interactive deletion requires --force")
-	}
-
 	if clearCache {
+		if !interactive && !force {
+			return false, errors.New("non-interactive deletion requires --force")
+		}
 		yes := input.PromptUserForYesOrNo("Do you want to delete the OpenShift cluster cache", force)
 		if yes {
 			_ = os.RemoveAll(cacheDir)
@@ -46,6 +45,10 @@ func deleteMachine(client machine.Client, clearCache bool, cacheDir string, inte
 
 	if err := checkIfMachineMissing(client); err != nil {
 		return false, err
+	}
+
+	if !interactive && !force {
+		return false, errors.New("non-interactive deletion requires --force")
 	}
 
 	yes := input.PromptUserForYesOrNo("Do you want to delete the OpenShift cluster", force)

--- a/pkg/crc/machine/status.go
+++ b/pkg/crc/machine/status.go
@@ -74,13 +74,12 @@ func getOpenShiftStatus(sshRunner *crcssh.Runner, monitoringEnabled bool) string
 		logging.Debugf("cannot get OpenShift status: %v", err)
 		return "Not Reachable"
 	}
-	if status.Progressing {
+	switch {
+	case status.Progressing:
 		return "Starting"
-	}
-	if status.Degraded {
+	case status.Degraded:
 		return "Degraded"
-	}
-	if status.Available {
+	case status.Available:
 		return "Running"
 	}
 	return "Stopped"


### PR DESCRIPTION
**Fixes:** Issue #1909 

Before
```
$ ./crc status -o json
Machine 'crc' does not exist. Use 'crc start' to create it
```

Now
```
$ ./crc status -ojson
{
  "success": false,
  "error": "Machine 'crc' does not exist. Use 'crc start' to create it"
}
```
