### PR TITLE
[E2E] Fix cleanup expected output on MacOS to common minimum expected information

### DIFF
--- a/test/e2e/features/basic.feature
+++ b/test/e2e/features/basic.feature
@@ -157,13 +157,11 @@ Feature: Basic test
     @darwin
     Scenario Outline: CRC clean-up
         When executing "crc cleanup" succeeds
-        Then stderr should contain "Unload CodeReady Containers tray"
+        Then stderr should contain "Removing /etc/resolver/testing file"
         And stderr should contain "Unload CodeReady Containers daemon"
-        And stderr should contain "Removing launchd configuration for tray"
-        And stderr should contain "Removing launchd configuration for daemon"
-        And stderr should contain "Removing /etc/resolver/testing file"
-        And stderr should contain "Using root access: Removing file /etc/resolver/testing"
+        And stderr should contain "Removing pull secret from the keyring"
         And stdout should contain "Cleanup finished"
+
 
     @linux
     Scenario Outline: CRC clean-up


### PR DESCRIPTION
Related to #2195

This is a patch for checking minimum expected output from cleanup command on MacOS, as described on the related issue the output differs depending on the crc distribution used on MacOS. This patch will cover the output for binary distribution and most of pkg.

Also this modification is required due to new mechanism to handle daemon process. So now this process is not handle by launchd.

Pkg clean up command will be tested from ux / installer feature and it will check beyond the output the right expected state for the host (no tray process, no hyperkit, ...) 

The [run](https://crcqe-jenkins-csb-codeready.cloud.paas.psi.redhat.com/blue/organizations/jenkins/qe%2Fbundle_baremetal_macos15-brno/detail/bundle_baremetal_macos15-brno/168/pipeline/) for this PR can be checked on our downstream CI 
