### PR TITLE
Bump the minimal supported macOS version

### DIFF
--- a/docs/source/topics/ref_minimum-system-requirements.adoc
+++ b/docs/source/topics/ref_minimum-system-requirements.adoc
@@ -32,7 +32,7 @@ To assign more resources to the {prod} virtual machine, see link:{crc-gsg-url}#c
 
 === {mac}
 
-* On {mac}, {prod} requires macOS 10.12 Sierra or newer.
+* On {mac}, {prod} requires macOS 10.14 Mojave or newer.
 {prod} does not work on earlier versions of {mac}.
 
 === Linux


### PR DESCRIPTION
10.14 is the best we can do with the tray.
Apple itself doesn't support older versions.
