### PR TITLE
Proposition: use Ginkgo to run monitoring pipeline

### DIFF
--- a/test/integration/monitoring_test.go
+++ b/test/integration/monitoring_test.go
@@ -29,6 +29,6 @@ var _ = Describe("run openshift with monitoring stack", func() {
 	It("collect pods usage", func() {
 		stdout, _, err := Exec(exec.Command("oc", "adm", "top", "pods", "-A"), nil)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(ioutil.WriteFile(filepath.Join("out", "oc-adm-top-pods.txt"), []byte(stdout), 0600)).To(Succeed())
+		Expect(ioutil.WriteFile(filepath.Join(outputDirectory, "oc-adm-top-pods.txt"), []byte(stdout), 0600)).To(Succeed())
 	})
 })

--- a/test/integration/monitoring_test.go
+++ b/test/integration/monitoring_test.go
@@ -1,0 +1,34 @@
+package integration_test
+
+import (
+	"io/ioutil"
+	"os/exec"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("run openshift with monitoring stack", func() {
+	BeforeAll(cleanUp())
+
+	It("setup CRC", func() {
+		RunCRCExpectSuccess("config", "set", "memory", "16000")
+		RunCRCExpectSuccess("config", "set", "enable-cluster-monitoring", "true")
+		Expect(RunCRCExpectSuccess("setup")).To(ContainSubstring("Your system is correctly setup for using CodeReady Containers"))
+	})
+
+	It("start CRC", func() {
+		if bundlePath == "embedded" {
+			Expect(RunCRCExpectSuccess("start", "-p", pullSecretPath)).To(ContainSubstring("Started the OpenShift cluster"))
+		} else {
+			Expect(RunCRCExpectSuccess("start", "-b", bundlePath, "-p", pullSecretPath)).To(ContainSubstring("Started the OpenShift cluster"))
+		}
+	})
+
+	It("collect pods usage", func() {
+		stdout, _, err := Exec(exec.Command("oc", "adm", "top", "pods", "-A"), nil)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(ioutil.WriteFile(filepath.Join("out", "oc-adm-top-pods.txt"), []byte(stdout), 0600)).To(Succeed())
+	})
+})

--- a/test/integration/resize_test.go
+++ b/test/integration/resize_test.go
@@ -11,7 +11,6 @@ var _ = Describe("vary VM parameters: memory cpus, disk", func() {
 	BeforeAll(cleanUp())
 
 	Describe("use default values", func() {
-
 		It("setup CRC", func() {
 			Expect(RunCRCExpectSuccess("setup")).To(ContainSubstring("Your system is correctly setup for using CodeReady Containers"))
 		})
@@ -47,11 +46,9 @@ var _ = Describe("vary VM parameters: memory cpus, disk", func() {
 		It("stop CRC", func() {
 			Expect(RunCRCExpectSuccess("stop", "-f")).To(ContainSubstring("Stopped the OpenShift cluster"))
 		})
-
 	})
 
 	Describe("use custom values", func() {
-
 		It("start CRC", func() {
 			if runtime.GOOS == "darwin" {
 				Expect(RunCRCExpectFail("start", "--memory", "12000", "--cpus", "6", "--disk-size", "40")).To(ContainSubstring("Disk resizing is not supported on macOS"))
@@ -90,13 +87,14 @@ var _ = Describe("vary VM parameters: memory cpus, disk", func() {
 	})
 
 	Describe("use flawed values", func() {
-
 		It("start CRC with sub-minimum memory", func() { // less than min = 9216
 			Expect(RunCRCExpectFail("start", "--memory", "9000")).To(ContainSubstring("requires memory in MiB >= 9216"))
 		})
+
 		It("start CRC with sub-minimum cpus", func() { // fewer than min
 			Expect(RunCRCExpectFail("start", "--cpus", "3")).To(ContainSubstring("requires CPUs >= 4"))
 		})
+
 		It("start CRC with smaller disk", func() { // bigger than default && smaller than current
 			switch runtime.GOOS {
 			case "darwin":
@@ -107,13 +105,13 @@ var _ = Describe("vary VM parameters: memory cpus, disk", func() {
 				Expect(RunCRCExpectFail("start", "--disk-size", "35")).To(ContainSubstring("Failed to set disk size to"))
 			}
 		})
+
 		It("start CRC with sub-minimum disk", func() { // smaller than min = default = 31GiB
 			Expect(RunCRCExpectFail("start", "--disk-size", "30")).To(ContainSubstring("requires disk size in GiB >= 31")) // TODO: message should be different on macOS!
 		})
 	})
 
 	Describe("use default values again", func() {
-
 		It("start CRC", func() {
 			Expect(RunCRCExpectSuccess("start")).To(ContainSubstring("Started the OpenShift cluster")) // default values: "--memory", "9216", "--cpus", "4", "disk-size", "31"
 		})

--- a/test/integration/resize_test.go
+++ b/test/integration/resize_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 var _ = Describe("vary VM parameters: memory cpus, disk", func() {
+	BeforeAll(cleanUp())
 
 	Describe("use default values", func() {
 
@@ -137,12 +138,5 @@ var _ = Describe("vary VM parameters: memory cpus, disk", func() {
 				Expect(out).Should(MatchRegexp(`.*40G[\s].*[\s]/sysroot`))
 			})
 		}
-
-		It("clean up", func() {
-			RunCRCExpectSuccess("stop", "-f")
-			RunCRCExpectSuccess("delete", "-f")
-			RunCRCExpectSuccess("cleanup")
-
-		})
 	})
 })

--- a/test/integration/resize_test.go
+++ b/test/integration/resize_test.go
@@ -1,4 +1,4 @@
-package test_test
+package integration_test
 
 import (
 	"runtime"

--- a/test/integration/testsuite_test.go
+++ b/test/integration/testsuite_test.go
@@ -13,6 +13,8 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+const outputDirectory = "out"
+
 type versionAnswer struct {
 	Embedded bool `json:"embedded"`
 }
@@ -26,7 +28,8 @@ var (
 func TestTest(t *testing.T) {
 	RegisterFailHandler(Fail)
 
-	junitReporter := reporters.NewJUnitReporter(filepath.Join("out", "integration.xml"))
+	_ = os.MkdirAll(outputDirectory, os.ModePerm)
+	junitReporter := reporters.NewJUnitReporter(filepath.Join(outputDirectory, "integration.xml"))
 	RunSpecsWithDefaultAndCustomReporters(t, "Test Suite", []Reporter{junitReporter})
 }
 
@@ -41,7 +44,7 @@ var _ = BeforeSuite(func() {
 	var versionInfo versionAnswer
 	Expect(json.Unmarshal([]byte(raw), &versionInfo)).NotTo(HaveOccurred())
 
-	Expect(ioutil.WriteFile(filepath.Join("out", "crc-version.json"), []byte(raw), 0600)).To(Succeed())
+	Expect(ioutil.WriteFile(filepath.Join(outputDirectory, "crc-version.json"), []byte(raw), 0600)).To(Succeed())
 
 	// bundle location
 	bundlePath = "embedded"

--- a/test/integration/testsuite_test.go
+++ b/test/integration/testsuite_test.go
@@ -73,3 +73,21 @@ var _ = BeforeSuite(func() {
 	Expect(pullSecretPath).To(BeAnExistingFile()) // not checking if it's a valid pull secret file
 
 })
+
+func BeforeAll(fn func()) {
+	first := true
+	BeforeEach(func() {
+		if first {
+			fn()
+			first = false
+		}
+	})
+}
+
+func cleanUp() func() {
+	return func() {
+		_, _ = NewCRCCommand("delete", "-f").Exec()
+		_, _ = NewCRCCommand("cleanup").Exec()
+		_ = os.Remove(filepath.Join(userHome, ".crc", "crc.json"))
+	}
+}

--- a/test/integration/testsuite_test.go
+++ b/test/integration/testsuite_test.go
@@ -1,4 +1,4 @@
-package test_test
+package integration_test
 
 import (
 	"encoding/json"

--- a/test/integration/testsuite_test.go
+++ b/test/integration/testsuite_test.go
@@ -2,6 +2,7 @@ package integration_test
 
 import (
 	"encoding/json"
+	"io/ioutil"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -39,6 +40,8 @@ var _ = BeforeSuite(func() {
 
 	var versionInfo versionAnswer
 	Expect(json.Unmarshal([]byte(raw), &versionInfo)).NotTo(HaveOccurred())
+
+	Expect(ioutil.WriteFile(filepath.Join("out", "crc-version.json"), []byte(raw), 0600)).To(Succeed())
 
 	// bundle location
 	bundlePath = "embedded"

--- a/test/integration/utilities_test.go
+++ b/test/integration/utilities_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/code-ready/crc/pkg/crc/ssh"
 	. "github.com/onsi/gomega"
 	"github.com/sirupsen/logrus"
+	k8sexec "k8s.io/client-go/util/exec"
 )
 
 // CRCBuilder is used to build, customize and execute a CRC command.
@@ -100,7 +101,7 @@ func Exec(cmd *exec.Cmd, timeout <-chan time.Time) (string, string, error) {
 				rc = int(ee.Sys().(syscall.WaitStatus).ExitStatus())
 				logrus.Infof("rc: %d", rc)
 			}
-			return stdout.String(), stderr.String(), CodeExitError{
+			return stdout.String(), stderr.String(), k8sexec.CodeExitError{
 				Err:  fmt.Errorf("error running %v:\nCommand stdout:\n%v\nstderr:\n%v\nerror:\n%v", cmd, cmd.Stdout, cmd.Stderr, err),
 				Code: rc,
 			}
@@ -150,39 +151,4 @@ func SendCommandToVM(cmd string) (string, error) {
 		return "", err
 	}
 	return string(out), nil
-}
-
-// ExitError is an interface that presents an API similar to os.ProcessState, which is
-// what ExitError from os/exec is.  This is designed to make testing a bit easier and
-// probably loses some of the cross-platform properties of the underlying library.
-type ExitError interface {
-	String() string
-	Error() string
-	Exited() bool
-	ExitStatus() int
-}
-
-// CodeExitError is an implementation of ExitError consisting of an error object
-// and an exit code (the upper bits of os.exec.ExitStatus).
-type CodeExitError struct {
-	Err  error
-	Code int
-}
-
-var _ ExitError = CodeExitError{}
-
-func (e CodeExitError) Error() string {
-	return e.Err.Error()
-}
-
-func (e CodeExitError) String() string {
-	return e.Err.Error()
-}
-
-func (e CodeExitError) Exited() bool {
-	return true
-}
-
-func (e CodeExitError) ExitStatus() int {
-	return e.Code
 }

--- a/test/integration/utilities_test.go
+++ b/test/integration/utilities_test.go
@@ -1,4 +1,4 @@
-package test_test
+package integration_test
 
 import (
 	"bytes"


### PR DESCRIPTION
Jenkins would run integration tests with option `-ginkgo.focus monitoring`. 
Artifacts contains cpu/memory usage and crc version. It would be archived every day in Jenkins. 
Something is still needed to import this data in elastic or something else. 