### PR TITLE
Ask the user to stop the application before updating

### DIFF
--- a/packaging/darwin/Distribution.in
+++ b/packaging/darwin/Distribution.in
@@ -10,6 +10,14 @@
     <installation-check script="installCheck();"/>
     <script>
 function installCheck() {
+	var apps = system.applications.fromIdentifier('com.redhat.codeready.containers');
+	if(apps) {
+        my.result.title = 'Update failed';
+        my.result.message = 'CodeReady Containers is running. Please stop the application before updating.';
+        my.result.type = 'Fatal';
+        return false;
+	}
+
     if(!(system.compareVersions(system.version.ProductVersion, '10.14.0') >= 0)) {
         my.result.title = 'Unable to install';
         my.result.message = 'CodeReady Containers requires macOS 10.14 or later.';


### PR DESCRIPTION
It’s better to ask the user to shutdown the application before upgrading.
    
Hyperkit or crc CLI still can be running.
    
This is important to have this when changing the path of the application from
`/Library/CodeReady Containers/1.24.0/` to `/Applications/CodeReady Containers`.
We will only have one copy of the application at the same time.

<img width="732" alt="Screenshot 2021-03-29 at 09 06 19" src="https://user-images.githubusercontent.com/172624/112800162-93c71700-906f-11eb-89ef-41ff7f84677d.png">
