### PR TITLE
Bump crc trays' version

### DIFF
--- a/pkg/crc/version/version.go
+++ b/pkg/crc/version/version.go
@@ -29,9 +29,9 @@ var (
 const (
 	releaseInfoLink = "https://mirror.openshift.com/pub/openshift-v4/clients/crc/latest/release-info.json"
 	// Tray version to be embedded in executable
-	crcMacTrayVersion = "1.0.0-alpha.6"
+	crcMacTrayVersion = "1.0.0-beta.1"
 	// Windows forms application version type major.minor.buildnumber.revesion
-	crcWindowsTrayVersion = "0.2.0.0"
+	crcWindowsTrayVersion = "0.3.0.0"
 )
 
 type CrcReleaseInfo struct {


### PR DESCRIPTION
macOS tray updated to 1.0.0-beta.1
windows tray updated to 0.3.0.0