### PR TITLE
Improve logging of daemon protocol

### DIFF
--- a/pkg/crc/api/api.go
+++ b/pkg/crc/api/api.go
@@ -90,7 +90,7 @@ func (api Server) handleConnections(conn net.Conn) {
 		logging.Error("Error reading from socket")
 		return
 	}
-	logging.Debug("Received Request:", string(inBuffer[0:numBytes]))
+	logging.Debugf("rpc:%p: Received request: %s", conn, string(inBuffer[0:numBytes]))
 	err = json.Unmarshal(inBuffer[0:numBytes], &req)
 	if err != nil {
 		logging.Error("Error decoding request: ", err.Error())
@@ -125,6 +125,8 @@ func (api Server) handleConnections(conn net.Conn) {
 }
 
 func writeStringToSocket(socket net.Conn, msg string) {
+	logging.Debugf("rpc:%p: Sending answer: %s", socket, msg)
+
 	var outBuffer bytes.Buffer
 	_, err := outBuffer.WriteString(msg)
 	if err != nil {


### PR DESCRIPTION
We currently log the input data, but not the answer which is sent.
This commit ensures both are logged, and also logs the address of the
socket as multiple requests can be handled concurrently, but they use
differet sockets, so this should help identify which answer corresponds
to which request.