### PR TITLE
Bump system trays

### DIFF
--- a/pkg/crc/version/version.go
+++ b/pkg/crc/version/version.go
@@ -31,7 +31,7 @@ const (
 	// Tray version to be embedded in executable
 	crcMacTrayVersion = "1.0.1"
 	// Windows forms application version type major.minor.buildnumber.revesion
-	crcWindowsTrayVersion = "0.3.0.0"
+	crcWindowsTrayVersion = "0.4.0.0"
 )
 
 type CrcReleaseInfo struct {

--- a/pkg/crc/version/version.go
+++ b/pkg/crc/version/version.go
@@ -29,7 +29,7 @@ var (
 const (
 	releaseInfoLink = "https://mirror.openshift.com/pub/openshift-v4/clients/crc/latest/release-info.json"
 	// Tray version to be embedded in executable
-	crcMacTrayVersion = "1.0.0-beta.1"
+	crcMacTrayVersion = "1.0.1"
 	// Windows forms application version type major.minor.buildnumber.revesion
 	crcWindowsTrayVersion = "0.3.0.0"
 )


### PR DESCRIPTION
Windows tray (0.4.0.0): https://github.com/code-ready/tray-windows/releases/tag/v0.4.0.0
macOS tray (1.0.1): https://github.com/code-ready/tray-macos/releases/tag/v1.0.1