### PR TITLE
RFC: put the bundle name logic in one place

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -231,9 +231,9 @@ endif
 	@$(call check_defined, BUNDLE_DIR, "Embedding bundle requires BUNDLE_DIR set to a directory containing CRC bundles for all hypervisors")
 
 embed_bundle: clean cross $(HOST_BUILD_DIR)/crc-embedder check_bundledir $(HYPERKIT_BUNDLENAME) $(HYPERV_BUNDLENAME) $(LIBVIRT_BUNDLENAME)
-	$(HOST_BUILD_DIR)/crc-embedder embed --log-level debug --goos=darwin --bundle-dir=$(BUNDLE_DIR) $(BUILD_DIR)/macos-amd64/crc
-	$(HOST_BUILD_DIR)/crc-embedder embed --log-level debug --goos=linux --bundle-dir=$(BUNDLE_DIR) $(BUILD_DIR)/linux-amd64/crc
-	$(HOST_BUILD_DIR)/crc-embedder embed --log-level debug --goos=windows --bundle-dir=$(BUNDLE_DIR) $(BUILD_DIR)/windows-amd64/crc.exe
+	$(HOST_BUILD_DIR)/crc-embedder embed --log-level debug --goos=darwin --bundle=$(HYPERKIT_BUNDLENAME) $(BUILD_DIR)/macos-amd64/crc
+	$(HOST_BUILD_DIR)/crc-embedder embed --log-level debug --goos=linux --bundle=$(LIBVIRT_BUNDLENAME) $(BUILD_DIR)/linux-amd64/crc
+	$(HOST_BUILD_DIR)/crc-embedder embed --log-level debug --goos=windows --bundle=$(HYPERV_BUNDLENAME) $(BUILD_DIR)/windows-amd64/crc.exe
 
 .PHONY: update-go-version
 update-go-version:

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,14 @@ RELEASE_INFO := release-info.json
 
 MOCK_BUNDLE ?= false
 
+HYPERKIT_BUNDLENAME = crc_hyperkit_$(BUNDLE_VERSION).$(BUNDLE_EXTENSION)
+HYPERV_BUNDLENAME = crc_hyperv_$(BUNDLE_VERSION).$(BUNDLE_EXTENSION)
+LIBVIRT_BUNDLENAME = crc_libvirt_$(BUNDLE_VERSION).$(BUNDLE_EXTENSION)
+
+HYPERKIT_BUNDLEPATH = $(BUNDLE_DIR)/$(HYPERKIT_BUNDLENAME)
+HYPERV_BUNDLEPATH = $(BUNDLE_DIR)/$(HYPERV_BUNDLENAME)
+LIBVIRT_BUNDLEPATH = $(BUNDLE_DIR)/$(LIBVIRT_BUNDLENAME)
+
 # Check that given variables are set and all have non-empty values,
 # die with an error otherwise.
 #
@@ -219,21 +227,17 @@ release: cross-lint embed_bundle build_docs_pdf gen_release_info
 	
 	pushd $(RELEASE_DIR) && sha256sum * > sha256sum.txt && popd
 
-HYPERKIT_BUNDLENAME = $(BUNDLE_DIR)/crc_hyperkit_$(BUNDLE_VERSION).$(BUNDLE_EXTENSION)
-HYPERV_BUNDLENAME = $(BUNDLE_DIR)/crc_hyperv_$(BUNDLE_VERSION).$(BUNDLE_EXTENSION)
-LIBVIRT_BUNDLENAME = $(BUNDLE_DIR)/crc_libvirt_$(BUNDLE_VERSION).$(BUNDLE_EXTENSION)
-
 .PHONY: embed_bundle check_bundledir
 check_bundledir:
 ifeq ($(MOCK_BUNDLE),true)
