### PR TITLE
Note systemd-resolved usage for RHEL 8

### DIFF
--- a/docs/source/meta/product-attributes.adoc
+++ b/docs/source/meta/product-attributes.adoc
@@ -36,3 +36,5 @@
 :odo-docs-url: https://docs.openshift.com/container-platform/latest/cli_reference/developer_cli_odo/understanding-odo.html
 :odo-docs-url-installing: https://docs.openshift.com/container-platform/latest/cli_reference/developer_cli_odo/installing-odo.html
 :odo-docs-url-single-component: https://docs.openshift.com/container-platform/latest/cli_reference/developer_cli_odo/creating_and_deploying_applications_with_odo/creating-a-single-component-application-with-odo.html
+
+:rhel-resolved-docs: https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/configuring_and_managing_networking/using-different-dns-servers-for-different-domains_configuring-and-managing-networking

--- a/docs/source/topics/ref_dns-configuration.adoc
+++ b/docs/source/topics/ref_dns-configuration.adoc
@@ -39,8 +39,6 @@ exit 0
 
 [NOTE]
 ====
-:rhel-resolved-docs: https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/configuring_and_managing_networking/using-different-dns-servers-for-different-domains_configuring-and-managing-networking
-
 `systemd-resolved` is also available as an unsupported Technology Preview on {rhel} and {centos} 8.3. After {rhel-resolved-docs}[configuring the host] to use `systemd-resolved`, any {prod} `dnsmasq` configurations need to be removed and the above script needs to be created with executable permissions.
 
 Configure the {prod} binary to skip startup checks for `dnsmasq` and NetworkManager configuration:

--- a/docs/source/topics/ref_dns-configuration.adoc
+++ b/docs/source/topics/ref_dns-configuration.adoc
@@ -29,12 +29,25 @@ This configuration is used on Fedora 33 or newer, and on Ubuntu Desktop editions
 * `systemd-resolved` configuration is done through a NetworkManager dispatcher script in `/etc/NetworkManager/dispatcher.d/99-crc.sh`:
 +
 ----
+#!/bin/sh
 resolvectl domain crc ~testing
 resolvectl dns crc 192.168.130.11
 resolvectl default-route crc false
 
 exit 0
 ----
+
+[NOTE]
+====
+`systemd-resolved` is also available as a Tech Preview on {rhel} and {centos} 8.3. After configuring the host to use systemd-resolved, any CRC dnsmasq configurations need to be removed and the above script needs to be created with executable permissions.
+
+The crc virtual machine presently needs to be configured to skip certain checks during startup:
+
+----
+$ crc config set skip-check-crc-dnsmasq-file true
+$ crc config set skip-check-network-manager-config true
+----
+====
 
 === NetworkManager + dnsmasq
 

--- a/docs/source/topics/ref_dns-configuration.adoc
+++ b/docs/source/topics/ref_dns-configuration.adoc
@@ -39,13 +39,16 @@ exit 0
 
 [NOTE]
 ====
-`systemd-resolved` is also available as a Tech Preview on {rhel} and {centos} 8.3. After configuring the host to use systemd-resolved, any CRC dnsmasq configurations need to be removed and the above script needs to be created with executable permissions.
+:rhel-resolved-docs: https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/configuring_and_managing_networking/using-different-dns-servers-for-different-domains_configuring-and-managing-networking
 
-The crc virtual machine presently needs to be configured to skip certain checks during startup:
+`systemd-resolved` is also available as an unsupported Technology Preview on {rhel} and {centos} 8.3. After {rhel-resolved-docs}[configuring the host] to use `systemd-resolved`, any {prod} `dnsmasq` configurations need to be removed and the above script needs to be created with executable permissions.
 
+Configure the {prod} binary to skip startup checks for `dnsmasq` and NetworkManager configuration:
+
+[subs="+quotes,attributes"]
 ----
-$ crc config set skip-check-crc-dnsmasq-file true
-$ crc config set skip-check-network-manager-config true
+$ {bin} config set skip-check-crc-dnsmasq-file true
+$ {bin} config set skip-check-network-manager-config true
 ----
 ====
 


### PR DESCRIPTION
systemd-resolved can be used on RHEL 8.3 and compatible distributions as it is available as a Tech Preview. However, there are some configurations that need to be made for this system to actually work with present releases.

This is a documentation pull request, it does not alter functionality of CRC itself. I have personally been running with this setup on RHEL 8 for several days now with no obvious issues.