### PR TITLE
Remove setup output checks which differ across linux flavours

### DIFF
--- a/test/e2e/features/basic.feature
+++ b/test/e2e/features/basic.feature
@@ -51,14 +51,6 @@ Feature: Basic test
         And stderr should contain "Checking if libvirt 'crc' network is active"
         And stderr should contain "Checking if NetworkManager is installed"
         And stderr should contain "Checking if NetworkManager service is running"
-        And stderr should contain "Checking if /etc/NetworkManager/conf.d/crc-nm-dnsmasq.conf exists"
-        And stderr should contain "Writing Network Manager config for crc"
-        And stderr should contain "Using root access: Writing NetworkManager configuration to /etc/NetworkManager/conf.d/crc-nm-dnsmasq.conf"
-        And stderr should contain "Using root access: Executing systemctl daemon-reload command"
-        And stderr should contain "Using root access: Executing systemctl reload NetworkManager"
-        And stderr should contain "Checking if /etc/NetworkManager/dnsmasq.d/crc.conf exists"
-        And stderr should contain "Writing dnsmasq config for crc"
-        And stderr should contain "Using root access: Writing NetworkManager configuration to /etc/NetworkManager/dnsmasq.d/crc.conf"
         And stderr should contain "Using root access: Executing systemctl daemon-reload command"
         And stderr should contain "Using root access: Executing systemctl reload NetworkManager"
         And stdout should contain "Setup is complete, you can now run 'crc start -b $bundlename' to start the OpenShift cluster" if bundle is not embedded
@@ -177,15 +169,12 @@ Feature: Basic test
     Scenario Outline: CRC clean-up
         When executing "crc cleanup" succeeds
         Then stderr should contain "Removing the crc VM if exists"
-        And stderr should contain "Removing /etc/NetworkManager/dnsmasq.d/crc.conf file"
-        And stderr should contain "Using root access: Removing NetworkManager configuration file in /etc/NetworkManager/dnsmasq.d/crc.conf"
-        And stderr should contain "Using root access: Executing systemctl daemon-reload command"
-        And stderr should contain "Using root access: Executing systemctl reload NetworkManager"
-        And stderr should contain "Removing /etc/NetworkManager/conf.d/crc-nm-dnsmasq.conf file"
-        And stderr should contain "Using root access: Removing NetworkManager configuration file in /etc/NetworkManager/conf.d/crc-nm-dnsmasq.conf"
-        And stderr should contain "Using root access: Executing systemctl daemon-reload command"
-        And stderr should contain "Using root access: Executing systemctl reload NetworkManager"
         And stderr should contain "Removing 'crc' network from libvirt"
+        And stderr should contain "Using root access: Executing systemctl daemon-reload command"
+        And stderr should contain "Using root access: Executing systemctl reload NetworkManager"
+        And stderr should contain "Removing pull secret from the keyring"
+        And stderr should contain "Removing older logs"
+        And stderr should contain "Removing CRC Machine Instance directory"
         And stdout should contain "Cleanup finished"
 
     @windows

--- a/test/e2e/features/config.feature
+++ b/test/e2e/features/config.feature
@@ -84,7 +84,6 @@ Feature: Test configuration settings
         Examples:
             | property                             | value1 | value2 |
             | skip-check-bundle-extracted          | true   | false  |
-            | skip-check-crc-dnsmasq-file          | true   | false  |
             | skip-check-crc-network               | true   | false  |
             | skip-check-crc-network-active        | true   | false  |
             | skip-check-kvm-enabled               | true   | false  |
@@ -92,7 +91,6 @@ Feature: Test configuration settings
             | skip-check-libvirt-installed         | true   | false  |
             | skip-check-libvirt-running           | true   | false  |
             | skip-check-libvirt-version           | true   | false  |
-            | skip-check-network-manager-config    | true   | false  |
             | skip-check-network-manager-installed | true   | false  |
             | skip-check-network-manager-running   | true   | false  |
             | skip-check-root-user                 | true   | false  |


### PR DESCRIPTION
There are a few trivial fails in e2e tests when run on Fedora 33. These are due to network solution differences. These changes remove the checks which aren't the same across different linuxes.

## Proposed changes

1. Update `setup` output checks
2. Update `cleanup` output checks
3. Remove config options.

## Testing

1. `make e2e` should pass on all linuxes

Successful [pipeline run on F33](https://crcqe-jenkins-csb-codeready.cloud.paas.psi.redhat.com/blue/organizations/jenkins/qe%2Fbundle_virtualized_fedora33/detail/bundle_virtualized_fedora33/38/pipeline/).
