### PR TITLE
test: give more time to kubelet to restart user pods

### DIFF
--- a/test/e2e/features/story_health.feature
+++ b/test/e2e/features/story_health.feature
@@ -53,7 +53,7 @@ Feature: End-to-end health check
         Then checking that CRC is stopped
         When starting CRC with default bundle succeeds
         Then checking that CRC is running
-        And with up to "2" retries with wait period of "1m" http response from "http://httpd-example-testproj.apps-crc.testing" has status code "200"
+        And with up to "4" retries with wait period of "1m" http response from "http://httpd-example-testproj.apps-crc.testing" has status code "200"
 
     @darwin @linux @windows
     Scenario: Switch off CRC


### PR DESCRIPTION
Even though crc is running, this doesn't mean user pods are running.
crc only waits for cluster operators to be stable.

This should help for this kind of failure: https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/code-ready_crc/2140/pull-ci-code-ready-crc-master-e2e-crc/1374587957696008192