### PR TITLE
Bump minimum macOS version in the installer

### DIFF
--- a/packaging/darwin/Distribution.in
+++ b/packaging/darwin/Distribution.in
@@ -10,9 +10,9 @@
     <installation-check script="installCheck();"/>
     <script>
 function installCheck() {
-    if(!(system.compareVersions(system.version.ProductVersion, '10.12.0') >= 0)) {
+    if(!(system.compareVersions(system.version.ProductVersion, '10.14.0') >= 0)) {
         my.result.title = 'Unable to install';
-        my.result.message = 'CodeReady Containers requires macOS 10.12 or later.';
+        my.result.message = 'CodeReady Containers requires macOS 10.14 or later.';
         my.result.type = 'Fatal';
         return false;
     }


### PR DESCRIPTION
16b3480958 changed the minimum supported macOS version in the
documentation, but the installer also has a check for this version.
This commit changes this check to match the documentation.