### PR TITLE
Cherry-pick of Revert "Remove tray and daemon preflight checks from experimental"

### DIFF
--- a/pkg/crc/preflight/preflight_darwin.go
+++ b/pkg/crc/preflight/preflight_darwin.go
@@ -113,7 +113,7 @@ func getAllPreflightChecks() []Check {
 	return getPreflightChecks(true, true, network.DefaultMode)
 }
 
-func getPreflightChecks(_ bool, trayAutostart bool, mode network.Mode) []Check {
+func getPreflightChecks(experimentalFeatures bool, trayAutostart bool, mode network.Mode) []Check {
 	checks := []Check{}
 
 	checks = append(checks, nonWinPreflightChecks[:]...)
@@ -121,16 +121,18 @@ func getPreflightChecks(_ bool, trayAutostart bool, mode network.Mode) []Check {
 	checks = append(checks, hyperkitPreflightChecks(mode)...)
 	checks = append(checks, dnsPreflightChecks[:]...)
 
-	if trayAutostart || mode == network.VSockMode {
+	switch mode {
+	case network.DefaultMode:
+		checks = append(checks, resolverPreflightChecks[:]...)
+	case network.VSockMode:
 		checks = append(checks, daemonSetupChecks[:]...)
 	}
 
-	if trayAutostart {
+	if experimentalFeatures && trayAutostart {
+		if mode != network.VSockMode {
+			checks = append(checks, daemonSetupChecks[:]...)
+		}
 		checks = append(checks, traySetupChecks[:]...)
-	}
-
-	if mode == network.DefaultMode {
-		checks = append(checks, resolverPreflightChecks[:]...)
 	}
 
 	checks = append(checks, bundleCheck)

--- a/pkg/crc/preflight/preflight_darwin_test.go
+++ b/pkg/crc/preflight/preflight_darwin_test.go
@@ -23,8 +23,8 @@ func TestCountPreflights(t *testing.T) {
 	assert.Len(t, getPreflightChecks(true, true, network.VSockMode), 19)
 
 	assert.Len(t, getPreflightChecks(true, false, network.VSockMode), 15)
-	assert.Len(t, getPreflightChecks(false, true, network.VSockMode), 19)
+	assert.Len(t, getPreflightChecks(false, true, network.VSockMode), 15)
 
-	assert.Len(t, getPreflightChecks(false, true, network.DefaultMode), 20)
+	assert.Len(t, getPreflightChecks(false, true, network.DefaultMode), 14)
 	assert.Len(t, getPreflightChecks(true, false, network.DefaultMode), 14)
 }


### PR DESCRIPTION
Commits come from https://github.com/code-ready/crc/pull/2049

No conflicts.