### PR TITLE
Add support for dynamically checking network stack

### DIFF
--- a/docs/source/topics/ref_dns-configuration.adoc
+++ b/docs/source/topics/ref_dns-configuration.adoc
@@ -11,7 +11,7 @@ The `apps-crc.testing` domain is for accessing OpenShift applications deployed o
 For example, the OpenShift API server will be exposed as `api.crc.testing` while the OpenShift console is accessed through `console-openshift-console.apps-crc.testing`.
 These DNS domains are served by a `dnsmasq` DNS container running inside the {prod} virtual machine.
 
-Running [command]`{bin} setup` will adjust your system DNS configuration so that it can resolve these domains.
+Running [command]`{bin} setup` will detect and adjust your system DNS configuration so that it can resolve these domains.
 Additional checks are done to verify DNS is properly configured when running [command]`{bin} start`.
 
 [id="dns-configuration-linux_{context}"]
@@ -21,7 +21,7 @@ On Linux, depending on your distribution, {prod} expects the following DNS confi
 
 === NetworkManager + systemd-resolved
 
-This configuration is used on Fedora 33 or newer, and on Ubuntu Desktop editions.
+This configuration is used by default on Fedora 33 or newer, and on Ubuntu Desktop editions.
 
 * {prod} expects NetworkManager to manage networking.
 * {prod} configures `systemd-resolved` to forward requests for the `testing` domain to the `192.168.130.11` DNS server.
@@ -30,29 +30,23 @@ This configuration is used on Fedora 33 or newer, and on Ubuntu Desktop editions
 +
 ----
 #!/bin/sh
-resolvectl domain crc ~testing
-resolvectl dns crc 192.168.130.11
-resolvectl default-route crc false
+
+export LC_ALL=C
+
+systemd-resolve --interface crc --set-dns 192.168.130.11 --set-domain ~testing
 
 exit 0
 ----
 
 [NOTE]
 ====
-`systemd-resolved` is also available as an unsupported Technology Preview on {rhel} and {centos} 8.3. After {rhel-resolved-docs}[configuring the host] to use `systemd-resolved`, any {prod} `dnsmasq` configurations need to be removed and the above script needs to be created with executable permissions.
-
-Configure the {prod} binary to skip startup checks for `dnsmasq` and NetworkManager configuration:
-
-[subs="+quotes,attributes"]
-----
-$ {bin} config set skip-check-crc-dnsmasq-file true
-$ {bin} config set skip-check-network-manager-config true
-----
+`systemd-resolved` is also available as an unsupported Technology Preview on {rhel} and {centos} 8.3.
+After {rhel-resolved-docs}[configuring the host] to use `systemd-resolved`, stop any running clusters and rerun [command]`{bin} setup`.
 ====
 
 === NetworkManager + dnsmasq
 
-This configuration is used on Fedora 32 or older, on {rhel}, and on {centos}.
+This configuration is used by default on Fedora 32 or older, on {rhel}, and on {centos}.
 
 * {prod} expects NetworkManager to manage networking.
 * NetworkManager uses `dnsmasq` through the [filename]`/etc/NetworkManager/conf.d/crc-nm-dnsmasq.conf` configuration file.

--- a/pkg/crc/preflight/preflight_checks_network_linux.go
+++ b/pkg/crc/preflight/preflight_checks_network_linux.go
@@ -80,9 +80,13 @@ dns=dnsmasq
 #
 # The corresponding crc bridge is not created through NetworkManager, so
 # it cannot be configured permanently through NetworkManager. We make the
-# change directly using resolvectl instead.
+# change directly using systemd-resolve instead.
 #
-# NetworkManager will overwrite this resolvectl configuration every time a
+# systemd-resolve is used instead of resolvectl due to distributions shipping
+# systemd releases older than 239 not having the newer renamed tool. resolvectl
+# supports being called as systemd-resolve, correctly handling the old CLI.
+#
+# NetworkManager will overwrite this systemd-resolve configuration every time a
 # network connection goes up/down, so we run this script on each of these events
 # to restore our settings. This is a NetworkManager bug which is fixed in
 # version 1.26.6 by this commit:
@@ -90,9 +94,7 @@ dns=dnsmasq
 
 export LC_ALL=C
 
