### PR TITLE
add details to telemetry about libvirt network failure

### DIFF
--- a/pkg/crc/preflight/preflight_checks_linux.go
+++ b/pkg/crc/preflight/preflight_checks_linux.go
@@ -349,7 +349,7 @@ func fixLibvirtCrcNetworkAvailable() error {
 	err = cmd.Run()
 	if err != nil {
 		logging.Debugf("%v : %s", err, buf.String())
-		return fmt.Errorf("Failed to create libvirt 'crc' network")
+		return fmt.Errorf("Failed to create libvirt 'crc' network: %v - %s", err, buf.String())
 	}
 	logging.Debug("libvirt 'crc' network created")
 	return nil


### PR DESCRIPTION
* Collect why crc network creation failed in telemetry