### PR TITLE
add login-as flag to allow auto login

### DIFF
--- a/cmd/crc/cmd/config/config.go
+++ b/cmd/crc/cmd/config/config.go
@@ -29,6 +29,7 @@ const (
 	ProxyCAFile             = "proxy-ca-file"
 	ConsentTelemetry        = "consent-telemetry"
 	EnableClusterMonitoring = "enable-cluster-monitoring"
+	AutoLoginAs             = "login-as"
 )
 
 func RegisterSettings(cfg *config.Config) {
@@ -52,6 +53,8 @@ func RegisterSettings(cfg *config.Config) {
 
 	// Telemeter Configuration
 	cfg.AddSetting(ConsentTelemetry, "", config.ValidateYesNo, config.SuccessfullyApplied)
+
+	cfg.AddSetting(AutoLoginAs, "", config.ValidateAdminOrDeveloper, config.SuccessfullyApplied)
 }
 
 func isPreflightKey(key string) bool {

--- a/pkg/crc/config/validations.go
+++ b/pkg/crc/config/validations.go
@@ -103,3 +103,10 @@ func ValidateYesNo(value interface{}) (bool, string) {
 	}
 	return false, "must be yes or no"
 }
+
+func ValidateAdminOrDeveloper(value interface{}) (bool, string) {
+	if cast.ToString(value) == "admin" || cast.ToString(value) == "developer" {
+		return true, ""
+	}
+	return false, "must be admin or developer"
+}


### PR DESCRIPTION
this change should remove the need for people to copy and paste the login command

## Solution/Idea

Added `login-as` flag that can be set to `admin` or `developer` and triggers an automated run of `oc login` when the cluster is ready.
I thought about it when I copy-pasted my 100st login command.
Not sure if this change makes sense and is executed correctly. Couldn't run the local build yet, not sure why.

## Proposed changes

List main as well as consequential changes you introduced or had to introduce.

1. Add `login-as` flag.
2. This means users can provide the flag so they don't have to copy the login command after the cluster is up.
3. (optional) This could default to developer, but I didn't want to be that invasive as the user might not expect their Kubernetes context to change without them knowing.

## Testing

What is the _bottom-line_ functionality that needs testing? Describe in pseudo-code or in English. Use verifiable statements that tie your changes to existing functionality.

1. `start` succeeds with the `login-as` flag set 
2. `oc login` gets called with admin credentials if the flag is set to `admin`
3. `oc login` gets called with developer credentials if the flag is set to `developer`
