### PR TITLE
Issue #2276 Check if interface is nil before trying to convert it

### DIFF
--- a/pkg/crc/api/handlers.go
+++ b/pkg/crc/api/handlers.go
@@ -143,7 +143,11 @@ func (h *Handler) SetConfig(args json.RawMessage) string {
 		return encodeStructToJSON(setConfigResult)
 	}
 
-	configs := a["properties"].(map[string]interface{})
+	configs, ok := a["properties"].(map[string]interface{})
+	if !ok {
+		setConfigResult.Error = "No config keys provided"
+		return encodeStructToJSON(setConfigResult)
+	}
 
 	// successProps slice contains the properties that were successfully set
 	var successProps []string


### PR DESCRIPTION
This fixes the panic during interface conversion when the daemon is provided unexpected data
like: `echo '{"command":"setconfig", "args":{}}' | nc -U ~/.crc/crc.sock`

which results in the following panic:
```
DEBU rpc:0xc000114048: Received request: {"command":"setconfig", "args":{}}
panic: interface conversion: interface {} is nil, not map[string]interface {}

goroutine 88 [running]:
github.com/code-ready/crc/pkg/crc/api.(*Handler).SetConfig(0xc0005a80c0, 0xc00011a118, 0x2, 0x8, 0x0, 0x0)
	/home/anjan/github.com/code-ready/crc/pkg/crc/api/handlers.go:146 +0x717
github.com/code-ready/crc/pkg/crc/api.Server.handleRequest(0xc0005a80c0, 0x155bb60, 0xc0005a2240, 0xc00011a130, 0x9, 0xc00011a118, 0x2, 0x8, 0x156c1e0, 0xc000114048)
	/home/anjan/github.com/code-ready/crc/pkg/crc/api/api.go:61 +0x425
created by github.com/code-ready/crc/pkg/crc/api.Server.handleConnections
	/home/anjan/github.com/code-ready/crc/pkg/crc/api/api.go:92 +0x3c7

```