### PR TITLE
Check the tray version when checking if tray executable exists

### DIFF
--- a/pkg/crc/preflight/preflight_checks_tray_windows.go
+++ b/pkg/crc/preflight/preflight_checks_tray_windows.go
@@ -155,7 +155,7 @@ func stopDaemon() error {
 }
 
 func checkTrayExecutableExists() error {
-	if os.FileExists(constants.TrayExecutablePath) {
+	if os.FileExists(constants.TrayExecutablePath) && checkTrayVersion() {
 		return nil
 	}
 	return fmt.Errorf("Tray executable does not exists")


### PR DESCRIPTION
If an old executable is present then it doesn't download the newer
one since the check succeeded as it was not checking the version


## Testing

1. `crc setup --enable-experimental-features` succeeds  and installs the latest windows tray (0.3.0.0)