### PR TITLE
[e2e] Add check for crc-admin context set

### DIFF
--- a/test/e2e/crcsuite/crcsuite.go
+++ b/test/e2e/crcsuite/crcsuite.go
@@ -49,6 +49,8 @@ func FeatureContext(s *godog.Suite) {
 		UnsetConfigPropertySucceedsOrFails)
 	s.Step(`^login to the oc cluster (succeeds|fails)$`,
 		LoginToOcClusterSucceedsOrFails)
+	s.Step(`^setting kubeconfig context to "(.*)" (succeeds|fails)$`,
+		SetKubeConfigContextSucceedsOrFails)
 	s.Step(`^with up to "(\d+)" retries with wait period of "(\d*(?:ms|s|m))" all cluster operators are running$`,
 		CheckClusterOperatorsWithRetry)
 	s.Step(`^with up to "(\d+)" retries with wait period of "(\d*(?:ms|s|m))" http response from "(.*)" has status code "(\d+)"$`,
@@ -374,6 +376,11 @@ func LoginToOcClusterSucceedsOrFails(expected string) error {
 	err = clicumber.ExecuteCommandSucceedsOrFails(cmd, expected)
 
 	return err
+}
+
+func SetKubeConfigContextSucceedsOrFails(context, expected string) error {
+	cmd := fmt.Sprintf("oc config use-context %s", context)
+	return clicumber.ExecuteCommandSucceedsOrFails(cmd, expected)
 }
 
 func StartCRCWithDefaultBundleSucceedsOrFails(expected string) error {

--- a/test/e2e/features/basic.feature
+++ b/test/e2e/features/basic.feature
@@ -125,7 +125,7 @@ Feature: Basic test
     Scenario: Monitoring stack check
         Given checking that CRC is running
         When executing "eval $(crc oc-env)" succeeds
-        And login to the oc cluster succeeds
+        And setting kubeconfig context to "crc-admin" succeeds
         And executing "oc get pods -n openshift-monitoring" succeeds
         Then stdout matches ".*cluster-monitoring-operator-\w+-\w+\ *2/2\ *Running.*"
         And unsetting config property "enable-cluster-monitoring" succeeds
@@ -135,7 +135,7 @@ Feature: Basic test
     Scenario: Monitoring stack check
         Given checking that CRC is running
         And executing "crc oc-env | Invoke-Expression" succeeds
-        And login to the oc cluster succeeds
+        And setting kubeconfig context to "crc-admin" succeeds
         And executing "oc get pods -n openshift-monitoring" succeeds
         Then stdout matches ".*cluster-monitoring-operator-\w+-\w+\ *2/2\ *Running.*"
         And unsetting config property "enable-cluster-monitoring" succeeds

--- a/test/e2e/features/basic.feature
+++ b/test/e2e/features/basic.feature
@@ -145,6 +145,7 @@ Feature: Basic test
     Scenario: CRC forcible stop
         When executing "crc stop -f"
         Then stdout should match "(.*)[Ss]topped the OpenShift cluster"
+        And executing "oc whoami" fails
 
     @darwin @linux @windows
     Scenario: CRC status check


### PR DESCRIPTION
This patch will make sure the context feature is working as expected.

fixes: #1966
