### PR TITLE
Remove extra line in crc start output

### DIFF
--- a/cmd/crc/cmd/start.go
+++ b/cmd/crc/cmd/start.go
@@ -140,7 +140,6 @@ func (s *startResult) prettyPrintTo(writer io.Writer) error {
 	}
 
 	_, err := fmt.Fprintln(writer, strings.Join([]string{
-		"\n",
 		"Started the OpenShift cluster",
 		"",
 		"To access the cluster, first set up your environment by following the instructions returned by executing 'crc oc-env'.",

--- a/cmd/crc/cmd/start_test.go
+++ b/cmd/crc/cmd/start_test.go
@@ -26,9 +26,7 @@ func TestRenderActionPlainSuccess(t *testing.T) {
 			},
 		},
 	}, out, ""))
-	assert.Equal(t, `
-
-Started the OpenShift cluster
+	assert.Equal(t, `Started the OpenShift cluster
 
 To access the cluster, first set up your environment by following the instructions returned by executing 'crc oc-env'.
 Then you can access your cluster by running 'oc login -u developer -p developer https://api.crc.testing:6443'.


### PR DESCRIPTION
It removes 2 empty lines.

Previous output:
```
$ crc start  -b ~/Downloads/crc_libvirt_4.6.9.crcbundle  -p ~/pull-secret.txt 2> /dev/null


Started the OpenShift cluster

To access the cluster, first set up your environment by following the instructions returned by executing 'crc oc-env'.
```