### PR TITLE
Add latest version check in version command

### DIFF
--- a/cmd/crc/cmd/version.go
+++ b/cmd/crc/cmd/version.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 
+	cmdConfig "github.com/code-ready/crc/cmd/crc/cmd/config"
 	"github.com/code-ready/crc/pkg/crc/constants"
 	crcversion "github.com/code-ready/crc/pkg/crc/version"
 	"github.com/spf13/cobra"
@@ -25,6 +26,7 @@ var versionCmd = &cobra.Command{
 }
 
 func runPrintVersion(writer io.Writer, version *version, outputFormat string) error {
+	checkIfNewVersionAvailable(config.Get(cmdConfig.DisableUpdateCheck).AsBool())
 	return render(version, writer, outputFormat)
 }
 


### PR DESCRIPTION
This patch enable version command to provide if a new crc version
is available for download. Till now this functionality was part of
`crc start` but just to get version info user shouldn't start the
cluster.

fixes: #1952

