### PR TITLE
Increase apiserver wait time for a min

### DIFF
--- a/pkg/crc/cluster/cluster.go
+++ b/pkg/crc/cluster/cluster.go
@@ -320,7 +320,7 @@ func WaitForAPIServer(ocConfig oc.Config) error {
 		logging.Debug(stdout)
 		return nil
 	}
-	return errors.RetryAfter(2*time.Minute, waitForAPIServer, time.Second)
+	return errors.RetryAfter(3*time.Minute, waitForAPIServer, time.Second)
 }
 
 func DeleteOpenshiftAPIServerPods(ocConfig oc.Config) error {


### PR DESCRIPTION
In openshift 4.7 looks like the moment we start the kubelet service
and kubelet being able to start the pod, have added more than a min
time. This patch will unblocks us to start the 4.7.0-rc testing.

We should revert it as soon as https://bugzilla.redhat.com/show_bug.cgi?id=1927263
is fixed.

