### PR TITLE
start: Add log with VM's IP when it started

### DIFF
--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -277,6 +277,7 @@ func (client *client) Start(ctx context.Context, startConfig types.StartConfig) 
 	if err != nil {
 		return nil, errors.Wrap(err, "Error getting the IP")
 	}
+	logging.Infof("CodeReady Containers instance is running with IP %s", instanceIP)
 	sshRunner, err := crcssh.CreateRunner(instanceIP, getSSHPort(client.useVSock()), crcBundleMetadata.GetSSHKeyPath(), constants.GetPrivateKeyPath(), constants.GetRsaPrivateKeyPath())
 	if err != nil {
 		return nil, errors.Wrap(err, "Error creating the ssh client")


### PR DESCRIPTION
This can be useful to detect some `crc start` issues early, and is not
always present in the debug log at the moment.

This is related to https://github.com/code-ready/crc/issues/2214