### PR TITLE
[images/docs-builder] Bump nodejs module to 14

### DIFF
--- a/images/docs-builder/Dockerfile
+++ b/images/docs-builder/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER CodeReady Containers <devtools-cdk@redhat.com>
 RUN yum update -y && \
     yum install --setopt=tsflags=nodocs -y \
     ruby rubygems python38 && \
-    yum module install nodejs:12 -y && \
+    yum module install nodejs:14 -y && \
     yum clean all && rm -rf /var/cache/yum/*
 
 RUN gem install asciidoctor asciidoctor-pdf --pre && \


### PR DESCRIPTION
quay.io security scan detected vulnerabilities
in the image due to nodejs 12

_Already pushed the updated image to `crcont/docs-builder`_

For reference to the security scan, please check: https://quay.io/repository/anjan/docs-builder/manifest/sha256:53e315ec2ca28462164642b72f0c918523b38c1acc3ac5f4393acc0fbcd8d208?tab=vulnerabilities