### PR TITLE
Fix #1874 Do not run preflights if VM already running

### DIFF
--- a/cmd/crc/cmd/start.go
+++ b/cmd/crc/cmd/start.go
@@ -60,10 +60,6 @@ func runStart(ctx context.Context) (*machine.StartResult, error) {
 
 	checkIfNewVersionAvailable(config.Get(cmdConfig.DisableUpdateCheck).AsBool())
 
-	if err := preflight.StartPreflightChecks(config); err != nil {
-		return nil, err
-	}
-
 	telemetry.SetContextProperty(ctx, cmdConfig.CPUs, config.Get(cmdConfig.CPUs).AsInt())
 	telemetry.SetContextProperty(ctx, cmdConfig.Memory, uint64(config.Get(cmdConfig.Memory).AsInt())*1024*1024)
 	telemetry.SetContextProperty(ctx, cmdConfig.DiskSize, uint64(config.Get(cmdConfig.DiskSize).AsInt())*1024*1024*1024)
@@ -78,6 +74,14 @@ func runStart(ctx context.Context) (*machine.StartResult, error) {
 	}
 
 	client := newMachine()
+	isRunning, _ := client.IsRunning()
+
+	if !isRunning {
+		if err := preflight.StartPreflightChecks(config); err != nil {
+			return nil, err
+		}
+	}
+
 	return client.Start(startConfig)
 }
 

--- a/pkg/crc/machine/client.go
+++ b/pkg/crc/machine/client.go
@@ -16,6 +16,7 @@ type Client interface {
 	Start(startConfig StartConfig) (*StartResult, error)
 	Status() (*ClusterStatusResult, error)
 	Stop() (state.State, error)
+	IsRunning() (bool, error)
 }
 
 type client struct {

--- a/pkg/crc/machine/fakemachine/client.go
+++ b/pkg/crc/machine/fakemachine/client.go
@@ -100,3 +100,7 @@ func (c *Client) Status() (*machine.ClusterStatusResult, error) {
 func (c *Client) Exists() (bool, error) {
 	return true, nil
 }
+
+func (c *Client) IsRunning() (bool, error) {
+	return true, nil
+}


### PR DESCRIPTION
Signed-off-by: Gerard Braad <me@gbraad.nl>


**Fixes:** Issue #1874

## Solution/Idea

Preflights were run for an akready running VM. This means they have been able to pass the pre-flights before.

## Proposed changes

```
PS> .\crc.exe start
INFO A CodeReady Containers VM for OpenShift 4.7.0-0.nightly-2021-01-22-134922 is already running
Started the OpenShift cluster

To access the cluster, first set up your environment by following the instructions returned by executing 'crc oc-env'.
Then you can access your cluster by running 'oc login -u developer -p developer https://api.crc.testing:6443'.
To login as a cluster admin, run 'oc login -u kubeadmin -p ex6Fy-ALyjf-kIy8N-4NXNH https://api.crc.testing:6443'.

You can also run 'crc console' and use the above credentials to access the OpenShift web console.
The console will open in your default browser.
```

## Testing

  * Initial start will run preflights
  * When start is run again, the message 'is already running' follows. No preflight checks
  * When stop is called, the preflights will run again on start
  * When delete is called, the preflights will run again on start

