### PR TITLE
Daemon should exit with an error if it can't accept connections

### DIFF
--- a/pkg/crc/api/api.go
+++ b/pkg/crc/api/api.go
@@ -41,8 +41,11 @@ func (api Server) Serve() error {
 	for {
 		conn, err := api.listener.Accept()
 		if err != nil {
-			logging.Error("Error establishing communication: ", err.Error())
-			continue
+			if neterr, ok := err.(net.Error); ok && neterr.Temporary() {
+				logging.Errorf("accept temporary error: %v", err)
+				continue
+			}
+			return err
 		}
 		api.handleConnections(conn) // handle version, status, webconsole, etc. requests
 	}


### PR DESCRIPTION
This is the default behavior of most servers (http.Server, etc.)

---

https://golang.org/src/net/http/server.go?s=45531:45575 look for Accept()