### PR TITLE
Fix kubeconfig update on restarts

### DIFF
--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -403,11 +403,13 @@ func (client *client) Start(ctx context.Context, startConfig types.StartConfig) 
 		return nil, errors.Wrap(err, "Failed to update cluster pull secret")
 	}
 
-	kubeAdminPassword, err := cluster.UpdateKubeAdminUserPassword(ocConfig)
-	if err != nil {
+	if err := cluster.UpdateKubeAdminUserPassword(ocConfig); err != nil {
 		return nil, errors.Wrap(err, "Failed to update kubeadmin user password")
 	}
-	clusterConfig.KubeAdminPass = kubeAdminPassword
+	clusterConfig.KubeAdminPass, err = cluster.GetKubeadminPassword(crcBundleMetadata)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to get kubeadmin user password")
+	}
 
 	if err := cluster.EnsureClusterIDIsNotEmpty(ocConfig); err != nil {
 		return nil, errors.Wrap(err, "Failed to update cluster ID")


### PR DESCRIPTION
Since f974ac2f, running crc start && crc stop &&
crc start displays:

INFO Adding crc-admin and crc-developer contexts to kubeconfig...
ERRO Cannot update kubeconfig: challenger chose not to retry the request

This is because on the 2nd start, we mistakenly set
clusterConfig.KubeAdminPass to "" after calling
UpdateKubeAdminUserPassword.

This patch will make sure that UpdateKubeadminUserPassword will just
do the update of password and not return the updated password instead
use 'GetKubeadminPassword' for getting the password which always
provides correct password for kubeadmin user.

fixes: #2199