### PR TITLE
Propagate context to eventually cancel the startup sequence of the VM

### DIFF
--- a/pkg/crc/api/adapter.go
+++ b/pkg/crc/api/adapter.go
@@ -12,7 +12,7 @@ type AdaptedClient interface {
 
 	Delete() Result
 	GetConsoleURL() ConsoleResult
-	Start(startConfig machine.StartConfig) StartResult
+	Start(ctx context.Context, startConfig machine.StartConfig) StartResult
 	Status() ClusterStatusResult
 	Stop() Result
 }
@@ -87,8 +87,8 @@ func (a *Adapter) GetConsoleURL() ConsoleResult {
 	}
 }
 
-func (a *Adapter) Start(startConfig machine.StartConfig) StartResult {
-	res, err := a.Underlying.Start(context.Background(), startConfig)
+func (a *Adapter) Start(ctx context.Context, startConfig machine.StartConfig) StartResult {
+	res, err := a.Underlying.Start(ctx, startConfig)
 	if err != nil {
 		logging.Error(err)
 		return StartResult{

--- a/pkg/crc/api/handlers.go
+++ b/pkg/crc/api/handlers.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 
@@ -52,7 +53,7 @@ func (h *Handler) Start(args json.RawMessage) string {
 	}
 
 	startConfig := getStartConfig(h.Config, parsedArgs)
-	status := h.MachineClient.Start(startConfig)
+	status := h.MachineClient.Start(context.Background(), startConfig)
 	return encodeStructToJSON(status)
 }
 

--- a/pkg/crc/ssh/client.go
+++ b/pkg/crc/ssh/client.go
@@ -67,7 +67,7 @@ func clientConfig(user string, keys []string) (*ssh.ClientConfig, error) {
 		Auth: []ssh.AuthMethod{ssh.PublicKeys(privateKeys...)},
 		// #nosec G106
 		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
-		Timeout:         time.Minute,
+		Timeout:         10 * time.Second,
 	}, nil
 }
 


### PR DESCRIPTION
If the machine.Start() caller cancels the context, as soon as the code
will enter a wait loop, start will returned an error.

