### PR TITLE
Install macOS tray by default during crc setup

### DIFF
--- a/cmd/crc/cmd/config/config.go
+++ b/cmd/crc/cmd/config/config.go
@@ -10,6 +10,7 @@ import (
 	"github.com/code-ready/crc/pkg/crc/config"
 	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/code-ready/crc/pkg/crc/network"
+	"github.com/code-ready/crc/pkg/crc/tray"
 	"github.com/spf13/cobra"
 )
 
@@ -30,6 +31,7 @@ const (
 	ProxyCAFile             = "proxy-ca-file"
 	ConsentTelemetry        = "consent-telemetry"
 	EnableClusterMonitoring = "enable-cluster-monitoring"
+	AutostartTray           = "autostart-tray"
 )
 
 func RegisterSettings(cfg *config.Config) {
@@ -63,6 +65,9 @@ func RegisterSettings(cfg *config.Config) {
 		"Network mode (default or vsock)")
 	cfg.AddSetting(HostNetworkAccess, false, validateHostNetworkAccess, config.SuccessfullyApplied,
 		"Allow TCP/IP connections from the CodeReday Containers VM to services running on the host (true/false, default: false)")
+	// System tray auto-start config
+	cfg.AddSetting(AutostartTray, true, tray.ValidateTrayAutostart, tray.DisableEnableTrayAutostart,
+		"Automatically start the tray (true/false, default: true)")
 	// Proxy Configuration
 	cfg.AddSetting(HTTPProxy, "", config.ValidateURI, config.SuccessfullyApplied,
 		"HTTP proxy URL (string, like 'http://my-proxy.com:8443')")

--- a/cmd/crc/cmd/config/config.go
+++ b/cmd/crc/cmd/config/config.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/code-ready/crc/pkg/crc/config"
 	"github.com/code-ready/crc/pkg/crc/constants"
+	"github.com/code-ready/crc/pkg/crc/errors"
 	"github.com/code-ready/crc/pkg/crc/network"
 	"github.com/code-ready/crc/pkg/crc/tray"
 	"github.com/spf13/cobra"
@@ -44,6 +45,23 @@ func RegisterSettings(cfg *config.Config) {
 		return config.ValidateBool(value)
 	}
 
+	disableEnableTrayAutostart := func(key string, value interface{}) string {
+		mode := network.ParseMode(cfg.Get(NetworkMode).AsString())
+		var mErr = errors.MultiError{}
+		if err := tray.DisableTrayAutostart(); err != nil {
+			mErr.Collect(err)
+		}
+		if mode == network.DefaultMode {
+			if err := tray.DisableDaemonAutostart(); err != nil {
+				mErr.Collect(err)
+			}
+		}
+		if len(mErr.Errors) > 0 {
+			return fmt.Sprintf("Error occurred on disabling tray autostart: %s", mErr.Error())
+		}
+		return "Successfully disabled autostart of tray at login."
+	}
+
 	// Start command settings in config
 	cfg.AddSetting(Bundle, constants.DefaultBundlePath, config.ValidateBundlePath, config.SuccessfullyApplied,
 		fmt.Sprintf("Bundle path (string, default '%s')", constants.DefaultBundlePath))
@@ -66,7 +84,7 @@ func RegisterSettings(cfg *config.Config) {
 	cfg.AddSetting(HostNetworkAccess, false, validateHostNetworkAccess, config.SuccessfullyApplied,
 		"Allow TCP/IP connections from the CodeReday Containers VM to services running on the host (true/false, default: false)")
 	// System tray auto-start config
-	cfg.AddSetting(AutostartTray, true, tray.ValidateTrayAutostart, tray.DisableEnableTrayAutostart,
+	cfg.AddSetting(AutostartTray, true, tray.ValidateTrayAutostart, disableEnableTrayAutostart,
 		"Automatically start the tray (true/false, default: true)")
 	// Proxy Configuration
 	cfg.AddSetting(HTTPProxy, "", config.ValidateURI, config.SuccessfullyApplied,

--- a/pkg/crc/config/callbacks.go
+++ b/pkg/crc/config/callbacks.go
@@ -15,3 +15,8 @@ func RequiresRestartMsg(key string, _ interface{}) string {
 func SuccessfullyApplied(key string, value interface{}) string {
 	return fmt.Sprintf("Successfully configured %s to %s", key, cast.ToString(value))
 }
+
+func RequiresCRCSetup(key string, _ interface{}) string {
+	return fmt.Sprintf("Changes to configuration property '%s' are only applied during 'crc setup'.\n"+
+		"Please run 'crc setup' for this configuration to take effect.", key)
+}

--- a/pkg/crc/preflight/preflight.go
+++ b/pkg/crc/preflight/preflight.go
@@ -154,7 +154,8 @@ func doRegisterSettings(cfg config.Schema, checks []Check) {
 func StartPreflightChecks(config config.Storage) error {
 	experimentalFeatures := config.Get(cmdConfig.ExperimentalFeatures).AsBool()
 	mode := network.ParseMode(config.Get(cmdConfig.NetworkMode).AsString())
-	if err := doPreflightChecks(config, getPreflightChecks(experimentalFeatures, mode)); err != nil {
+	trayAutostart := config.Get(cmdConfig.AutostartTray).AsBool()
+	if err := doPreflightChecks(config, getPreflightChecks(experimentalFeatures, trayAutostart, mode)); err != nil {
 		return &errors.PreflightError{Err: err}
 	}
 	return nil
@@ -164,7 +165,8 @@ func StartPreflightChecks(config config.Storage) error {
 func SetupHost(config config.Storage) error {
 	experimentalFeatures := config.Get(cmdConfig.ExperimentalFeatures).AsBool()
 	mode := network.ParseMode(config.Get(cmdConfig.NetworkMode).AsString())
-	return doFixPreflightChecks(config, getPreflightChecks(experimentalFeatures, mode))
+	trayAutostart := config.Get(cmdConfig.AutostartTray).AsBool()
+	return doFixPreflightChecks(config, getPreflightChecks(experimentalFeatures, trayAutostart, mode))
 }
 
 func RegisterSettings(config config.Schema) {

--- a/pkg/crc/preflight/preflight_darwin.go
+++ b/pkg/crc/preflight/preflight_darwin.go
@@ -107,17 +107,20 @@ var traySetupChecks = [...]Check{
 }
 
 func getAllPreflightChecks() []Check {
-	return getPreflightChecks(true, network.DefaultMode)
+	return getPreflightChecks(true, true, network.DefaultMode)
 }
 
-func getPreflightChecks(experimentalFeatures bool, mode network.Mode) []Check {
+func getPreflightChecks(_ bool, trayAutostart bool, mode network.Mode) []Check {
 	checks := []Check{}
 
 	checks = append(checks, nonWinPreflightChecks[:]...)
 	checks = append(checks, genericPreflightChecks[:]...)
 	checks = append(checks, hyperkitPreflightChecks(mode)...)
 	checks = append(checks, dnsPreflightChecks[:]...)
-	checks = append(checks, traySetupChecks[:]...)
+
+	if trayAutostart {
+		checks = append(checks, traySetupChecks[:]...)
+	}
 
 	if mode == network.DefaultMode {
 		checks = append(checks, resolverPreflightChecks[:]...)

--- a/pkg/crc/preflight/preflight_darwin.go
+++ b/pkg/crc/preflight/preflight_darwin.go
@@ -117,13 +117,10 @@ func getPreflightChecks(experimentalFeatures bool, mode network.Mode) []Check {
 	checks = append(checks, genericPreflightChecks[:]...)
 	checks = append(checks, hyperkitPreflightChecks(mode)...)
 	checks = append(checks, dnsPreflightChecks[:]...)
+	checks = append(checks, traySetupChecks[:]...)
 
 	if mode == network.DefaultMode {
 		checks = append(checks, resolverPreflightChecks[:]...)
-	}
-	// Experimental feature
-	if experimentalFeatures {
-		checks = append(checks, traySetupChecks[:]...)
 	}
 
 	checks = append(checks, bundleCheck)

--- a/pkg/crc/preflight/preflight_darwin_test.go
+++ b/pkg/crc/preflight/preflight_darwin_test.go
@@ -19,10 +19,10 @@ func TestCountPreflights(t *testing.T) {
 	assert.Len(t, getPreflightChecks(false, false, network.DefaultMode), 14)
 	assert.Len(t, getPreflightChecks(true, true, network.DefaultMode), 20)
 
-	assert.Len(t, getPreflightChecks(false, false, network.VSockMode), 13)
+	assert.Len(t, getPreflightChecks(false, false, network.VSockMode), 15)
 	assert.Len(t, getPreflightChecks(true, true, network.VSockMode), 19)
 
-	assert.Len(t, getPreflightChecks(true, false, network.VSockMode), 13)
+	assert.Len(t, getPreflightChecks(true, false, network.VSockMode), 15)
 	assert.Len(t, getPreflightChecks(false, true, network.VSockMode), 19)
 
 	assert.Len(t, getPreflightChecks(false, true, network.DefaultMode), 20)

--- a/pkg/crc/preflight/preflight_darwin_test.go
+++ b/pkg/crc/preflight/preflight_darwin_test.go
@@ -16,9 +16,9 @@ func TestCountConfigurationOptions(t *testing.T) {
 }
 
 func TestCountPreflights(t *testing.T) {
-	assert.Len(t, getPreflightChecks(false, network.DefaultMode), 14)
+	assert.Len(t, getPreflightChecks(false, network.DefaultMode), 20)
 	assert.Len(t, getPreflightChecks(true, network.DefaultMode), 20)
 
-	assert.Len(t, getPreflightChecks(false, network.VSockMode), 13)
+	assert.Len(t, getPreflightChecks(false, network.VSockMode), 19)
 	assert.Len(t, getPreflightChecks(true, network.VSockMode), 19)
 }

--- a/pkg/crc/preflight/preflight_darwin_test.go
+++ b/pkg/crc/preflight/preflight_darwin_test.go
@@ -16,9 +16,15 @@ func TestCountConfigurationOptions(t *testing.T) {
 }
 
 func TestCountPreflights(t *testing.T) {
-	assert.Len(t, getPreflightChecks(false, network.DefaultMode), 20)
-	assert.Len(t, getPreflightChecks(true, network.DefaultMode), 20)
+	assert.Len(t, getPreflightChecks(false, false, network.DefaultMode), 14)
+	assert.Len(t, getPreflightChecks(true, true, network.DefaultMode), 20)
 
-	assert.Len(t, getPreflightChecks(false, network.VSockMode), 19)
-	assert.Len(t, getPreflightChecks(true, network.VSockMode), 19)
+	assert.Len(t, getPreflightChecks(false, false, network.VSockMode), 13)
+	assert.Len(t, getPreflightChecks(true, true, network.VSockMode), 19)
+
+	assert.Len(t, getPreflightChecks(true, false, network.VSockMode), 13)
+	assert.Len(t, getPreflightChecks(false, true, network.VSockMode), 19)
+
+	assert.Len(t, getPreflightChecks(false, true, network.DefaultMode), 20)
+	assert.Len(t, getPreflightChecks(true, false, network.DefaultMode), 14)
 }

--- a/pkg/crc/preflight/preflight_linux.go
+++ b/pkg/crc/preflight/preflight_linux.go
@@ -215,7 +215,7 @@ func getAllPreflightChecks() []Check {
 	return checks
 }
 
-func getPreflightChecks(_ bool, networkMode network.Mode) []Check {
+func getPreflightChecks(_ bool, _ bool, networkMode network.Mode) []Check {
 	return getPreflightChecksForDistro(distro(), networkMode)
 }
 

--- a/pkg/crc/preflight/preflight_windows.go
+++ b/pkg/crc/preflight/preflight_windows.go
@@ -138,10 +138,10 @@ func fixVsock() error {
 }
 
 func getAllPreflightChecks() []Check {
-	return getPreflightChecks(true, network.VSockMode)
+	return getPreflightChecks(true, true, network.VSockMode)
 }
 
-func getPreflightChecks(experimentalFeatures bool, networkMode network.Mode) []Check {
+func getPreflightChecks(experimentalFeatures bool, _ bool, networkMode network.Mode) []Check {
 	checks := []Check{}
 	checks = append(checks, genericPreflightChecks[:]...)
 	checks = append(checks, hypervPreflightChecks[:]...)

--- a/pkg/crc/preflight/preflight_windows_test.go
+++ b/pkg/crc/preflight/preflight_windows_test.go
@@ -15,9 +15,9 @@ func TestCountConfigurationOptions(t *testing.T) {
 }
 
 func TestCountPreflights(t *testing.T) {
-	assert.Len(t, getPreflightChecks(false, network.DefaultMode), 16)
-	assert.Len(t, getPreflightChecks(true, network.DefaultMode), 19)
+	assert.Len(t, getPreflightChecks(false, false, network.DefaultMode), 16)
+	assert.Len(t, getPreflightChecks(true, true, network.DefaultMode), 19)
 
-	assert.Len(t, getPreflightChecks(false, network.VSockMode), 17)
-	assert.Len(t, getPreflightChecks(true, network.VSockMode), 20)
+	assert.Len(t, getPreflightChecks(false, false, network.VSockMode), 17)
+	assert.Len(t, getPreflightChecks(true, true, network.VSockMode), 20)
 }

--- a/pkg/crc/tray/util_darwin.go
+++ b/pkg/crc/tray/util_darwin.go
@@ -1,27 +1,21 @@
 package tray
 
 import (
-	"fmt"
-
 	"github.com/code-ready/crc/pkg/crc/config"
 	"github.com/code-ready/crc/pkg/os/launchd"
-	"github.com/spf13/cast"
 )
 
-var agentLabels = []string{"crc.tray", "crc.daemon"}
+const (
+	trayAgentLabel   = "crc.tray"
+	daemonAgentLabel = "crc.daemon"
+)
 
-func DisableEnableTrayAutostart(key string, value interface{}) string {
-	// Enable
-	if cast.ToBool(value) {
-		return config.RequiresCRCSetup(key, value)
-	}
-	// Disable
-	for _, agentLabel := range agentLabels {
-		if err := launchd.RemovePlist(agentLabel); err != nil {
-			return fmt.Sprintf("Error trying to disable auto-start of tray: %s", err.Error())
-		}
-	}
-	return "Successfully disabled auto-start of tray at login."
+func DisableTrayAutostart() error {
+	return launchd.RemovePlist(trayAgentLabel)
+}
+
+func DisableDaemonAutostart() error {
+	return launchd.RemovePlist(daemonAgentLabel)
 }
 
 // ValidateTrayAutostart checks tray-auto-start is used in macOS and its a bool

--- a/pkg/crc/tray/util_darwin.go
+++ b/pkg/crc/tray/util_darwin.go
@@ -1,0 +1,30 @@
+package tray
+
+import (
+	"fmt"
+
+	"github.com/code-ready/crc/pkg/crc/config"
+	"github.com/code-ready/crc/pkg/os/launchd"
+	"github.com/spf13/cast"
+)
+
+var agentLabels = []string{"crc.tray", "crc.daemon"}
+
+func DisableEnableTrayAutostart(key string, value interface{}) string {
+	// Enable
+	if cast.ToBool(value) {
+		return config.RequiresCRCSetup(key, value)
+	}
+	// Disable
+	for _, agentLabel := range agentLabels {
+		if err := launchd.RemovePlist(agentLabel); err != nil {
+			return fmt.Sprintf("Error trying to disable auto-start of tray: %s", err.Error())
+		}
+	}
+	return "Successfully disabled auto-start of tray at login."
+}
+
+// ValidateTrayAutostart checks tray-auto-start is used in macOS and its a bool
+func ValidateTrayAutostart(value interface{}) (bool, string) {
+	return config.ValidateBool(value)
+}

--- a/pkg/crc/tray/util_linux.go
+++ b/pkg/crc/tray/util_linux.go
@@ -1,8 +1,13 @@
 package tray
 
-func DisableEnableTrayAutostart(key string, value interface{}) string {
+func DisableTrayAutostart() error {
 	// noop
-	return ""
+	return nil
+}
+
+func DisableDaemonAutostart() error {
+	// noop
+	return nil
 }
 
 // ValidateTrayAutostart checks tray-auto-start is used in macOS and its a bool

--- a/pkg/crc/tray/util_linux.go
+++ b/pkg/crc/tray/util_linux.go
@@ -1,0 +1,11 @@
+package tray
+
+func DisableEnableTrayAutostart(key string, value interface{}) string {
+	// noop
+	return ""
+}
+
+// ValidateTrayAutostart checks tray-auto-start is used in macOS and its a bool
+func ValidateTrayAutostart(value interface{}) (bool, string) {
+	return false, "Not supported on Linux"
+}

--- a/pkg/crc/tray/util_windows.go
+++ b/pkg/crc/tray/util_windows.go
@@ -1,0 +1,11 @@
+package tray
+
+func DisableEnableTrayAutostart(key string, value interface{}) string {
+	// noop
+	return ""
+}
+
+// ValidateTrayAutostart checks tray-auto-start is used in macOS and its a bool
+func ValidateTrayAutostart(value interface{}) (bool, string) {
+	return false, "Not supported on Windows"
+}

--- a/pkg/crc/tray/util_windows.go
+++ b/pkg/crc/tray/util_windows.go
@@ -1,8 +1,13 @@
 package tray
 
-func DisableEnableTrayAutostart(key string, value interface{}) string {
+func DisableTrayAutostart() error {
 	// noop
-	return ""
+	return nil
+}
+
+func DisableDaemonAutostart() error {
+	// noop
+	return nil
 }
 
 // ValidateTrayAutostart checks tray-auto-start is used in macOS and its a bool


### PR DESCRIPTION
Fixes: #1937 

## Proposed changes
1. Add `tray-auto-start` config key.

## Testing
### First Installation
1. `crc setup` should install the tray.
2. Reboot -> tray should start on its own.

### Disable auto start of the tray
1. `crc config set auto-start-tray false`
2. reboot -> tray should not start.

### Re-Install
1. `crc config set auto-start-tray true`
2. `crc setup` -> tray should be started
3.  reboot -> tray should be started on its own