### PR TITLE
After waiting cluster operators, directly write kubeconfig without waiting for authentication

### DIFF
--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -398,7 +398,7 @@ func (client *client) Start(ctx context.Context, startConfig StartConfig) (*Star
 
 	waitForProxyPropagation(ocConfig, proxyConfig)
 
-	logging.Info("Updating kubeconfig")
+	logging.Info("Adding crc-admin and crc-developer contexts to kubeconfig...")
 	if err := writeKubeconfig(instanceIP, clusterConfig); err != nil {
 		logging.Warnf("Cannot update kubeconfig: %v", err)
 	}

--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -399,7 +399,7 @@ func (client *client) Start(ctx context.Context, startConfig StartConfig) (*Star
 	waitForProxyPropagation(ocConfig, proxyConfig)
 
 	logging.Info("Updating kubeconfig")
-	if err := eventuallyWriteKubeconfig(ocConfig, instanceIP, clusterConfig); err != nil {
+	if err := writeKubeconfig(instanceIP, clusterConfig); err != nil {
 		logging.Warnf("Cannot update kubeconfig: %v", err)
 	}
 


### PR DESCRIPTION
Since d6cc7a1, all operators should be
either up or really broken before this function call.
If it's up, then the kubeconfig will be created directly.
If it's down, we don't wait 1 extra minute, we directly skip this.

