### PR TITLE
Change the root check error message

### DIFF
--- a/pkg/crc/preflight/preflight_checks_nonwin.go
+++ b/pkg/crc/preflight/preflight_checks_nonwin.go
@@ -3,6 +3,7 @@
 package preflight
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"syscall"
@@ -17,7 +18,7 @@ var nonWinPreflightChecks = [...]Check{
 		configKeySuffix:  "check-root-user",
 		checkDescription: "Checking if running as non-root",
 		check:            checkIfRunningAsNormalUser,
-		fixDescription:   "crc should be ran as a normal user",
+		fixDescription:   "crc should not be run as root",
 		flags:            NoFix,
 	},
 	{
@@ -32,7 +33,7 @@ func checkIfRunningAsNormalUser() error {
 		return nil
 	}
 	logging.Debug("Ran as root")
-	return fmt.Errorf("crc should be ran as a normal user")
+	return errors.New("crc should not be run as root")
 }
 
 func setSuid(path string) error {


### PR DESCRIPTION
Hopefully, it will increase the success rate of crc setup.

It's not perfect but I guess still good to take:

First run:
```
$ sudo crc setup
CodeReady Containers is constantly improving and we would like to know more about usage (more details at https://developers.redhat.com/article/tool-data-collection)
Your preference can be changed manually if desired using 'crc config set consent-telemetry <yes/no>'
Would you like to contribute anonymous usage statistics? [y/N]: 
No worry, you can still enable telemetry manually with the command 'crc config set consent-telemetry yes'.
INFO Checking if running as root                  
crc should not be run as root
``` 

The telemetry message is annoying here :/