### PR TITLE
#2206 macOS pkg: use hyperkit, driver and admin-helper directly from app dir

### DIFF
--- a/packaging/package.sh
+++ b/packaging/package.sh
@@ -31,6 +31,8 @@ sign "${BASEDIR}/root/Applications/CodeReady Containers.app"
 
 codesign --verify --verbose "${binDir}/hyperkit"
 
+sudo chmod +sx "${binDir}/hyperkit" "${binDir}/admin-helper-darwin" "${binDir}/crc-driver-hyperkit"
+
 pkgbuild --identifier com.redhat.crc --version ${version} \
   --scripts "${BASEDIR}/darwin/scripts" \
   --root "${BASEDIR}/root" \

--- a/pkg/crc/adminhelper/hosts.go
+++ b/pkg/crc/adminhelper/hosts.go
@@ -8,7 +8,7 @@ import (
 )
 
 var (
-	adminHelperPath = filepath.Join(constants.CrcBinDir, constants.AdminHelperExecutableName)
+	adminHelperPath = filepath.Join(constants.BinDir(), constants.AdminHelperExecutableName)
 )
 
 // UpdateHostsFile updates the host's /etc/hosts file with Instance IP.

--- a/pkg/crc/constants/constants.go
+++ b/pkg/crc/constants/constants.go
@@ -114,6 +114,13 @@ func defaultBundlePath() string {
 	return filepath.Join(MachineCacheDir, GetDefaultBundle())
 }
 
