### PR TITLE
Be sure that crc start ends up with a working cluster

### DIFF
--- a/pkg/crc/cluster/clusteroperator.go
+++ b/pkg/crc/cluster/clusteroperator.go
@@ -20,6 +20,10 @@ type Status struct {
 	Disabled    bool
 }
 
+func (status *Status) IsReady() bool {
+	return status.Available && !status.Progressing && !status.Degraded && !status.Disabled
+}
+
 func GetClusterOperatorStatus(ocConfig oc.Config, operator string) (*Status, error) {
 	return getStatus(ocConfig, defaultIgnoredClusterOperators, []string{operator})
 }

--- a/pkg/crc/cluster/clusteroperator_test.go
+++ b/pkg/crc/cluster/clusteroperator_test.go
@@ -16,6 +16,7 @@ var (
 	progressing = &Status{
 		Available:   true,
 		Progressing: true,
+		progressing: []string{"authentication"},
 	}
 )
 

--- a/pkg/crc/cluster/status.go
+++ b/pkg/crc/cluster/status.go
@@ -24,7 +24,13 @@ func WaitForClusterStable(ocConfig oc.Config, monitoringEnabled bool) error {
 			// update counter for consecutive matches
 			if status.IsReady() {
 				count++
+				if count == 1 {
+					logging.Info("All operators are available. Ensuring stability ...")
+				} else {
+					logging.Infof("Operators are stable (%d/%d) ...", count, numConsecutive)
+				}
 			} else {
+				logging.Info(status.String())
 				count = 0
 			}
 			// break if done

--- a/pkg/crc/cluster/status.go
+++ b/pkg/crc/cluster/status.go
@@ -1,0 +1,42 @@
+package cluster
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/code-ready/crc/pkg/crc/logging"
+	"github.com/code-ready/crc/pkg/crc/oc"
+)
+
+// WaitForClusterStable checks that the cluster is running a number of consecutive times
+func WaitForClusterStable(ocConfig oc.Config, monitoringEnabled bool) error {
+	startTime := time.Now()
+
+	retryDuration := 30 * time.Second
+	retryCount := 20 // 10 minutes
+
+	numConsecutive := 3
+	var count int // holds num of consecutive matches
+
+	for i := 0; i < retryCount; i++ {
+		status, err := GetClusterOperatorsStatus(ocConfig, monitoringEnabled)
+		if err == nil {
+			// update counter for consecutive matches
+			if status.IsReady() {
+				count++
+			} else {
+				count = 0
+			}
+			// break if done
+			if count == numConsecutive {
+				logging.Debugf("Cluster took %s to stabilize", time.Since(startTime))
+				return nil
+			}
+		} else {
+			count = 0
+		}
+		time.Sleep(retryDuration)
+	}
+
+	return fmt.Errorf("cluster operators are still not stable after %s", time.Since(startTime))
+}

--- a/pkg/crc/machine/kubeconfig.go
+++ b/pkg/crc/machine/kubeconfig.go
@@ -36,7 +36,7 @@ func eventuallyWriteKubeconfig(ocConfig oc.Config, ip string, clusterConfig *Clu
 		if err != nil {
 			return &errors.RetriableError{Err: err}
 		}
-		if isReady(status) {
+		if status.IsReady() {
 			return nil
 		}
 		return &errors.RetriableError{Err: goerrors.New("cluster operator authentication not ready")}
@@ -46,10 +46,6 @@ func eventuallyWriteKubeconfig(ocConfig oc.Config, ip string, clusterConfig *Clu
 		return err
 	}
 	return nil
-}
-
-func isReady(status *cluster.Status) bool {
-	return status.Available && !status.Progressing && !status.Degraded && !status.Disabled
 }
 
 func WriteKubeconfig(ip string, clusterConfig *ClusterConfig) error {

--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -378,9 +378,11 @@ func (client *client) Start(ctx context.Context, startConfig StartConfig) (*Star
 		}
 	}
 
-	logging.Info("Starting OpenShift cluster ... [waiting 3m]")
+	logging.Info("Starting OpenShift cluster ... [waiting for the cluster to stabilize]")
 
-	time.Sleep(time.Minute * 3)
+	if err := cluster.WaitForClusterStable(ocConfig, client.monitoringEnabled()); err != nil {
+		logging.Errorf("Cluster is not ready: %v", err)
+	}
 
 	waitForProxyPropagation(ocConfig, proxyConfig)
 


### PR DESCRIPTION
Most of the time, at the end of crc start, the cluster is broken: 3min is not enough. 
@jsliacan solved this in the CI by waiting 3 consecutive running statuses (1min interval). 

This PR replaces the sleep(3 min) by a check of 3 consecutive checks (30s interval). 

It also changes the output of the crc start. It says now why it is waiting (and this is not CRC fault).

I found this PR really needed since we changed the output of crc start. Now if the user clicks on the console URL, it will simply work.

4.6.16 bundle: 

```
INFO Starting OpenShift cluster ... [waiting for the cluster to stabilize] 
INFO 2 operators are progressing: authentication, image-registry 
INFO 3 operators are progressing: authentication, image-registry, operator-lifecycle-manager-packageserver 
INFO 3 operators are progressing: authentication, dns, image-registry 
INFO Operator image-registry is progressing       
INFO 2 operators are not available: authentication, openshift-apiserver 
INFO Operator kube-apiserver is progressing       
INFO Operator kube-apiserver is progressing       
INFO Operator kube-apiserver is progressing       
INFO Operator kube-apiserver is progressing       
INFO Operator kube-apiserver is progressing       
INFO All operators are available. Ensuring stability ... 
INFO Operators are stable (2/3) ...               
INFO Operators are stable (3/3) ...    
```

4.6.15 bundle (4m10s total wait):
```
INFO Starting OpenShift cluster ... [waiting for the cluster to stabilize] 
INFO 7 operators are progressing: authentication, dns, image-registry, network, openshift-controller-manager, operator-lifecycle-manager-packageserver, service-ca 
INFO 7 operators are progressing: authentication, dns, image-registry, network, openshift-controller-manager, operator-lifecycle-manager-packageserver, service-ca 
INFO 4 operators are progressing: authentication, image-registry, openshift-controller-manager, service-ca 
INFO 4 operators are progressing: authentication, console, image-registry, service-ca 
INFO Operator ingress is degraded                 
INFO Operator authentication is progressing       
INFO All operators are available. Ensuring stability ... 
INFO Operators are stable (2/3) ...               
INFO Operators are stable (3/3) ...    
```