### PR TITLE
circleci: Update ubuntu image and podman package

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
 
   build_mock_release:
     machine:
-      image: ubuntu-1604:202007-01
+      image: ubuntu-2004:202101-01
     environment:
       GOVERSION: "1.14.13"
       CONTAINER_RUNTIME: "docker"
@@ -72,7 +72,7 @@ jobs:
 
   build_docs:
     machine:
-      image: ubuntu-1604:201903-01
+      image: ubuntu-2004:202101-01
     steps:
     - checkout
     - run:
@@ -80,13 +80,13 @@ jobs:
         command: sudo rm -f /etc/apt/sources.list.d/google-chrome.list
     - run:
         name: Add podman ppa and update repo
-        command: sudo add-apt-repository -y ppa:projectatomic/ppa && sudo apt -y update
+        command: |
+          echo 'deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_20.04/ /' | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
+          curl -fsSL https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/xUbuntu_20.04/Release.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/devel_kubic_libcontainers_stable.gpg > /dev/null
+          sudo apt update
     - run:
         name: Install podman
         command: sudo apt -y install podman
-    - run:
-        name: Install slirp4netns
-        command: sudo apt -y install slirp4netns
     - run:
         name: Check podman
         command: podman info
@@ -104,7 +104,7 @@ jobs:
 
   docs_deploy:
     machine:
-      image: ubuntu-1604:201903-01
+      image: ubuntu-2004:202101-01
     steps:
     - attach_workspace:
         at: docs/build


### PR DESCRIPTION
We were using old (16.04) ubuntu and podman (1.6.x) versions.
This updates them to 20.04 and podman 3.x.
The separate slirp4netns installation is removed as it's now a podman
dependency.
Hopefully this will help with intermittent `make docs_check_links`
network issues.


--

Just a circle CI change, should not impact other CI/testing in general/...