### PR TITLE
exec: Return stdout/stderr when user not in sudoers

### DIFF
--- a/pkg/os/exec.go
+++ b/pkg/os/exec.go
@@ -48,8 +48,8 @@ func RunPrivileged(reason string, cmdAndArgs ...string) (string, string, error) 
 	if err != nil {
 		return "", "", errors.New("sudo executable not found")
 	}
-	if _, _, err := run(sudo, []string{"--validate"}, map[string]string{}); err != nil {
-		return "", "", errors.New("user is not allowed to use the 'sudo' command")
+	if stdout, stderr, err := run(sudo, []string{"--validate"}, map[string]string{}); err != nil {
+		return stdout, stderr, errors.New("user is not allowed to use the 'sudo' command")
 	}
 	logging.Infof("Using root access: %s", reason)
 	return run(sudo, cmdAndArgs, map[string]string{})


### PR DESCRIPTION
Most RunPrivileged() error paths (for example in
preflight_checks_nonwin.go) print stdout/stderr when it returns an
error. If we return an empty stderr, the error message for a failed sudo
check would be:
`Unable to set ownership of /home/teuf/.crc/bin/admin-helper-linux to root:  user is not allowed to use the 'sudo' command:`
(note the trailing `:`).

Since runCmd() print stdout/stderr in debug, we could remove stderr
from the user-visible output. However, this close to the release, let's
go with a simpler fix/less invasive fix.