### PR TITLE
Improve bundle checks/bundle extraction

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,8 +52,7 @@ __check_defined = \
 VERSION_VARIABLES := -X $(REPOPATH)/pkg/crc/version.crcVersion=$(CRC_VERSION) \
 	-X $(REPOPATH)/pkg/crc/version.bundleVersion=$(BUNDLE_VERSION) \
 	-X $(REPOPATH)/pkg/crc/version.commitSha=$(COMMIT_SHA)
-RELEASE_VERSION_VARIABLES := -X $(REPOPATH)/pkg/crc/segment.WriteKey=cvpHsNcmGCJqVzf6YxrSnVlwFSAZaYtp \
-	-X $(REPOPATH)/pkg/crc/version.isRelease=true
+RELEASE_VERSION_VARIABLES := -X $(REPOPATH)/pkg/crc/segment.WriteKey=cvpHsNcmGCJqVzf6YxrSnVlwFSAZaYtp
 
 ifdef OKD_VERSION
 	VERSION_VARIABLES := $(VERSION_VARIABLES) -X $(REPOPATH)/pkg/crc/version.okdBuild=true

--- a/cmd/crc/cmd/config/config.go
+++ b/cmd/crc/cmd/config/config.go
@@ -33,7 +33,7 @@ const (
 
 func RegisterSettings(cfg *config.Config) {
 	// Start command settings in config
-	cfg.AddSetting(Bundle, constants.DefaultBundlePath, config.ValidateBundle, config.SuccessfullyApplied)
+	cfg.AddSetting(Bundle, constants.DefaultBundlePath, config.ValidateBundlePath, config.SuccessfullyApplied)
 	cfg.AddSetting(CPUs, constants.DefaultCPUs, config.ValidateCPUs, config.RequiresRestartMsg)
 	cfg.AddSetting(Memory, constants.DefaultMemory, config.ValidateMemory, config.RequiresRestartMsg)
 	cfg.AddSetting(DiskSize, constants.DefaultDiskSize, config.ValidateDiskSize, config.RequiresRestartMsg)

--- a/cmd/crc/cmd/setup.go
+++ b/cmd/crc/cmd/setup.go
@@ -6,10 +6,10 @@ import (
 	"os"
 
 	cmdConfig "github.com/code-ready/crc/cmd/crc/cmd/config"
+	"github.com/code-ready/crc/pkg/crc/constants"
 	crcErrors "github.com/code-ready/crc/pkg/crc/errors"
 	"github.com/code-ready/crc/pkg/crc/input"
 	"github.com/code-ready/crc/pkg/crc/preflight"
-	pkgversion "github.com/code-ready/crc/pkg/crc/version"
 	"github.com/spf13/cobra"
 )
 
@@ -69,7 +69,7 @@ func (s *setupResult) prettyPrintTo(writer io.Writer) error {
 
 func extraArguments() string {
 	var bundle string
-	if !pkgversion.IsRelease() {
+	if !constants.IsRelease() {
 		bundle = " -b $bundlename"
 	}
 	return bundle

--- a/cmd/crc/cmd/start.go
+++ b/cmd/crc/cmd/start.go
@@ -169,7 +169,7 @@ func validateStartFlags() error {
 	if err := validation.ValidateDiskSize(config.Get(cmdConfig.DiskSize).AsInt()); err != nil {
 		return err
 	}
-	if err := validation.ValidateBundle(config.Get(cmdConfig.Bundle).AsString()); err != nil {
+	if err := validation.ValidateBundlePath(config.Get(cmdConfig.Bundle).AsString()); err != nil {
 		return err
 	}
 	if config.Get(cmdConfig.NameServer).AsString() != "" {

--- a/cmd/crc/cmd/start.go
+++ b/cmd/crc/cmd/start.go
@@ -169,7 +169,7 @@ func validateStartFlags() error {
 	if err := validation.ValidateDiskSize(config.Get(cmdConfig.DiskSize).AsInt()); err != nil {
 		return err
 	}
-	if err := validation.ValidateBundlePath(config.Get(cmdConfig.Bundle).AsString()); err != nil {
+	if err := validation.ValidateBundle(config.Get(cmdConfig.Bundle).AsString()); err != nil {
 		return err
 	}
 	if config.Get(cmdConfig.NameServer).AsString() != "" {

--- a/pkg/crc/config/validations.go
+++ b/pkg/crc/config/validations.go
@@ -56,9 +56,9 @@ func ValidateMemory(value interface{}) (bool, string) {
 	return true, ""
 }
 
-// ValidateBundle checks if provided bundle path is valid
-func ValidateBundle(value interface{}) (bool, string) {
-	if err := validation.ValidateBundle(cast.ToString(value)); err != nil {
+// ValidateBundlePath checks if the provided bundle path is valid
+func ValidateBundlePath(value interface{}) (bool, string) {
+	if err := validation.ValidateBundlePath(cast.ToString(value)); err != nil {
 		return false, err.Error()
 	}
 	return true, ""

--- a/pkg/crc/constants/constants.go
+++ b/pkg/crc/constants/constants.go
@@ -139,7 +139,7 @@ func EnsureBaseDirectoriesExist() error {
 	return os.MkdirAll(CrcBaseDir, 0750)
 }
 
-// IsBundleEmbedded returns true if the executable was compiled to contain the bundle
+// BundleEmbedded returns true if the executable was compiled to contain the bundle
 func BundleEmbedded() bool {
 	executablePath, err := os.Executable()
 	if err != nil {
@@ -150,6 +150,10 @@ func BundleEmbedded() bool {
 		return false
 	}
 	return contains(extractor.AvalibleData(), GetDefaultBundle())
+}
+
+func IsRelease() bool {
+	return BundleEmbedded() || version.IsMacosInstallPathSet()
 }
 
 func contains(arr []string, str string) bool {

--- a/pkg/crc/machine/bundle/metadata.go
+++ b/pkg/crc/machine/bundle/metadata.go
@@ -118,7 +118,7 @@ func (bundle *CrcBundleInfo) GetOpenshiftVersion() string {
 	return bundle.ClusterInfo.OpenShiftVersion
 }
 
-func (bundle *CrcBundleInfo) Verify() error {
+func (bundle *CrcBundleInfo) verify() error {
 	files := []string{
 		bundle.resolvePath(constants.OcExecutableName),
 		bundle.resolvePath(bundle.ClusterInfo.KubeadminPasswordFile),

--- a/pkg/crc/machine/bundle/metadata_test.go
+++ b/pkg/crc/machine/bundle/metadata_test.go
@@ -40,7 +40,7 @@ const reference = `{
       {
         "name": "crc.qcow2",
         "format": "qcow2",
-        "size": "12268273664",
+	"size": "9",
         "sha256sum": "245a0e5acd4f09000a9a5f37d731082ed1cf3fdcad1b5320cbe9b153c9fd82a4"
       }
     ]
@@ -50,47 +50,50 @@ const reference = `{
   }
 }`
 
+var parsedReference = CrcBundleInfo{
+	Version: "1.0",
+	Type:    "snc",
+	BuildInfo: BuildInfo{
+		BuildTime:                 "2020-10-26T04:48:26+00:00",
+		OpenshiftInstallerVersion: "./openshift-install v4.6.0\nbuilt from commit ebdbda57fc18d3b73e69f0f2cc499ddfca7e6593\nrelease image registry.svc.ci.openshift.org/origin/release:4.5",
+		SncVersion:                "git4.1.14-137-g14e7",
+	},
+	ClusterInfo: ClusterInfo{
+		OpenShiftVersion:      "4.6.1",
+		ClusterName:           "crc",
+		BaseDomain:            "testing",
+		AppsDomain:            "apps-crc.testing",
+		SSHPrivateKeyFile:     "id_ecdsa_crc",
+		KubeConfig:            "kubeconfig",
+		KubeadminPasswordFile: "kubeadmin-password",
+	}, Nodes: []Node{
+		{
+			Kind:       []string{"master", "worker"},
+			Hostname:   "crc-h66l2-master-0",
+			DiskImage:  "crc.qcow2",
+			InternalIP: "192.168.126.11",
+		},
+	},
+	Storage: Storage{
+		DiskImages: []DiskImage{
+			{
+				Name:     "crc.qcow2",
+				Format:   "qcow2",
+				Size:     "9",
+				Checksum: "245a0e5acd4f09000a9a5f37d731082ed1cf3fdcad1b5320cbe9b153c9fd82a4",
+			},
+		},
+	},
+	DriverInfo: DriverInfo{
+		Name: "libvirt",
+	},
+	cachedPath: "",
+}
+
 func TestUnmarshalMarshal(t *testing.T) {
 	var bundle CrcBundleInfo
 	assert.NoError(t, json.Unmarshal([]byte(reference), &bundle))
-	assert.Equal(t, CrcBundleInfo{
-		Version: "1.0",
-		Type:    "snc",
-		BuildInfo: BuildInfo{
-			BuildTime:                 "2020-10-26T04:48:26+00:00",
-			OpenshiftInstallerVersion: "./openshift-install v4.6.0\nbuilt from commit ebdbda57fc18d3b73e69f0f2cc499ddfca7e6593\nrelease image registry.svc.ci.openshift.org/origin/release:4.5",
-			SncVersion:                "git4.1.14-137-g14e7",
-		},
-		ClusterInfo: ClusterInfo{
-			OpenShiftVersion:      "4.6.1",
-			ClusterName:           "crc",
-			BaseDomain:            "testing",
-			AppsDomain:            "apps-crc.testing",
-			SSHPrivateKeyFile:     "id_ecdsa_crc",
-			KubeConfig:            "kubeconfig",
-			KubeadminPasswordFile: "kubeadmin-password",
-		}, Nodes: []Node{
-			{
-				Kind:       []string{"master", "worker"},
-				Hostname:   "crc-h66l2-master-0",
-				DiskImage:  "crc.qcow2",
-				InternalIP: "192.168.126.11",
-			},
-		},
-		Storage: Storage{
-			DiskImages: []DiskImage{
-				{
-					Name:     "crc.qcow2",
-					Format:   "qcow2",
-					Size:     "12268273664",
-					Checksum: "245a0e5acd4f09000a9a5f37d731082ed1cf3fdcad1b5320cbe9b153c9fd82a4",
-				},
-			},
-		},
-		DriverInfo: DriverInfo{
-			Name: "libvirt",
-		},
-		cachedPath: ""}, bundle)
+	assert.Equal(t, parsedReference, bundle)
 	bin, err := json.Marshal(bundle)
 	assert.NoError(t, err)
 	assert.JSONEq(t, string(bin), reference)

--- a/pkg/crc/machine/bundle/repository.go
+++ b/pkg/crc/machine/bundle/repository.go
@@ -45,6 +45,9 @@ func (repo *Repository) Get(bundleName string) (*CrcBundleInfo, error) {
 		return nil, err
 	}
 	bundleInfo.cachedPath = path
+	if err := bundleInfo.verify(); err != nil {
+		return nil, err
+	}
 	return &bundleInfo, nil
 }
 

--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -124,11 +124,6 @@ func (client *client) Start(startConfig StartConfig) (*StartResult, error) {
 			return nil, errors.Wrap(err, "Error getting bundle metadata")
 		}
 
-		logging.Infof("Verifying bundle %s ...", filepath.Base(startConfig.BundlePath))
-		if err := crcBundleMetadata.Verify(); err != nil {
-			return nil, errors.Wrapf(err, "Invalid bundle %s", filepath.Base(startConfig.BundlePath))
-		}
-
 		logging.Infof("Creating CodeReady Containers VM for OpenShift %s...", crcBundleMetadata.GetOpenshiftVersion())
 
 		// Retrieve metadata info

--- a/pkg/crc/preflight/preflight_checks_common.go
+++ b/pkg/crc/preflight/preflight_checks_common.go
@@ -10,7 +10,6 @@ import (
 	"github.com/code-ready/crc/pkg/crc/logging"
 	"github.com/code-ready/crc/pkg/crc/machine/bundle"
 	"github.com/code-ready/crc/pkg/crc/validation"
-	"github.com/code-ready/crc/pkg/crc/version"
 	"github.com/code-ready/crc/pkg/embed"
 	"github.com/docker/go-units"
 	"github.com/pkg/errors"
@@ -61,7 +60,7 @@ var genericPreflightChecks = [...]Check{
 }
 
 func checkBundleExtracted() error {
-	if !version.IsRelease() {
+	if !constants.IsRelease() {
 		return nil
 	}
 	if _, err := os.Stat(constants.DefaultBundlePath); os.IsNotExist(err) {
@@ -77,7 +76,7 @@ func fixBundleExtracted() error {
 	if err := os.Chmod(constants.MachineCacheDir, 0775); err != nil {
 		logging.Debugf("Error changing %s permissions to 0775", constants.MachineCacheDir)
 	}
-	if version.IsRelease() {
+	if constants.IsRelease() {
 		bundleDir := filepath.Dir(constants.DefaultBundlePath)
 		if err := os.MkdirAll(bundleDir, 0775); err != nil {
 			return fmt.Errorf("Cannot create directory %s: %v", bundleDir, err)

--- a/pkg/crc/preflight/preflight_checks_common.go
+++ b/pkg/crc/preflight/preflight_checks_common.go
@@ -11,6 +11,7 @@ import (
 	"github.com/code-ready/crc/pkg/crc/machine/bundle"
 	"github.com/code-ready/crc/pkg/crc/validation"
 	"github.com/code-ready/crc/pkg/embed"
+	crcos "github.com/code-ready/crc/pkg/os"
 	"github.com/docker/go-units"
 	"github.com/pkg/errors"
 )
@@ -61,11 +62,15 @@ var genericPreflightChecks = [...]Check{
 
 func checkBundleExtracted() error {
 	if !constants.IsRelease() {
+		logging.Debugf("Development build, skipping check")
 		return nil
 	}
-	if _, err := os.Stat(constants.DefaultBundlePath); os.IsNotExist(err) {
+	logging.Infof("Checking if %s exists", constants.DefaultBundlePath)
+	if _, err := bundle.GetCachedBundleInfo(constants.GetDefaultBundle()); err != nil {
+		logging.Debugf("error getting bundle info for %s: %v", constants.GetDefaultBundle(), err)
 		return err
 	}
+	logging.Debugf("%s exists", constants.DefaultBundlePath)
 	return nil
 }
 
@@ -76,19 +81,32 @@ func fixBundleExtracted() error {
 	if err := os.Chmod(constants.MachineCacheDir, 0775); err != nil {
 		logging.Debugf("Error changing %s permissions to 0775", constants.MachineCacheDir)
 	}
-	if constants.IsRelease() {
-		bundleDir := filepath.Dir(constants.DefaultBundlePath)
-		if err := os.MkdirAll(bundleDir, 0775); err != nil {
-			return fmt.Errorf("Cannot create directory %s: %v", bundleDir, err)
-		}
 
-		if err := embed.Extract(filepath.Base(constants.DefaultBundlePath), constants.DefaultBundlePath); err != nil {
+	if !constants.IsRelease() {
+		return fmt.Errorf("CRC bundle is not embedded in the executable")
+	}
+
+	bundleDir := filepath.Dir(constants.DefaultBundlePath)
+	logging.Infof("Ensuring directory %s exists", bundleDir)
+	if err := os.MkdirAll(bundleDir, 0775); err != nil {
+		return fmt.Errorf("Cannot create directory %s: %v", bundleDir, err)
+	}
+
+	if !crcos.FileExists(constants.DefaultBundlePath) && constants.BundleEmbedded() {
+		logging.Infof("Extracting embedded bundle %s to %s", constants.GetDefaultBundle(), bundleDir)
+		if err := embed.Extract(constants.GetDefaultBundle(), constants.DefaultBundlePath); err != nil {
 			return err
 		}
+	}
+
+	_, err := bundle.GetCachedBundleInfo(constants.GetDefaultBundle())
+	if err != nil {
+		logging.Infof("Uncompressing %s", constants.GetDefaultBundle())
 		_, err := bundle.Extract(constants.DefaultBundlePath)
 		return err
 	}
-	return fmt.Errorf("CRC bundle is not embedded in the executable")
+
+	return nil
 }
 
 // Check if podman executable is cached or not

--- a/pkg/crc/validation/validation.go
+++ b/pkg/crc/validation/validation.go
@@ -56,8 +56,8 @@ func ValidateEnoughMemory(value int) error {
 	return nil
 }
 
-// ValidateBundle checks if the provided bundle path exist
-func ValidateBundle(bundle string) error {
+// ValidateBundlePath checks if the provided bundle path exist
+func ValidateBundlePath(bundle string) error {
 	if err := ValidatePath(bundle); err != nil {
 		if constants.BundleEmbedded() {
 			return fmt.Errorf("Run 'crc setup' to unpack the bundle to disk")

--- a/pkg/crc/validation/validation.go
+++ b/pkg/crc/validation/validation.go
@@ -70,7 +70,7 @@ func ValidateBundle(bundle string) error {
 	releaseBundleVersion := version.GetBundleVersion()
 	userProvidedBundleVersion := filepath.Base(bundle)
 	if !strings.Contains(userProvidedBundleVersion, fmt.Sprintf("%s.crcbundle", releaseBundleVersion)) {
-		if !version.IsRelease() {
+		if !constants.IsRelease() {
 			logging.Warnf("Using unsupported bundle %s", userProvidedBundleVersion)
 			return nil
 		}

--- a/pkg/crc/validation/validation.go
+++ b/pkg/crc/validation/validation.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/code-ready/crc/pkg/crc/logging"
+	"github.com/code-ready/crc/pkg/crc/machine/bundle"
 	"github.com/docker/go-units"
 	"github.com/pbnjay/memory"
 )
@@ -73,6 +74,16 @@ func ValidateBundlePath(bundle string) error {
 		}
 		return fmt.Errorf("%s is not supported by this crc executable, please use %s", userProvidedBundle, constants.GetDefaultBundle())
 	}
+	return nil
+}
+
+func ValidateBundle(bundlePath string) error {
+	bundleName := filepath.Base(bundlePath)
+	_, err := bundle.GetCachedBundleInfo(bundleName)
+	if err != nil {
+		return ValidateBundlePath(bundlePath)
+	}
+	/* 'bundle' is already unpacked in ~/.crc/cache */
 	return nil
 }
 

--- a/pkg/crc/validation/validation.go
+++ b/pkg/crc/validation/validation.go
@@ -8,11 +8,9 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"strings"
 
 	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/code-ready/crc/pkg/crc/logging"
-	"github.com/code-ready/crc/pkg/crc/version"
 	"github.com/docker/go-units"
 	"github.com/pbnjay/memory"
 )
@@ -58,7 +56,7 @@ func ValidateEnoughMemory(value int) error {
 	return nil
 }
 
-// ValidateBundle checks if provided bundle path exist
+// ValidateBundle checks if the provided bundle path exist
 func ValidateBundle(bundle string) error {
 	if err := ValidatePath(bundle); err != nil {
 		if constants.BundleEmbedded() {
@@ -66,15 +64,14 @@ func ValidateBundle(bundle string) error {
 		}
 		return fmt.Errorf("%s not found, please provide the path to a valid bundle using the -b option", bundle)
 	}
-	// Check if the version of the bundle provided by user is same as what is released with crc.
-	releaseBundleVersion := version.GetBundleVersion()
-	userProvidedBundleVersion := filepath.Base(bundle)
-	if !strings.Contains(userProvidedBundleVersion, fmt.Sprintf("%s.crcbundle", releaseBundleVersion)) {
+
+	userProvidedBundle := filepath.Base(bundle)
+	if userProvidedBundle != constants.GetDefaultBundle() {
 		if !constants.IsRelease() {
-			logging.Warnf("Using unsupported bundle %s", userProvidedBundleVersion)
+			logging.Warnf("Using unsupported bundle %s", userProvidedBundle)
 			return nil
 		}
-		return fmt.Errorf("%s is not supported by this crc executable, please use %s", userProvidedBundleVersion, constants.GetDefaultBundle())
+		return fmt.Errorf("%s is not supported by this crc executable, please use %s", userProvidedBundle, constants.GetDefaultBundle())
 	}
 	return nil
 }

--- a/pkg/crc/version/version.go
+++ b/pkg/crc/version/version.go
@@ -24,8 +24,6 @@ var (
 	okdBuild = "false"
 
 	macosInstallPath = "/unset"
-
-	isRelease = "false"
 )
 
 const (
@@ -56,10 +54,6 @@ func GetBundleVersion() string {
 
 func IsOkdBuild() bool {
 	return okdBuild == "true"
-}
-
-func IsRelease() bool {
-	return isRelease == "true"
 }
 
 func GetCRCMacTrayVersion() string {


### PR DESCRIPTION
This pull request fixes various things related to bundle extraction/validation.
At `setup` time, for release builds, it now checks that the default bundle is uncompressed and valid.
If not, it extracts the bundle from the binary if needed and then uncompresses it.

At `start` time, it's now checking more accurately that the bundle is uncompressed and valid before trying to use it.
This should fix some corner cases with partially uncompressed bundles/failures when the `.crcbundle` file is removed while the uncompressed bundle is present, ...