### PR TITLE
Add containerized build using go-toolset

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,19 @@
+stages:
+  - build
+
+containerized-cross-build:
+  image: registry.fedoraproject.org/fedora:latest
+  stage: build
+  script:
+    # setup base image to allow Makefile to run
+    - dnf install -y make git-core golang podman
+    # The following changes are needed to allow podman to run in podman/docker
+    - cp /usr/share/containers/containers.conf /etc/containers/containers.conf 
+    - sed -i '/^# cgroup_manager = "systemd"/ a cgroup_manager = "cgroupfs"' /etc/containers/containers.conf
+    - sed -i '/^# events_logger = "journald"/ a events_logger = "file"' /etc/containers/containers.conf
+    - sed -i '/^driver = "overlay"/ c\driver = "vfs"' /etc/containers/storage.conf
+    # run the actual containerized build
+    - make containerized
+  artifacts:
+    paths:
+      - out

--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,14 @@ $(HOST_BUILD_DIR)/crc-embedder: $(SOURCES)
 .PHONY: cross ## Cross compiles all binaries
 cross: $(BUILD_DIR)/macos-amd64/crc $(BUILD_DIR)/linux-amd64/crc $(BUILD_DIR)/windows-amd64/crc.exe
 
+.PHONY: containerized ## Cross compile from container
+containerized: clean
+	${CONTAINER_RUNTIME} build -t crc-build -f images/build .
+	${CONTAINER_RUNTIME} run --name crc-cross crc-build make cross
+	${CONTAINER_RUNTIME} cp crc-cross:/opt/app-root/src/out ./
+	${CONTAINER_RUNTIME} rm crc-cross
+	${CONTAINER_RUNTIME} rmi crc-build
+
 .PHONY: test
 test:
 	go test -race --tags build -v -ldflags="$(VERSION_VARIABLES)" ./pkg/... ./cmd/...

--- a/images/build/Dockerfile
+++ b/images/build/Dockerfile
@@ -1,0 +1,5 @@
+FROM registry.access.redhat.com/ubi8/go-toolset:1.14.12
+MAINTAINER CodeReady Containers <devtools-cdk@redhat.com>
+
+WORKDIR $APP_ROOT/src
+COPY . .


### PR DESCRIPTION
Fixes #1766; Initial container build

Seperated the git install step as this would re-use the containers between routes-controller, gvisor-tap-vsock, etc.

---
```
$ make containerized
podman build -t crc-build .
STEP 1: FROM registry.access.redhat.com/ubi8/ubi AS build
STEP 2: WORKDIR /go/src/app
--> Using cache b1fe4c0c69acdbe1480a0430c23a457d85e5f4288d8114e44d09e13418d8c551
--> b1fe4c0c69a
STEP 3: RUN yum -y install golang make
--> Using cache 047ae8989bf2d77d6d07e2901e4f5aa3134daeeceb009aff92cff29be18e79e7
--> 047ae8989bf
STEP 4: RUN yum -y install git-core
--> Using cache 33f530f208bc13a01423b813aee9f8cd7415fdc07a24c081cef421143119fda1
--> 33f530f208b
STEP 5: COPY . .
STEP 6: COMMIT crc-build
--> cbd377eb88a
cbd377eb88ab037e34646e8e72006717436783a310b2eead654451c231a0c967
podman run --name crc-cross crc-build make cross
GOARCH=amd64 GOOS=darwin go build -ldflags="-X github.com/code-ready/crc/pkg/crc/version.crcVersion=1.21.0 -X github.com/code-ready/crc/pkg/crc/version.bundleVersion=4.6.13 -X github.com/code-ready/crc/pkg/crc/version.commitSha=df022a04 -extldflags='-static' -s -w" -o out/macos-amd64/crc ./cmd/crc
GOOS=linux GOARCH=amd64 go build -ldflags="-X github.com/code-ready/crc/pkg/crc/version.crcVersion=1.21.0 -X github.com/code-ready/crc/pkg/crc/version.bundleVersion=4.6.13 -X github.com/code-ready/crc/pkg/crc/version.commitSha=df022a04 -extldflags='-static' -s -w" -o out/linux-amd64/crc ./cmd/crc
GOARCH=amd64 GOOS=windows go build -ldflags="-X github.com/code-ready/crc/pkg/crc/version.crcVersion=1.21.0 -X github.com/code-ready/crc/pkg/crc/version.bundleVersion=4.6.13 -X github.com/code-ready/crc/pkg/crc/version.commitSha=df022a04 -extldflags='-static' -s -w" -o out/windows-amd64/crc.exe ./cmd/crc
podman cp crc-cross:/go/src/app/out ./
podman rm crc-cross
61c5095fc4502f6a2518374605234a58c7e58c2597173662856fbcd321f9495e
podman rmi crc-build
Untagged: localhost/crc-build:latest
Deleted: cbd377eb88ab037e34646e8e72006717436783a310b2eead654451c231a0c967
```