+func BinDir() string {
+	if runtime.GOOS == "darwin" && version.IsMacosInstallPathSet() {
+		return version.GetMacosInstallPath()
+	}
+	return CrcBinDir
+}
+
 // GetHomeDir returns the home directory for the current user
 func GetHomeDir() string {
 	if runtime.GOOS == "windows" {

--- a/pkg/crc/machine/driver_darwin.go
+++ b/pkg/crc/machine/driver_darwin.go
@@ -17,7 +17,7 @@ func newHost(api libmachine.API, machineConfig config.MachineConfig) (*host.Host
 	if err != nil {
 		return nil, errors.New("Failed to marshal driver options")
 	}
-	return api.NewHost("hyperkit", constants.CrcBinDir, json)
+	return api.NewHost("hyperkit", constants.BinDir(), json)
 }
 
 func loadDriverConfig(host *host.Host) (*machineHyperkit.Driver, error) {

--- a/pkg/crc/machine/hyperkit/driver_darwin.go
+++ b/pkg/crc/machine/hyperkit/driver_darwin.go
@@ -18,7 +18,7 @@ func CreateHost(machineConfig config.MachineConfig) *hyperkit.Driver {
 	hyperkitDriver.Cmdline = machineConfig.KernelCmdLine
 	hyperkitDriver.VmlinuzPath = machineConfig.Kernel
 	hyperkitDriver.InitrdPath = machineConfig.Initramfs
-	hyperkitDriver.HyperKitPath = filepath.Join(constants.CrcBinDir, HyperKitCommand)
+	hyperkitDriver.HyperKitPath = filepath.Join(constants.BinDir(), HyperKitCommand)
 
 	hyperkitDriver.VMNet = machineConfig.NetworkMode == network.DefaultMode
 

--- a/pkg/crc/preflight/preflight_checks_common.go
+++ b/pkg/crc/preflight/preflight_checks_common.go
@@ -12,6 +12,7 @@ import (
 	"github.com/code-ready/crc/pkg/crc/logging"
 	"github.com/code-ready/crc/pkg/crc/machine/bundle"
 	"github.com/code-ready/crc/pkg/crc/validation"
+	"github.com/code-ready/crc/pkg/crc/version"
 	"github.com/code-ready/crc/pkg/embed"
 	crcos "github.com/code-ready/crc/pkg/os"
 	"github.com/docker/go-units"
@@ -140,6 +141,10 @@ func fixPodmanExecutableCached() error {
 
 // Check if helper executable is cached or not
 func checkAdminHelperExecutableCached() error {
+	if version.IsMacosInstallPathSet() {
+		return nil
+	}
+
 	helper := cache.NewAdminHelperCache()
 	if !helper.IsCached() {
 		return errors.New("admin-helper executable is not cached")
@@ -152,6 +157,10 @@ func checkAdminHelperExecutableCached() error {
 }
 
 func fixAdminHelperExecutableCached() error {
+	if version.IsMacosInstallPathSet() {
+		return nil
+	}
+
 	helper := cache.NewAdminHelperCache()
 	if err := helper.EnsureIsCached(); err != nil {
 		return errors.Wrap(err, "Unable to download admin-helper executable")

--- a/pkg/crc/preflight/preflight_checks_darwin.go
+++ b/pkg/crc/preflight/preflight_checks_darwin.go
@@ -12,6 +12,7 @@ import (
 	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/code-ready/crc/pkg/crc/logging"
 	"github.com/code-ready/crc/pkg/crc/network"
+	"github.com/code-ready/crc/pkg/crc/version"
 	crcos "github.com/code-ready/crc/pkg/os"
 	"golang.org/x/sys/unix"
 )
@@ -24,6 +25,10 @@ const (
 
 func checkHyperKitInstalled(networkMode network.Mode) func() error {
 	return func() error {
+		if version.IsMacosInstallPathSet() {
+			return nil
+		}
+
 		h := cache.NewHyperKitCache()
 		if !h.IsCached() {
 			return fmt.Errorf("%s executable is not cached", h.GetExecutableName())
@@ -45,6 +50,10 @@ func checkHyperKitInstalled(networkMode network.Mode) func() error {
 
 func fixHyperKitInstallation(networkMode network.Mode) func() error {
 	return func() error {
+		if version.IsMacosInstallPathSet() {
+			return nil
+		}
+
 		h := cache.NewHyperKitCache()
 
 		logging.Debugf("Installing %s", h.GetExecutableName())
@@ -61,6 +70,10 @@ func fixHyperKitInstallation(networkMode network.Mode) func() error {
 
 func checkMachineDriverHyperKitInstalled(networkMode network.Mode) func() error {
 	return func() error {
+		if version.IsMacosInstallPathSet() {
+			return nil
+		}
+
 		hyperkitDriver := cache.NewMachineDriverHyperKitCache()
 
 		logging.Debugf("Checking if %s is installed", hyperkitDriver.GetExecutableName())
@@ -80,6 +93,10 @@ func checkMachineDriverHyperKitInstalled(networkMode network.Mode) func() error 
 
 func fixMachineDriverHyperKitInstalled(networkMode network.Mode) func() error {
 	return func() error {
+		if version.IsMacosInstallPathSet() {
+			return nil
+		}
+
 		hyperkitDriver := cache.NewMachineDriverHyperKitCache()
 
 		logging.Debugf("Installing %s", hyperkitDriver.GetExecutableName())
@@ -192,7 +209,7 @@ func stopCRCHyperkitProcess() error {
 	if err != nil {
 		return fmt.Errorf("Could not find 'pgrep'. %w", err)
 	}
-	if _, _, err := crcos.RunWithDefaultLocale(pgrepPath, "-f", filepath.Join(constants.CrcBinDir, "hyperkit")); err != nil {
+	if _, _, err := crcos.RunWithDefaultLocale(pgrepPath, "-f", filepath.Join(constants.BinDir(), "hyperkit")); err != nil {
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) {
 			/* 1: no processes matched */
@@ -209,7 +226,7 @@ func stopCRCHyperkitProcess() error {
 	if err != nil {
 		return fmt.Errorf("Could not find 'pkill'. %w", err)
 	}
-	if _, _, err := crcos.RunWithDefaultLocale(pkillPath, "-SIGKILL", "-f", filepath.Join(constants.CrcBinDir, "hyperkit")); err != nil {
+	if _, _, err := crcos.RunWithDefaultLocale(pkillPath, "-SIGKILL", "-f", filepath.Join(constants.BinDir(), "hyperkit")); err != nil {
 		return fmt.Errorf("Failed to kill 'hyperkit' process. %w", err)
 	}
 	return nil


### PR DESCRIPTION
It removes the copy from the application directoy to ~/.crc/.
crc directly use binaries from /Application/CodeReady Containers.app.

**Fixes:** Issue #2206

---

I start to dislike the spread of `if version.IsMacosInstallPathSet() { }` blocks :)
Would it be better with a build tag ? 🤔 

Also, I need to double check code signing is ok with this. 
