### PR TITLE
Fix 'CodeReady Container' typo

### DIFF
--- a/images/dnsmasq/Dockerfile
+++ b/images/dnsmasq/Dockerfile
@@ -1,5 +1,5 @@
 FROM registry.access.redhat.com/ubi8/ubi
-MAINTAINER CodeReady Container <devtools-cdk@redhat.com>
+MAINTAINER CodeReady Containers <devtools-cdk@redhat.com>
 
 RUN yum -y install dnsmasq && \
     yum clean all

--- a/images/squid/Dockerfile
+++ b/images/squid/Dockerfile
@@ -1,5 +1,5 @@
 FROM registry.centos.org/centos/centos:centos8
-MAINTAINER CodeReady Container <devtools-cdk@redhat.com>
+MAINTAINER CodeReady Containers <devtools-cdk@redhat.com>
 
 ENV SQUID_CACHE_DIR=/var/spool/squid \
     SQUID_LOG_DIR=/var/log/squid \


### PR DESCRIPTION
Two of our container images use mispelt 'CodeReady Container' for their
MAINTAINER field.