### PR TITLE
Improve launchd preflight checks and fix hyperkit startup crash

### DIFF
--- a/pkg/os/launchd/launchd_darwin.go
+++ b/pkg/os/launchd/launchd_darwin.go
@@ -133,7 +133,7 @@ func AgentRunning(label string) bool {
 	// output if the agent is not loaded in launchd
 	launchctlListCommand := `launchctl list | grep %s | awk '{print $1}'`
 	cmd := fmt.Sprintf(launchctlListCommand, label)
-	out, err := exec.Command("bash", "-c", cmd).Output() // #nosec G204
+	out, _, err := os.RunWithDefaultLocale("bash", "-c", cmd)
 	if err != nil {
 		return false
 	}

--- a/pkg/os/launchd/launchd_darwin.go
+++ b/pkg/os/launchd/launchd_darwin.go
@@ -36,6 +36,8 @@ const (
 			<false/>
 			<key>RunAtLoad</key>
 			<true/>
+			<key>ProcessType</key>
+			<string>Interactive</string>
 		</dict>
 	</plist>`
 )


### PR DESCRIPTION
This makes error reporting a bit better, and makes sure plist files are recreated when their content changed.
For testing, the main change is that the path in `~/Library/LaunchAgents/crc.daemon.plist` is updated when the absolute path of crc changes.
You can either check its content after running `crc setup` with the crc binary being in different directories, or just check `ps aux |grep 'crc daemon'` after running `crc setup`