### PR TITLE
Issue #2112: Check VM disk size from inside the VM

### DIFF
--- a/test/integration/resize_test.go
+++ b/test/integration/resize_test.go
@@ -33,16 +33,9 @@ var _ = Describe("vary VM parameters: memory cpus, disk", func() {
 		})
 
 		It("check VM's disk size", func() {
-			switch runtime.GOOS {
-			case "linux":
-				out, err := RunOnHostWithPrivilege("virsh", "vol-info", "crc.qcow2", "--pool", "crc")
-				Expect(err).NotTo(HaveOccurred())
-				Expect(out).Should(MatchRegexp(`Capacity:[\s]*31.00 GiB`))
-			case "windows":
-				out, err := RunOnHost("powershell", "Get-VHD", "-Path", "C:/Users/crcqe/.crc/machines/crc/crc.vhdx")
-				Expect(err).NotTo(HaveOccurred())
-				Expect(out).Should(MatchRegexp(`Size[\s]*:[\s]*3328\d{7}`)) // 31GiB = 33285996544B
-			}
+			out, err := SendCommandToVM("df -h | grep sysroot")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(out).Should(MatchRegexp(`.*31G[\s].*[\s]/sysroot`))
 		})
 
 		It("stop CRC", func() {
@@ -76,16 +69,9 @@ var _ = Describe("vary VM parameters: memory cpus, disk", func() {
 		})
 
 		It("check VM's disk size", func() {
-			switch runtime.GOOS {
-			case "linux":
-				out, err := RunOnHostWithPrivilege("virsh", "vol-info", "crc.qcow2", "--pool", "crc")
-				Expect(err).NotTo(HaveOccurred())
-				Expect(out).Should(MatchRegexp(`Capacity:[\s]*40.00 GiB`))
-			case "windows":
-				out, err := RunOnHost("powershell", "Get-VHD", "-Path", "C:/Users/crcqe/.crc/machines/crc/crc.vhdx")
-				Expect(err).NotTo(HaveOccurred())
-				Expect(out).Should(MatchRegexp(`Size[\s]*:[\s]*4294\d{7}`)) // 40GiB = 42949672960B
-			}
+			out, err := SendCommandToVM("df -h | grep sysroot")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(out).Should(MatchRegexp(`.*40G[\s].*[\s]/sysroot`))
 		})
 
 		It("stop CRC", func() {
@@ -135,18 +121,13 @@ var _ = Describe("vary VM parameters: memory cpus, disk", func() {
 			Expect(out).ShouldNot(MatchRegexp(`processor[\s]*\:[\s]*4`))
 		})
 
-		It("check VM's disk size", func() {
-			switch runtime.GOOS {
-			case "linux":
-				out, err := RunOnHostWithPrivilege("virsh", "vol-info", "crc.qcow2", "--pool", "crc")
+		if runtime.GOOS != "darwin" {
+			It("check VM's disk size", func() {
+				out, err := SendCommandToVM("df -h | grep sysroot")
 				Expect(err).NotTo(HaveOccurred())
-				Expect(out).Should(MatchRegexp(`Capacity:[\s]*40.00 GiB`)) // cannot shrink
-			case "windows":
-				out, err := RunOnHost("powershell", "Get-VHD", "-Path", "C:/Users/crcqe/.crc/machines/crc/crc.vhdx")
-				Expect(err).NotTo(HaveOccurred())
-				Expect(out).Should(MatchRegexp(`Size[\s]*:[\s]*4294\d{7}`)) // 40GiB = 42949672960B; cannot shrink
-			}
-		})
+				Expect(out).Should(MatchRegexp(`.*40G[\s].*[\s]/sysroot`))
+			})
+		}
 
 		It("clean up", func() {
 			RunCRCExpectSuccess("stop", "-f")

--- a/test/integration/utilities_test.go
+++ b/test/integration/utilities_test.go
@@ -133,24 +133,6 @@ func RunCRCExpectFail(args ...string) (string, error) {
 	return stderr, nil
 }
 
-// Run command in the shell on the host (assuming linux bash)
-func RunOnHost(cmd string, args ...string) (string, error) {
-	out, err := exec.Command(cmd, args...).Output()
-	if err != nil {
-		return "", err
-	}
-	return string(out), nil
-}
-
-// Run command in the shell on the host (assuming linux bash)
-func RunOnHostWithPrivilege(args ...string) (string, error) {
-	out, err := exec.Command("sudo", args...).Output()
-	if err != nil {
-		return "", err
-	}
-	return string(out), nil
-}
-
 // Send command to CRC VM via SSH
 func SendCommandToVM(cmd string) (string, error) {
 	client := machine.NewClient(constants.DefaultName, false, crcConfig.New(crcConfig.NewEmptyInMemoryStorage()))


### PR DESCRIPTION
**Fixes:** Issue #2112 

**Relates to:** Issue #2104 

We checked the disk size through libvirt/hyper-v instead of going into the VM and getting info from there. This PR changes that. It would have caught the #2104 issue (didn't test, but pretty sure). Thanks @cfergeau for pointing this out.

## Testing
1. Should fail the resize step with e.g. release 1.23.1

## Notes
- Checked on the following platforms (even though this should be platform independent)
    - [Fedora 33](https://gist.github.com/jsliacan/b01e1df3349f82ef53dd498051792648)
    - [RHEL 8](https://crcqe-jenkins-csb-codeready.cloud.paas.psi.redhat.com/blue/organizations/jenkins/qe%2Fbundle_baremetal_rhel8-brno/detail/bundle_baremetal_rhel8-brno/133/pipeline)
    - [Win 10](https://crcqe-jenkins-csb-codeready.cloud.paas.psi.redhat.com/blue/organizations/jenkins/qe%2Fbundle_baremetal_windows10-brno/detail/bundle_baremetal_windows10-brno/166/pipeline)
    - [Mac 10.15](https://crcqe-jenkins-csb-codeready.cloud.paas.psi.redhat.com/blue/organizations/jenkins/qe%2Fbundle_baremetal_macos15-brno/detail/bundle_baremetal_macos15-brno/127/pipeline)
- Not sure if `.*` spans over multiple lines in regexp (could give false positives). [Doesn't span over newlines](https://stackoverflow.com/questions/43706322/regex-newline-and-whitespace-in-golang).
- Should we have error bars around values we check for? E.g. if looking for 41G, check 40 < x < 42? User can only enter positive ints  in GiB. So we shouldn't need +/- for robustness. And _even if_ the user could enter decimals, `df -h` most likely already rounded the value by `ceil()`. I'll leave it as it is and change it later if turns out to be unstable.