### PR TITLE
vsock: allow the VM to reach host services.

### DIFF
--- a/cmd/crc/cmd/daemon.go
+++ b/cmd/crc/cmd/daemon.go
@@ -27,6 +27,8 @@ func init() {
 	rootCmd.AddCommand(daemonCmd)
 }
 
+const hostVirtualIP = "192.168.127.254"
+
 var daemonCmd = &cobra.Command{
 	Use:    "daemon",
 	Short:  "Run the crc daemon",
@@ -75,6 +77,10 @@ var daemonCmd = &cobra.Command{
 							Regexp: regexp.MustCompile("crc-(.*?)-master-0"),
 							IP:     net.ParseIP("192.168.126.11"),
 						},
+						{
+							Name: "host",
+							IP:   net.ParseIP(hostVirtualIP),
+						},
 					},
 				},
 			},
@@ -82,6 +88,9 @@ var daemonCmd = &cobra.Command{
 				fmt.Sprintf(":%d", constants.VsockSSHPort): "192.168.127.2:22",
 				":6443": "192.168.127.2:6443",
 				":443":  "192.168.127.2:443",
+			},
+			NAT: map[string]string{
+				hostVirtualIP: "127.0.0.1",
 			},
 		}, endpoints)
 		return err


### PR DESCRIPTION
The user can now use host.crc.testing DNS name to reach a service on the
host.

Example:
(host) $ python3 -m http.server
Serving HTTP on 0.0.0.0 port 8000 (http://0.0.0.0:8000/) ...

(vm) $ curl host.crc.testing:8000
<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">

(see https://github.com/code-ready/gvisor-tap-vsock/commit/7743cc7beb33a795983bb5b439e36f9b351581e6 for the real code)