-	touch $(HYPERKIT_BUNDLENAME) $(HYPERV_BUNDLENAME) $(LIBVIRT_BUNDLENAME)
+	touch $(HYPERKIT_BUNDLEPATH) $(HYPERV_BUNDLEPATH) $(LIBVIRT_BUNDLEPATH)
 endif
 	@$(call check_defined, BUNDLE_DIR, "Embedding bundle requires BUNDLE_DIR set to a directory containing CRC bundles for all hypervisors")
 
-embed_bundle: clean cross $(HOST_BUILD_DIR)/crc-embedder check_bundledir $(HYPERKIT_BUNDLENAME) $(HYPERV_BUNDLENAME) $(LIBVIRT_BUNDLENAME)
-	$(HOST_BUILD_DIR)/crc-embedder embed --log-level debug --goos=darwin --bundle=$(HYPERKIT_BUNDLENAME) $(BUILD_DIR)/macos-amd64/crc
-	$(HOST_BUILD_DIR)/crc-embedder embed --log-level debug --goos=linux --bundle=$(LIBVIRT_BUNDLENAME) $(BUILD_DIR)/linux-amd64/crc
-	$(HOST_BUILD_DIR)/crc-embedder embed --log-level debug --goos=windows --bundle=$(HYPERV_BUNDLENAME) $(BUILD_DIR)/windows-amd64/crc.exe
+embed_bundle: clean cross $(HOST_BUILD_DIR)/crc-embedder check_bundledir $(HYPERKIT_BUNDLEPATH) $(HYPERV_BUNDLEPATH) $(LIBVIRT_BUNDLEPATH)
+	$(HOST_BUILD_DIR)/crc-embedder embed --log-level debug --goos=darwin --bundle=$(HYPERKIT_BUNDLEPATH) $(BUILD_DIR)/macos-amd64/crc
+	$(HOST_BUILD_DIR)/crc-embedder embed --log-level debug --goos=linux --bundle=$(LIBVIRT_BUNDLEPATH) $(BUILD_DIR)/linux-amd64/crc
+	$(HOST_BUILD_DIR)/crc-embedder embed --log-level debug --goos=windows --bundle=$(HYPERV_BUNDLEPATH) $(BUILD_DIR)/windows-amd64/crc.exe
 
 .PHONY: update-go-version
 update-go-version:
@@ -255,7 +259,7 @@ packagedir: clean check_bundledir $(BUILD_DIR)/macos-amd64/crc $(HOST_BUILD_DIR)
 	tar -C packaging/root/"$(MACOS_INSTALL_PATH)"/$(CRC_VERSION)/ -xvzf packaging/root/"$(MACOS_INSTALL_PATH)"/$(CRC_VERSION)/crc-tray-macos.tar.gz
 	rm packaging/root/"$(MACOS_INSTALL_PATH)"/$(CRC_VERSION)/crc-tray-macos.tar.gz
 
-	cp $(HYPERKIT_BUNDLENAME) packaging/root/"$(MACOS_INSTALL_PATH)"/$(CRC_VERSION)/
+	cp $(HYPERKIT_BUNDLEPATH) packaging/root/"$(MACOS_INSTALL_PATH)"/$(CRC_VERSION)/
 	cp $(BUILD_DIR)/macos-amd64/crc packaging/root/"$(MACOS_INSTALL_PATH)"/$(CRC_VERSION)/
 	cp LICENSE packaging/darwin/Resources/LICENSE.txt
 	pkgbuild --analyze --root packaging/root packaging/components.plist

--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,12 @@ endif
 # https://golang.org/cmd/link/
 LDFLAGS := $(VERSION_VARIABLES) -extldflags='-static' -s -w
 
+LINUX_LDFLAGS += $(LDFLAGS) -X $(REPOPATH)/pkg/crc/version.bundle=$(LIBVIRT_BUNDLENAME)
+DARWIN_LDFLAGS += $(LDFLAGS) -X $(REPOPATH)/pkg/crc/version.bundle=$(HYPERKIT_BUNDLENAME)
+WINDOWS_LDFLAGS += $(LDFLAGS) -X $(REPOPATH)/pkg/crc/version.bundle=$(HYPERV_BUNDLENAME)
+
+GOOS_LDFLAGS := $(GOOS)_LDFLAGS
+
 # Add default target
 .PHONY: default
 default: install
