### PR TITLE
Fix 'crc podman-env' command

### DIFF
--- a/cmd/crc/cmd/ip.go
+++ b/cmd/crc/cmd/ip.go
@@ -25,10 +25,10 @@ func runIP(arguments []string) error {
 		return err
 	}
 
-	ip, err := client.IP()
+	connectionDetails, err := client.ConnectionDetails()
 	if err != nil {
 		return err
 	}
-	fmt.Println(ip)
+	fmt.Println(connectionDetails.IP)
 	return nil
 }

--- a/cmd/crc/cmd/podman_env.go
+++ b/cmd/crc/cmd/podman_env.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/code-ready/crc/pkg/crc/constants"
@@ -14,12 +13,11 @@ var podmanEnvCmd = &cobra.Command{
 	Short: "Setup podman environment",
 	Long:  `Setup environment for 'podman' executable to access podman on CRC VM`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		// See issue #961; Currently does not work on Windows in combination with the CRC vm.
-		return errors.New("currently not supported")
+		return runPodmanEnv()
 	},
 }
 
-func RunPodmanEnv(args []string) error {
+func runPodmanEnv() error {
 	userShell, err := shell.GetShell(forceShell)
 	if err != nil {
 		return fmt.Errorf("Error running the podman-env command: %s", err.Error())
@@ -35,11 +33,13 @@ func RunPodmanEnv(args []string) error {
 		return err
 	}
 
-	fmt.Println(shell.GetPathEnvString(userShell, constants.CrcBinDir))
-	fmt.Println(shell.GetEnvString(userShell, "PODMAN_USER", connectionDetails.SSHUsername))
-	fmt.Println(shell.GetEnvString(userShell, "PODMAN_HOST", connectionDetails.IP))
-	fmt.Println(shell.GetEnvString(userShell, "PODMAN_IDENTITY_FILE", connectionDetails.SSHKeys[0]))
-	fmt.Println(shell.GetEnvString(userShell, "PODMAN_IGNORE_HOSTS", "1"))
+	fmt.Println(shell.GetPathEnvString(userShell, constants.CrcOcBinDir))
+	fmt.Println(shell.GetEnvString(userShell, "CONTAINER_SSHKEY", connectionDetails.SSHKeys[0]))
+	fmt.Println(shell.GetEnvString(userShell, "CONTAINER_HOST",
+		fmt.Sprintf("ssh://%s@%s:%d/run/user/1000/podman/podman.sock",
+			connectionDetails.SSHUsername,
+			connectionDetails.IP,
+			connectionDetails.SSHPort)))
 	fmt.Println(shell.GenerateUsageHintWithComment(userShell, "crc podman-env"))
 	return nil
 }

--- a/cmd/crc/cmd/podman_env.go
+++ b/cmd/crc/cmd/podman_env.go
@@ -30,15 +30,15 @@ func RunPodmanEnv(args []string) error {
 		return err
 	}
 
-	ip, err := client.IP()
+	connectionDetails, err := client.ConnectionDetails()
 	if err != nil {
 		return err
 	}
 
 	fmt.Println(shell.GetPathEnvString(userShell, constants.CrcBinDir))
-	fmt.Println(shell.GetEnvString(userShell, "PODMAN_USER", constants.DefaultSSHUser))
-	fmt.Println(shell.GetEnvString(userShell, "PODMAN_HOST", ip))
-	fmt.Println(shell.GetEnvString(userShell, "PODMAN_IDENTITY_FILE", constants.GetPrivateKeyPath()))
+	fmt.Println(shell.GetEnvString(userShell, "PODMAN_USER", connectionDetails.SSHUsername))
+	fmt.Println(shell.GetEnvString(userShell, "PODMAN_HOST", connectionDetails.IP))
+	fmt.Println(shell.GetEnvString(userShell, "PODMAN_IDENTITY_FILE", connectionDetails.SSHKeys[0]))
 	fmt.Println(shell.GetEnvString(userShell, "PODMAN_IGNORE_HOSTS", "1"))
 	fmt.Println(shell.GenerateUsageHintWithComment(userShell, "crc podman-env"))
 	return nil

--- a/pkg/crc/machine/bundle/metadata.go
+++ b/pkg/crc/machine/bundle/metadata.go
@@ -67,9 +67,16 @@ type DiskImage struct {
 	Format string `json:"format"`
 }
 
+type FileType string
+
+const (
+	OcExecutable     FileType = "oc-executable"
+	PodmanExecutable FileType = "podman-executable"
+)
+
 type FileListItem struct {
 	File
-	Type string `json:"type"`
+	Type FileType `json:"type"`
 }
 
 type DriverInfo struct {
@@ -102,7 +109,17 @@ func (bundle *CrcBundleInfo) GetKubeConfigPath() string {
 
 func (bundle *CrcBundleInfo) GetOcPath() string {
 	for _, file := range bundle.Storage.Files {
-		if file.Type == "oc-executable" {
+		if file.Type == OcExecutable {
+			return bundle.resolvePath(file.Name)
+		}
+	}
+
+	return ""
+}
+
+func (bundle *CrcBundleInfo) GetPodmanPath() string {
+	for _, file := range bundle.Storage.Files {
+		if file.Type == PodmanExecutable {
 			return bundle.resolvePath(file.Name)
 		}
 	}

--- a/pkg/crc/machine/bundle/repository.go
+++ b/pkg/crc/machine/bundle/repository.go
@@ -84,6 +84,9 @@ func (repo *Repository) Use(bundleName string) (*CrcBundleInfo, error) {
 	if err := bundleInfo.createSymlinkOrCopyOpenShiftClient(repo.OcBinDir); err != nil {
 		return nil, err
 	}
+	if err := bundleInfo.createSymlinkOrCopyPodmanClient(repo.OcBinDir); err != nil {
+		return nil, err
+	}
 	return bundleInfo, nil
 }
 
@@ -115,6 +118,23 @@ func (bundle *CrcBundleInfo) createSymlinkOrCopyOpenShiftClient(ocBinDir string)
 		return crcos.CopyFileContents(ocInBundle, ocInBinDir, 0750)
 	}
 	return os.Symlink(ocInBundle, ocInBinDir)
+}
+
+func (bundle *CrcBundleInfo) createSymlinkOrCopyPodmanClient(ocBinDir string) error {
+	podmanInBundle := bundle.GetPodmanPath()
+	if podmanInBundle == "" {
+		return nil
+	}
+	podmanInBinDir := filepath.Join(ocBinDir, filepath.Base(podmanInBundle))
+
+	if err := os.MkdirAll(ocBinDir, 0750); err != nil {
+		return err
+	}
+	_ = os.Remove(podmanInBinDir)
+	if runtime.GOOS == "windows" {
+		return crcos.CopyFileContents(podmanInBundle, podmanInBinDir, 0750)
+	}
+	return os.Symlink(podmanInBundle, podmanInBinDir)
 }
 
 func (repo *Repository) Extract(path string) error {

--- a/pkg/crc/machine/client.go
+++ b/pkg/crc/machine/client.go
@@ -12,11 +12,11 @@ import (
 
 type Client interface {
 	GetName() string
+	GetConsoleURL() (*types.ConsoleResult, error)
+	ConnectionDetails() (*types.ConnectionDetails, error)
 
 	Delete() error
 	Exists() (bool, error)
-	GetConsoleURL() (*types.ConsoleResult, error)
-	IP() (string, error)
 	PowerOff() error
 	Start(ctx context.Context, startConfig types.StartConfig) (*types.StartResult, error)
 	Status() (*types.ClusterStatusResult, error)

--- a/pkg/crc/machine/fakemachine/client.go
+++ b/pkg/crc/machine/fakemachine/client.go
@@ -57,8 +57,8 @@ func (c *Client) GetProxyConfig(machineName string) (*network.ProxyConfig, error
 	return nil, errors.New("not implemented")
 }
 
-func (c *Client) IP() (string, error) {
-	return "", errors.New("not implemented")
+func (c *Client) ConnectionDetails() (*types.ConnectionDetails, error) {
+	return nil, errors.New("not implemented")
 }
 
 func (c *Client) PowerOff() error {

--- a/pkg/crc/machine/ip.go
+++ b/pkg/crc/machine/ip.go
@@ -1,18 +1,32 @@
 package machine
 
-import "github.com/pkg/errors"
+import (
+	"github.com/code-ready/crc/pkg/crc/constants"
+	"github.com/code-ready/crc/pkg/crc/machine/types"
+	"github.com/pkg/errors"
+)
 
-func (client *client) IP() (string, error) {
+func (client *client) ConnectionDetails() (*types.ConnectionDetails, error) {
 	libMachineAPIClient, cleanup := createLibMachineClient()
 	defer cleanup()
 	host, err := libMachineAPIClient.Load(client.name)
-
 	if err != nil {
-		return "", errors.Wrap(err, "Cannot load machine")
+		return nil, errors.Wrap(err, "Cannot load machine")
 	}
+
+	bundle, err := getBundleMetadataFromDriver(host.Driver)
+	if err != nil {
+		return nil, errors.Wrap(err, "Error loading bundle metadata")
+	}
+
 	ip, err := getIP(host, client.useVSock())
 	if err != nil {
-		return "", errors.Wrap(err, "Cannot get IP")
+		return nil, errors.Wrap(err, "Cannot get IP")
 	}
-	return ip, nil
+	return &types.ConnectionDetails{
+		IP:          ip,
+		SSHPort:     getSSHPort(client.useVSock()),
+		SSHUsername: constants.DefaultSSHUser,
+		SSHKeys:     []string{constants.GetPrivateKeyPath(), constants.GetRsaPrivateKeyPath(), bundle.GetSSHKeyPath()},
+	}, nil
 }

--- a/pkg/crc/machine/sync.go
+++ b/pkg/crc/machine/sync.go
@@ -154,8 +154,8 @@ func (s *Synchronized) GetConsoleURL() (*types.ConsoleResult, error) {
 	return s.underlying.GetConsoleURL()
 }
 
-func (s *Synchronized) IP() (string, error) {
-	return s.underlying.IP()
+func (s *Synchronized) ConnectionDetails() (*types.ConnectionDetails, error) {
+	return s.underlying.ConnectionDetails()
 }
 
 func (s *Synchronized) PowerOff() error {

--- a/pkg/crc/machine/sync_test.go
+++ b/pkg/crc/machine/sync_test.go
@@ -135,8 +135,8 @@ func (m *waitingMachine) GetConsoleURL() (*types.ConsoleResult, error) {
 	return nil, errors.New("not implemented")
 }
 
-func (m *waitingMachine) IP() (string, error) {
-	return "", errors.New("not implemented")
+func (m *waitingMachine) ConnectionDetails() (*types.ConnectionDetails, error) {
+	return nil, errors.New("not implemented")
 }
 
 func (m *waitingMachine) PowerOff() error {

--- a/pkg/crc/machine/types/types.go
+++ b/pkg/crc/machine/types/types.go
@@ -56,3 +56,10 @@ type ConsoleResult struct {
 	ClusterConfig ClusterConfig
 	State         state.State
 }
+
+type ConnectionDetails struct {
+	IP          string
+	SSHPort     int
+	SSHUsername string
+	SSHKeys     []string
+}

--- a/test/e2e/crcsuite/collect.go
+++ b/test/e2e/crcsuite/collect.go
@@ -177,12 +177,7 @@ type VMCommandCollector struct {
 }
 
 func (collector *VMCommandCollector) Collect(w Writer) error {
-	client := machine.NewClient(constants.DefaultName, true, crcConfig.New(crcConfig.NewEmptyInMemoryStorage()))
-	ip, err := client.IP()
-	if err != nil {
-		return err
-	}
-	ssh, err := ssh.NewClient(constants.DefaultSSHUser, ip, 22, constants.GetPrivateKeyPath())
+	ssh, err := sshClient()
 	if err != nil {
 		return err
 	}
@@ -198,12 +193,7 @@ type ContainerLogCollector struct {
 }
 
 func (collector *ContainerLogCollector) Collect(w Writer) error {
-	client := machine.NewClient(constants.DefaultName, true, crcConfig.New(crcConfig.NewEmptyInMemoryStorage()))
-	ip, err := client.IP()
-	if err != nil {
-		return err
-	}
-	ssh, err := ssh.NewClient(constants.DefaultSSHUser, ip, 22, constants.GetPrivateKeyPath())
+	ssh, err := sshClient()
 	if err != nil {
 		return err
 	}
@@ -232,6 +222,15 @@ func (collector *ContainerLogCollector) Collect(w Writer) error {
 		}
 	}
 	return nil
+}
+
+func sshClient() (ssh.Client, error) {
+	client := machine.NewClient(constants.DefaultName, true, crcConfig.New(crcConfig.NewEmptyInMemoryStorage()))
+	connectionDetails, err := client.ConnectionDetails()
+	if err != nil {
+		return nil, err
+	}
+	return ssh.NewClient(connectionDetails.SSHUsername, connectionDetails.IP, connectionDetails.SSHPort, connectionDetails.SSHKeys...)
 }
 
 func command(command, target string) *CommandCollector {

--- a/test/integration/utilities_test.go
+++ b/test/integration/utilities_test.go
@@ -136,12 +136,11 @@ func RunCRCExpectFail(args ...string) (string, error) {
 // Send command to CRC VM via SSH
 func SendCommandToVM(cmd string) (string, error) {
 	client := machine.NewClient(constants.DefaultName, false, crcConfig.New(crcConfig.NewEmptyInMemoryStorage()))
-	ip, err := client.IP()
+	connectionDetails, err := client.ConnectionDetails()
 	if err != nil {
 		return "", err
 	}
-
-	ssh, err := ssh.NewClient(constants.DefaultSSHUser, ip, 22, constants.GetPrivateKeyPath())
+	ssh, err := ssh.NewClient(connectionDetails.SSHUsername, connectionDetails.IP, connectionDetails.SSHPort, connectionDetails.SSHKeys...)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
It enables the user to use rootless podman. 

This is very early stage and tbh, it doesn't work well.
With bundle 4.7.5, podman 2.2.1, a simple 'podman ps' hangs half of the time. It also freezes the VM (cannot ssh during the podman hang). 

With podman rootless, I have this error when it hangs:
```
$ systemctl --user status podman.service
● podman.service - Podman API Service
   Loaded: loaded (/usr/lib/systemd/user/podman.service; static; vendor preset: enabled)
   Active: activating (start) since Fri 2021-04-16 20:00:56 UTC; 735ms ago
     Docs: man:podman-system-service(1)
 Main PID: 3990 (podman)
   CGroup: /user.slice/user-1000.slice/user@1000.service/podman.service
           ├─3990 /usr/bin/podman --log-level=info system service
           └─4000 /usr/bin/podman --log-level=info system service

Apr 16 20:00:56 crc-xl2km-master-0 systemd[3830]: Starting Podman API Service...
Apr 16 20:00:56 crc-xl2km-master-0 podman[3990]: time="2021-04-16T20:00:56Z" level=info msg="/usr/bin/podman filtering at log level info"
Apr 16 20:00:56 crc-xl2km-master-0 podman[3990]: time="2021-04-16T20:00:56Z" level=warning msg="Error initializing configured OCI runtime kata: no valid executable found for OCI runtime kata: invalid a>
Apr 16 20:00:56 crc-xl2km-master-0 podman[3990]: time="2021-04-16T20:00:56Z" level=info msg="Setting parallel job count to 13"
Apr 16 20:00:56 crc-xl2km-master-0 podman[3990]: time="2021-04-16T20:00:56Z" level=info msg="/usr/bin/podman filtering at log level info"
Apr 16 20:00:56 crc-xl2km-master-0 podman[3990]: time="2021-04-16T20:00:56Z" level=warning msg="Error initializing configured OCI runtime kata: no valid executable found for OCI runtime kata: invalid a>
Apr 16 20:00:56 crc-xl2km-master-0 podman[3990]: time="2021-04-16T20:00:56Z" level=info msg="Setting parallel job count to 13"
Apr 16 20:00:56 crc-xl2km-master-0 podman[3990]: time="2021-04-16T20:00:56Z" level=info msg="using API endpoint: 'unix:/run/user/1000/podman/podman.sock'"
Apr 16 20:00:56 crc-xl2km-master-0 podman[3990]: time="2021-04-16T20:00:56Z" level=info msg="API server listening on \"/run/user/1000/podman/podman.sock\""
Apr 16 20:00:56 crc-xl2km-master-0 systemd[3830]: podman.service: Got notification message from PID 4000, but reception only permitted for main PID 3990
```

With podman root, I have this error when it hangs:
```
Apr 16 19:53:04 crc-xl2km-master-0 systemd[3830]: Failed to connect to API bus: Connection refused
```