### PR TITLE
Bump macos tray to 1.0.3

### DIFF
--- a/pkg/crc/version/version.go
+++ b/pkg/crc/version/version.go
@@ -29,7 +29,7 @@ var (
 const (
 	releaseInfoLink = "https://mirror.openshift.com/pub/openshift-v4/clients/crc/latest/release-info.json"
 	// Tray version to be embedded in executable
-	crcMacTrayVersion = "1.0.2"
+	crcMacTrayVersion = "1.0.3"
 	// Windows forms application version type major.minor.buildnumber.revesion
 	crcWindowsTrayVersion = "0.4.0.0"
 )


### PR DESCRIPTION
This should be the final build for the 1.23 release.
Cropped labels are fixed, and the 'disk size' setting is removed.