### PR TITLE
bump hyperkit and libvirt driver to version 0.13.0

### DIFF
--- a/pkg/crc/machine/hyperkit/constants.go
+++ b/pkg/crc/machine/hyperkit/constants.go
@@ -6,7 +6,7 @@ import "fmt"
 
 const (
 	MachineDriverCommand = "crc-driver-hyperkit"
-	MachineDriverVersion = "0.12.14"
+	MachineDriverVersion = "0.13.0"
 	HyperKitCommand      = "hyperkit"
 	HyperKitVersion      = "v0.20200224-44-gb54460"
 )

--- a/pkg/crc/machine/libvirt/constants.go
+++ b/pkg/crc/machine/libvirt/constants.go
@@ -16,7 +16,7 @@ const (
 
 const (
 	MachineDriverCommand = "crc-driver-libvirt"
-	MachineDriverVersion = "0.12.15"
+	MachineDriverVersion = "0.13.0"
 )
 
 var (


### PR DESCRIPTION
https://github.com/code-ready/machine-driver-hyperkit/releases/tag/v0.13.0

https://github.com/code-ready/machine-driver-libvirt/releases/tag/0.13.0