@@ -90,16 +96,16 @@ check: cross build_e2e $(HOST_BUILD_DIR)/crc-embedder test cross-lint vendorchec
 
 .PHONY: install
 install: $(SOURCES)
-	go install -ldflags="$(LDFLAGS)" ./cmd/crc
+	go install -ldflags="$($(GOOS_LDFLAGS))" ./cmd/crc
 
 $(BUILD_DIR)/macos-amd64/crc: $(SOURCES)
-	GOARCH=amd64 GOOS=darwin go build -ldflags="$(LDFLAGS)" -o $(BUILD_DIR)/macos-amd64/crc ./cmd/crc
+	GOARCH=amd64 GOOS=darwin go build -ldflags="$(DARWIN_LDFLAGS)" -o $(BUILD_DIR)/macos-amd64/crc ./cmd/crc
 
 $(BUILD_DIR)/linux-amd64/crc: $(SOURCES)
-	GOOS=linux GOARCH=amd64 go build -ldflags="$(LDFLAGS)" -o $(BUILD_DIR)/linux-amd64/crc ./cmd/crc
+	GOOS=linux GOARCH=amd64 go build -ldflags="$(LINUX_LDFLAGS)" -o $(BUILD_DIR)/linux-amd64/crc ./cmd/crc
 
 $(BUILD_DIR)/windows-amd64/crc.exe: $(SOURCES)
-	GOARCH=amd64 GOOS=windows go build -ldflags="$(LDFLAGS)" -o $(BUILD_DIR)/windows-amd64/crc.exe ./cmd/crc
+	GOARCH=amd64 GOOS=windows go build -ldflags="$(WINDOWS_LDFLAGS)" -o $(BUILD_DIR)/windows-amd64/crc.exe ./cmd/crc
 
 $(HOST_BUILD_DIR)/crc-embedder: $(SOURCES)
 	go build --tags="build" -ldflags="$(LDFLAGS)" -o $(HOST_BUILD_DIR)/crc-embedder ./cmd/crc-embedder

--- a/cmd/crc-embedder/cmd/embed.go
+++ b/cmd/crc-embedder/cmd/embed.go
@@ -19,12 +19,12 @@ import (
 )
 
 var (
-	bundleDir string
-	goos      string
+	bundlePath string
+	goos       string
 )
 
 func init() {
-	embedCmd.Flags().StringVar(&bundleDir, "bundle-dir", constants.MachineCacheDir, "Directory where the OpenShift bundle can be found")
+	embedCmd.Flags().StringVar(&bundlePath, "bundle", "", "OpenShift bundle can be to append")
 	embedCmd.Flags().StringVar(&goos, "goos", runtime.GOOS, "Target platform (darwin, linux or windows)")
 	rootCmd.AddCommand(embedCmd)
 }
@@ -53,7 +53,6 @@ func runEmbed(args []string) {
 		logging.Fatalf("Failed to download data files: %v", err)
 	}
 
-	bundlePath := path.Join(bundleDir, constants.GetDefaultBundleForOs(goos))
 	downloadedFiles = append(downloadedFiles, bundlePath)
 	err = embedFiles(executablePath, downloadedFiles)
 	if err != nil {

--- a/pkg/crc/constants/constants.go
+++ b/pkg/crc/constants/constants.go
@@ -79,16 +79,12 @@ func defaultBundleForOs(bundleVersion string) map[string]string {
 	}
 }
 
