### PR TITLE
Change default network mode to vsock for macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL := /bin/bash
 
-BUNDLE_VERSION = 4.7.8
+BUNDLE_VERSION ?= 4.7.8
 BUNDLE_EXTENSION = crcbundle
 CRC_VERSION = 1.25.0
 COMMIT_SHA=$(shell git rev-parse --short HEAD)

--- a/cmd/crc/cmd/config/config.go
+++ b/cmd/crc/cmd/config/config.go
@@ -11,6 +11,7 @@ import (
 	"github.com/code-ready/crc/pkg/crc/config"
 	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/code-ready/crc/pkg/crc/network"
+	"github.com/code-ready/crc/pkg/crc/version"
 	"github.com/spf13/cast"
 	"github.com/spf13/cobra"
 )
@@ -82,7 +83,7 @@ func RegisterSettings(cfg *config.Config) {
 		"Disable update check (true/false, default: false)")
 	cfg.AddSetting(ExperimentalFeatures, false, config.ValidateBool, config.SuccessfullyApplied,
 		"Enable experimental features (true/false, default: false)")
-	cfg.AddSetting(NetworkMode, string(network.DefaultMode), network.ValidateMode, network.SuccessfullyAppliedMode,
+	cfg.AddSetting(NetworkMode, string(defaultNetworkMode()), network.ValidateMode, network.SuccessfullyAppliedMode,
 		"Network mode (default or vsock)")
 	cfg.AddSetting(HostNetworkAccess, false, validateHostNetworkAccess, config.SuccessfullyApplied,
 		"Allow TCP/IP connections from the CodeReady Containers VM to services running on the host (true/false, default: false)")
@@ -105,6 +106,13 @@ func RegisterSettings(cfg *config.Config) {
 	// Telemeter Configuration
 	cfg.AddSetting(ConsentTelemetry, "", config.ValidateYesNo, config.SuccessfullyApplied,
 		"Consent to collection of anonymous usage data (yes/no)")
+}
+
+func defaultNetworkMode() network.Mode {
+	if runtime.GOOS == "darwin" && version.IsMacosInstallPathSet() {
+		return network.VSockMode
+	}
+	return network.DefaultMode
 }
 
 func isPreflightKey(key string) bool {


### PR DESCRIPTION
With the routes controller and the pkg (almost) in place, we can now change the network mode to vsock.

Maybe I should block all commands with `checkDaemonStarted` apart from setup/cleanup/version/daemon. WDYT?

---

When https://cloud.redhat.com/openshift/create/local will serve the pkg, we can merge this