### PR TITLE
Slightly change the end of crc start

### DIFF
--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -410,7 +410,7 @@ func (client *client) Start(ctx context.Context, startConfig StartConfig) (*Star
 
 	logging.Info("Adding crc-admin and crc-developer contexts to kubeconfig...")
 	if err := writeKubeconfig(instanceIP, clusterConfig); err != nil {
-		logging.Warnf("Cannot update kubeconfig: %v", err)
+		logging.Errorf("Cannot update kubeconfig: %v", err)
 	}
 
 	return &StartResult{

--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -413,7 +413,6 @@ func (client *client) Start(ctx context.Context, startConfig StartConfig) (*Star
 		logging.Warnf("Cannot update kubeconfig: %v", err)
 	}
 
-	logging.Warn("The cluster might report a degraded or error state. This is expected since several operators have been disabled to lower the resource usage. For more information, please consult the documentation")
 	return &StartResult{
 		KubeletStarted: true,
 		ClusterConfig:  *clusterConfig,


### PR DESCRIPTION
* List only 5 operators in the status debug string
* Remove the not-so-useful warning