### PR TITLE
#1948 don't use viper to write the config file

### DIFF
--- a/pkg/crc/config/viper_config_test.go
+++ b/pkg/crc/config/viper_config_test.go
@@ -157,6 +157,7 @@ func TestViperConfigBindFlagSet(t *testing.T) {
 	flagSet := pflag.NewFlagSet("start", pflag.ExitOnError)
 	flagSet.IntP(CPUs, "c", 4, "")
 	flagSet.StringP(NameServer, "n", "", "")
+	flagSet.StringP("extra", "e", "", "")
 
 	_ = storage.BindFlagSet(flagSet)
 
@@ -183,6 +184,10 @@ func TestViperConfigBindFlagSet(t *testing.T) {
 		Value:     6,
 		IsDefault: false,
 	}, config.Get(CPUs))
+
+	bin, err := ioutil.ReadFile(configFile)
+	assert.NoError(t, err)
+	assert.JSONEq(t, `{"cpus":6,"extra":"","nameservers":""}`, string(bin))
 }
 
 func TestViperConfigCastSet(t *testing.T) {

--- a/pkg/crc/config/viper_config_test.go
+++ b/pkg/crc/config/viper_config_test.go
@@ -180,14 +180,9 @@ func TestViperConfigBindFlagSet(t *testing.T) {
 	_, err = config.Set(CPUs, "6")
 	assert.NoError(t, err)
 
-	assert.Equal(t, SettingValue{
-		Value:     6,
-		IsDefault: false,
-	}, config.Get(CPUs))
-
 	bin, err := ioutil.ReadFile(configFile)
 	assert.NoError(t, err)
-	assert.JSONEq(t, `{"cpus":6,"extra":"","nameservers":""}`, string(bin))
+	assert.JSONEq(t, `{"cpus":6}`, string(bin))
 }
 
 func TestViperConfigCastSet(t *testing.T) {


### PR DESCRIPTION
Viper is not made for writing config file. When using flags, it adds
them in the config file even if they are not config key we defined.
    
This change uses traditional method to edit json and then, asks viper to
reload the configuration.

Fixes #1948 