### PR TITLE
Use regex to replace the carriage return to '\n' char

### DIFF
--- a/pkg/crc/cluster/cluster.go
+++ b/pkg/crc/cluster/cluster.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -214,8 +215,9 @@ func addProxyCACertToCluster(sshRunner *ssh.Runner, ocConfig oc.Config, proxy *n
   }
 }
 `
-	// Replace the carriage return with `\n` char
-	p := fmt.Sprintf(proxyCABundleTemplate, strings.ReplaceAll(proxy.ProxyCACert, "\n", `\n`), trustedCAName)
+	// Replace the carriage return ("\n" or "\r\n") with literal `\n` string
+	re := regexp.MustCompile(`\r?\n`)
+	p := fmt.Sprintf(proxyCABundleTemplate, re.ReplaceAllString(proxy.ProxyCACert, `\n`), trustedCAName)
 	err := sshRunner.CopyData([]byte(p), proxyConfigMapFileName, 0644)
 	if err != nil {
 		return err


### PR DESCRIPTION
With this patch, carriage return for windows (`\r\n`) and unix ('\n')
replaced with `\n` char. Till now it was only replacing it for unix.


