### PR TITLE
vsock: expose port 80

### DIFF
--- a/pkg/crc/machine/vsock.go
+++ b/pkg/crc/machine/vsock.go
@@ -45,6 +45,7 @@ func isOpened(exposed []types.ExposeRequest, port types.ExposeRequest) bool {
 const (
 	virtualMachineIP = "192.168.127.2"
 	internalSSHPort  = 22
+	httpPort         = 80
 	httpsPort        = 443
 	apiPort          = 6443
 )
@@ -62,6 +63,10 @@ func vsockPorts() []types.ExposeRequest {
 		{
 			Local:  fmt.Sprintf(":%d", httpsPort),
 			Remote: fmt.Sprintf("%s:%d", virtualMachineIP, httpsPort),
+		},
+		{
+			Local:  fmt.Sprintf(":%d", httpPort),
+			Remote: fmt.Sprintf("%s:%d", virtualMachineIP, httpPort),
 		},
 	}
 }


### PR DESCRIPTION
This is needed when using the OpenShift registry with Docker as insecure
registry for instance.

List of ports exposed by the router:
https://github.com/openshift/router/blob/release-4.7/deploy/router.yaml#L39


**Fixes:** Issue #2193
