### PR TITLE
Change the cluster started summary

### DIFF
--- a/cmd/crc/cmd/oc_env.go
+++ b/cmd/crc/cmd/oc_env.go
@@ -39,7 +39,7 @@ func runOcEnv(args []string) error {
 		fmt.Println(shell.GetEnvString(userShell, "HTTPS_PROXY", proxyConfig.HTTPSProxy))
 		fmt.Println(shell.GetEnvString(userShell, "NO_PROXY", proxyConfig.GetNoProxyString()))
 	}
-	fmt.Println(shell.GenerateUsageHint(userShell, "crc oc-env"))
+	fmt.Println(shell.GenerateUsageHintWithComment(userShell, "crc oc-env"))
 	return nil
 }
 

--- a/cmd/crc/cmd/podman_env.go
+++ b/cmd/crc/cmd/podman_env.go
@@ -40,7 +40,7 @@ func RunPodmanEnv(args []string) error {
 	fmt.Println(shell.GetEnvString(userShell, "PODMAN_HOST", ip))
 	fmt.Println(shell.GetEnvString(userShell, "PODMAN_IDENTITY_FILE", constants.GetPrivateKeyPath()))
 	fmt.Println(shell.GetEnvString(userShell, "PODMAN_IGNORE_HOSTS", "1"))
-	fmt.Println(shell.GenerateUsageHint(userShell, "crc podman-env"))
+	fmt.Println(shell.GenerateUsageHintWithComment(userShell, "crc podman-env"))
 	return nil
 }
 

--- a/pkg/os/shell/shell.go
+++ b/pkg/os/shell/shell.go
@@ -31,23 +31,31 @@ func isSupportedShell(userShell string) bool {
 	return false
 }
 
-func GenerateUsageHint(userShell, cmdLine string) string {
-	cmd := ""
-	comment := "#"
+func GenerateUsageHintWithComment(userShell, cmdLine string) string {
+	return fmt.Sprintf("%s Run this command to configure your shell:\n%s %s",
+		comment(userShell),
+		comment(userShell),
+		GenerateUsageHint(userShell, cmdLine))
+}
 
+func comment(userShell string) string {
+	if userShell == "cmd" {
+		return "REM"
+	}
+	return "#"
+}
+
+func GenerateUsageHint(userShell, cmdLine string) string {
 	switch userShell {
 	case "fish":
-		cmd = fmt.Sprintf("eval (%s)", cmdLine)
+		return fmt.Sprintf("eval (%s)", cmdLine)
 	case "powershell":
-		cmd = fmt.Sprintf("& %s | Invoke-Expression", cmdLine)
+		return fmt.Sprintf("& %s | Invoke-Expression", cmdLine)
 	case "cmd":
-		cmd = fmt.Sprintf("\t@FOR /f \"tokens=*\" %%i IN ('%s') DO @call %%i", cmdLine)
-		comment = "REM"
+		return fmt.Sprintf("@FOR /f \"tokens=*\" %%i IN ('%s') DO @call %%i", cmdLine)
 	default:
-		cmd = fmt.Sprintf("eval $(%s)", cmdLine)
+		return fmt.Sprintf("eval $(%s)", cmdLine)
 	}
-
-	return fmt.Sprintf("%s Run this command to configure your shell:\n%s %s", comment, comment, cmd)
 }
 
 func GetEnvString(userShell string, envName string, envValue string) string {

--- a/test/e2e/features/basic.feature
+++ b/test/e2e/features/basic.feature
@@ -97,8 +97,8 @@ Feature: Basic test
         When starting CRC with default bundle succeeds
         Then stdout should contain "Started the OpenShift cluster"
         # Check if user can copy-paste login details for developer and kubeadmin users
-        And stdout should match "(?s)(.*)oc login -u developer -p developer https:\/\/api\.crc\.testing:6443(.*)$"
-        And stdout should match "(?s)(.*)oc login -u kubeadmin -p ([a-zA-Z0-9]{5}-){3}[a-zA-Z0-9]{5} https:\/\/api\.crc\.testing:6443(.*)$"
+        And stdout should match "(?s)(.*)oc login https:\/\/api\.crc\.testing:6443(.*)$"
+        And stdout should match "(?s)(.*)https:\/\/console-openshift-console\.apps-crc\.testing(.*)$"
 
     @darwin @linux @windows
     Scenario: CRC status and disk space check


### PR DESCRIPTION
**Fixes:** Issue #1764

* Directly add the link to the webconsole. No more indirection with crc
console.
* Better display credentials
* Include a small how-to for the oc command line

```
$ crc start
Started the OpenShift cluster.

The server is accessible via web console at:
  https://console-openshift-console.apps-crc.testing

Log in as administrator:
  Username: kubeadmin
  Password: APBEh-jjrVy-hLQZX-VI9Kg

Log in as user:
  Username: developer
  Password: developer

Use the 'oc' command line interface:
  $ eval $(crc oc-env)
  $ oc login https://api.crc.testing:6443
```
