### PR TITLE
Fix story health residual statuscheck

### DIFF
--- a/test/e2e/crcsuite/crcsuite.go
+++ b/test/e2e/crcsuite/crcsuite.go
@@ -12,13 +12,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/code-ready/crc/pkg/crc/cluster"
 	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/cucumber/godog"
 	"github.com/cucumber/messages-go/v10"
 
 	clicumber "github.com/code-ready/clicumber/testsuite"
-	"github.com/code-ready/crc/pkg/crc/oc"
 )
 
 var (
@@ -51,8 +49,6 @@ func FeatureContext(s *godog.Suite) {
 		LoginToOcClusterSucceedsOrFails)
 	s.Step(`^setting kubeconfig context to "(.*)" (succeeds|fails)$`,
 		SetKubeConfigContextSucceedsOrFails)
-	s.Step(`^with up to "(\d+)" retries with wait period of "(\d*(?:ms|s|m))" all cluster operators are running$`,
-		CheckClusterOperatorsWithRetry)
 	s.Step(`^with up to "(\d+)" retries with wait period of "(\d*(?:ms|s|m))" http response from "(.*)" has status code "(\d+)"$`,
 		CheckHTTPResponseWithRetry)
 	s.Step(`^with up to "(\d+)" retries with wait period of "(\d*(?:ms|s|m))" command "(.*)" output (should match|matches|should not match|does not match) "(.*)"$`,
@@ -163,28 +159,6 @@ func FeatureContext(s *godog.Suite) {
 			fmt.Printf("Could not delete CRC VM: %s.", err)
 		}
 	})
-}
-
-func CheckClusterOperatorsWithRetry(retryCount int, retryWait string) error {
-
-	retryDuration, err := time.ParseDuration(retryWait)
-	if err != nil {
-		return err
-	}
-
-	ocConfig := oc.UseOCWithConfig("crc")
-	for i := 0; i < retryCount; i++ {
-		s, err := cluster.GetClusterOperatorsStatus(ocConfig, false)
-		if err != nil {
-			return err
-		}
-		if s.Available {
-			return nil
-		}
-		time.Sleep(retryDuration)
-	}
-
-	return fmt.Errorf("Some cluster operators are still not running")
 }
 
 func CheckHTTPResponseWithRetry(retryCount int, retryWait string, address string, expectedStatusCode int) error {

--- a/test/e2e/features/story_health.feature
+++ b/test/e2e/features/story_health.feature
@@ -26,14 +26,6 @@ Feature: End-to-end health check
         When checking that CRC is running
         Then login to the oc cluster succeeds
 
-    @linux @darwin @windows
-    Scenario: Check cluster health
-        When executing "oc get nodes"
-        Then stdout contains "Ready"
-        And stdout does not contain "Not ready"
-        # next line checks similar things as `crc status` except gives more informative output
-        And with up to "5" retries with wait period of "1m" all cluster operators are running
-
     @darwin @linux @windows
     Scenario: Create project
         When executing "oc new-project testproj" succeeds


### PR DESCRIPTION
e2e story health feature had a specific 

```feature
scenario: Check cluster health 
```
to check the cluster state and wait to execute the subsequent scenarios within the feature. This control was duplicated with the addition of a new step on a previous scenario to check if the cluster is running:

```feature
When checking that CRC is running 
```
This PR removes the duplicated status check during the e2e. 

PR passing downstream CI on [macos14](https://crcqe-jenkins-csb-codeready.cloud.paas.psi.redhat.com/blue/organizations/jenkins/qe%2Fbundle_baremetal_macos14-brno/detail/bundle_baremetal_macos14-brno/147/pipeline)

PR passing downstream CI on [windows10](https://crcqe-jenkins-csb-codeready.cloud.paas.psi.redhat.com/blue/organizations/jenkins/qe%2Fbundle_baremetal_windows10-brno/detail/bundle_baremetal_windows10-brno/103/pipeline)