### PR TITLE
docs: Remove reference to `htpasswd_provider`

### DIFF
--- a/docs/source/topics/proc_accessing-the-openshift-web-console.adoc
+++ b/docs/source/topics/proc_accessing-the-openshift-web-console.adoc
@@ -13,8 +13,6 @@ To access the OpenShift web console, follow these steps:
 . Run [command]`{bin} console`.
 This will open your web browser and direct it to the web console.
 
-. Choose the **htpasswd_provider** option in the OpenShift web console.
-
 . Log in as the `developer` user with the password printed in the output of the [command]`{bin} start` command.
 +
 [NOTE]


### PR DESCRIPTION
**Fixes:** Issue #1972
