### PR TITLE
Fix e2e basic feature for windows platform

### DIFF
--- a/test/e2e/crcsuite/crcsuite.go
+++ b/test/e2e/crcsuite/crcsuite.go
@@ -57,8 +57,8 @@ func FeatureContext(s *godog.Suite) {
 		CheckOutputMatchWithRetry)
 	s.Step(`^checking that CRC is (running|stopped)$`,
 		CheckCRCStatus)
-	s.Step(`stdout (?:should contain|contains) "(.*)" if bundle (is|is not) embedded$`,
-		StdoutContainsIfBundleEmbeddedOrNot)
+	s.Step(`^(stdout|stderr) (?:should contain|contains) "(.*)" if bundle (is|is not) embedded$`,
+		CommandReturnShouldContainIfBundleEmbeddedOrNot)
 
 	// CRC file operations
 	s.Step(`^file "([^"]*)" exists in CRC home folder$`,
@@ -415,18 +415,18 @@ func StartCRCWithDefaultBundleAndNameServerSucceedsOrFails(nameserver string, ex
 	return clicumber.ExecuteCommandSucceedsOrFails(cmd, expected)
 }
 
-func StdoutContainsIfBundleEmbeddedOrNot(value string, expected string) error {
+func CommandReturnShouldContainIfBundleEmbeddedOrNot(commandField string, value string, expected string) error {
 	if expected == "is" { // expect embedded
 		if bundleEmbedded { // really embedded
-			return clicumber.CommandReturnShouldContain("stdout", value)
+			return clicumber.CommandReturnShouldContain(commandField, value)
 		}
-		return clicumber.CommandReturnShouldNotContain("stdout", value)
+		return clicumber.CommandReturnShouldNotContain(commandField, value)
 	}
 	// expect not embedded
 	if !bundleEmbedded { // really not embedded
-		return clicumber.CommandReturnShouldContain("stdout", value)
+		return clicumber.CommandReturnShouldContain(commandField, value)
 	}
-	return clicumber.CommandReturnShouldNotContain("stdout", value)
+	return clicumber.CommandReturnShouldNotContain(commandField, value)
 }
 
 func SetConfigPropertyToValueSucceedsOrFails(property string, value string, expected string) error {

--- a/test/e2e/features/basic.feature
+++ b/test/e2e/features/basic.feature
@@ -191,7 +191,6 @@ Feature: Basic test
     Scenario Outline: CRC clean-up
         When executing "crc cleanup" succeeds
         Then stderr should contain "Uninstalling tray if installed"
-        And stderr should contain "Will run as admin: Uninstalling CodeReady Containers System Tray"
         And stderr should contain "Removing the crc VM if exists"
         And stderr should contain "Removing dns server from interface"
         And stderr should contain "Will run as admin: Remove dns entry for default switch"

--- a/test/e2e/features/basic.feature
+++ b/test/e2e/features/basic.feature
@@ -121,10 +121,20 @@ Feature: Basic test
         Then stdout should contain "To login as a regular user, run 'oc login -u developer -p developer"
         And stdout should contain "To login as an admin, run 'oc login -u kubeadmin -p "
 
-    @darwin @linux @windows
+    @darwin @linux
     Scenario: Monitoring stack check
         Given checking that CRC is running
         When executing "eval $(crc oc-env)" succeeds
+        And login to the oc cluster succeeds
+        And executing "oc get pods -n openshift-monitoring" succeeds
+        Then stdout matches ".*cluster-monitoring-operator-\w+-\w+\ *2/2\ *Running.*"
+        And unsetting config property "enable-cluster-monitoring" succeeds
+        And unsetting config property "memory" succeeds
+
+    @windows
+    Scenario: Monitoring stack check
+        Given checking that CRC is running
+        And executing "crc oc-env | Invoke-Expression" succeeds
         And login to the oc cluster succeeds
         And executing "oc get pods -n openshift-monitoring" succeeds
         Then stdout matches ".*cluster-monitoring-operator-\w+-\w+\ *2/2\ *Running.*"

--- a/test/e2e/features/basic.feature
+++ b/test/e2e/features/basic.feature
@@ -191,6 +191,7 @@ Feature: Basic test
     Scenario Outline: CRC clean-up
         When executing "crc cleanup" succeeds
         Then stderr should contain "Uninstalling tray if installed"
+        Then stderr should contain "Uninstalling daemon if installed"
         And stderr should contain "Removing the crc VM if exists"
         And stderr should contain "Removing dns server from interface"
         And stderr should contain "Will run as admin: Remove dns entry for default switch"


### PR DESCRIPTION
This PR change scenarios for windows platform on basic feature to adapt the expectations to the current development state.

The e2e pipeline results for windows platform for this branch can be inspected at the internal ci: [windows build 72](https://crcqe-jenkins-csb-codeready.cloud.paas.psi.redhat.com/blue/organizations/jenkins/qe%2Fbundle_baremetal_windows10-brno/detail/bundle_baremetal_windows10-brno/72/).
