### PR TITLE
Issue #2054 Ask user to run setup when 'autostart-tray' set to true

### DIFF
--- a/cmd/crc/cmd/config/config.go
+++ b/cmd/crc/cmd/config/config.go
@@ -9,9 +9,9 @@ import (
 
 	"github.com/code-ready/crc/pkg/crc/config"
 	"github.com/code-ready/crc/pkg/crc/constants"
-	"github.com/code-ready/crc/pkg/crc/errors"
 	"github.com/code-ready/crc/pkg/crc/network"
 	"github.com/code-ready/crc/pkg/crc/tray"
+	"github.com/spf13/cast"
 	"github.com/spf13/cobra"
 )
 
@@ -46,20 +46,16 @@ func RegisterSettings(cfg *config.Config) {
 	}
 
 	disableEnableTrayAutostart := func(key string, value interface{}) string {
-		mode := network.ParseMode(cfg.Get(NetworkMode).AsString())
-		var mErr = errors.MultiError{}
-		if err := tray.DisableTrayAutostart(); err != nil {
-			mErr.Collect(err)
+		if cast.ToBool(value) {
+			return fmt.Sprintf(
+				"Successfully configured '%s' to '%s'. Run 'crc setup' for it to take effect.",
+				key, cast.ToString(value),
+			)
 		}
-		if mode == network.DefaultMode {
-			if err := tray.DisableDaemonAutostart(); err != nil {
-				mErr.Collect(err)
-			}
-		}
-		if len(mErr.Errors) > 0 {
-			return fmt.Sprintf("Error occurred on disabling tray autostart: %s", mErr.Error())
-		}
-		return "Successfully disabled autostart of tray at login."
+		return fmt.Sprintf(
+			"Successfully configured '%s' to '%s'. Run 'crc cleanup' and then 'crc setup' for it to take effect.",
+			key, cast.ToString(value),
+		)
 	}
 
 	// Start command settings in config

--- a/pkg/crc/tray/util_darwin.go
+++ b/pkg/crc/tray/util_darwin.go
@@ -2,21 +2,7 @@ package tray
 
 import (
 	"github.com/code-ready/crc/pkg/crc/config"
-	"github.com/code-ready/crc/pkg/os/launchd"
 )
-
-const (
-	trayAgentLabel   = "crc.tray"
-	daemonAgentLabel = "crc.daemon"
-)
-
-func DisableTrayAutostart() error {
-	return launchd.RemovePlist(trayAgentLabel)
-}
-
-func DisableDaemonAutostart() error {
-	return launchd.RemovePlist(daemonAgentLabel)
-}
 
 // ValidateTrayAutostart checks tray-auto-start is used in macOS and its a bool
 func ValidateTrayAutostart(value interface{}) (bool, string) {

--- a/pkg/crc/tray/util_linux.go
+++ b/pkg/crc/tray/util_linux.go
@@ -1,15 +1,5 @@
 package tray
 
-func DisableTrayAutostart() error {
-	// noop
-	return nil
-}
-
-func DisableDaemonAutostart() error {
-	// noop
-	return nil
-}
-
 // ValidateTrayAutostart checks tray-auto-start is used in macOS and its a bool
 func ValidateTrayAutostart(value interface{}) (bool, string) {
 	return false, "Not supported on Linux"

--- a/pkg/crc/tray/util_windows.go
+++ b/pkg/crc/tray/util_windows.go
@@ -1,15 +1,5 @@
 package tray
 
-func DisableTrayAutostart() error {
-	// noop
-	return nil
-}
-
-func DisableDaemonAutostart() error {
-	// noop
-	return nil
-}
-
 // ValidateTrayAutostart checks tray-auto-start is used in macOS and its a bool
 func ValidateTrayAutostart(value interface{}) (bool, string) {
 	return false, "Not supported on Windows"


### PR DESCRIPTION
When 'autostart-tray' is set to false, we can just delete the launchd
config of the tray to prevent it from starting automatically on login
but when 'autostart-tray' is set to true, we need have the daemon and
the tray executable, so better to ask the user to run 'crc setup'

Fixes #2054 