### PR TITLE
Add --check-only to crc setup

### DIFF
--- a/cmd/crc/cmd/setup_test.go
+++ b/cmd/crc/cmd/setup_test.go
@@ -14,7 +14,7 @@ func TestSetupRenderActionPlainSuccess(t *testing.T) {
 	assert.NoError(t, render(&setupResult{
 		Success: true,
 	}, out, ""))
-	assert.Equal(t, "Setup is complete, you can now run 'crc start -b $bundlename' to start the OpenShift cluster\n", out.String())
+	assert.Equal(t, "Your system is correctly setup for using CodeReady Containers, you can now run 'crc start -b $bundlename' to start the OpenShift cluster\n", out.String())
 }
 
 func TestSetupRenderActionPlainFailure(t *testing.T) {

--- a/test/e2e/features/basic.feature
+++ b/test/e2e/features/basic.feature
@@ -38,7 +38,8 @@ Feature: Basic test
 
     @linux
     Scenario: CRC setup on Linux
-        When executing "crc setup" succeeds
+        When executing "crc setup --check-only" fails
+        And executing "crc setup" succeeds
         And stderr should contain "Checking if CRC bundle is extracted in '$HOME/.crc'"
         And stderr should contain "Checking if running as non-root"
         And stderr should contain "Checking if Virtualization is enabled"
@@ -53,12 +54,13 @@ Feature: Basic test
         And stderr should contain "Checking if NetworkManager service is running"
         And stderr should contain "Using root access: Executing systemctl daemon-reload command"
         And stderr should contain "Using root access: Executing systemctl reload NetworkManager"
-        And stdout should contain "Setup is complete, you can now run 'crc start -b $bundlename' to start the OpenShift cluster" if bundle is not embedded
-        And stdout should contain "Setup is complete, you can now run 'crc start' to start the OpenShift cluster" if bundle is embedded
+        And stdout should contain "Your system is correctly setup for using CodeReady Containers, you can now run 'crc start -b $bundlename' to start the OpenShift cluster" if bundle is not embedded
+        And stdout should contain "Your system is correctly setup for using CodeReady Containers, you can now run 'crc start' to start the OpenShift cluster" if bundle is embedded
 
     @darwin
     Scenario: CRC setup on Mac
-        When executing "crc setup" succeeds
+        When executing "crc setup --check-only" fails
+        And executing "crc setup" succeeds
         And stderr should contain "Checking if running as non-root"
         And stderr should contain "Checking if HyperKit is installed"
         And stderr should contain "Checking if crc-driver-hyperkit is installed"

--- a/test/integration/resize_test.go
+++ b/test/integration/resize_test.go
@@ -12,7 +12,7 @@ var _ = Describe("vary VM parameters: memory cpus, disk", func() {
 	Describe("use default values", func() {
 
 		It("setup CRC", func() {
-			Expect(RunCRCExpectSuccess("setup")).To(ContainSubstring("Setup is complete"))
+			Expect(RunCRCExpectSuccess("setup")).To(ContainSubstring("Your system is correctly setup for using CodeReady Containers"))
 		})
 
 		It("start CRC", func() {


### PR DESCRIPTION
This adds a way of checking if `crc setup` has to be run before `crc
start` can be called:

$ ./crc setup --check-only
INFO Checking if running as non-root
INFO Checking if podman remote executable is cached
INFO Checking if admin-helper executable is cached
admin-helper executable is not cached

$ echo $?
2

$ ./crc setup --check-only -ojson
INFO Checking if running as non-root
INFO Checking if podman remote executable is cached
INFO Checking if admin-helper executable is cached
{
  "success": false,
  "error": "admin-helper executable is not cached"
}

$ echo $?
0

This should fix https://github.com/code-ready/crc/issues/2170