-func GetDefaultBundleForOs(os string) string {
-	return GetBundleFosOs(os, version.GetBundleVersion())
-}
-
 func GetBundleFosOs(os, bundleVersion string) string {
 	return defaultBundleForOs(bundleVersion)[os]
 }
 
 func GetDefaultBundle() string {
-	return GetDefaultBundleForOs(runtime.GOOS)
+	return GetBundleFosOs(runtime.GOOS, version.GetBundleVersion())
 }
 
 var (

--- a/pkg/crc/constants/constants.go
+++ b/pkg/crc/constants/constants.go
@@ -71,20 +71,8 @@ func GetAdminHelperURL() string {
 	return adminHelperURLForOs[runtime.GOOS]
 }
 
-func defaultBundleForOs(bundleVersion string) map[string]string {
-	return map[string]string{
-		"darwin":  fmt.Sprintf("crc_hyperkit_%s.crcbundle", bundleVersion),
-		"linux":   fmt.Sprintf("crc_libvirt_%s.crcbundle", bundleVersion),
-		"windows": fmt.Sprintf("crc_hyperv_%s.crcbundle", bundleVersion),
-	}
-}
-
-func GetBundleFosOs(os, bundleVersion string) string {
-	return defaultBundleForOs(bundleVersion)[os]
-}
-
 func GetDefaultBundle() string {
-	return GetBundleFosOs(runtime.GOOS, version.GetBundleVersion())
+	return version.GetBundle()
 }
 
 var (

--- a/pkg/crc/version/version.go
+++ b/pkg/crc/version/version.go
@@ -21,6 +21,9 @@ var (
 	// Bundle version which used for the release.
 	bundleVersion = "0.0.0-unset"
 
+	// Bundle which used for the release.
+	bundle = ""
+
 	okdBuild = "false"
 
 	macosInstallPath = "/unset"
@@ -46,6 +49,10 @@ func GetCRCVersion() string {
 
 func GetCommitSha() string {
 	return commitSha
+}
+
+func GetBundle() string {
+	return bundle
 }
 
 func GetBundleVersion() string {

--- a/test/e2e/crcsuite/crcsuite.go
+++ b/test/e2e/crcsuite/crcsuite.go
@@ -12,11 +12,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/code-ready/crc/pkg/crc/constants"
+	clicumber "github.com/code-ready/clicumber/testsuite"
 	"github.com/cucumber/godog"
 	"github.com/cucumber/messages-go/v10"
-
-	clicumber "github.com/code-ready/clicumber/testsuite"
 )
 
 var (
@@ -95,7 +93,7 @@ func FeatureContext(s *godog.Suite) {
 				fmt.Println("User must specify --bundle-version if bundle is embedded")
 				os.Exit(1)
 			}
-			bundleName = constants.GetBundleFosOs(runtime.GOOS, bundleVersion)
+			bundleName = getBundleFosOs(runtime.GOOS, bundleVersion)
 		} else {
 			bundleEmbedded = false
 			_, bundleName = filepath.Split(bundleLocation)
@@ -159,6 +157,18 @@ func FeatureContext(s *godog.Suite) {
 			fmt.Printf("Could not delete CRC VM: %s.", err)
 		}
 	})
+}
+
+func defaultBundleForOs(bundleVersion string) map[string]string {
+	return map[string]string{
+		"darwin":  fmt.Sprintf("crc_hyperkit_%s.crcbundle", bundleVersion),
+		"linux":   fmt.Sprintf("crc_libvirt_%s.crcbundle", bundleVersion),
+		"windows": fmt.Sprintf("crc_hyperv_%s.crcbundle", bundleVersion),
+	}
+}
+
+func getBundleFosOs(os, bundleVersion string) string {
+	return defaultBundleForOs(bundleVersion)[os]
 }
 
 func CheckHTTPResponseWithRetry(retryCount int, retryWait string, address string, expectedStatusCode int) error {


### PR DESCRIPTION
When I modified crc to use a podman_hyperkit_3.0.0 bundle, I had to change the name both in Makefile and in the Go code. This was not obvious. I try in this PR to change this.

For the e2e test, I am not sure what I should do. Should I try to remove --bundle-version?
For the OpenShiftVersion in crc version, I guess I should read it from the bundle embedded and not get it from the variable. WDYT?