### PR TITLE
macos: Rename installer to crc-installer-macos-amd64.pkg

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -251,5 +251,5 @@ package: clean check_bundledir $(BUILD_DIR)/macos-amd64/crc $(HOST_BUILD_DIR)/cr
 	productbuild --distribution packaging/darwin/Distribution \
 		--resources packaging/darwin/Resources \
 		--package-path $(BUILD_DIR)/macos-amd64 \
-		$(BUILD_DIR)/macos-amd64/crc-installer.pkg
+		$(BUILD_DIR)/macos-amd64/crc-installer-macos-amd64.pkg
 	rm $(BUILD_DIR)/macos-amd64/crc.pkg


### PR DESCRIPTION
The new name makes it easy to know it's a macos installer, and
also hints that it won't work on Apple M1s machines. It's consistent
with the naming used for our tarballs (crc-macos-amd64.tar.xz)