-resolvectl domain crc ~testing
-resolvectl dns crc 192.168.130.11
-resolvectl default-route crc false
+systemd-resolve --interface crc --set-dns 192.168.130.11 --set-domain ~testing
 
 exit 0
 `

--- a/pkg/crc/preflight/preflight_linux.go
+++ b/pkg/crc/preflight/preflight_linux.go
@@ -228,7 +228,7 @@ func getPreflightChecks(_ bool, _ bool, networkMode network.Mode) []Check {
 	return getPreflightChecksForDistro(distro(), networkMode, usingSystemdResolved == nil)
 }
 
-func getNetworkChecksForDistro(networkMode network.Mode, systemdResolved bool) []Check {
+func getNetworkChecks(networkMode network.Mode, systemdResolved bool) []Check {
 	var checks []Check
 
 	if networkMode == network.VSockMode {
@@ -251,7 +251,7 @@ func getPreflightChecksForDistro(distro *linux.OsRelease, networkMode network.Mo
 	checks = append(checks, nonWinPreflightChecks[:]...)
 	checks = append(checks, genericPreflightChecks[:]...)
 	checks = append(checks, libvirtPreflightChecks(distro)...)
-	networkChecks := getNetworkChecksForDistro(networkMode, systemdResolved)
+	networkChecks := getNetworkChecks(networkMode, systemdResolved)
 	checks = append(checks, networkChecks...)
 	if networkMode == network.DefaultMode {
 		checks = append(checks, libvirtNetworkPreflightChecks[:]...)

--- a/pkg/crc/preflight/preflight_linux_test.go
+++ b/pkg/crc/preflight/preflight_linux_test.go
@@ -35,7 +35,7 @@ var (
 
 	rhel = crcos.OsRelease{
 		ID:        crcos.RHEL,
-		VersionID: "8.2",
+		VersionID: "8.3",
 		IDLike:    string(crcos.Fedora),
 	}
 
@@ -51,15 +51,17 @@ var (
 )
 
 type checkListForDistro struct {
-	distro      *crcos.OsRelease
-	networkMode network.Mode
-	checks      []Check
+	distro          *crcos.OsRelease
+	networkMode     network.Mode
+	systemdResolved bool
+	checks          []Check
 }
 
 var checkListForDistros = []checkListForDistro{
 	{
-		distro:      &fedora,
-		networkMode: network.DefaultMode,
+		distro:          &fedora,
+		networkMode:     network.DefaultMode,
+		systemdResolved: true,
 		checks: []Check{
 			{check: checkIfRunningAsNormalUser},
 			{cleanup: adminhelper.CleanHostsFile},
@@ -90,34 +92,9 @@ var checkListForDistros = []checkListForDistro{
 		},
 	},
 	{
-		distro:      &fedora,
-		networkMode: network.VSockMode,
-		checks: []Check{
-			{check: checkIfRunningAsNormalUser},
-			{cleanup: adminhelper.CleanHostsFile},
-			{check: checkPodmanExecutableCached},
-			{check: checkAdminHelperExecutableCached},
-			{configKeySuffix: "check-ram"},
-			{cleanup: removeCRCMachinesDir},
-			{cleanup: removeOldLogs},
-			{cleanup: cluster.ForgetPullSecret},
-			{check: checkVirtualizationEnabled},
-			{check: checkKvmEnabled},
-			{check: checkLibvirtInstalled},
-			{check: checkUserPartOfLibvirtGroup},
-			{configKeySuffix: "check-libvirt-group-active"},
-			{check: checkLibvirtServiceRunning},
-			{check: checkLibvirtVersion},
-			{check: checkMachineDriverLibvirtInstalled},
-			{cleanup: removeCrcVM},
-			{check: checkVsock},
-			{check: checkIfCRCDaemonRunning},
-			{check: checkBundleExtracted},
-		},
-	},
-	{
-		distro:      &rhel,
-		networkMode: network.DefaultMode,
+		distro:          &fedora,
+		networkMode:     network.DefaultMode,
+		systemdResolved: false,
 		checks: []Check{
 			{check: checkIfRunningAsNormalUser},
 			{cleanup: adminhelper.CleanHostsFile},
@@ -147,8 +124,9 @@ var checkListForDistros = []checkListForDistro{
 		},
 	},
 	{
-		distro:      &rhel,
-		networkMode: network.VSockMode,
+		distro:          &fedora,
+		networkMode:     network.VSockMode,
+		systemdResolved: false,
 		checks: []Check{
 			{check: checkIfRunningAsNormalUser},
 			{cleanup: adminhelper.CleanHostsFile},
@@ -173,8 +151,42 @@ var checkListForDistros = []checkListForDistro{
 		},
 	},
 	{
-		distro:      &unexpected,
-		networkMode: network.DefaultMode,
+		distro:          &rhel,
+		networkMode:     network.DefaultMode,
+		systemdResolved: true,
+		checks: []Check{
+			{check: checkIfRunningAsNormalUser},
+			{cleanup: adminhelper.CleanHostsFile},
+			{check: checkPodmanExecutableCached},
+			{check: checkAdminHelperExecutableCached},
+			{configKeySuffix: "check-ram"},
+			{cleanup: removeCRCMachinesDir},
+			{cleanup: removeOldLogs},
+			{cleanup: cluster.ForgetPullSecret},
+			{check: checkVirtualizationEnabled},
+			{check: checkKvmEnabled},
+			{check: checkLibvirtInstalled},
+			{check: checkUserPartOfLibvirtGroup},
+			{configKeySuffix: "check-libvirt-group-active"},
+			{check: checkLibvirtServiceRunning},
+			{check: checkLibvirtVersion},
+			{check: checkMachineDriverLibvirtInstalled},
+			{cleanup: removeCrcVM},
+			{check: checkSystemdNetworkdIsNotRunning},
+			{check: checkNetworkManagerInstalled},
+			{check: checkNetworkManagerIsRunning},
+			{check: checkCrcDnsmasqAndNetworkManagerConfigFile},
+			{check: checkSystemdResolvedIsRunning},
+			{check: checkCrcNetworkManagerDispatcherFile},
+			{check: checkLibvirtCrcNetworkAvailable},
+			{check: checkLibvirtCrcNetworkActive},
+			{check: checkBundleExtracted},
+		},
+	},
+	{
+		distro:          &rhel,
+		networkMode:     network.DefaultMode,
+		systemdResolved: false,
 		checks: []Check{
 			{check: checkIfRunningAsNormalUser},
 			{cleanup: adminhelper.CleanHostsFile},
@@ -204,8 +216,9 @@ var checkListForDistros = []checkListForDistro{
 		},
 	},
 	{
-		distro:      &unexpected,
-		networkMode: network.VSockMode,
+		distro:          &rhel,
+		networkMode:     network.VSockMode,
+		systemdResolved: false,
 		checks: []Check{
 			{check: checkIfRunningAsNormalUser},
 			{cleanup: adminhelper.CleanHostsFile},
@@ -230,8 +243,101 @@ var checkListForDistros = []checkListForDistro{
 		},
 	},
 	{
-		distro:      &ubuntu,
-		networkMode: network.DefaultMode,
+		distro:          &unexpected,
+		networkMode:     network.DefaultMode,
+		systemdResolved: true,
+		checks: []Check{
+			{check: checkIfRunningAsNormalUser},
+			{cleanup: adminhelper.CleanHostsFile},
+			{check: checkPodmanExecutableCached},
+			{check: checkAdminHelperExecutableCached},
+			{configKeySuffix: "check-ram"},
+			{cleanup: removeCRCMachinesDir},
+			{cleanup: removeOldLogs},
+			{cleanup: cluster.ForgetPullSecret},
+			{check: checkVirtualizationEnabled},
+			{check: checkKvmEnabled},
+			{check: checkLibvirtInstalled},
+			{check: checkUserPartOfLibvirtGroup},
+			{configKeySuffix: "check-libvirt-group-active"},
+			{check: checkLibvirtServiceRunning},
+			{check: checkLibvirtVersion},
+			{check: checkMachineDriverLibvirtInstalled},
+			{cleanup: removeCrcVM},
+			{check: checkSystemdNetworkdIsNotRunning},
+			{check: checkNetworkManagerInstalled},
+			{check: checkNetworkManagerIsRunning},
+			{check: checkCrcDnsmasqAndNetworkManagerConfigFile},
+			{check: checkSystemdResolvedIsRunning},
+			{check: checkCrcNetworkManagerDispatcherFile},
+			{check: checkLibvirtCrcNetworkAvailable},
+			{check: checkLibvirtCrcNetworkActive},
+			{check: checkBundleExtracted},
+		},
+	},
+	{
+		distro:          &unexpected,
+		networkMode:     network.DefaultMode,
+		systemdResolved: false,
+		checks: []Check{
+			{check: checkIfRunningAsNormalUser},
+			{cleanup: adminhelper.CleanHostsFile},
+			{check: checkPodmanExecutableCached},
+			{check: checkAdminHelperExecutableCached},
+			{configKeySuffix: "check-ram"},
+			{cleanup: removeCRCMachinesDir},
+			{cleanup: removeOldLogs},
+			{cleanup: cluster.ForgetPullSecret},
+			{check: checkVirtualizationEnabled},
+			{check: checkKvmEnabled},
+			{check: checkLibvirtInstalled},
+			{check: checkUserPartOfLibvirtGroup},
+			{configKeySuffix: "check-libvirt-group-active"},
+			{check: checkLibvirtServiceRunning},
+			{check: checkLibvirtVersion},
+			{check: checkMachineDriverLibvirtInstalled},
+			{cleanup: removeCrcVM},
+			{check: checkSystemdNetworkdIsNotRunning},
+			{check: checkNetworkManagerInstalled},
+			{check: checkNetworkManagerIsRunning},
+			{check: checkCrcNetworkManagerConfig},
+			{check: checkCrcDnsmasqConfigFile},
+			{check: checkLibvirtCrcNetworkAvailable},
+			{check: checkLibvirtCrcNetworkActive},
+			{check: checkBundleExtracted},
+		},
+	},
+	{
+		distro:          &unexpected,
+		networkMode:     network.VSockMode,
+		systemdResolved: false,
+		checks: []Check{
+			{check: checkIfRunningAsNormalUser},
+			{cleanup: adminhelper.CleanHostsFile},
+			{check: checkPodmanExecutableCached},
+			{check: checkAdminHelperExecutableCached},
+			{configKeySuffix: "check-ram"},
+			{cleanup: removeCRCMachinesDir},
+			{cleanup: removeOldLogs},
+			{cleanup: cluster.ForgetPullSecret},
+			{check: checkVirtualizationEnabled},
+			{check: checkKvmEnabled},
+			{check: checkLibvirtInstalled},
+			{check: checkUserPartOfLibvirtGroup},
+			{configKeySuffix: "check-libvirt-group-active"},
+			{check: checkLibvirtServiceRunning},
+			{check: checkLibvirtVersion},
+			{check: checkMachineDriverLibvirtInstalled},
+			{cleanup: removeCrcVM},
+			{check: checkVsock},
+			{check: checkIfCRCDaemonRunning},
+			{check: checkBundleExtracted},
+		},
+	},
+	{
+		distro:          &ubuntu,
+		networkMode:     network.DefaultMode,
+		systemdResolved: true,
 		checks: []Check{
 			{check: checkIfRunningAsNormalUser},
 			{cleanup: adminhelper.CleanHostsFile},
@@ -263,8 +369,42 @@ var checkListForDistros = []checkListForDistro{
 		},
 	},
 	{
-		distro:      &ubuntu,
-		networkMode: network.VSockMode,
+		distro:          &ubuntu,
+		networkMode:     network.DefaultMode,
+		systemdResolved: false,
+		checks: []Check{
+			{check: checkIfRunningAsNormalUser},
+			{cleanup: adminhelper.CleanHostsFile},
+			{check: checkPodmanExecutableCached},
+			{check: checkAdminHelperExecutableCached},
+			{configKeySuffix: "check-ram"},
+			{cleanup: removeCRCMachinesDir},
+			{cleanup: removeOldLogs},
+			{cleanup: cluster.ForgetPullSecret},
+			{check: checkVirtualizationEnabled},
+			{check: checkKvmEnabled},
+			{check: checkLibvirtInstalled},
+			{check: checkUserPartOfLibvirtGroup},
+			{configKeySuffix: "check-libvirt-group-active"},
+			{check: checkLibvirtServiceRunning},
+			{check: checkLibvirtVersion},
+			{check: checkMachineDriverLibvirtInstalled},
+			{cleanup: removeCrcVM},
+			{configKeySuffix: "check-apparmor-profile-setup"},
+			{check: checkSystemdNetworkdIsNotRunning},
+			{check: checkNetworkManagerInstalled},
+			{check: checkNetworkManagerIsRunning},
+			{check: checkCrcNetworkManagerConfig},
+			{check: checkCrcDnsmasqConfigFile},
+			{check: checkLibvirtCrcNetworkAvailable},
+			{check: checkLibvirtCrcNetworkActive},
+			{check: checkBundleExtracted},
+		},
+	},
+	{
+		distro:          &ubuntu,
+		networkMode:     network.VSockMode,
+		systemdResolved: false,
 		checks: []Check{
 			{check: checkIfRunningAsNormalUser},
 			{cleanup: adminhelper.CleanHostsFile},
@@ -299,11 +439,11 @@ func assertFuncEqual(t *testing.T, func1 interface{}, func2 interface{}) {
 	assert.Equal(t, reflect.ValueOf(func1).Pointer(), reflect.ValueOf(func2).Pointer(), "%s != %s", funcToString(func1), funcToString(func2))
 }
 
-func assertExpectedPreflights(t *testing.T, distro *crcos.OsRelease, networkMode network.Mode) {
-	preflights := getPreflightChecksForDistro(distro, networkMode)
+func assertExpectedPreflights(t *testing.T, distro *crcos.OsRelease, networkMode network.Mode, systemdResolved bool) {
+	preflights := getPreflightChecksForDistro(distro, networkMode, systemdResolved)
 	var expected checkListForDistro
 	for _, expected = range checkListForDistros {
-		if expected.distro == distro && expected.networkMode == networkMode {
+		if expected.distro == distro && expected.networkMode == networkMode && expected.systemdResolved == systemdResolved {
 			break
 		}
 	}
@@ -328,15 +468,19 @@ func assertExpectedPreflights(t *testing.T, distro *crcos.OsRelease, networkMode
 }
 
 func TestCountPreflights(t *testing.T) {
-	assertExpectedPreflights(t, &fedora, network.DefaultMode)
-	assertExpectedPreflights(t, &fedora, network.VSockMode)
+	assertExpectedPreflights(t, &fedora, network.DefaultMode, true)
+	assertExpectedPreflights(t, &fedora, network.DefaultMode, false)
+	assertExpectedPreflights(t, &fedora, network.VSockMode, false)
 
-	assertExpectedPreflights(t, &rhel, network.DefaultMode)
-	assertExpectedPreflights(t, &rhel, network.VSockMode)
+	assertExpectedPreflights(t, &rhel, network.DefaultMode, true)
+	assertExpectedPreflights(t, &rhel, network.DefaultMode, false)
+	assertExpectedPreflights(t, &rhel, network.VSockMode, false)
 
-	assertExpectedPreflights(t, &unexpected, network.DefaultMode)
-	assertExpectedPreflights(t, &unexpected, network.VSockMode)
+	assertExpectedPreflights(t, &unexpected, network.DefaultMode, true)
+	assertExpectedPreflights(t, &unexpected, network.DefaultMode, false)
+	assertExpectedPreflights(t, &unexpected, network.VSockMode, false)
 
-	assertExpectedPreflights(t, &ubuntu, network.DefaultMode)
-	assertExpectedPreflights(t, &ubuntu, network.VSockMode)
+	assertExpectedPreflights(t, &ubuntu, network.DefaultMode, true)
+	assertExpectedPreflights(t, &ubuntu, network.DefaultMode, false)
+	assertExpectedPreflights(t, &ubuntu, network.VSockMode, false)
 }


### PR DESCRIPTION
This is a naive attempt to alter the network stack selection on Linux from hard-coded by distribution to seeing what the host is presently running with.

I don't think any changes to the test suite are needed as I didn't add/alter any checks, but I'm not sure if there needs to be a new check for the dnsmasq list to remove any systemd-resolved related dispatch files.

None of this code has been tested, so unsure if the `systemd-resolve` command will actually work.

This looks to address notes in #1991 #2056 and #1572

(I am presently fighting with VSCode on some linting that made it into the commit)