### PR TITLE
Load the kubeadmin password in a more robust way: remove extra spaces

### DIFF
--- a/pkg/crc/machine/bundle/metadata.go
+++ b/pkg/crc/machine/bundle/metadata.go
@@ -107,7 +107,10 @@ func (bundle *CrcBundleInfo) GetInitramfsPath() string {
 
 func (bundle *CrcBundleInfo) GetKubeadminPassword() (string, error) {
 	rawData, err := ioutil.ReadFile(bundle.resolvePath(bundle.ClusterInfo.KubeadminPasswordFile))
-	return string(rawData), err
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(rawData)), nil
 }
 
 func (bundle *CrcBundleInfo) GetBundleBuildTime() (time.Time, error) {


### PR DESCRIPTION
The password is in a file that can contain extra newline at the end.
This newline breaks `oc login` when crc does it with the oc library.
Also, `crc start` output shows this extra line.