### PR TITLE
Add Help parameter for config setting struct

### DIFF
--- a/cmd/crc/cmd/config/config.go
+++ b/cmd/crc/cmd/config/config.go
@@ -95,42 +95,19 @@ func less(lhsKey, rhsKey string) bool {
 }
 
 func configurableFields(config *config.Config) string {
-	var fields []string
+	settings := config.AllSettings()
+	sort.Slice(settings, func(i, j int) bool {
+		return less(settings[i].Name, settings[j].Name)
+	})
+
 	var buf bytes.Buffer
 	writer := tabwriter.NewWriter(&buf, 0, 8, 1, ' ', tabwriter.TabIndent)
-	for _, keyAndValueType := range keysAndValueType(config) {
-		fmt.Fprintln(writer, keyAndValueType)
+	for _, cfg := range settings {
+		fmt.Fprintf(writer, "* %s\t%s\n", cfg.Name, cfg.Help)
 	}
 	writer.Flush()
-	keys := strings.Split(buf.String(), "\n")
-	sort.Slice(keys, func(i, j int) bool {
-		return less(keys[i], keys[j])
-	})
-	for _, key := range keys {
-		if key == "" {
-			continue
-		}
-		fields = append(fields, " * "+key)
-	}
-	return strings.Join(fields, "\n")
-}
-func keysAndValueType(config *config.Config) []string {
-	var keyAndValueType []string
-	for key, value := range config.AllConfigs() {
-		var valueType string
-		switch value.Value.(type) {
-		case int:
-			valueType = "Number"
-		case string:
-			valueType = "String"
-		case bool:
-			valueType = "true/false"
-		default:
-			valueType = fmt.Sprintf("%T", value.Value)
-		}
-		keyAndValueType = append(keyAndValueType, fmt.Sprintf("%s\t%s", key, valueType))
-	}
-	return keyAndValueType
+
+	return buf.String()
 }
 
 func GetConfigCmd(config *config.Config) *cobra.Command {

--- a/cmd/crc/cmd/config/config.go
+++ b/cmd/crc/cmd/config/config.go
@@ -33,25 +33,40 @@ const (
 
 func RegisterSettings(cfg *config.Config) {
 	// Start command settings in config
-	cfg.AddSetting(Bundle, constants.DefaultBundlePath, config.ValidateBundlePath, config.SuccessfullyApplied)
-	cfg.AddSetting(CPUs, constants.DefaultCPUs, config.ValidateCPUs, config.RequiresRestartMsg)
-	cfg.AddSetting(Memory, constants.DefaultMemory, config.ValidateMemory, config.RequiresRestartMsg)
-	cfg.AddSetting(DiskSize, constants.DefaultDiskSize, config.ValidateDiskSize, config.RequiresRestartMsg)
-	cfg.AddSetting(NameServer, "", config.ValidateIPAddress, config.SuccessfullyApplied)
-	cfg.AddSetting(PullSecretFile, "", config.ValidatePath, config.SuccessfullyApplied)
-	cfg.AddSetting(DisableUpdateCheck, false, config.ValidateBool, config.SuccessfullyApplied)
-	cfg.AddSetting(ExperimentalFeatures, false, config.ValidateBool, config.SuccessfullyApplied)
-	cfg.AddSetting(NetworkMode, string(network.DefaultMode), network.ValidateMode, network.SuccessfullyAppliedMode)
+	cfg.AddSetting(Bundle, constants.DefaultBundlePath, config.ValidateBundlePath, config.SuccessfullyApplied,
+		fmt.Sprintf("Bundle path (string, default '%s')", constants.DefaultBundlePath))
+	cfg.AddSetting(CPUs, constants.DefaultCPUs, config.ValidateCPUs, config.RequiresRestartMsg,
+		fmt.Sprintf("Number of CPU cores (must be greater than or equal to '%d')", constants.DefaultCPUs))
+	cfg.AddSetting(Memory, constants.DefaultMemory, config.ValidateMemory, config.RequiresRestartMsg,
+		fmt.Sprintf("Memory size in MiB (must be greater than or equal to '%d')", constants.DefaultMemory))
+	cfg.AddSetting(DiskSize, constants.DefaultDiskSize, config.ValidateDiskSize, config.RequiresRestartMsg,
+		fmt.Sprintf("Total size in GiB of the disk (must be greater than or equal to '%d')", constants.DefaultDiskSize))
+	cfg.AddSetting(NameServer, "", config.ValidateIPAddress, config.SuccessfullyApplied,
+		"IPv4 address of nameserver (string, like '1.1.1.1 or 8.8.8.8')")
+	cfg.AddSetting(PullSecretFile, "", config.ValidatePath, config.SuccessfullyApplied,
+		fmt.Sprintf("Path of image pull secret (download from %s)", constants.CrcLandingPageURL))
+	cfg.AddSetting(DisableUpdateCheck, false, config.ValidateBool, config.SuccessfullyApplied,
+		"Disable update check (true/false, default: false)")
+	cfg.AddSetting(ExperimentalFeatures, false, config.ValidateBool, config.SuccessfullyApplied,
+		"Enable experimental features (true/false, default: false)")
+	cfg.AddSetting(NetworkMode, string(network.DefaultMode), network.ValidateMode, network.SuccessfullyAppliedMode,
+		"Network mode (default or vsock)")
 	// Proxy Configuration
-	cfg.AddSetting(HTTPProxy, "", config.ValidateURI, config.SuccessfullyApplied)
-	cfg.AddSetting(HTTPSProxy, "", config.ValidateURI, config.SuccessfullyApplied)
-	cfg.AddSetting(NoProxy, "", config.ValidateNoProxy, config.SuccessfullyApplied)
-	cfg.AddSetting(ProxyCAFile, "", config.ValidatePath, config.SuccessfullyApplied)
+	cfg.AddSetting(HTTPProxy, "", config.ValidateURI, config.SuccessfullyApplied,
+		"HTTP proxy URL (string, like 'http://my-proxy.com:8443')")
+	cfg.AddSetting(HTTPSProxy, "", config.ValidateURI, config.SuccessfullyApplied,
+		"HTTPS proxy URL (string, like 'https://my-proxy.com:8443')")
+	cfg.AddSetting(NoProxy, "", config.ValidateNoProxy, config.SuccessfullyApplied,
+		"Hosts, ipv4 addresses or CIDR which do not use a proxy (string, comma-separated list such as '127.0.0.1,192.168.100.1/24')")
+	cfg.AddSetting(ProxyCAFile, "", config.ValidatePath, config.SuccessfullyApplied,
+		"Path to an HTTPS proxy certificate authority (CA)")
 
-	cfg.AddSetting(EnableClusterMonitoring, false, config.ValidateBool, config.SuccessfullyApplied)
+	cfg.AddSetting(EnableClusterMonitoring, false, config.ValidateBool, config.SuccessfullyApplied,
+		"Enable cluster monitoring Operator (true/false, default: false)")
 
 	// Telemeter Configuration
-	cfg.AddSetting(ConsentTelemetry, "", config.ValidateYesNo, config.SuccessfullyApplied)
+	cfg.AddSetting(ConsentTelemetry, "", config.ValidateYesNo, config.SuccessfullyApplied,
+		"Consent to collection of anonymous usage data (yes/no)")
 }
 
 func isPreflightKey(key string) bool {

--- a/cmd/crc/cmd/config/set.go
+++ b/cmd/crc/cmd/config/set.go
@@ -13,7 +13,8 @@ func configSetCmd(config *config.Config) *cobra.Command {
 	return &cobra.Command{
 		Use:   "set CONFIG-KEY VALUE",
 		Short: "Set a crc configuration property",
-		Long:  `Sets a crc configuration property.`,
+		Long: `Sets a crc configuration property.
+CONFIG-KEYS: ` + "\n\n" + configurableFields(config),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 2 {
 				return errors.New("Please provide a configuration property and its value as in 'crc config set KEY VALUE'")

--- a/cmd/crc/cmd/config/set.go
+++ b/cmd/crc/cmd/config/set.go
@@ -9,7 +9,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func configSetCmd(config config.Storage) *cobra.Command {
+func configSetCmd(config *config.Config) *cobra.Command {
 	return &cobra.Command{
 		Use:   "set CONFIG-KEY VALUE",
 		Short: "Set a crc configuration property",

--- a/pkg/crc/config/config.go
+++ b/pkg/crc/config/config.go
@@ -37,6 +37,14 @@ func (c *Config) AllConfigs() map[string]SettingValue {
 	return allConfigs
 }
 
+func (c *Config) AllSettings() []Setting {
+	var settings []Setting
+	for _, setting := range c.settingsByName {
+		settings = append(settings, setting)
+	}
+	return settings
+}
+
 // AddSetting returns a filled struct of ConfigSetting
 // takes the config name and default value as arguments
 func (c *Config) AddSetting(name string, defValue interface{}, validationFn ValidationFnType, callbackFn SetFn, help string) {

--- a/pkg/crc/config/config.go
+++ b/pkg/crc/config/config.go
@@ -39,12 +39,13 @@ func (c *Config) AllConfigs() map[string]SettingValue {
 
 // AddSetting returns a filled struct of ConfigSetting
 // takes the config name and default value as arguments
-func (c *Config) AddSetting(name string, defValue interface{}, validationFn ValidationFnType, callbackFn SetFn) {
+func (c *Config) AddSetting(name string, defValue interface{}, validationFn ValidationFnType, callbackFn SetFn, help string) {
 	c.settingsByName[name] = Setting{
 		Name:         name,
 		defaultValue: defValue,
 		validationFn: validationFn,
 		callbackFn:   callbackFn,
+		Help:         help,
 	}
 }
 

--- a/pkg/crc/config/types.go
+++ b/pkg/crc/config/types.go
@@ -10,7 +10,7 @@ type Storage interface {
 }
 
 type Schema interface {
-	AddSetting(name string, defValue interface{}, validationFn ValidationFnType, callbackFn SetFn)
+	AddSetting(name string, defValue interface{}, validationFn ValidationFnType, callbackFn SetFn, help string)
 }
 
 type Setting struct {
@@ -18,6 +18,7 @@ type Setting struct {
 	defaultValue interface{}
 	validationFn ValidationFnType
 	callbackFn   SetFn
+	Help         string
 }
 
 type SettingValue struct {

--- a/pkg/crc/config/viper_config_test.go
+++ b/pkg/crc/config/viper_config_test.go
@@ -22,8 +22,8 @@ func newTestConfig(configFile, envPrefix string) (*Config, error) {
 		return nil, err
 	}
 	config := New(storage)
-	config.AddSetting(CPUs, 4, ValidateCPUs, RequiresRestartMsg)
-	config.AddSetting(NameServer, "", ValidateIPAddress, SuccessfullyApplied)
+	config.AddSetting(CPUs, 4, ValidateCPUs, RequiresRestartMsg, "")
+	config.AddSetting(NameServer, "", ValidateIPAddress, SuccessfullyApplied, "")
 	return config, nil
 }
 
@@ -151,8 +151,8 @@ func TestViperConfigBindFlagSet(t *testing.T) {
 	storage, err := NewViperStorage(configFile, "CRC")
 	require.NoError(t, err)
 	config := New(storage)
-	config.AddSetting(CPUs, 4, ValidateCPUs, RequiresRestartMsg)
-	config.AddSetting(NameServer, "", ValidateIPAddress, SuccessfullyApplied)
+	config.AddSetting(CPUs, 4, ValidateCPUs, RequiresRestartMsg, "")
+	config.AddSetting(NameServer, "", ValidateIPAddress, SuccessfullyApplied, "")
 
 	flagSet := pflag.NewFlagSet("start", pflag.ExitOnError)
 	flagSet.IntP(CPUs, "c", 4, "")

--- a/pkg/crc/preflight/preflight.go
+++ b/pkg/crc/preflight/preflight.go
@@ -144,7 +144,8 @@ func doCleanUpPreflightChecks(checks []Check) error {
 func doRegisterSettings(cfg config.Schema, checks []Check) {
 	for _, check := range checks {
 		if check.configKeySuffix != "" {
-			cfg.AddSetting(check.getSkipConfigName(), false, config.ValidateBool, config.SuccessfullyApplied)
+			cfg.AddSetting(check.getSkipConfigName(), false, config.ValidateBool, config.SuccessfullyApplied,
+				"Skip preflight check (true/false, default: false)")
 		}
 	}
 }


### PR DESCRIPTION
This patch will make use of help string for key and show output
as following.
```
* bundle                          Bundle path (string, default '/home/prkumar/.crc/cache/crc_libvirt_4.6.15.crcbundle')
* consent-telemetry               Send feedback about CodeReady Containers (yes/no)
* cpus                            Number of CPU cores (integer, default '4')
* disable-update-check            Don't check for update (default false)
* disk-size                       Total size in GiB of the disk (integer, default '31')
* enable-cluster-monitoring       Enable cluster monitoring operator (default false)
```