### PR TITLE
Bump macOS tray to 1.0.6

### DIFF
--- a/pkg/crc/version/version.go
+++ b/pkg/crc/version/version.go
@@ -29,7 +29,7 @@ var (
 const (
 	releaseInfoLink = "https://mirror.openshift.com/pub/openshift-v4/clients/crc/latest/release-info.json"
 	// Tray version to be embedded in executable
-	crcMacTrayVersion = "1.0.5"
+	crcMacTrayVersion = "1.0.6"
 	// Windows forms application version type major.minor.buildnumber.revesion
 	crcWindowsTrayVersion = "0.4.0.0"
 )


### PR DESCRIPTION
https://github.com/code-ready/tray-macos/releases/tag/v1.0.6

