### PR TITLE
oc login needs to take username parameter to force basic auth

### DIFF
--- a/test/e2e/features/basic.feature
+++ b/test/e2e/features/basic.feature
@@ -89,7 +89,7 @@ Feature: Basic test
         When starting CRC with default bundle succeeds
         Then stdout should contain "Started the OpenShift cluster"
         # Check if user can copy-paste login details for developer and kubeadmin users
-        And stdout should match "(?s)(.*)oc login https:\/\/api\.crc\.testing:6443(.*)$"
+        And stdout should match "(?s)(.*)oc login -u developer https:\/\/api\.crc\.testing:6443(.*)$"
         And stdout should match "(?s)(.*)https:\/\/console-openshift-console\.apps-crc\.testing(.*)$"
 
     @darwin @linux @windows


### PR DESCRIPTION
Related to #2033

This change fix the expected output for e2e tests according to the change on #2033

The test ok can be checked on downstream CI at this [link](https://crcqe-jenkins-csb-codeready.cloud.paas.psi.redhat.com/blue/organizations/jenkins/qe%2Fbundle_baremetal_macos14-brno/detail/bundle_baremetal_macos14-brno/161/pipeline)