### PR TITLE
Ignore clean host file error in case admin helper binary is not present

### DIFF
--- a/pkg/crc/preflight/preflight_checks_nonwin.go
+++ b/pkg/crc/preflight/preflight_checks_nonwin.go
@@ -23,7 +23,7 @@ var nonWinPreflightChecks = [...]Check{
 	},
 	{
 		cleanupDescription: "Removing hosts file records added by CRC",
-		cleanup:            adminhelper.CleanHostsFile,
+		cleanup:            removeHostsFileEntry,
 		flags:              CleanUpOnly,
 	},
 }
@@ -66,4 +66,12 @@ func checkSuid(path string) error {
 	}
 
 	return nil
+}
+
+func removeHostsFileEntry() error {
+	err := adminhelper.CleanHostsFile()
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	return err
 }

--- a/pkg/crc/preflight/preflight_linux_test.go
+++ b/pkg/crc/preflight/preflight_linux_test.go
@@ -5,7 +5,6 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/code-ready/crc/pkg/crc/adminhelper"
 	"github.com/code-ready/crc/pkg/crc/cluster"
 	"github.com/code-ready/crc/pkg/crc/config"
 	"github.com/code-ready/crc/pkg/crc/network"
@@ -64,7 +63,7 @@ var checkListForDistros = []checkListForDistro{
 		systemdResolved: true,
 		checks: []Check{
 			{check: checkIfRunningAsNormalUser},
-			{cleanup: adminhelper.CleanHostsFile},
+			{cleanup: removeHostsFileEntry},
 			{check: checkPodmanExecutableCached},
 			{check: checkAdminHelperExecutableCached},
 			{configKeySuffix: "check-ram"},
@@ -97,7 +96,7 @@ var checkListForDistros = []checkListForDistro{
 		systemdResolved: false,
 		checks: []Check{
 			{check: checkIfRunningAsNormalUser},
-			{cleanup: adminhelper.CleanHostsFile},
+			{cleanup: removeHostsFileEntry},
 			{check: checkPodmanExecutableCached},
 			{check: checkAdminHelperExecutableCached},
 			{configKeySuffix: "check-ram"},
@@ -129,7 +128,7 @@ var checkListForDistros = []checkListForDistro{
 		systemdResolved: false,
 		checks: []Check{
 			{check: checkIfRunningAsNormalUser},
-			{cleanup: adminhelper.CleanHostsFile},
+			{cleanup: removeHostsFileEntry},
 			{check: checkPodmanExecutableCached},
 			{check: checkAdminHelperExecutableCached},
 			{configKeySuffix: "check-ram"},
@@ -156,7 +155,7 @@ var checkListForDistros = []checkListForDistro{
 		systemdResolved: true,
 		checks: []Check{
 			{check: checkIfRunningAsNormalUser},
-			{cleanup: adminhelper.CleanHostsFile},
+			{cleanup: removeHostsFileEntry},
 			{check: checkPodmanExecutableCached},
 			{check: checkAdminHelperExecutableCached},
 			{configKeySuffix: "check-ram"},
@@ -189,7 +188,7 @@ var checkListForDistros = []checkListForDistro{
 		systemdResolved: false,
 		checks: []Check{
 			{check: checkIfRunningAsNormalUser},
-			{cleanup: adminhelper.CleanHostsFile},
+			{cleanup: removeHostsFileEntry},
 			{check: checkPodmanExecutableCached},
 			{check: checkAdminHelperExecutableCached},
 			{configKeySuffix: "check-ram"},
@@ -221,7 +220,7 @@ var checkListForDistros = []checkListForDistro{
 		systemdResolved: false,
 		checks: []Check{
 			{check: checkIfRunningAsNormalUser},
-			{cleanup: adminhelper.CleanHostsFile},
+			{cleanup: removeHostsFileEntry},
 			{check: checkPodmanExecutableCached},
 			{check: checkAdminHelperExecutableCached},
 			{configKeySuffix: "check-ram"},
@@ -248,7 +247,7 @@ var checkListForDistros = []checkListForDistro{
 		systemdResolved: true,
 		checks: []Check{
 			{check: checkIfRunningAsNormalUser},
-			{cleanup: adminhelper.CleanHostsFile},
+			{cleanup: removeHostsFileEntry},
 			{check: checkPodmanExecutableCached},
 			{check: checkAdminHelperExecutableCached},
 			{configKeySuffix: "check-ram"},
@@ -281,7 +280,7 @@ var checkListForDistros = []checkListForDistro{
 		systemdResolved: false,
 		checks: []Check{
 			{check: checkIfRunningAsNormalUser},
-			{cleanup: adminhelper.CleanHostsFile},
+			{cleanup: removeHostsFileEntry},
 			{check: checkPodmanExecutableCached},
 			{check: checkAdminHelperExecutableCached},
 			{configKeySuffix: "check-ram"},
@@ -313,7 +312,7 @@ var checkListForDistros = []checkListForDistro{
 		systemdResolved: false,
 		checks: []Check{
 			{check: checkIfRunningAsNormalUser},
-			{cleanup: adminhelper.CleanHostsFile},
+			{cleanup: removeHostsFileEntry},
 			{check: checkPodmanExecutableCached},
 			{check: checkAdminHelperExecutableCached},
 			{configKeySuffix: "check-ram"},
@@ -340,7 +339,7 @@ var checkListForDistros = []checkListForDistro{
 		systemdResolved: true,
 		checks: []Check{
 			{check: checkIfRunningAsNormalUser},
-			{cleanup: adminhelper.CleanHostsFile},
+			{cleanup: removeHostsFileEntry},
 			{check: checkPodmanExecutableCached},
 			{check: checkAdminHelperExecutableCached},
 			{configKeySuffix: "check-ram"},
@@ -374,7 +373,7 @@ var checkListForDistros = []checkListForDistro{
 		systemdResolved: false,
 		checks: []Check{
 			{check: checkIfRunningAsNormalUser},
-			{cleanup: adminhelper.CleanHostsFile},
+			{cleanup: removeHostsFileEntry},
 			{check: checkPodmanExecutableCached},
 			{check: checkAdminHelperExecutableCached},
 			{configKeySuffix: "check-ram"},
@@ -407,7 +406,7 @@ var checkListForDistros = []checkListForDistro{
 		systemdResolved: false,
 		checks: []Check{
 			{check: checkIfRunningAsNormalUser},
-			{cleanup: adminhelper.CleanHostsFile},
+			{cleanup: removeHostsFileEntry},
 			{check: checkPodmanExecutableCached},
 			{check: checkAdminHelperExecutableCached},
 			{configKeySuffix: "check-ram"},


### PR DESCRIPTION
If a user downlond the crc and execute `crc cleanup` as first command
it will fail with following error because there is no admin-helper
binary present.
```
fork/exec Users/crcqe/.crc/bin/admin-helper-darwin: no such file or directory
fork/exec /Users/crcqe/.crc/bin/admin-helper-darwin: no such file or directory
```

This patch validate the error and if it is because of file not present
the ignore that host file cleanup.

fixes: #2188
