### PR TITLE
When all operators are running, check that containers are also up

### DIFF
--- a/pkg/crc/cluster/clusteroperator.go
+++ b/pkg/crc/cluster/clusteroperator.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/code-ready/crc/pkg/crc/logging"
@@ -30,25 +31,42 @@ func (status *Status) String() string {
 	if len(status.progressing) == 1 {
 		return fmt.Sprintf("Operator %s is progressing", status.progressing[0])
 	} else if len(status.progressing) > 1 {
-		return fmt.Sprintf("%d operators are progressing: %s", len(status.progressing), strings.Join(status.progressing, ", "))
+		return fmt.Sprintf("%d operators are progressing: %s", len(status.progressing), joinWithLimit(status.progressing))
 	}
 
 	if len(status.degraded) == 1 {
 		return fmt.Sprintf("Operator %s is degraded", status.degraded[0])
 	} else if len(status.degraded) > 0 {
-		return fmt.Sprintf("%d operators are degraded: %s", len(status.degraded), strings.Join(status.degraded, ", "))
+		return fmt.Sprintf("%d operators are degraded: %s", len(status.degraded), joinWithLimit(status.degraded))
 	}
 
 	if len(status.unavailable) == 1 {
 		return fmt.Sprintf("Operator %s is not yet available", status.unavailable[0])
 	} else if len(status.unavailable) > 0 {
-		return fmt.Sprintf("%d operators are not available: %s", len(status.unavailable), strings.Join(status.unavailable, ", "))
+		return fmt.Sprintf("%d operators are not available: %s", len(status.unavailable), joinWithLimit(status.unavailable))
 	}
 
 	if status.IsReady() {
 		return "All operators are ready"
 	}
 	return "Operators are not ready yet"
+}
+
+func joinWithLimit(names []string) string {
+	const maxNames = 5
+	sort.Strings(names)
+	ret := strings.Join(names[0:min(len(names), maxNames)], ", ")
+	if len(names) > maxNames {
+		ret += "..."
+	}
+	return ret
+}
+
+func min(a, b int) int {
+	if a > b {
+		return b
+	}
+	return a
 }
 
 func (status *Status) IsReady() bool {

--- a/pkg/crc/cluster/crictl.go
+++ b/pkg/crc/cluster/crictl.go
@@ -1,0 +1,81 @@
+package cluster
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/code-ready/crc/pkg/os"
+)
+
+type crictlContainersList struct {
+	Containers []crictlContainer `json:"containers"`
+}
+
+type crictlContainer struct {
+	Metadata struct {
+		Name string `json:"name"`
+	} `json:"metadata"`
+	State  string `json:"state"`
+	Labels struct {
+		Namespace string `json:"io.kubernetes.pod.namespace"`
+	} `json:"labels"`
+}
+
+func VerifyOperatorContainersAreRunning(ssh os.CommandRunner, status *Status) error {
+	if !status.IsReady() {
+		return nil
+	}
+
+	operatorContainers := map[string]string{
+		"authentication":               "authentication-operator",
+		"dns":                          "dns-operator",
+		"etcd":                         "etcd-operator",
+		"network":                      "network-operator",
+		"openshift-apiserver":          "openshift-apiserver-operator",
+		"service-ca":                   "service-ca-operator",
+		"config-operator":              "openshift-config-operator",
+		"console":                      "console-operator",
+		"image-registry":               "cluster-image-registry-operator",
+		"ingress":                      "ingress-operator",
+		"kube-apiserver":               "kube-apiserver-operator",
+		"kube-controller-manager":      "kube-controller-manager-operator",
+		"kube-scheduler":               "kube-scheduler-operator-container",
+		"marketplace":                  "marketplace-operator",
+		"node-tuning":                  "cluster-node-tuning-operator",
+		"openshift-controller-manager": "openshift-controller-manager-operator",
+		"openshift-samples":            "cluster-samples-operator",
+		"operator-lifecycle-manager":   "olm-operator",
+	}
+
+	ctrs, err := runningOpenShiftContainers(ssh)
+	if err != nil {
+		return err
+	}
+
+	for operator, container := range operatorContainers {
+		if !contains(operator, status.unavailable) && !contains(container, ctrs) {
+			status.Available = false
+			status.unavailable = append(status.unavailable, operator)
+		}
+	}
+
+	return nil
+}
+
+func runningOpenShiftContainers(runner os.CommandRunner) ([]string, error) {
+	output, _, err := runner.RunPrivileged("crictl ps", "timeout", "5s", "crictl", "ps", "-o", "json")
+	if err != nil {
+		return nil, err
+	}
+	var list crictlContainersList
+	if err := json.Unmarshal([]byte(output), &list); err != nil {
+		return nil, err
+	}
+	var ret []string
+	for _, container := range list.Containers {
+		if container.State == "CONTAINER_RUNNING" && strings.HasPrefix(container.Labels.Namespace, "openshift-") {
+			ret = append(ret, container.Metadata.Name)
+		}
+	}
+	return ret, nil
+}

