### PR TITLE
#949 Add synchronisation between Start/Stop/Delete actions

### DIFF
--- a/cmd/crc/cmd/root.go
+++ b/cmd/crc/cmd/root.go
@@ -164,7 +164,7 @@ func newViperConfig() (*crcConfig.Config, *crcConfig.ViperStorage, error) {
 }
 
 func newMachine() machine.Client {
-	return machine.NewClient(constants.DefaultName, isDebugLog(), config)
+	return machine.NewSynchronizedMachine(machine.NewClient(constants.DefaultName, isDebugLog(), config))
 }
 
 func addForceFlag(cmd *cobra.Command) {

--- a/pkg/crc/api/api.go
+++ b/pkg/crc/api/api.go
@@ -22,8 +22,7 @@ func CreateServer(socketPath string, config crcConfig.Storage, machine machine.C
 
 func createServerWithListener(listener net.Listener, config crcConfig.Storage, machine machine.Client, logger Logger) (Server, error) {
 	apiServer := Server{
-		listener:               listener,
-		clusterOpsRequestsChan: make(chan clusterOpsRequest, 10),
+		listener: listener,
 		handler: &Handler{
 			Config:        config,
 			MachineClient: &Adapter{Underlying: machine},
@@ -34,7 +33,6 @@ func createServerWithListener(listener net.Listener, config crcConfig.Storage, m
 }
 
 func (api Server) Serve() error {
-	go api.handleClusterOperations() // go routine that handles start, stop and delete calls
 	for {
 		conn, err := api.listener.Accept()
 		if err != nil {
@@ -45,12 +43,6 @@ func (api Server) Serve() error {
 			return err
 		}
 		api.handleConnections(conn) // handle version, status, webconsole, etc. requests
-	}
-}
-
-func (api Server) handleClusterOperations() {
-	for req := range api.clusterOpsRequestsChan {
-		api.handleRequest(req.command, req.socket)
 	}
 }
 
@@ -99,32 +91,7 @@ func (api Server) handleConnections(conn net.Conn) {
 		logging.Error("Error decoding request: ", err.Error())
 		return
 	}
-	// start, stop and delete are slow operations, and change the VM state so they have to run sequentially.
-	// We don't want other operations querying the status of the VM to be blocked by these,
-	// so they are treated by a dedicated go routine
-
-	switch req.Command {
-	case "start", "stop", "delete":
-		// queue new request to channel
-		r := clusterOpsRequest{
-			command: req,
-			socket:  conn,
-		}
-		if !addRequestToChannel(r, api.clusterOpsRequestsChan) {
-			logging.Error("Channel capacity reached, unable to add new request")
-			errMsg := encodeErrorToJSON("Sockets channel capacity reached, unable to add new request")
-			writeStringToSocket(conn, errMsg)
-			conn.Close()
-		}
-
-	case "status", "version", "setconfig", "getconfig", "unsetconfig", "webconsoleurl", "logs":
-		go api.handleRequest(req, conn)
-
-	default:
-		err := encodeErrorToJSON(fmt.Sprintf("Unknown command supplied: %s", req.Command))
-		writeStringToSocket(conn, err)
-		conn.Close()
-	}
+	go api.handleRequest(req, conn)
 }
 
 func writeStringToSocket(socket net.Conn, msg string) {
@@ -140,14 +107,5 @@ func writeStringToSocket(socket net.Conn, msg string) {
 	if err != nil {
 		logging.Error("Failed writing string to socket", err.Error())
 		return
-	}
-}
-
-func addRequestToChannel(req clusterOpsRequest, requestsChan chan clusterOpsRequest) bool {
-	select {
-	case requestsChan <- req:
-		return true
-	default:
-		return false
 	}
 }

--- a/pkg/crc/api/types.go
+++ b/pkg/crc/api/types.go
@@ -6,9 +6,8 @@ import (
 )
 
 type Server struct {
-	handler                RequestHandler
-	listener               net.Listener
-	clusterOpsRequestsChan chan clusterOpsRequest
+	handler  RequestHandler
+	listener net.Listener
 }
 
 type RequestHandler interface {
@@ -22,12 +21,6 @@ type RequestHandler interface {
 	GetConfig(json.RawMessage) string
 	GetWebconsoleInfo() string
 	Logs() string
-}
-
-// clusterOpsRequest struct is used to store the command request and associated socket
-type clusterOpsRequest struct {
-	command commandRequest
-	socket  net.Conn
 }
 
 // commandRequest struct is used to decode the json request from tray

--- a/pkg/crc/machine/sync.go
+++ b/pkg/crc/machine/sync.go
@@ -1,0 +1,170 @@
+package machine
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/code-ready/crc/pkg/crc/logging"
+	"github.com/code-ready/machine/libmachine/state"
+)
+
+const startCancelTimeout = 15 * time.Second
+
+type State string
+
+const (
+	Idle     State = "Idle"
+	Deleting State = "Deleting"
+	Stopping State = "Stopping"
+	Starting State = "Starting"
+)
+
+type Synchronized struct {
+	underlying Client
+
+	stateLock    sync.Mutex
+	currentState State
+	startCancel  context.CancelFunc
+
+	syncOperationDone chan State
+}
+
+func NewSynchronizedMachine(machine Client) *Synchronized {
+	return &Synchronized{
+		underlying:        machine,
+		currentState:      Idle,
+		syncOperationDone: make(chan State, 1),
+	}
+}
+
+func (s *Synchronized) CurrentState() State {
+	s.stateLock.Lock()
+	defer s.stateLock.Unlock()
+
+	return s.currentStateUnlocked()
+}
+
+func (s *Synchronized) currentStateUnlocked() State {
+	select {
+	case st := <-s.syncOperationDone:
+		if s.currentState == st {
+			s.currentState = Idle
+		}
+		if st == Starting {
+			s.startCancel = nil
+		}
+	default:
+	}
+	return s.currentState
+}
+
+func (s *Synchronized) Delete() error {
+	if err := s.prepareStopDelete(Deleting); err != nil {
+		return err
+	}
+
+	err := s.underlying.Delete()
+	s.syncOperationDone <- Deleting
+	return err
+}
+
+func (s *Synchronized) prepareStart(startCancel context.CancelFunc) error {
+	s.stateLock.Lock()
+	defer s.stateLock.Unlock()
+	if s.currentStateUnlocked() != Idle {
+		return errors.New("cluster is busy")
+	}
+	s.startCancel = startCancel
+	s.currentState = Starting
+
+	return nil
+}
+
+func (s *Synchronized) Start(ctx context.Context, startConfig StartConfig) (*StartResult, error) {
+	ctx, startCancel := context.WithCancel(ctx)
+	if err := s.prepareStart(startCancel); err != nil {
+		return nil, err
+	}
+
+	startResult, err := s.underlying.Start(ctx, startConfig)
+	s.syncOperationDone <- Starting
+	return startResult, err
+}
+
+/* cancel ongoing start, and wait until the start is fully cancelled. Time out if cancellation takes more than 'timeout'
+ * s.stateLock must be locked before calling this function
+ */
+func (s *Synchronized) cancelUnlocked(timeout time.Duration) error {
+	if s.startCancel != nil {
+		logging.Infof("Cancelling virtual machine start...")
+		s.startCancel()
+	}
+	select {
+	case <-s.syncOperationDone:
+		return nil
+	case <-time.After(timeout):
+		return errors.New("cannot abort startup sequence quickly enough")
+	}
+}
+
+func (s *Synchronized) prepareStopDelete(state State) error {
+	s.stateLock.Lock()
+	defer s.stateLock.Unlock()
+
+	switch s.currentStateUnlocked() {
+	case Starting:
+		if err := s.cancelUnlocked(startCancelTimeout); err != nil {
+			return err
+		}
+	case Idle:
+		break
+	case Deleting, Stopping:
+		return errors.New("cluster is stopping or deleting")
+	default:
+		return errors.New("invalid condition")
+	}
+
+	s.currentState = state
+	return nil
+}
+
+func (s *Synchronized) Stop() (state.State, error) {
+	if err := s.prepareStopDelete(Stopping); err != nil {
+		return state.Error, err
+	}
+
+	st, err := s.underlying.Stop()
+	s.syncOperationDone <- Stopping
+
+	return st, err
+}
+
+func (s *Synchronized) GetName() string {
+	return s.underlying.GetName()
+}
+
+func (s *Synchronized) Exists() (bool, error) {
+	return s.underlying.Exists()
+}
+
+func (s *Synchronized) GetConsoleURL() (*ConsoleResult, error) {
+	return s.underlying.GetConsoleURL()
+}
+
+func (s *Synchronized) IP() (string, error) {
+	return s.underlying.IP()
+}
+
+func (s *Synchronized) PowerOff() error {
+	return s.underlying.PowerOff()
+}
+
+func (s *Synchronized) Status() (*ClusterStatusResult, error) {
+	return s.underlying.Status()
+}
+
+func (s *Synchronized) IsRunning() (bool, error) {
+	return s.underlying.IsRunning()
+}

--- a/pkg/crc/machine/sync_test.go
+++ b/pkg/crc/machine/sync_test.go
@@ -1,0 +1,166 @@
+package machine
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/code-ready/machine/libmachine/state"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOneStartAtTheSameTime(t *testing.T) {
+	isRunning := make(chan struct{}, 1)
+	startCh := make(chan struct{}, 1)
+	waitingMachine := &waitingMachine{
+		isRunning:       isRunning,
+		startCompleteCh: startCh,
+	}
+	syncMachine := NewSynchronizedMachine(waitingMachine)
+	assert.Equal(t, Idle, syncMachine.CurrentState())
+
+	lock := &sync.WaitGroup{}
+	lock.Add(1)
+	go func() {
+		defer lock.Done()
+		_, err := syncMachine.Start(context.Background(), StartConfig{})
+		assert.NoError(t, err)
+	}()
+
+	<-isRunning
+	assert.Equal(t, Starting, syncMachine.CurrentState())
+	assert.Equal(t, waitingMachine.GetName(), syncMachine.GetName())
+	_, err := syncMachine.Start(context.Background(), StartConfig{})
+	assert.EqualError(t, err, "cluster is busy")
+
+	startCh <- struct{}{}
+	lock.Wait()
+
+	assert.Equal(t, Idle, syncMachine.CurrentState())
+}
+
+func TestDeleteStop(t *testing.T) {
+	isRunning := make(chan struct{}, 1)
+	deleteCh := make(chan struct{}, 1)
+	waitingMachine := &waitingMachine{
+		isRunning:        isRunning,
+		deleteCompleteCh: deleteCh,
+	}
+	syncMachine := NewSynchronizedMachine(waitingMachine)
+	assert.Equal(t, Idle, syncMachine.CurrentState())
+
+	lock := &sync.WaitGroup{}
+	lock.Add(1)
+	go func() {
+		defer lock.Done()
+		assert.NoError(t, syncMachine.Delete())
+	}()
+
+	<-isRunning
+	assert.Equal(t, Deleting, syncMachine.CurrentState())
+	assert.EqualError(t, syncMachine.Delete(), "cluster is stopping or deleting")
+	_, err := syncMachine.Stop()
+	assert.EqualError(t, err, "cluster is stopping or deleting")
+	_, err = syncMachine.Start(context.Background(), StartConfig{})
+	assert.EqualError(t, err, "cluster is busy")
+
+	deleteCh <- struct{}{}
+	lock.Wait()
+
+	assert.Equal(t, Idle, syncMachine.CurrentState())
+}
+
+func TestCancelStart(t *testing.T) {
+	isRunning := make(chan struct{}, 1)
+	deleteCh := make(chan struct{}, 1)
+	waitingMachine := &waitingMachine{
+		isRunning:        isRunning,
+		startCompleteCh:  make(chan struct{}, 1),
+		deleteCompleteCh: deleteCh,
+	}
+	syncMachine := NewSynchronizedMachine(waitingMachine)
+	assert.Equal(t, Idle, syncMachine.CurrentState())
+
+	lock := &sync.WaitGroup{}
+	lock.Add(1)
+	go func() {
+		defer lock.Done()
+		_, err := syncMachine.Start(context.Background(), StartConfig{})
+		assert.EqualError(t, err, "context canceled")
+	}()
+
+	<-isRunning
+	assert.Equal(t, Starting, syncMachine.CurrentState())
+
+	lock.Add(1)
+	go func() {
+		defer lock.Done()
+		assert.NoError(t, syncMachine.Delete())
+	}()
+
+	deleteCh <- struct{}{}
+	lock.Wait()
+
+	assert.Equal(t, Idle, syncMachine.CurrentState())
+}
+
+type waitingMachine struct {
+	isRunning        chan struct{}
+	startCompleteCh  chan struct{}
+	stopCompleteCh   chan struct{}
+	deleteCompleteCh chan struct{}
+}
+
+func (m *waitingMachine) IsRunning() (bool, error) {
+	return false, errors.New("not implemented")
+}
+
+func (m *waitingMachine) GetName() string {
+	return "waiting machine"
+}
+
+func (m *waitingMachine) Delete() error {
+	m.isRunning <- struct{}{}
+	<-m.deleteCompleteCh
+	return nil
+}
+
+func (m *waitingMachine) Exists() (bool, error) {
+	return false, errors.New("not implemented")
+}
+
+func (m *waitingMachine) GetConsoleURL() (*ConsoleResult, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m *waitingMachine) IP() (string, error) {
+	return "", errors.New("not implemented")
+}
+
+func (m *waitingMachine) PowerOff() error {
+	return nil
+}
+
+func (m *waitingMachine) Start(context context.Context, _ StartConfig) (*StartResult, error) {
+	m.isRunning <- struct{}{}
+	select {
+	case <-context.Done():
+		return nil, context.Err()
+	case <-m.startCompleteCh:
+		return &StartResult{
+			Status:         state.Running,
+			KubeletStarted: true,
+		}, nil
+	}
+}
+
+func (m *waitingMachine) Status() (*ClusterStatusResult, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m *waitingMachine) Stop() (state.State, error) {
+	m.isRunning <- struct{}{}
+	<-m.stopCompleteCh
+	return state.Stopped, nil
+}


### PR DESCRIPTION
Related to https://github.com/code-ready/crc/issues/949

This PR implements cancel for machine start.

If the user clicks stop or delete in the tray, it will first abort startup sequence and then perform stop/delete.