### PR TITLE
bump macOS tray version to 1.0.2

### DIFF
--- a/pkg/crc/version/version.go
+++ b/pkg/crc/version/version.go
@@ -29,7 +29,7 @@ var (
 const (
 	releaseInfoLink = "https://mirror.openshift.com/pub/openshift-v4/clients/crc/latest/release-info.json"
 	// Tray version to be embedded in executable
-	crcMacTrayVersion = "1.0.1"
+	crcMacTrayVersion = "1.0.2"
 	// Windows forms application version type major.minor.buildnumber.revesion
 	crcWindowsTrayVersion = "0.4.0.0"
 )


### PR DESCRIPTION
We found that the 1.0.1 version of tray was not
running on macOS 10.14, the next release  fixes
the issue

Tray release: https://github.com/code-ready/tray-macos/releases/tag/v1.0.2