### PR TITLE
Rotate logs only in crc command line, not in the daemon

### DIFF
--- a/cmd/crc/cmd/delete.go
+++ b/cmd/crc/cmd/delete.go
@@ -54,8 +54,10 @@ func deleteMachine(client machine.Client, clearCache bool, cacheDir string, inte
 
 	yes := input.PromptUserForYesOrNo("Do you want to delete the OpenShift cluster", force)
 	if yes {
-		defer logging.BackupLogFile()
-		return true, client.Delete()
+		if err := client.Delete(); err != nil {
+			return true, err
+		}
+		return true, logging.BackupLogFile()
 	}
 	return false, nil
 }

--- a/cmd/crc/cmd/delete.go
+++ b/cmd/crc/cmd/delete.go
@@ -9,6 +9,7 @@ import (
 	"github.com/code-ready/crc/pkg/crc/constants"
 	crcErrors "github.com/code-ready/crc/pkg/crc/errors"
 	"github.com/code-ready/crc/pkg/crc/input"
+	"github.com/code-ready/crc/pkg/crc/logging"
 	"github.com/code-ready/crc/pkg/crc/machine"
 	"github.com/spf13/cobra"
 )
@@ -53,6 +54,7 @@ func deleteMachine(client machine.Client, clearCache bool, cacheDir string, inte
 
 	yes := input.PromptUserForYesOrNo("Do you want to delete the OpenShift cluster", force)
 	if yes {
+		defer logging.BackupLogFile()
 		return true, client.Delete()
 	}
 	return false, nil

--- a/pkg/crc/logging/logging.go
+++ b/pkg/crc/logging/logging.go
@@ -34,11 +34,11 @@ func CloseLogging() {
 	logrus.StandardLogger().ReplaceHooks(make(logrus.LevelHooks))
 }
 
-func BackupLogFile() {
+func BackupLogFile() error {
 	if logfile == nil {
-		return
+		return nil
 	}
-	os.Rename(logfile.Name(), fmt.Sprintf("%s_%s", logfile.Name(), time.Now().Format("20060102150405"))) // nolint
+	return os.Rename(logfile.Name(), fmt.Sprintf("%s_%s", logfile.Name(), time.Now().Format("20060102150405")))
 }
 
 func InitLogrus(logLevel, logFilePath string) {

--- a/pkg/crc/logging/logging.go
+++ b/pkg/crc/logging/logging.go
@@ -35,6 +35,9 @@ func CloseLogging() {
 }
 
 func BackupLogFile() {
+	if logfile == nil {
+		return
+	}
 	os.Rename(logfile.Name(), fmt.Sprintf("%s_%s", logfile.Name(), time.Now().Format("20060102150405"))) // nolint
 }
 

--- a/pkg/crc/machine/delete.go
+++ b/pkg/crc/machine/delete.go
@@ -1,13 +1,11 @@
 package machine
 
 import (
-	"github.com/code-ready/crc/pkg/crc/logging"
 	"github.com/pkg/errors"
 )
 
 func (client *client) Delete() error {
 	libMachineAPIClient, cleanup := createLibMachineClient()
-	defer logging.BackupLogFile()
 	defer cleanup()
 	host, err := libMachineAPIClient.Load(client.name)
 


### PR DESCRIPTION
**Fixes:** Issue #2051

Move the function call of `BackupLogFile` the the CLI only.
