### PR TITLE
Small fixes to data sent to segment

### DIFF
--- a/cmd/crc/cmd/start.go
+++ b/cmd/crc/cmd/start.go
@@ -66,9 +66,9 @@ func runStart(ctx context.Context) (*machine.StartResult, error) {
 		return nil, err
 	}
 
-	for _, key := range []string{cmdConfig.CPUs, cmdConfig.Memory, cmdConfig.DiskSize} {
-		telemetry.SetContextProperty(ctx, key, config.Get(key).AsInt())
-	}
+	telemetry.SetContextProperty(ctx, cmdConfig.CPUs, config.Get(cmdConfig.CPUs).AsInt())
+	telemetry.SetContextProperty(ctx, cmdConfig.Memory, uint64(config.Get(cmdConfig.Memory).AsInt())*1024*1024)
+	telemetry.SetContextProperty(ctx, cmdConfig.DiskSize, uint64(config.Get(cmdConfig.DiskSize).AsInt())*1024*1024*1024)
 
 	startConfig := machine.StartConfig{
 		BundlePath: config.Get(cmdConfig.Bundle).AsString(),

--- a/pkg/crc/segment/segment.go
+++ b/pkg/crc/segment/segment.go
@@ -13,6 +13,7 @@ import (
 	crcConfig "github.com/code-ready/crc/pkg/crc/config"
 	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/code-ready/crc/pkg/crc/logging"
+	"github.com/code-ready/crc/pkg/crc/network"
 	"github.com/code-ready/crc/pkg/crc/telemetry"
 	"github.com/code-ready/crc/pkg/crc/version"
 	"github.com/pborman/uuid"
@@ -101,7 +102,11 @@ func addConfigTraits(c *crcConfig.Config, in analytics.Traits) analytics.Traits 
 }
 
 func isProxyUsed(c *crcConfig.Config) bool {
-	return c.Get(config.HTTPProxy).AsString() != "" || c.Get(config.HTTPSProxy).AsString() != ""
+	proxyConfig, err := network.NewProxyConfig()
+	if err != nil {
+		return false
+	}
+	return proxyConfig.IsEnabled()
 }
 
 func getUserIdentity(telemetryFilePath string) (string, error) {


### PR DESCRIPTION
This is a follow-up to https://github.com/code-ready/crc/pull/1885 to
convert Memory/DiskSize to bytes before sending them, and to avoid some
false negatives in segment.isProxySet().
   
Testing:

1. check that Memory and DiskSize are sent to segment in bytes
2. check that IsProxy is true in segment when proxy is configured through `http_proxy`/`https_proxy`