### PR TITLE
Remove generation of PDF documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,10 +124,6 @@ test-rpmbuild: spec
 build_docs:
 	${CONTAINER_RUNTIME} run -v $(CURDIR)/docs:/docs:Z --rm $(DOCS_BUILD_CONTAINER) build_docs -b html5 -D /$(DOCS_BUILD_DIR) -o index.html $(DOCS_BUILD_TARGET)
 
-.PHONY: build_docs_pdf
-build_docs_pdf:
-	${CONTAINER_RUNTIME} run -v $(CURDIR)/docs:/docs:Z --rm $(DOCS_BUILD_CONTAINER) build_docs_pdf -D /$(DOCS_BUILD_DIR) -o doc.pdf $(DOCS_BUILD_TARGET)
-
 .PHONY: docs_serve
 docs_serve: build_docs
 	${CONTAINER_RUNTIME} run -it -v $(CURDIR)/docs:/docs:Z --rm -p 8088:8088/tcp $(DOCS_BUILD_CONTAINER) docs_serve 
@@ -214,19 +210,19 @@ gen_release_info:
 
 .PHONY: release
 release: LDFLAGS += $(RELEASE_VERSION_VARIABLES)
-release: cross-lint embed_bundle build_docs_pdf gen_release_info
+release: cross-lint embed_bundle gen_release_info
 	mkdir $(RELEASE_DIR)
 	
 	@mkdir -p $(BUILD_DIR)/crc-macos-$(CRC_VERSION)-amd64
-	@cp LICENSE $(DOCS_BUILD_DIR)/doc.pdf $(BUILD_DIR)/macos-amd64/crc $(BUILD_DIR)/crc-macos-$(CRC_VERSION)-amd64
+	@cp LICENSE $(BUILD_DIR)/macos-amd64/crc $(BUILD_DIR)/crc-macos-$(CRC_VERSION)-amd64
 	tar cJSf $(RELEASE_DIR)/crc-macos-amd64.tar.xz -C $(BUILD_DIR) crc-macos-$(CRC_VERSION)-amd64 --owner=0 --group=0
 
 	@mkdir -p $(BUILD_DIR)/crc-linux-$(CRC_VERSION)-amd64
-	@cp LICENSE $(DOCS_BUILD_DIR)/doc.pdf $(BUILD_DIR)/linux-amd64/crc $(BUILD_DIR)/crc-linux-$(CRC_VERSION)-amd64
+	@cp LICENSE $(BUILD_DIR)/linux-amd64/crc $(BUILD_DIR)/crc-linux-$(CRC_VERSION)-amd64
 	tar cJSf $(RELEASE_DIR)/crc-linux-amd64.tar.xz -C $(BUILD_DIR) crc-linux-$(CRC_VERSION)-amd64 --owner=0 --group=0
 	
 	@mkdir -p $(BUILD_DIR)/crc-windows-$(CRC_VERSION)-amd64
-	@cp LICENSE $(DOCS_BUILD_DIR)/doc.pdf $(BUILD_DIR)/windows-amd64/crc.exe $(BUILD_DIR)/crc-windows-$(CRC_VERSION)-amd64
+	@cp LICENSE $(BUILD_DIR)/windows-amd64/crc.exe $(BUILD_DIR)/crc-windows-$(CRC_VERSION)-amd64
 	cd $(BUILD_DIR) && zip -r $(CURDIR)/$(RELEASE_DIR)/crc-windows-amd64.zip crc-windows-$(CRC_VERSION)-amd64
 
 	@mv $(RELEASE_INFO) $(RELEASE_DIR)/$(RELEASE_INFO)

--- a/images/docs-builder/Dockerfile
+++ b/images/docs-builder/Dockerfile
@@ -7,7 +7,7 @@ RUN yum update -y && \
     yum module install nodejs:14 -y && \
     yum clean all && rm -rf /var/cache/yum/*
 
-RUN gem install asciidoctor asciidoctor-pdf --pre && \
+RUN gem install asciidoctor && \
     npm install -g asciidoc-link-check
 
 COPY entrypoint.sh /sbin/entrypoint.sh

--- a/images/docs-builder/entrypoint.sh
+++ b/images/docs-builder/entrypoint.sh
@@ -2,7 +2,7 @@
 set -e
 
 if [ $# -lt 1 ]; then
-	echo "You need to provide an argument [build_docs, build_docs_pdf, docs_check_links, docs_serve]"
+	echo "You need to provide an argument [build_docs, docs_check_links, docs_serve]"
 fi
 
 case $1 in
@@ -10,11 +10,6 @@ case $1 in
 		echo "Generating html from docs source"
 		shift 
 		asciidoctor $@
-		;;
-	build_docs_pdf)
-		echo "Generating pdf from docs source"
-		shift 
-		asciidoctor-pdf $@
 		;;
 	docs_check_links)
 		echo "Checking if all links are alive in docs source"
@@ -25,7 +20,7 @@ case $1 in
 		python3 -m http.server 8088
 		;;
 	*)
-		echo "Need to provide one of: build_docs, build_docs_pdf, docs_check_links, docs_serve"
+		echo "Need to provide one of: build_docs, docs_check_links, docs_serve"
 		exit 1
 		;;
 esac


### PR DESCRIPTION
Previously, the documentation was generated as a PDF file and included in the archive for CodeReady Containers releases as an accessible way for users to consult the Getting Started Guide before we had a presence on the Customer Portal. We now have the documentation readily available there and it can be updated asynchronously, unlike the PDF file. Likewise, the PDF is not included in the MSI installer for Windows or the .pkg for macOS.