### PR TITLE
[Doc] Remove `as=system:admin` for developer user

### DIFF
--- a/docs/source/topics/proc_accessing-the-openshift-cluster-with-oc.adoc
+++ b/docs/source/topics/proc_accessing-the-openshift-cluster-with-oc.adoc
@@ -33,11 +33,15 @@ You can also view it by running the [command]`{bin} console --credentials` comma
 ====
 
 . You can now use [command]`oc` to interact with your OpenShift cluster.
-For example, to verify that the OpenShift cluster Operators are available, run the following command with administrator privileges:
+For example, to verify that the OpenShift cluster Operators are available, you need to be logged in as `kubeadmin` user and
+run the following command:
 +
 [subs="+quotes,attributes",options="nowrap"]
 ----
-$ oc get co --as system:admin
+$ oc config use-context crc-admin
+$ oc whoami
+kubeadmin
+$ oc get co
 ----
 +
 [NOTE]


### PR DESCRIPTION
With https://github.com/code-ready/snc/pull/361, developer user
is not part of sudoers cluster role. This patch remove `as=system:admin`
mentions for developer user.

fixes: #2097
