### PR TITLE
Use the same error field for json errors and backend errors

### DIFF
--- a/pkg/crc/api/handlers.go
+++ b/pkg/crc/api/handlers.go
@@ -221,8 +221,9 @@ func encodeStructToJSON(v interface{}) string {
 	s, err := json.Marshal(v)
 	if err != nil {
 		logging.Error(err.Error())
-		err := commandError{
-			Err: "Failed while encoding JSON to string",
+		err := Result{
+			Success: false,
+			Error:   "Failed while encoding JSON to string",
 		}
 		s, _ := json.Marshal(err)
 		return string(s)
@@ -231,8 +232,9 @@ func encodeStructToJSON(v interface{}) string {
 }
 
 func encodeErrorToJSON(errMsg string) string {
-	err := commandError{
-		Err: errMsg,
+	err := Result{
+		Success: false,
+		Error:   errMsg,
 	}
 	return encodeStructToJSON(err)
 }

--- a/pkg/crc/api/types.go
+++ b/pkg/crc/api/types.go
@@ -5,10 +5,6 @@ import (
 	"net"
 )
 
-type commandError struct {
-	Err string
-}
-
 type Server struct {
 	handler                RequestHandler
 	listener               net.Listener


### PR DESCRIPTION
It's now always `Error`. This was an issue in the macOS tray. `Err` is
not handled.
