### PR TITLE
machine: Fix error handling in Stop()

### DIFF
--- a/pkg/crc/machine/stop.go
+++ b/pkg/crc/machine/stop.go
@@ -17,9 +17,9 @@ func (client *client) Stop() (state.State, error) {
 
 	logging.Info("Stopping the OpenShift cluster, this may take a few minutes...")
 	if err := host.Stop(); err != nil {
-		status, err := host.Driver.GetState()
-		if err != nil {
-			logging.Debugf("Cannot get VM status after stopping it: %v", err)
+		status, stateErr := host.Driver.GetState()
+		if stateErr != nil {
+			logging.Debugf("Cannot get VM status after stopping it: %v", stateErr)
 		}
 		return status, errors.Wrap(err, "Cannot stop machine")
 	}


### PR DESCRIPTION
The changes introduced in commit 33355194 overwrite the error returned
by driver.Stop(). If Stop() fails because of a timeout, but the
GetState() succeeds, machine.Stop() will return success. This is not
what the upper layers want, as on Stop() errors, we want to ask the user
if they want to forcefully stop the VM.