### PR TITLE
Correctly retry on error. Without the pointer, it doesn't retry at all.

### DIFF
--- a/pkg/crc/errors/multierror.go
+++ b/pkg/crc/errors/multierror.go
@@ -77,7 +77,7 @@ type RetriableError struct {
 	Err error
 }
 
-func (r RetriableError) Error() string {
+func (r *RetriableError) Error() string {
 	return "Temporary error: " + r.Err.Error()
 }
 

--- a/pkg/crc/machine/bundle/repository.go
+++ b/pkg/crc/machine/bundle/repository.go
@@ -124,7 +124,7 @@ func (repo *Repository) Extract(path string) error {
 	bundleDir := strings.TrimSuffix(bundleName, bundleExtension)
 	return crcerrors.RetryAfter(time.Minute, func() error {
 		if err := os.Rename(filepath.Join(tmpDir, bundleDir), filepath.Join(repo.CacheDir, bundleDir)); err != nil {
-			return crcerrors.RetriableError{Err: err}
+			return &crcerrors.RetriableError{Err: err}
 		}
 		return nil
 	}, 5*time.Second)

--- a/pkg/libmachine/host/host.go
+++ b/pkg/libmachine/host/host.go
@@ -97,7 +97,7 @@ func MachineInState(d drivers.Driver, desiredState state.State) func() error {
 		if currentState == desiredState {
 			return nil
 		}
-		return crcerrors.RetriableError{
+		return &crcerrors.RetriableError{
 			Err: fmt.Errorf("expected machine state %s, got %s", desiredState.String(), currentState.String()),
 		}
 	}


### PR DESCRIPTION
RetryAfter() is running this check:
if _, ok := err.(*RetriableError); !ok {
}
