### PR TITLE
Use container runtime as docker for doc build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,23 +76,10 @@ jobs:
   build_docs:
     machine:
       image: ubuntu-2004:202101-01
+    environment:
+      CONTAINER_RUNTIME: "docker"
     steps:
     - checkout
-    - run:
-        name: Remove google chrome repository
-        command: sudo rm -f /etc/apt/sources.list.d/google-chrome.list
-    - run:
-        name: Add podman ppa and update repo
-        command: |
-          echo 'deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_20.04/ /' | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
-          curl -fsSL https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/xUbuntu_20.04/Release.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/devel_kubic_libcontainers_stable.gpg > /dev/null
-          sudo apt update
-    - run:
-        name: Install podman
-        command: sudo apt -y install podman
-    - run:
-        name: Check podman
-        command: podman info
     - run:
         name: Make build_docs
         # force GOPATH to a sane value as the image we are using has an older go version


### PR DESCRIPTION
There is an issue with podman storage side which stops us to build
the docs and produce following error.
```
make GOPATH="/home/circleci/go" build_docs

podman run -v /home/circleci/project/docs:/docs:Z --rm quay.io/crcont/docs-builder:latest build_docs -b html5 -D /docs/build -o index.html /docs/source/getting_started/master.adoc
Trying to pull quay.io/crcont/docs-builder:latest...
Getting image source signatures
[...]
Writing manifest to image destination
Storing signatures
  Error processing tar file(exit status 1): operation not permitted
Error: Error committing the finished image: error adding layer with blob "sha256:d2320253299952d6acf67a183191a320661feeec9a7c4f1cb5107ab23cef7d8e": Error processing tar file(exit status 1): operation not permitted
make: *** [Makefile:125: build_docs] Error 125

Exited with code exit status 2
```

- https://github.com/containers/buildah/issues/2326

fixes: #2267
