### PR TITLE
Report status as "Unreachable" instead of "Not Reachable"

### DIFF
--- a/pkg/crc/machine/status.go
+++ b/pkg/crc/machine/status.go
@@ -72,7 +72,7 @@ func getOpenShiftStatus(sshRunner *crcssh.Runner, monitoringEnabled bool) string
 	status, err := cluster.GetClusterOperatorsStatus(oc.UseOCWithSSH(sshRunner), monitoringEnabled)
 	if err != nil {
 		logging.Debugf("cannot get OpenShift status: %v", err)
-		return "Not Reachable"
+		return "Unreachable"
 	}
 	if status.Progressing {
 		return "Starting"


### PR DESCRIPTION
The word unreachable is far more used when comparing Google search
results.

```
$ crc status
CRC VM:          Running
OpenShift:       Unreachable (v4.6.9)
Disk Usage:      8.641GB of 32.72GB (Inside the CRC VM)
Cache Usage:     10.75GB
Cache Directory: /Users/guillaumerose/.crc/cache
```

Purely subjective! I found it nicer :)