### PR TITLE
Increase the timeout to 2min for cluster operator authentication

### DIFF
--- a/pkg/crc/machine/kubeconfig.go
+++ b/pkg/crc/machine/kubeconfig.go
@@ -31,7 +31,7 @@ const (
 )
 
 func eventuallyWriteKubeconfig(ocConfig oc.Config, ip string, clusterConfig *ClusterConfig) error {
-	if err := errors.RetryAfter(60*time.Second, func() error {
+	if err := errors.RetryAfter(120*time.Second, func() error {
 		status, err := cluster.GetClusterOperatorStatus(ocConfig, "authentication")
 		if err != nil {
 			return &errors.RetriableError{Err: err}


### PR DESCRIPTION
The log message printed to the user says 2min but we waited 1min. I hope it will help/solve the openshift CI. 