### PR TITLE
Fix disk resize with 4.7 bundles

### DIFF
--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -31,6 +31,8 @@ import (
 	"github.com/code-ready/machine/libmachine/state"
 	"github.com/docker/go-units"
 	"github.com/pkg/errors"
+
+	"golang.org/x/crypto/ssh"
 )
 
 const minimumMemoryForMonitoring = 14336
@@ -91,6 +93,21 @@ func (client *client) updateVMConfig(startConfig StartConfig, api libmachine.API
 	return nil
 }
 
+func growRootFileSystem(sshRunner *crcssh.Runner) error {
+	// With 4.7, this is quite a manual process until https://github.com/openshift/installer/pull/4746 gets fixed
+	// See https://github.com/code-ready/crc/issues/2104 for details
+	if _, _, err := sshRunner.Run("sudo /usr/bin/growpart /dev/vda 4"); err != nil {
+		var sshErr *ssh.ExitError
+		if errors.As(err, &sshErr) {
+			logging.Debugf("/dev/vda4 already has the expected size, nothing to do")
+			return nil
+		}
+
+		return err
+	}
+	_, _, err := sshRunner.Run("sudo mount -o remount,rw /sysroot && sudo xfs_growfs /dev/vda4")
+	return err
+}
 func (client *client) Start(ctx context.Context, startConfig StartConfig) (*StartResult, error) {
 	telemetry.SetCPUs(ctx, startConfig.CPUs)
 	telemetry.SetMemory(ctx, uint64(startConfig.Memory)*1024*1024)
@@ -267,7 +284,7 @@ func (client *client) Start(ctx context.Context, startConfig StartConfig) (*Star
 	}
 
 	// Trigger disk resize, this will be a no-op if no disk size change is needed
-	if _, _, err = sshRunner.Run("sudo xfs_growfs / >/dev/null"); err != nil {
+	if err := growRootFileSystem(sshRunner); err != nil {
 		return nil, errors.Wrap(err, "Error updating filesystem size")
 	}
 

--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -21,7 +21,6 @@ import (
 	"github.com/code-ready/crc/pkg/crc/oc"
 	"github.com/code-ready/crc/pkg/crc/services"
 	"github.com/code-ready/crc/pkg/crc/services/dns"
-	"github.com/code-ready/crc/pkg/crc/ssh"
 	crcssh "github.com/code-ready/crc/pkg/crc/ssh"
 	"github.com/code-ready/crc/pkg/crc/systemd"
 	"github.com/code-ready/crc/pkg/crc/telemetry"
@@ -510,7 +509,7 @@ func updateSSHKeyPair(sshRunner *crcssh.Runner) error {
 
 		// Generate ssh key pair
 		logging.Info("Generating new SSH Key pair ...")
-		if err := ssh.GenerateSSHKey(constants.GetPrivateKeyPath()); err != nil {
+		if err := crcssh.GenerateSSHKey(constants.GetPrivateKeyPath()); err != nil {
 			return fmt.Errorf("Error generating ssh key pair: %v", err)
 		}
 	}

--- a/pkg/crc/ssh/ssh.go
+++ b/pkg/crc/ssh/ssh.go
@@ -86,7 +86,7 @@ func (runner *Runner) runSSHCommand(command string, runPrivate bool) (string, st
 	if err != nil {
 		return string(stdout), string(stderr), fmt.Errorf(`ssh command error:
 command : %s
-err     : %v\n`, command, err)
+err     : %w\n`, command, err)
 	}
 
 	return string(stdout), string(stderr), nil


### PR DESCRIPTION
With 4.6 bundles, /dev/vda4 was automatically extended at startup to
fill unused disk space. This no longer happens in 4.7, possibly until
https://github.com/openshift/installer/pull/4746 is fixed.
This makes the xfs_growfs call in crc ineffective, as /dev/vda4 still
has its initial size.
This commit makes crc grow the partition itself until this bug is fixed.

This fixes https://github.com/code-ready/crc/issues/2104