### PR TITLE
Add global 5s timeout to oc command

### DIFF
--- a/pkg/crc/cluster/cluster.go
+++ b/pkg/crc/cluster/cluster.go
@@ -195,7 +195,7 @@ func AddProxyConfigToCluster(sshRunner *ssh.Runner, ocConfig oc.Config, proxy *n
 	logging.Debugf("Patch string %s", string(patchEncode))
 
 	cmdArgs := []string{"patch", "proxy", "cluster", "-p", fmt.Sprintf("'%s'", string(patchEncode)), "-n", "openshift-config", "--type", "merge"}
-	if _, stderr, err := ocConfig.RunOcCommand(cmdArgs...); err != nil {
+	if _, stderr, err := ocConfig.RunOcCommandPrivate(cmdArgs...); err != nil {
 		return fmt.Errorf("Failed to add proxy details %v: %s", err, stderr)
 	}
 	return nil
@@ -223,7 +223,7 @@ func addProxyCACertToCluster(sshRunner *ssh.Runner, ocConfig oc.Config, proxy *n
 		return err
 	}
 	cmdArgs := []string{"apply", "-f", proxyConfigMapFileName}
-	if _, stderr, err := ocConfig.RunOcCommand(cmdArgs...); err != nil {
+	if _, stderr, err := ocConfig.RunOcCommandPrivate(cmdArgs...); err != nil {
 		return fmt.Errorf("Failed to add proxy cert details %v: %s", err, stderr)
 	}
 	return nil
@@ -346,7 +346,7 @@ func CheckProxySettingsForOperator(ocConfig oc.Config, proxy *network.ProxyConfi
 		return true, nil
 	}
 	cmdArgs := []string{"set", "env", "deployment", deployment, "--list", "-n", namespace}
-	out, _, err := ocConfig.RunOcCommand(cmdArgs...)
+	out, _, err := ocConfig.RunOcCommandPrivate(cmdArgs...)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/crc/cluster/csr.go
+++ b/pkg/crc/cluster/csr.go
@@ -28,7 +28,7 @@ func WaitForOpenshiftResource(ocConfig oc.Config, resource string) error {
 // approveNodeCSR approves the certificate for the node.
 func approveNodeCSR(ocConfig oc.Config, expectedSignerName string) error {
 	logging.Debug("Approving pending CSRs")
-	output, stderr, err := ocConfig.RunOcCommandPrivate("get", "csr", "-ojson")
+	output, stderr, err := ocConfig.RunOcCommand("get", "csr", "-ojson")
 	if err != nil {
 		return fmt.Errorf("Failed to get all certificate signing requests: %v %s", err, stderr)
 	}

--- a/pkg/crc/oc/oc.go
+++ b/pkg/crc/oc/oc.go
@@ -8,6 +8,8 @@ import (
 	crcos "github.com/code-ready/crc/pkg/os"
 )
 
+const timeout = "5s"
+
 type Config struct {
 	Runner           crcos.CommandRunner
 	OcExecutablePath string
@@ -39,10 +41,10 @@ func (oc Config) runCommand(isPrivate bool, args ...string) (string, string, err
 	}
 
 	if isPrivate {
-		return oc.Runner.RunPrivate(oc.OcExecutablePath, args...)
+		return oc.Runner.RunPrivate("timeout", append([]string{timeout, oc.OcExecutablePath}, args...)...)
 	}
 
-	return oc.Runner.Run(oc.OcExecutablePath, args...)
+	return oc.Runner.Run("timeout", append([]string{timeout, oc.OcExecutablePath}, args...)...)
 }
 
 func (oc Config) RunOcCommand(args ...string) (string, string, error) {

--- a/pkg/crc/ssh/ssh.go
+++ b/pkg/crc/ssh/ssh.go
@@ -67,9 +67,9 @@ func (runner *Runner) CopyFile(srcFilename string, destFilename string, mode os.
 
 func (runner *Runner) runSSHCommand(command string, runPrivate bool) (string, string, error) {
 	if runPrivate {
-		logging.Debugf("About to run SSH command with hidden output")
+		logging.Debugf("Running private SSH command")
 	} else {
-		logging.Debugf("About to run SSH command:\n%s", command)
+		logging.Debugf("Running SSH command: %s", command)
 	}
 
 	stdout, stderr, err := runner.client.Run(command)


### PR DESCRIPTION
crc status can take a long time (> 20s) to  answer. If the apiserver is taking too long, then, we can say the cluster is unreachable.

For crc start, it will help retry loop: they will be more reactive and will not wait 20s before trying again. 
The issue I can see is in specific calls like "patch clusterversion", "apply specific config". If it takes too long, it can break the start process. Should the timeout limited to get requests? Should I use a 30s timeout for other requests?