### PR TITLE
hyperkit: Revert back to 0.12.11 machine driver

### DIFF
--- a/pkg/crc/machine/hyperkit/constants.go
+++ b/pkg/crc/machine/hyperkit/constants.go
@@ -6,7 +6,7 @@ import "fmt"
 
 const (
 	MachineDriverCommand = "crc-driver-hyperkit"
-	MachineDriverVersion = "0.12.12"
+	MachineDriverVersion = "0.12.11"
 	HyperKitCommand      = "hyperkit"
 	HyperKitVersion      = "v0.20200224-44-gb54460"
 )


### PR DESCRIPTION
The only significant change between 0.12.11 and 0.12.12/0.12.13 is the
update of the hyperkit go module to a newer version. This has been
causing failures during QE tests because of qcow2 issues.

This commit reverts to the last known good hyperkit machine driver
version for the release.