### PR TITLE
[Integration] Testing with embedded bundle or pkg

### DIFF
--- a/test/integration/resize_test.go
+++ b/test/integration/resize_test.go
@@ -76,7 +76,11 @@ var _ = Describe("vary VM parameters: memory cpus, disk", func() {
 		It("check VM's disk size", func() {
 			out, err := SendCommandToVM("df -h | grep sysroot")
 			Expect(err).NotTo(HaveOccurred())
-			Expect(out).Should(MatchRegexp(`.*40G[\s].*[\s]/sysroot`))
+			if runtime.GOOS == "darwin" { // darwin does not support resize
+				Expect(out).Should(MatchRegexp(`.*31G[\s].*[\s]/sysroot`))
+			} else {
+				Expect(out).Should(MatchRegexp(`.*40G[\s].*[\s]/sysroot`))
+			}
 		})
 
 		It("stop CRC", func() {

--- a/test/integration/resize_test.go
+++ b/test/integration/resize_test.go
@@ -16,7 +16,12 @@ var _ = Describe("vary VM parameters: memory cpus, disk", func() {
 		})
 
 		It("start CRC", func() {
-			Expect(RunCRCExpectSuccess("start", "-b", bundlePath, "-p", pullSecretPath)).To(ContainSubstring("Started the OpenShift cluster")) // default values: "--memory", "9216", "--cpus", "4", "disk-size", "31"
+			// default values: "--memory", "9216", "--cpus", "4", "disk-size", "31"
+			if bundlePath == "embedded" {
+				Expect(RunCRCExpectSuccess("start", "-p", pullSecretPath)).To(ContainSubstring("Started the OpenShift cluster"))
+			} else {
+				Expect(RunCRCExpectSuccess("start", "-b", bundlePath, "-p", pullSecretPath)).To(ContainSubstring("Started the OpenShift cluster"))
+			}
 		})
 
 		It("check VM's memory size", func() {
@@ -48,10 +53,10 @@ var _ = Describe("vary VM parameters: memory cpus, disk", func() {
 
 		It("start CRC", func() {
 			if runtime.GOOS == "darwin" {
-				Expect(RunCRCExpectFail("start", "-b", bundlePath, "--memory", "12000", "--cpus", "6", "--disk-size", "40")).To(ContainSubstring("Disk resizing is not supported on macOS"))
-				Expect(RunCRCExpectSuccess("start", "-b", bundlePath, "--memory", "12000", "--cpus", "6")).To(ContainSubstring("Started the OpenShift cluster"))
+				Expect(RunCRCExpectFail("start", "--memory", "12000", "--cpus", "6", "--disk-size", "40")).To(ContainSubstring("Disk resizing is not supported on macOS"))
+				Expect(RunCRCExpectSuccess("start", "--memory", "12000", "--cpus", "6")).To(ContainSubstring("Started the OpenShift cluster"))
 			} else {
-				Expect(RunCRCExpectSuccess("start", "-b", bundlePath, "--memory", "12000", "--cpus", "6", "--disk-size", "40")).To(ContainSubstring("Started the OpenShift cluster"))
+				Expect(RunCRCExpectSuccess("start", "--memory", "12000", "--cpus", "6", "--disk-size", "40")).To(ContainSubstring("Started the OpenShift cluster"))
 			}
 		})
 
@@ -105,7 +110,7 @@ var _ = Describe("vary VM parameters: memory cpus, disk", func() {
 	Describe("use default values again", func() {
 
 		It("start CRC", func() {
-			Expect(RunCRCExpectSuccess("start", "-b", bundlePath)).To(ContainSubstring("Started the OpenShift cluster")) // default values: "--memory", "9216", "--cpus", "4", "disk-size", "31"
+			Expect(RunCRCExpectSuccess("start")).To(ContainSubstring("Started the OpenShift cluster")) // default values: "--memory", "9216", "--cpus", "4", "disk-size", "31"
 		})
 
 		It("check VM's memory size", func() {

--- a/test/integration/testsuite_test.go
+++ b/test/integration/testsuite_test.go
@@ -55,16 +55,12 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 
 	// bundle location
+	bundlePath = "embedded"
 	if !versionInfo.Embedded {
-		bundlePath = os.Getenv("BUNDLE_PATH") // this env var should contain location of bundle
-		if bundlePath == "" {
-			logrus.Infof("Error: You need to set BUNDLE_PATH because your binary does not contain a bundle.")
-			logrus.Infof("%v", err)
-			Expect(err).NotTo(HaveOccurred())
+		bundlePath = os.Getenv("BUNDLE_PATH") // this env var should contain location of bundle or string "embedded"
+		if bundlePath != "embedded" {         // if real bundle
+			Expect(bundlePath).To(BeAnExistingFile())
 		}
-		Expect(bundlePath).To(BeAnExistingFile()) // not checking if it's an actual bundle
-	} else {
-		bundlePath = "embedded"
 	}
 
 	// pull-secret location


### PR DESCRIPTION
Changes to integration tests needed to run downstream CI on release binary (embedded) and pkg form of CRC. I made use of the fact that on re-start one does not need to specify bundle again. 

Additional commit to remove a bug for macos test. 

Passed tests on downstream CI.