--- a/pkg/crc/cluster/status.go
+++ b/pkg/crc/cluster/status.go
@@ -4,12 +4,13 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/code-ready/crc/pkg/crc/ssh"
+
 	"github.com/code-ready/crc/pkg/crc/logging"
-	"github.com/code-ready/crc/pkg/crc/oc"
 )
 
 // WaitForClusterStable checks that the cluster is running a number of consecutive times
-func WaitForClusterStable(ocConfig oc.Config, monitoringEnabled bool) error {
+func WaitForClusterStable(ssh *ssh.Runner, monitoringEnabled bool) error {
 	startTime := time.Now()
 
 	retryDuration := 30 * time.Second
@@ -19,7 +20,7 @@ func WaitForClusterStable(ocConfig oc.Config, monitoringEnabled bool) error {
 	var count int // holds num of consecutive matches
 
 	for i := 0; i < retryCount; i++ {
-		status, err := GetClusterOperatorsStatus(ocConfig, monitoringEnabled)
+		status, err := GetClusterOperatorsStatus(ssh, monitoringEnabled)
 		if err == nil {
 			// update counter for consecutive matches
 			if status.IsReady() {

--- a/pkg/crc/cluster/testdata/containers-missing.json
+++ b/pkg/crc/cluster/testdata/containers-missing.json
@@ -1,0 +1,688 @@
+{
+  "containers": [
+    {
+      "metadata": {
+        "name": "registry-server"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-marketplace"
+      }
+    },
+    {
+      "metadata": {
+        "name": "registry-server"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-marketplace"
+      }
+    },
+    {
+      "metadata": {
+        "name": "registry-server"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-marketplace"
+      }
+    },
+    {
+      "metadata": {
+        "name": "registry-server"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-marketplace"
+      }
+    },
+    {
+      "metadata": {
+        "name": "ingress-operator"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-ingress-operator"
+      }
+    },
+    {
+      "metadata": {
+        "name": "router"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-ingress"
+      }
+    },
+    {
+      "metadata": {
+        "name": "kube-rbac-proxy"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-multus"
+      }
+    },
+    {
+      "metadata": {
+        "name": "authentication-operator"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-authentication-operator"
+      }
+    },
+    {
+      "metadata": {
+        "name": "catalog-operator"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-operator-lifecycle-manager"
+      }
+    },
+    {
+      "metadata": {
+        "name": "marketplace-operator"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-marketplace"
+      }
+    },
+    {
+      "metadata": {
+        "name": "oauth-openshift"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-authentication"
+      }
+    },
+    {
+      "metadata": {
+        "name": "olm-operator"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-operator-lifecycle-manager"
+      }
+    },
+    {
+      "metadata": {
+        "name": "kube-scheduler-operator-container"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-kube-scheduler-operator"
+      }
+    },
+    {
+      "metadata": {
+        "name": "packageserver"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-operator-lifecycle-manager"
+      }
+    },
+    {
+      "metadata": {
+        "name": "etcd-operator"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-etcd-operator"
+      }
+    },
+    {
+      "metadata": {
+        "name": "multus-admission-controller"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-multus"
+      }
+    },
+    {
+      "metadata": {
+        "name": "check-endpoints"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-network-diagnostics"
+      }
+    },
+    {
+      "metadata": {
+        "name": "cluster-node-tuning-operator"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-cluster-node-tuning-operator"
+      }
+    },
+    {
+      "metadata": {
+        "name": "openshift-config-operator"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-config-operator"
+      }
+    },
+    {
+      "metadata": {
+        "name": "hello-openshift-canary"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-ingress-canary"
+      }
+    },
+    {
+      "metadata": {
+        "name": "kube-controller-manager-operator"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-kube-controller-manager-operator"
+      }
+    },
+    {
+      "metadata": {
+        "name": "cluster-samples-operator-watch"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-cluster-samples-operator"
+      }
+    },
+    {
+      "metadata": {
+        "name": "console"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-console"
+      }
+    },
+    {
+      "metadata": {
+        "name": "download-server"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-console"
+      }
+    },
+    {
+      "metadata": {
+        "name": "service-ca-operator"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-service-ca-operator"
+      }
+    },
+    {
+      "metadata": {
+        "name": "cluster-samples-operator"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-cluster-samples-operator"
+      }
+    },
+    {
+      "metadata": {
+        "name": "controller-manager"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-controller-manager"
+      }
+    },
+    {
+      "metadata": {
+        "name": "console-operator"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-console-operator"
+      }
+    },
+    {
+      "metadata": {
+        "name": "kube-rbac-proxy"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-dns-operator"
+      }
+    },
+    {
+      "metadata": {
+        "name": "packageserver"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-operator-lifecycle-manager"
+      }
+    },
+    {
+      "metadata": {
+        "name": "openshift-controller-manager-operator"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-controller-manager-operator"
+      }
+    },
+    {
+      "metadata": {
+        "name": "kube-multus"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-multus"
+      }
+    },
+    {
+      "metadata": {
+        "name": "kube-rbac-proxy"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-multus"
+      }
+    },
+    {
+      "metadata": {
+        "name": "dns-operator"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-dns-operator"
+      }
+    },
+    {
+      "metadata": {
+        "name": "console"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-console"
+      }
+    },
+    {
+      "metadata": {
+        "name": "download-server"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-console"
+      }
+    },
+    {
+      "metadata": {
+        "name": "dns-node-resolver"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-dns"
+      }
+    },
+    {
+      "metadata": {
+        "name": "kube-apiserver-operator"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-kube-apiserver-operator"
+      }
+    },
+    {
+      "metadata": {
+        "name": "network-metrics-daemon"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-multus"
+      }
+    },
+    {
+      "metadata": {
+        "name": "oauth-apiserver"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-oauth-apiserver"
+      }
+    },
+    {
+      "metadata": {
+        "name": "openshift-apiserver-check-endpoints"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-apiserver"
+      }
+    },
+    {
+      "metadata": {
+        "name": "registry"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-image-registry"
+      }
+    },
+    {
+      "metadata": {
+        "name": "service-ca-controller"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-service-ca"
+      }
+    },
+    {
+      "metadata": {
+        "name": "kube-rbac-proxy"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-ingress-operator"
+      }
+    },
+    {
+      "metadata": {
+        "name": "kube-rbac-proxy"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-dns"
+      }
+    },
+    {
+      "metadata": {
+        "name": "openshift-apiserver"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-apiserver"
+      }
+    },
+    {
+      "metadata": {
+        "name": "network-check-target-container"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-network-diagnostics"
+      }
+    },
+    {
+      "metadata": {
+        "name": "dns"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-dns"
+      }
+    },
+    {
+      "metadata": {
+        "name": "cluster-image-registry-operator"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-image-registry"
+      }
+    },
+    {
+      "metadata": {
+        "name": "oauth-openshift"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-authentication"
+      }
+    },
+    {
+      "metadata": {
+        "name": "openvswitch"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-sdn"
+      }
+    },
+    {
+      "metadata": {
+        "name": "kube-rbac-proxy"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-sdn"
+      }
+    },
+    {
+      "metadata": {
+        "name": "sdn"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-sdn"
+      }
+    },
+    {
+      "metadata": {
+        "name": "network-operator"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-network-operator"
+      }
+    },
+    {
+      "metadata": {
+        "name": "tuned"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-cluster-node-tuning-operator"
+      }
+    },
+    {
+      "metadata": {
+        "name": "node-ca"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-image-registry"
+      }
+    },
+    {
+      "metadata": {
+        "name": "machine-approver-controller"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-cluster-machine-approver"
+      }
+    },
+    {
+      "metadata": {
+        "name": "kube-rbac-proxy"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-cluster-machine-approver"
+      }
+    },
+    {
+      "metadata": {
+        "name": "cluster-version-operator"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-cluster-version"
+      }
+    },
+    {
+      "metadata": {
+        "name": "guard"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-etcd"
+      }
+    },
+    {
+      "metadata": {
+        "name": "sdn-controller"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-sdn"
+      }
+    },
+    {
+      "metadata": {
+        "name": "kube-apiserver-check-endpoints"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-kube-apiserver"
+      }
+    },
+    {
+      "metadata": {
+        "name": "kube-apiserver"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-kube-apiserver"
+      }
+    },
+    {
+      "metadata": {
+        "name": "etcd-metrics"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-etcd"
+      }
+    },
+    {
+      "metadata": {
+        "name": "etcd"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-etcd"
+      }
+    },
+    {
+      "metadata": {
+        "name": "etcdctl"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-etcd"
+      }
+    },
+    {
+      "metadata": {
+        "name": "kube-apiserver-insecure-readyz"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-kube-apiserver"
+      }
+    },
+    {
+      "metadata": {
+        "name": "kube-apiserver-cert-regeneration-controller"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-kube-apiserver"
+      }
+    },
+    {
+      "metadata": {
+        "name": "kube-scheduler-recovery-controller"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-kube-scheduler"
+      }
+    },
+    {
+      "metadata": {
+        "name": "kube-apiserver-cert-syncer"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-kube-apiserver"
+      }
+    },
+    {
+      "metadata": {
+        "name": "kube-scheduler-cert-syncer"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-kube-scheduler"
+      }
+    },
+    {
+      "metadata": {
+        "name": "kube-scheduler"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-kube-scheduler"
+      }
+    },
+    {
+      "metadata": {
+        "name": "kube-controller-manager-recovery-controller"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-kube-controller-manager"
+      }
+    },
+    {
+      "metadata": {
+        "name": "kube-controller-manager-cert-syncer"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-kube-controller-manager"
+      }
+    },
+    {
+      "metadata": {
+        "name": "cluster-policy-controller"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-kube-controller-manager"
+      }
+    },
+    {
+      "metadata": {
+        "name": "kube-controller-manager"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-kube-controller-manager"
+      }
+    }
+  ]
+}

--- a/pkg/crc/cluster/testdata/containers.json
+++ b/pkg/crc/cluster/testdata/containers.json
@@ -1,0 +1,697 @@
+{
+  "containers": [
+    {
+      "metadata": {
+        "name": "registry-server"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-marketplace"
+      }
+    },
+    {
+      "metadata": {
+        "name": "registry-server"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-marketplace"
+      }
+    },
+    {
+      "metadata": {
+        "name": "registry-server"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-marketplace"
+      }
+    },
+    {
+      "metadata": {
+        "name": "registry-server"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-marketplace"
+      }
+    },
+    {
+      "metadata": {
+        "name": "ingress-operator"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-ingress-operator"
+      }
+    },
+    {
+      "metadata": {
+        "name": "router"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-ingress"
+      }
+    },
+    {
+      "metadata": {
+        "name": "kube-rbac-proxy"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-multus"
+      }
+    },
+    {
+      "metadata": {
+        "name": "authentication-operator"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-authentication-operator"
+      }
+    },
+    {
+      "metadata": {
+        "name": "catalog-operator"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-operator-lifecycle-manager"
+      }
+    },
+    {
+      "metadata": {
+        "name": "marketplace-operator"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-marketplace"
+      }
+    },
+    {
+      "metadata": {
+        "name": "oauth-openshift"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-authentication"
+      }
+    },
+    {
+      "metadata": {
+        "name": "olm-operator"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-operator-lifecycle-manager"
+      }
+    },
+    {
+      "metadata": {
+        "name": "kube-scheduler-operator-container"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-kube-scheduler-operator"
+      }
+    },
+    {
+      "metadata": {
+        "name": "packageserver"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-operator-lifecycle-manager"
+      }
+    },
+    {
+      "metadata": {
+        "name": "etcd-operator"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-etcd-operator"
+      }
+    },
+    {
+      "metadata": {
+        "name": "multus-admission-controller"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-multus"
+      }
+    },
+    {
+      "metadata": {
+        "name": "check-endpoints"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-network-diagnostics"
+      }
+    },
+    {
+      "metadata": {
+        "name": "openshift-apiserver-operator"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-apiserver-operator"
+      }
+    },
+    {
+      "metadata": {
+        "name": "cluster-node-tuning-operator"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-cluster-node-tuning-operator"
+      }
+    },
+    {
+      "metadata": {
+        "name": "openshift-config-operator"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-config-operator"
+      }
+    },
+    {
+      "metadata": {
+        "name": "hello-openshift-canary"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-ingress-canary"
+      }
+    },
+    {
+      "metadata": {
+        "name": "kube-controller-manager-operator"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-kube-controller-manager-operator"
+      }
+    },
+    {
+      "metadata": {
+        "name": "cluster-samples-operator-watch"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-cluster-samples-operator"
+      }
+    },
+    {
+      "metadata": {
+        "name": "console"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-console"
+      }
+    },
+    {
+      "metadata": {
+        "name": "download-server"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-console"
+      }
+    },
+    {
+      "metadata": {
+        "name": "service-ca-operator"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-service-ca-operator"
+      }
+    },
+    {
+      "metadata": {
+        "name": "cluster-samples-operator"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-cluster-samples-operator"
+      }
+    },
+    {
+      "metadata": {
+        "name": "controller-manager"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-controller-manager"
+      }
+    },
+    {
+      "metadata": {
+        "name": "console-operator"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-console-operator"
+      }
+    },
+    {
+      "metadata": {
+        "name": "kube-rbac-proxy"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-dns-operator"
+      }
+    },
+    {
+      "metadata": {
+        "name": "packageserver"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-operator-lifecycle-manager"
+      }
+    },
+    {
+      "metadata": {
+        "name": "openshift-controller-manager-operator"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-controller-manager-operator"
+      }
+    },
+    {
+      "metadata": {
+        "name": "kube-multus"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-multus"
+      }
+    },
+    {
+      "metadata": {
+        "name": "kube-rbac-proxy"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-multus"
+      }
+    },
+    {
+      "metadata": {
+        "name": "dns-operator"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-dns-operator"
+      }
+    },
+    {
+      "metadata": {
+        "name": "console"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-console"
+      }
+    },
+    {
+      "metadata": {
+        "name": "download-server"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-console"
+      }
+    },
+    {
+      "metadata": {
+        "name": "dns-node-resolver"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-dns"
+      }
+    },
+    {
+      "metadata": {
+        "name": "kube-apiserver-operator"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-kube-apiserver-operator"
+      }
+    },
+    {
+      "metadata": {
+        "name": "network-metrics-daemon"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-multus"
+      }
+    },
+    {
+      "metadata": {
+        "name": "oauth-apiserver"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-oauth-apiserver"
+      }
+    },
+    {
+      "metadata": {
+        "name": "openshift-apiserver-check-endpoints"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-apiserver"
+      }
+    },
+    {
+      "metadata": {
+        "name": "registry"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-image-registry"
+      }
+    },
+    {
+      "metadata": {
+        "name": "service-ca-controller"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-service-ca"
+      }
+    },
+    {
+      "metadata": {
+        "name": "kube-rbac-proxy"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-ingress-operator"
+      }
+    },
+    {
+      "metadata": {
+        "name": "kube-rbac-proxy"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-dns"
+      }
+    },
+    {
+      "metadata": {
+        "name": "openshift-apiserver"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-apiserver"
+      }
+    },
+    {
+      "metadata": {
+        "name": "network-check-target-container"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-network-diagnostics"
+      }
+    },
+    {
+      "metadata": {
+        "name": "dns"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-dns"
+      }
+    },
+    {
+      "metadata": {
+        "name": "cluster-image-registry-operator"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-image-registry"
+      }
+    },
+    {
+      "metadata": {
+        "name": "oauth-openshift"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-authentication"
+      }
+    },
+    {
+      "metadata": {
+        "name": "openvswitch"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-sdn"
+      }
+    },
+    {
+      "metadata": {
+        "name": "kube-rbac-proxy"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-sdn"
+      }
+    },
+    {
+      "metadata": {
+        "name": "sdn"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-sdn"
+      }
+    },
+    {
+      "metadata": {
+        "name": "network-operator"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-network-operator"
+      }
+    },
+    {
+      "metadata": {
+        "name": "tuned"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-cluster-node-tuning-operator"
+      }
+    },
+    {
+      "metadata": {
+        "name": "node-ca"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-image-registry"
+      }
+    },
+    {
+      "metadata": {
+        "name": "machine-approver-controller"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-cluster-machine-approver"
+      }
+    },
+    {
+      "metadata": {
+        "name": "kube-rbac-proxy"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-cluster-machine-approver"
+      }
+    },
+    {
+      "metadata": {
+        "name": "cluster-version-operator"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-cluster-version"
+      }
+    },
+    {
+      "metadata": {
+        "name": "guard"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-etcd"
+      }
+    },
+    {
+      "metadata": {
+        "name": "sdn-controller"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-sdn"
+      }
+    },
+    {
+      "metadata": {
+        "name": "kube-apiserver-check-endpoints"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-kube-apiserver"
+      }
+    },
+    {
+      "metadata": {
+        "name": "kube-apiserver"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-kube-apiserver"
+      }
+    },
+    {
+      "metadata": {
+        "name": "etcd-metrics"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-etcd"
+      }
+    },
+    {
+      "metadata": {
+        "name": "etcd"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-etcd"
+      }
+    },
+    {
+      "metadata": {
+        "name": "etcdctl"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-etcd"
+      }
+    },
+    {
+      "metadata": {
+        "name": "kube-apiserver-insecure-readyz"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-kube-apiserver"
+      }
+    },
+    {
+      "metadata": {
+        "name": "kube-apiserver-cert-regeneration-controller"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-kube-apiserver"
+      }
+    },
+    {
+      "metadata": {
+        "name": "kube-scheduler-recovery-controller"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-kube-scheduler"
+      }
+    },
+    {
+      "metadata": {
+        "name": "kube-apiserver-cert-syncer"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-kube-apiserver"
+      }
+    },
+    {
+      "metadata": {
+        "name": "kube-scheduler-cert-syncer"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-kube-scheduler"
+      }
+    },
+    {
+      "metadata": {
+        "name": "kube-scheduler"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-kube-scheduler"
+      }
+    },
+    {
+      "metadata": {
+        "name": "kube-controller-manager-recovery-controller"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-kube-controller-manager"
+      }
+    },
+    {
+      "metadata": {
+        "name": "kube-controller-manager-cert-syncer"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-kube-controller-manager"
+      }
+    },
+    {
+      "metadata": {
+        "name": "cluster-policy-controller"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-kube-controller-manager"
+      }
+    },
+    {
+      "metadata": {
+        "name": "kube-controller-manager"
+      },
+      "state": "CONTAINER_RUNNING",
+      "labels": {
+        "io.kubernetes.pod.namespace": "openshift-kube-controller-manager"
+      }
+    }
+  ]
+}

--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -392,7 +392,7 @@ func (client *client) Start(ctx context.Context, startConfig StartConfig) (*Star
 
 	logging.Info("Starting OpenShift cluster ... [waiting for the cluster to stabilize]")
 
-	if err := cluster.WaitForClusterStable(ocConfig, client.monitoringEnabled()); err != nil {
+	if err := cluster.WaitForClusterStable(sshRunner, client.monitoringEnabled()); err != nil {
 		logging.Errorf("Cluster is not ready: %v", err)
 	}
 

--- a/pkg/crc/machine/status.go
+++ b/pkg/crc/machine/status.go
@@ -4,7 +4,6 @@ import (
 	"github.com/code-ready/crc/pkg/crc/cluster"
 	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/code-ready/crc/pkg/crc/logging"
-	"github.com/code-ready/crc/pkg/crc/oc"
 	crcssh "github.com/code-ready/crc/pkg/crc/ssh"
 	"github.com/code-ready/machine/libmachine/state"
 	"github.com/pkg/errors"
@@ -64,7 +63,7 @@ func (client *client) Status() (*ClusterStatusResult, error) {
 }
 
 func getOpenShiftStatus(sshRunner *crcssh.Runner, monitoringEnabled bool) string {
-	status, err := cluster.GetClusterOperatorsStatus(oc.UseOCWithSSH(sshRunner), monitoringEnabled)
+	status, err := cluster.GetClusterOperatorsStatus(sshRunner, monitoringEnabled)
 	if err != nil {
 		logging.Debugf("cannot get OpenShift status: %v", err)
 		return "Unreachable"

--- a/pkg/crc/oc/oc.go
+++ b/pkg/crc/oc/oc.go
@@ -75,7 +75,7 @@ type SSHRunner struct {
 	Runner *ssh.Runner
 }
 
-func UseOCWithSSH(sshRunner *ssh.Runner) Config {
+func UseOCWithSSH(sshRunner crcos.CommandRunner) Config {
 	return Config{
 		Runner:           sshRunner,
 		OcExecutablePath: "oc",

--- a/pkg/os/exec.go
+++ b/pkg/os/exec.go
@@ -66,6 +66,7 @@ type CommandRunner interface {
 	RunPrivate(command string, args ...string) (string, string, error)
 	RunPrivileged(reason string, cmdAndArgs ...string) (string, string, error)
 }
+
 type localRunner struct{}
 
 func (r *localRunner) Run(command string, args ...string) (string, string, error) {


### PR DESCRIPTION
When restarting a cluster, cluster operators statuses are stale. They
are all available but they are not running at all.

This change verifies this by looking at all containers running on the
machine with crictl. Each operator has a container that needs to be
running.

Sadly, this adds extra time when checking the status (both crc start and
crc status).

Fixes https://github.com/code-ready/crc/issues/2053

If you have other ideas! I don't really like the new call... It's one more 
slow thing to do when checking status.