### PR TITLE
pkg: remove destination select step

### DIFF
--- a/packaging/darwin/Distribution.in
+++ b/packaging/darwin/Distribution.in
@@ -7,6 +7,7 @@
     <license file="LICENSE.txt"/>
     <options customize="never" allow-external-scripts="no"/>
     <domains enable_localSystem="true" />
+    <options rootVolumeOnly="true"/>
     <installation-check script="installCheck();"/>
     <script>
 function installCheck() {


### PR DESCRIPTION
Application path is set at compilation time and cannot be changed. If the user
moves the application, crc won’t be able to find helper binaries, etc.

This option disables the select destination menu as per:
https://stackoverflow.com/questions/16458656/disable-change-install-location-button-in-installer-created-using-productbu

Fix https://github.com/code-ready/crc/issues/2190
