### PR TITLE
Don't enable host network access by default

### DIFF
--- a/cmd/crc/cmd/config/config.go
+++ b/cmd/crc/cmd/config/config.go
@@ -23,6 +23,7 @@ const (
 	DisableUpdateCheck      = "disable-update-check"
 	ExperimentalFeatures    = "enable-experimental-features"
 	NetworkMode             = "network-mode"
+	HostNetworkAccess       = "host-network-access"
 	HTTPProxy               = "http-proxy"
 	HTTPSProxy              = "https-proxy"
 	NoProxy                 = "no-proxy"
@@ -32,6 +33,15 @@ const (
 )
 
 func RegisterSettings(cfg *config.Config) {
+	validateHostNetworkAccess := func(value interface{}) (bool, string) {
+		mode := network.ParseMode(cfg.Get(NetworkMode).AsString())
+		if mode != network.VSockMode {
+			return false, fmt.Sprintf("%s can only be used with %s set to '%s'",
+				HostNetworkAccess, NetworkMode, network.VSockMode)
+		}
+		return config.ValidateBool(value)
+	}
+
 	// Start command settings in config
 	cfg.AddSetting(Bundle, constants.DefaultBundlePath, config.ValidateBundlePath, config.SuccessfullyApplied,
 		fmt.Sprintf("Bundle path (string, default '%s')", constants.DefaultBundlePath))
@@ -51,6 +61,8 @@ func RegisterSettings(cfg *config.Config) {
 		"Enable experimental features (true/false, default: false)")
 	cfg.AddSetting(NetworkMode, string(network.DefaultMode), network.ValidateMode, network.SuccessfullyAppliedMode,
 		"Network mode (default or vsock)")
+	cfg.AddSetting(HostNetworkAccess, false, validateHostNetworkAccess, config.SuccessfullyApplied,
+		"Allow TCP/IP connections from the CodeReday Containers VM to services running on the host (true/false, default: false)")
 	// Proxy Configuration
 	cfg.AddSetting(HTTPProxy, "", config.ValidateURI, config.SuccessfullyApplied,
 		"HTTP proxy URL (string, like 'http://my-proxy.com:8443')")


### PR DESCRIPTION
Since 'vsock: allow the VM to reach host services', when vsock is in
use, any containers running in the VM can connect to services listening
on a TCP port on the host. This is similar to podman --network=host.
Since this could be unexpected, and cause security issues in some cases,
it's preferrable not to enable this by default. This commit adds
a `host-network-access` boolean to control this which is false by
default.

This fixes https://github.com/code-ready/crc/issues/1986

**Fixes:** Issue #1986

## Solution/Idea

There is now a "host-network-access" configuration option to enable-disable this behaviour of the vsock stack.

## Proposed changes

List main as well as consequential changes you introduced or had to introduce.

1. Try `crc config set host-network-access true/false` with the default network mode -> it should fail
2. Try `crc config set host-network-access true/false` after `crc config set network-mode vsock` -> it should not fail
2. Run `crc daemon --log-level debug` after setting `host-network-access` to true -> the log should show:
```
DEBU Running 'crc daemon'
DEBU Enabling host network access
```
3. When `host-network-access` is true, the steps from https://github.com/code-ready/crc/commit/149aedafd9c5ae0625853700abffb7d128bd9b54 should still work
4. When `host-network-access` is false, these steps should fail