### PR TITLE
[E2E] Fix expected output on e2e setup scenario for windows

### DIFF
--- a/test/e2e/features/basic.feature
+++ b/test/e2e/features/basic.feature
@@ -70,7 +70,7 @@ Feature: Basic test
     @windows
     Scenario: CRC setup on Windows
         When executing "crc setup" succeeds
-        Then stderr should contain "Unpacking bundle from the CRC executable" if bundle is embedded
+        Then stderr should contain "Extracting bundle from the CRC executable" if bundle is embedded
         Then stderr should contain "Checking Windows 10 release"
         Then stderr should contain "Checking if Hyper-V is installed"
         Then stderr should contain "Checking if user is a member of the Hyper-V Administrators group"


### PR DESCRIPTION
This fix the expected output for bundle extraction when bundle is embedded during the setup scenario on Windows.

The pipeline execution for this PR can be checked at [downstream CI](https://crcqe-jenkins-csb-codeready.cloud.paas.psi.redhat.com/view/qe-crc-baremetal/job/qe/job/crc_executable_baremetal_windows10-brno/35/)
