### PR TITLE
Prettify data usage doc

### DIFF
--- a/usage-data.adoc
+++ b/usage-data.adoc
@@ -4,25 +4,25 @@ The following table describes the opt-in usage data collected by CodeReady Conta
 
 .Data points
 |===
-|Occasion          | Data                        | Type 
+|Occasion          | Data                         | Type 
 
-|*Install*         |Host OS                      |
-|                  |Host OS version              |
-|                  |CodeReady Containers version |
+|*Install*         | Host OS                      |
+|                  | Host OS version              |
+|                  | CodeReady Containers version |
 
-|*Setup*           | Error message               |
-|                  | Error type                  |
-|                  | First time run              | true/false
-|*Cluster startup* | Error message               |
-|                  | Proxy                       | true/false
-|                  | Network mode                | vsock/default
-|                  | Cluster monitoring          | true/false
-|                  | Experimental features       | true/false
-|                  | tty                         | true/false
-|                  | duration                    |
-|                  | remotely connected with SSH | true/false
+|*Setup*           | Error message                |
+|                  | Error type                   |
+|                  | First time run               | true/false
+|*Cluster startup* | Error message                |
+|                  | Proxy                        | true/false
+|                  | Network mode                 | vsock/default
+|                  | Cluster monitoring           | true/false
+|                  | Experimental features        | true/false
+|                  | Running from command line    | true/false
+|                  | Duration                     |
+|                  | Remotely connected with SSH  | true/false
 
-|*Config*          | Num of CPUs                 | 
-|                  | Memory size                 |
-|                  | Disk size                   |
+|*Config*          | Num of CPUs                  | 
+|                  | Memory size                  |
+|                  | Disk size                    |
 |===


### PR DESCRIPTION
Use friendly descriptions and keep capitalization consistent. E.g. instead of `tty` write what we aim to collect. 
