### PR TITLE
Fix kubeconfig update on restarts

### DIFF
--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -407,7 +407,9 @@ func (client *client) Start(ctx context.Context, startConfig types.StartConfig) 
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to update kubeadmin user password")
 	}
-	clusterConfig.KubeAdminPass = kubeAdminPassword
+	if kubeAdminPassword != "" {
+		clusterConfig.KubeAdminPass = kubeAdminPassword
+	}
 
 	if err := cluster.EnsureClusterIDIsNotEmpty(ocConfig); err != nil {
 		return nil, errors.Wrap(err, "Failed to update cluster ID")


### PR DESCRIPTION
Since `Simplify kubeadmin renewal code`, running `crc start && crc stop
&& crc start` displays:

INFO Adding crc-admin and crc-developer contexts to kubeconfig...
ERRO Cannot update kubeconfig: challenger chose not to retry the request

This is because on the 2nd start, we mistakenly set
`clusterConfig.KubeAdminPass` to ""  after calling
`UpdateKubeAdminUserPassword`.
This commit fixes this by adding a check that the kubeadmin password was
actually changed (its value is non-empty) before modifying its value in
`clusterConfig`