### PR TITLE
Change install path of crc to /Applications/CodeReady Containers.app

### DIFF
--- a/packaging/.gitignore
+++ b/packaging/.gitignore
@@ -4,3 +4,4 @@ root/
 /darwin/Resources/LICENSE.txt
 /darwin/Resources/welcome.html
 /darwin/scripts/postinstall
+/VERSION

--- a/packaging/darwin/postinstall.in
+++ b/packaging/darwin/postinstall.in
@@ -1,10 +1,10 @@
 #!/bin/bash
 set -e
 
-chmod 755 "__INSTALL_PATH__"/__VERSION__/crc
+chmod 755 "__INSTALL_PATH__"/crc
 
 [ -d /usr/local/bin ] || mkdir /usr/local/bin
 
 rm -f /usr/local/bin/crc
 
-ln -s "__INSTALL_PATH__"/__VERSION__/crc /usr/local/bin/crc
+ln -s "__INSTALL_PATH__"/crc /usr/local/bin/crc

--- a/packaging/package.sh
+++ b/packaging/package.sh
@@ -19,17 +19,19 @@ function sign() {
   codesign --deep --sign "${CODESIGN_IDENTITY}" --options runtime --force ${opts} "$1"
 }
 
-version=$(ls "${BASEDIR}/root/Library/CodeReady Containers/")
+binDir="${BASEDIR}/root/Applications/CodeReady Containers.app/Contents/Resources"
 
-binDir="${BASEDIR}/root/Library/CodeReady Containers/${version}"
+version=$(cat "${BASEDIR}/VERSION")
+
 sign "${binDir}/crc"
 sign "${binDir}/admin-helper-darwin"
 sign "${binDir}/crc-driver-hyperkit"
-sign "${binDir}/CodeReady Containers.app"
+
+sign "${BASEDIR}/root/Applications/CodeReady Containers.app"
 
 codesign --verify --verbose "${binDir}/hyperkit"
 
-pkgbuild --identifier com.redhat.crc.${version} --version ${version} \
+pkgbuild --identifier com.redhat.crc --version ${version} \
   --scripts "${BASEDIR}/darwin/scripts" \
   --root "${BASEDIR}/root" \
   --install-location / \

--- a/pkg/crc/constants/constants.go
+++ b/pkg/crc/constants/constants.go
@@ -106,7 +106,7 @@ var (
 
 func defaultBundlePath() string {
 	if runtime.GOOS == "darwin" && version.IsMacosInstallPathSet() {
-		path := filepath.Join(version.GetMacosInstallPath(), version.GetCRCVersion(), GetDefaultBundle())
+		path := filepath.Join(version.GetMacosInstallPath(), GetDefaultBundle())
 		if _, err := os.Stat(path); err == nil {
 			return path
 		}

--- a/pkg/crc/constants/constants_darwin.go
+++ b/pkg/crc/constants/constants_darwin.go
@@ -23,7 +23,7 @@ var (
 
 func trayAppBundlePath() string {
 	if version.IsMacosInstallPathSet() {
-		path := filepath.Join(version.GetMacosInstallPath(), version.GetCRCVersion(), TrayExecutableName)
+		path := filepath.Join(filepath.Dir(filepath.Dir(version.GetMacosInstallPath())), TrayExecutableName)
 		if _, err := os.Stat(path); err == nil {
 			return path
 		}

--- a/pkg/embed/embed.go
+++ b/pkg/embed/embed.go
@@ -14,7 +14,7 @@ import (
 
 func openEmbeddedFile(executablePath, embedName string) (io.ReadCloser, error) {
 	if runtime.GOOS == "darwin" && version.IsMacosInstallPathSet() {
-		path := filepath.Join(version.GetMacosInstallPath(), version.GetCRCVersion(), embedName)
+		path := filepath.Join(version.GetMacosInstallPath(), embedName)
 		if _, err := os.Stat(path); err == nil {
 			return os.Open(path)
 		}


### PR DESCRIPTION
Requires https://github.com/code-ready/tray-macos/pull/91

It uses the tray as a conveyor for the full crc application.
Everything is installed in /Applications/CodeReady Containers.app.
If the user wants to uninstall the app, he just has to drag and drop the
app in the trash (after running crc cleanup).

When upgrading, all files will be replaced with newer. There is no more
one directory per version.

