### PR TITLE
Improve status reporting

### DIFF
--- a/pkg/crc/machine/status.go
+++ b/pkg/crc/machine/status.go
@@ -44,7 +44,7 @@ func (client *client) Status() (*ClusterStatusResult, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "Error getting ip")
 	}
-	sshRunner, err := crcssh.CreateRunner(ip, getSSHPort(client.useVSock()), constants.GetPrivateKeyPath(), constants.GetRsaPrivateKeyPath())
+	sshRunner, err := crcssh.CreateRunner(ip, getSSHPort(client.useVSock()), constants.GetPrivateKeyPath(), constants.GetRsaPrivateKeyPath(), crcBundleMetadata.GetSSHKeyPath())
 	if err != nil {
 		return nil, errors.Wrap(err, "Error creating the ssh client")
 	}

--- a/pkg/crc/machine/status.go
+++ b/pkg/crc/machine/status.go
@@ -28,16 +28,17 @@ func (client *client) Status() (*ClusterStatusResult, error) {
 		return nil, errors.Wrap(err, "Cannot get machine state")
 	}
 
-	if vmStatus != state.Running {
-		return &ClusterStatusResult{
-			CrcStatus:       vmStatus,
-			OpenshiftStatus: "Stopped",
-		}, nil
-	}
-
 	_, crcBundleMetadata, err := getBundleMetadataFromDriver(host.Driver)
 	if err != nil {
 		return nil, errors.Wrap(err, "Error loading bundle metadata")
+	}
+
+	if vmStatus != state.Running {
+		return &ClusterStatusResult{
+			CrcStatus:        vmStatus,
+			OpenshiftStatus:  "Stopped",
+			OpenshiftVersion: crcBundleMetadata.GetOpenshiftVersion(),
+		}, nil
 	}
 
 	ip, err := getIP(host, client.useVSock())

--- a/pkg/crc/machine/status.go
+++ b/pkg/crc/machine/status.go
@@ -52,7 +52,7 @@ func (client *client) Status() (*ClusterStatusResult, error) {
 	// check if all the clusteroperators are running
 	diskSize, diskUse, err := cluster.GetRootPartitionUsage(sshRunner)
 	if err != nil {
-		return nil, errors.Wrap(err, "Cannot get root partition usage")
+		logging.Debugf("Cannot get root partition usage: %v", err)
 	}
 	return &ClusterStatusResult{
 		CrcStatus:        state.Running,


### PR DESCRIPTION
When the VM is starting (esp before ssh key rotation), these changes will help report a proper status and not just an error.

