### PR TITLE
Prepare 1.23 branch for release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ SHELL := /bin/bash
 
 BUNDLE_VERSION = 4.7.0
 BUNDLE_EXTENSION = crcbundle
-CRC_VERSION = 1.23.0
+CRC_VERSION = 1.23.1
 COMMIT_SHA=$(shell git rev-parse --short HEAD)
 MACOS_INSTALL_PATH = /Library/CodeReady Containers
 CONTAINER_RUNTIME ?= podman

--- a/pkg/crc/cluster/cluster.go
+++ b/pkg/crc/cluster/cluster.go
@@ -310,7 +310,7 @@ func WaitForRequestHeaderClientCaFile(sshRunner *ssh.Runner) error {
 }
 
 func WaitForAPIServer(ocConfig oc.Config) error {
-	logging.Debugf("Waiting for apiserver availability")
+	logging.Info("Waiting for kube-apiserver availability... [takes around 2min]")
 	waitForAPIServer := func() error {
 		stdout, stderr, err := ocConfig.WithFailFast().RunOcCommand("get", "nodes")
 		if err != nil {

--- a/pkg/crc/version/version.go
+++ b/pkg/crc/version/version.go
@@ -29,7 +29,7 @@ var (
 const (
 	releaseInfoLink = "https://mirror.openshift.com/pub/openshift-v4/clients/crc/latest/release-info.json"
 	// Tray version to be embedded in executable
-	crcMacTrayVersion = "1.0.1"
+	crcMacTrayVersion = "1.0.2"
 	// Windows forms application version type major.minor.buildnumber.revesion
 	crcWindowsTrayVersion = "0.4.0.0"
 )


### PR DESCRIPTION
This cherry-picks 2 commits from master to the 1.23 branch, and bumps the
release version.

Latest version of the macos tray has this known issue:
https://github.com/code-ready/tray-macos/issues/79 but works on macos 10.14.

We'll also need https://github.com/code-ready/crc/pull/2049 for the release.