### PR TITLE
Fix ValidateBool function to accept valid range of boolean

### DIFF
--- a/pkg/crc/config/validations.go
+++ b/pkg/crc/config/validations.go
@@ -13,10 +13,11 @@ import (
 // ValidateBool is a fail safe in the case user
 // makes a typo for boolean config values
 func ValidateBool(value interface{}) (bool, string) {
-	if cast.ToString(value) == "true" || cast.ToString(value) == "false" {
-		return true, ""
+	if _, err := cast.ToBoolE(value); err != nil {
+		return false, "must be true or false"
 	}
-	return false, "must be true or false"
+
+	return true, ""
 }
 
 // ValidateDiskSize checks if provided disk size is valid in the config


### PR DESCRIPTION
Till now we are casting the user input to string and the comparing
it with `true/false` but in golang accepts 1, t, T, TRUE, true, True, 0,
f, F, FALSE, false, False as boolean when parse it so all those are
valid boolean value. With this patch `cast.ToBoolE` is used to get
the error if casting not happen properly.
