### PR TITLE
centos-ci: fix uploading artifacts for master branch job

### DIFF
--- a/centos_ci.sh
+++ b/centos_ci.sh
@@ -95,9 +95,9 @@ function perform_artifacts_upload() {
   if [[ "$GIT_BRANCH" = "origin/master" ]]; then
     # http://stackoverflow.com/a/22908437/1120530; Using --relative as --rsync-path not working
     mkdir -p crc/master/$BUILD_NUMBER/
-    cp out/* crc/master/$BUILD_NUMBER/
+    cp -R out/* crc/master/$BUILD_NUMBER/
     RSYNC_PASSWORD=$1 rsync -a --relative crc/master/$BUILD_NUMBER/ minishift@artifacts.ci.centos.org::minishift/crc/
-    echo "Find Artifacts here http://artifacts.ci.centos.org/${REPO_OWNER}/${REPO_NAME}/master/$BUILD_NUMBER ."
+    echo "Find Artifacts here http://artifacts.ci.centos.org/minishift/crc/master/$BUILD_NUMBER ."
   else
     # http://stackoverflow.com/a/22908437/1120530; Using --relative as --rsync-path not working
     mkdir -p pr/$ghprbPullId/


### PR DESCRIPTION
The artifacts were not getting uploaded and failing with following error, see: https://ci.centos.org/job/codeready-crc-master/485/console

```
05:04:54 + perform_artifacts_upload c76f32e8-d789
05:04:54 + set +x
05:04:54 cp: -r not specified; omitting directory 'out/linux-amd64'
05:04:54 cp: -r not specified; omitting directory 'out/macos-amd64'
05:04:54 cp: -r not specified; omitting directory 'out/windows-amd64'
05:04:54 Find Artifacts here http://artifacts.ci.centos.org///master/485
```