### PR TITLE
#2058 Create oc symlink at crc start time

### DIFF
--- a/pkg/crc/machine/bundle/repository.go
+++ b/pkg/crc/machine/bundle/repository.go
@@ -126,7 +126,7 @@ var defaultRepo = &Repository{
 	OcBinDir: constants.CrcOcBinDir,
 }
 
-func GetCachedBundleInfo(bundleName string) (*CrcBundleInfo, error) {
+func Get(bundleName string) (*CrcBundleInfo, error) {
 	return defaultRepo.Use(bundleName)
 }
 

--- a/pkg/crc/machine/bundle/repository.go
+++ b/pkg/crc/machine/bundle/repository.go
@@ -48,6 +48,12 @@ func (repo *Repository) Get(bundleName string) (*CrcBundleInfo, error) {
 	if err := bundleInfo.verify(); err != nil {
 		return nil, err
 	}
+	if fmt.Sprintf(".%s", bundleInfo.ClusterInfo.AppsDomain) != constants.AppsDomain {
+		return nil, fmt.Errorf("unexpected bundle, it must have %s apps domain", constants.AppsDomain)
+	}
+	if bundleInfo.GetAPIHostname() != fmt.Sprintf("api%s", constants.ClusterDomain) {
+		return nil, fmt.Errorf("unexpected bundle, it must have %s base domain", constants.ClusterDomain)
+	}
 	return &bundleInfo, nil
 }
 
@@ -70,12 +76,6 @@ func (repo *Repository) Use(bundleName string) (*CrcBundleInfo, error) {
 	bundleInfo, err := repo.Get(bundleName)
 	if err != nil {
 		return nil, err
-	}
-	if fmt.Sprintf(".%s", bundleInfo.ClusterInfo.AppsDomain) != constants.AppsDomain {
-		return nil, fmt.Errorf("unexpected bundle, it must have %s apps domain", constants.AppsDomain)
-	}
-	if bundleInfo.GetAPIHostname() != fmt.Sprintf("api%s", constants.ClusterDomain) {
-		return nil, fmt.Errorf("unexpected bundle, it must have %s base domain", constants.ClusterDomain)
 	}
 	if err := bundleInfo.createSymlinkOrCopyOpenShiftClient(repo.OcBinDir); err != nil {
 		return nil, err
@@ -127,6 +127,10 @@ var defaultRepo = &Repository{
 }
 
 func Get(bundleName string) (*CrcBundleInfo, error) {
+	return defaultRepo.Get(bundleName)
+}
+
+func Use(bundleName string) (*CrcBundleInfo, error) {
 	return defaultRepo.Use(bundleName)
 }
 
@@ -134,5 +138,5 @@ func Extract(path string) (*CrcBundleInfo, error) {
 	if err := defaultRepo.Extract(path); err != nil {
 		return nil, err
 	}
-	return defaultRepo.Use(filepath.Base(path))
+	return defaultRepo.Get(filepath.Base(path))
 }

--- a/pkg/crc/machine/machine.go
+++ b/pkg/crc/machine/machine.go
@@ -41,7 +41,7 @@ func getBundleMetadataFromDriver(driver drivers.Driver) (string, *bundle.CrcBund
 		err := fmt.Errorf("Error getting bundle name from CodeReady Containers instance, make sure you ran 'crc setup' and are using the latest bundle")
 		return "", nil, err
 	}
-	metadata, err := bundle.GetCachedBundleInfo(bundleName)
+	metadata, err := bundle.Get(bundleName)
 	if err != nil {
 		return "", nil, err
 	}

--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -38,7 +38,7 @@ const minimumMemoryForMonitoring = 14336
 
 func getCrcBundleInfo(bundlePath string) (*bundle.CrcBundleInfo, error) {
 	bundleName := filepath.Base(bundlePath)
-	bundleInfo, err := bundle.GetCachedBundleInfo(bundleName)
+	bundleInfo, err := bundle.Get(bundleName)
 	if err == nil {
 		logging.Infof("Loading bundle: %s ...", bundleName)
 		return bundleInfo, nil

--- a/pkg/crc/preflight/preflight_checks_common.go
+++ b/pkg/crc/preflight/preflight_checks_common.go
@@ -73,7 +73,7 @@ func checkBundleExtracted() error {
 		return nil
 	}
 	logging.Infof("Checking if %s exists", constants.DefaultBundlePath)
-	if _, err := bundle.GetCachedBundleInfo(constants.GetDefaultBundle()); err != nil {
+	if _, err := bundle.Get(constants.GetDefaultBundle()); err != nil {
 		logging.Debugf("error getting bundle info for %s: %v", constants.GetDefaultBundle(), err)
 		return err
 	}
@@ -106,7 +106,7 @@ func fixBundleExtracted() error {
 		}
 	}
 
-	_, err := bundle.GetCachedBundleInfo(constants.GetDefaultBundle())
+	_, err := bundle.Get(constants.GetDefaultBundle())
 	if err != nil {
 		logging.Infof("Uncompressing %s", constants.GetDefaultBundle())
 		_, err := bundle.Extract(constants.DefaultBundlePath)

--- a/pkg/crc/validation/validation.go
+++ b/pkg/crc/validation/validation.go
@@ -79,7 +79,7 @@ func ValidateBundlePath(bundle string) error {
 
 func ValidateBundle(bundlePath string) error {
 	bundleName := filepath.Base(bundlePath)
-	_, err := bundle.GetCachedBundleInfo(bundleName)
+	_, err := bundle.Get(bundleName)
 	if err != nil {
 		return ValidateBundlePath(bundlePath)
 	}


### PR DESCRIPTION
Activate the bundle (eg install oc symlink) only on start action

Previously almost each commands recreated the symlink.
Fixes #2058

