### PR TITLE
os: Add RunningInTerminal() helper

### DIFF
--- a/pkg/crc/cluster/pullsecret.go
+++ b/pkg/crc/cluster/pullsecret.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"os"
 	"strings"
 
 	cmdConfig "github.com/code-ready/crc/cmd/crc/cmd/config"
@@ -13,7 +12,7 @@ import (
 	"github.com/code-ready/crc/pkg/crc/logging"
 	"github.com/code-ready/crc/pkg/crc/validation"
 	crcversion "github.com/code-ready/crc/pkg/crc/version"
-	terminal "golang.org/x/term"
+	crcos "github.com/code-ready/crc/pkg/os"
 	"gopkg.in/AlecAivazis/survey.v1"
 )
 
@@ -98,7 +97,7 @@ You can copy it from the Pull Secret section of %s.
 // promptUserForSecret can be used for any kind of secret like image pull
 // secret or for password.
 func promptUserForSecret() (string, error) {
-	if !terminal.IsTerminal(int(os.Stdin.Fd())) {
+	if !crcos.RunningInTerminal() {
 		return "", errors.New("cannot ask for secret, crc not launched by a terminal")
 	}
 

--- a/pkg/crc/input/input.go
+++ b/pkg/crc/input/input.go
@@ -2,17 +2,16 @@ package input
 
 import (
 	"fmt"
-	"os"
 	"strings"
 
-	terminal "golang.org/x/term"
+	crcos "github.com/code-ready/crc/pkg/os"
 )
 
 func PromptUserForYesOrNo(message string, force bool) bool {
 	if force {
 		return true
 	}
-	if !terminal.IsTerminal(int(os.Stdin.Fd())) {
+	if !crcos.RunningInTerminal() {
 		return false
 	}
 	var response string

--- a/pkg/crc/segment/segment.go
+++ b/pkg/crc/segment/segment.go
@@ -16,9 +16,9 @@ import (
 	"github.com/code-ready/crc/pkg/crc/network"
 	"github.com/code-ready/crc/pkg/crc/telemetry"
 	"github.com/code-ready/crc/pkg/crc/version"
+	crcos "github.com/code-ready/crc/pkg/os"
 	"github.com/pborman/uuid"
 	"github.com/segmentio/analytics-go"
-	terminal "golang.org/x/term"
 )
 
 var WriteKey = "R7jGNYYO5gH0Nl5gDlMEuZ3gPlDJKQak" // test
@@ -83,7 +83,7 @@ func (c *Client) Upload(ctx context.Context, action string, duration time.Durati
 	properties = properties.Set("version", version.GetCRCVersion()).
 		Set("success", err == nil).
 		Set("duration", duration.Milliseconds()).
-		Set("tty", terminal.IsTerminal(int(os.Stdin.Fd())))
+		Set("tty", crcos.RunningInTerminal())
 	if err != nil {
 		properties = properties.Set("error", err.Error())
 	}

--- a/pkg/os/util.go
+++ b/pkg/os/util.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 
 	"github.com/code-ready/crc/pkg/crc/logging"
+
+	terminal "golang.org/x/term"
 )
 
 // ReplaceOrAddEnv changes the value of an environment variable if it exists otherwise add the new variable
@@ -108,4 +110,8 @@ func RemoveFileIfExists(path string) error {
 		return os.Remove(path)
 	}
 	return nil
+}
+
+func RunningInTerminal() bool {
+	return terminal.IsTerminal(int(os.Stdin.Fd()))
 }


### PR DESCRIPTION
We're duplicating multiple times
`terminal.IsTerminal(int(os.Stdin.Fd()))` in our codebase, which is
short, but not very descriptive regarding what it's doing.
This adds a helper to be more explicit about what is being checked.