### PR TITLE
 #1903 aborting extract doesn't corrupt cache directory

### DIFF
--- a/pkg/crc/machine/bundle/repository.go
+++ b/pkg/crc/machine/bundle/repository.go
@@ -102,8 +102,20 @@ func (bundle *CrcBundleInfo) createSymlinkOrCopyOpenShiftClient(ocBinDir string)
 }
 
 func (repo *Repository) Extract(path string) error {
-	_, err := extract.Uncompress(path, repo.CacheDir, true)
-	return err
+	bundleName := filepath.Base(path)
+
+	tmpDir := filepath.Join(repo.CacheDir, "tmp-extract")
+	_ = os.RemoveAll(tmpDir) // clean up before using it
+	defer func() {
+		_ = os.RemoveAll(tmpDir) // clean up after using it
+	}()
+
+	if _, err := extract.Uncompress(path, tmpDir, true); err != nil {
+		return err
+	}
+
+	bundleDir := strings.TrimSuffix(bundleName, bundleExtension)
+	return os.Rename(filepath.Join(tmpDir, bundleDir), filepath.Join(repo.CacheDir, bundleDir))
 }
 
 var defaultRepo = &Repository{


### PR DESCRIPTION
Previously, when a user interrupted crc during the extraction, the
next crc start command failed because of corrupted bundle.
Now, the bundle is extracted to a temporary directory and at the end, if
everything is ok, it is copied to the final destination.

The directory structure of the archive is discarded. The bundle name is
built based on the metadata of the bundle.

