### PR TITLE
[Segment] Capture SSH_TTY env

### DIFF
--- a/pkg/crc/segment/segment.go
+++ b/pkg/crc/segment/segment.go
@@ -85,7 +85,8 @@ func (c *Client) Upload(ctx context.Context, action string, duration time.Durati
 	properties = properties.Set("version", version.GetCRCVersion()).
 		Set("success", err == nil).
 		Set("duration", duration.Milliseconds()).
-		Set("tty", crcos.RunningInTerminal())
+		Set("tty", crcos.RunningInTerminal()).
+		Set("remote", crcos.RunningUsingSSH())
 	if err != nil {
 		properties = properties.Set("error", telemetry.SetError(err)).
 			Set("error-type", errorType(err))

--- a/pkg/crc/segment/segment_test.go
+++ b/pkg/crc/segment/segment_test.go
@@ -35,6 +35,7 @@ type segmentResponse struct {
 			ErrorType string `json:"error-type"`
 			Version   string `json:"version"`
 			CPUs      int    `json:"cpus"`
+			Remote    bool   `json:"remote"`
 		} `json:"properties"`
 		Type string `json:"type"`
 	} `json:"batch"`
@@ -76,6 +77,9 @@ func TestClientUploadWithConsentAndWithSerializableError(t *testing.T) {
 	defer server.Close()
 	defer close(body)
 
+	require.NoError(t, os.Setenv("SSH_TTY", "test"))
+	defer os.Unsetenv("SSH_TTY")
+
 	dir, err := ioutil.TempDir("", "cfg")
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
@@ -107,6 +111,7 @@ func TestClientUploadWithConsentAndWithSerializableError(t *testing.T) {
 		require.Equal(t, s.Batch[1].Properties.Error, crcErr.VMNotExist.Error())
 		require.Equal(t, s.Batch[1].Properties.ErrorType, "errors.vmNotExist")
 		require.Equal(t, s.Batch[1].Properties.Version, version.GetCRCVersion())
+		require.Equal(t, s.Batch[1].Properties.Remote, true)
 	default:
 		require.Fail(t, "server should receive data")
 	}
@@ -141,6 +146,7 @@ func TestClientUploadWithConsentAndWithoutSerializableError(t *testing.T) {
 		require.Equal(t, s.Batch[1].Properties.Error, "an error occurred")
 		require.Equal(t, s.Batch[1].Properties.ErrorType, "*errors.errorString")
 		require.Equal(t, s.Batch[1].Properties.Version, version.GetCRCVersion())
+		require.Equal(t, s.Batch[1].Properties.Remote, false)
 	default:
 		require.Fail(t, "server should receive data")
 	}

--- a/pkg/os/util.go
+++ b/pkg/os/util.go
@@ -115,3 +115,7 @@ func RemoveFileIfExists(path string) error {
 func RunningInTerminal() bool {
 	return terminal.IsTerminal(int(os.Stdin.Fd()))
 }
+
+func RunningUsingSSH() bool {
+	return os.Getenv("SSH_TTY") != ""
+}

--- a/usage-data.adoc
+++ b/usage-data.adoc
@@ -20,6 +20,7 @@ The following table describes the opt-in usage data collected by CodeReady Conta
 |                  | Experimental features       | true/false
 |                  | tty                         | true/false
 |                  | duration                    |
+|                  | remotely connected with SSH | true/false
 
 |*Config*          | Num of CPUs                 | 
 |                  | Memory size                 |


### PR DESCRIPTION
This patch captures following scenario and set true for `SSH_TTY` which
able to provide us bit detail around how many user are using crc on
remote host.
- User ssh to a remote box
- User run `crc` commands from that box

fixes #2204
