### PR TITLE
Remove warn message for local dns reachable in case of vsock

### DIFF
--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -350,7 +350,6 @@ func (client *client) Start(ctx context.Context, startConfig types.StartConfig) 
 		if !client.useVSock() {
 			return nil, errors.Wrapf(err, "Failed internal DNS query: %s", queryOutput)
 		}
-		logging.Warn(fmt.Sprintf("Failed internal DNS query: %s: %v", queryOutput, err))
 	}
 	logging.Info("Check internal and public DNS query ...")
 


### PR DESCRIPTION
In case of default/legacy network `CheckCRCLocalDNSReachable` function
should error out because the dns setup is not properly happen but in
case of vsock mode the routes are taken care but route controller so
this function which try to look for `foo.apps-crc.testing` always give
a warning in case of vsock mode.

This patch will remove that warn message.

fix: #2259