### PR TITLE
Add another format to check capabilities

### DIFF
--- a/pkg/crc/preflight/preflight_linux.go
+++ b/pkg/crc/preflight/preflight_linux.go
@@ -129,7 +129,8 @@ func checkVsock() error {
 	if err != nil {
 		return err
 	}
-	if !strings.Contains(getcap, "cap_net_bind_service+eip") {
+	if !strings.Contains(getcap, "cap_net_bind_service+eip") &&
+		!strings.Contains(getcap, "cap_net_bind_service=eip") {
 		return fmt.Errorf("capabilities are not correct for %s", executable)
 	}
 


### PR DESCRIPTION
There is different output of `getcap` for latest fedora and rhel

On Fedora33
```
$ getcap crc
crc cap_net_bind_service=eip
```

On RHEL8.3
```
$ getcap crc
crc = cap_net_bind_service+eip
```

This patch will try to add both format as part of check.

fixes #2236


