### PR TITLE
docs: Amend minimum CPU requirements

### DIFF
--- a/docs/source/topics/ref_minimum-system-requirements.adoc
+++ b/docs/source/topics/ref_minimum-system-requirements.adoc
@@ -8,7 +8,7 @@
 
 {prod} requires the following system resources:
 
-* 4 virtual CPUs (vCPUs)
+* 4 physical CPU cores
 * 9 GB of free memory
 * 35 GB of storage space
 


### PR DESCRIPTION
Previously, the documentation incorrectly referred to "virtual CPUs" instead of physical CPU cores.

**Fixes:** Issue #2232

This change is so small it's almost silly. ;)