### PR TITLE
Change the error message when running as root on Windows

### DIFF
--- a/pkg/crc/preflight/preflight_checks_windows.go
+++ b/pkg/crc/preflight/preflight_checks_windows.go
@@ -184,7 +184,7 @@ func checkIfRunningAsNormalUser() error {
 		return nil
 	}
 	logging.Debug("Ran as administrator")
-	return fmt.Errorf("crc should be ran as a normal user")
+	return fmt.Errorf("crc should be ran in a shell without administrator rights")
 }
 
 func removeDNSServerAddress() error {

--- a/pkg/crc/preflight/preflight_windows.go
+++ b/pkg/crc/preflight/preflight_windows.go
@@ -12,9 +12,9 @@ import (
 var hypervPreflightChecks = [...]Check{
 	{
 		configKeySuffix:  "check-administrator-user",
-		checkDescription: "Checking if running as normal user",
+		checkDescription: "Checking if running in a shell with administrator rights",
 		check:            checkIfRunningAsNormalUser,
-		fixDescription:   "crc should be ran as a normal user",
+		fixDescription:   "crc should be ran in a shell without administrator rights",
 		flags:            NoFix,
 	},
 	{


### PR DESCRIPTION
I hope it will give a clue to the user: use an other shell, without
admin.
