### PR TITLE
Remove upgrade code that fixes /etc/hosts permissions on macOS

### DIFF
--- a/pkg/crc/preflight/preflight_checks_darwin.go
+++ b/pkg/crc/preflight/preflight_checks_darwin.go
@@ -22,7 +22,6 @@ import (
 const (
 	resolverDir  = "/etc/resolver"
 	resolverFile = "/etc/resolver/testing"
-	hostsFile    = "/etc/hosts"
 )
 
 func checkM1CPU() error {
@@ -120,35 +119,6 @@ func fixMachineDriverHyperKitInstalled(networkMode network.Mode) func() error {
 		}
 		return setSuid(hyperkitDriver.GetExecutablePath())
 	}
-}
-
-func checkEtcHostsFilePermissions() error {
-	logging.Debugf("Checking if /etc/hosts ownership/permissions need to be adjusted after crc upgrade")
-	fileinfo, err := os.Stat(hostsFile)
-	if err != nil {
-		return err
-	}
-	// Older crc releases were setting /etc/hosts permissions to 0600 and ownership to the current user
-	// This will cause issues if ownership is reset to root:wheel with permissions
-	// issue if other tools
-	if fileinfo.Mode().Perm() == 0600 {
-		return fmt.Errorf("%s permissions are not 0644", hostsFile)
-	}
-	return nil
-}
-
-func fixEtcHostsFilePermissions() error {
-	stdOut, stdErr, err := crcos.RunPrivileged(fmt.Sprintf("Changing ownership of %s", hostsFile), "chown", "root:wheel", hostsFile)
-	if err != nil {
-		return fmt.Errorf("Unable to change ownership of %s: %s %v: %s", hostsFile, stdOut, err, stdErr)
-	}
-
-	stdOut, stdErr, err = crcos.RunPrivileged(fmt.Sprintf("Changing permissions of %s", hostsFile), "chmod", "644", hostsFile)
-	if err != nil {
-		return fmt.Errorf("Unable to change permissions of %s to 0644: %s %v: %s", hostsFile, stdOut, err, stdErr)
-	}
-
-	return nil
 }
 
 func checkResolverFilePermissions() error {

--- a/pkg/crc/preflight/preflight_darwin.go
+++ b/pkg/crc/preflight/preflight_darwin.go
@@ -39,16 +39,6 @@ func hyperkitPreflightChecks(networkMode network.Mode) []Check {
 	}
 }
 
-var dnsPreflightChecks = [...]Check{
-	{
-		configKeySuffix:  "check-hosts-file-permissions",
-		checkDescription: fmt.Sprintf("Checking file permissions for %s", hostsFile),
-		check:            checkEtcHostsFilePermissions,
-		fixDescription:   fmt.Sprintf("Setting file permissions for %s", hostsFile),
-		fix:              fixEtcHostsFilePermissions,
-	},
-}
-
 var resolverPreflightChecks = [...]Check{
 	{
 		configKeySuffix:    "check-resolver-file-permissions",
@@ -104,7 +94,6 @@ func getPreflightChecks(experimentalFeatures bool, trayAutostart bool, mode netw
 	checks = append(checks, nonWinPreflightChecks[:]...)
 	checks = append(checks, genericPreflightChecks[:]...)
 	checks = append(checks, hyperkitPreflightChecks(mode)...)
-	checks = append(checks, dnsPreflightChecks[:]...)
 	checks = append(checks, daemonSetupChecks[:]...)
 
 	if mode == network.DefaultMode {

--- a/pkg/crc/preflight/preflight_darwin_test.go
+++ b/pkg/crc/preflight/preflight_darwin_test.go
@@ -12,13 +12,13 @@ import (
 func TestCountConfigurationOptions(t *testing.T) {
 	cfg := config.New(config.NewEmptyInMemoryStorage())
 	RegisterSettings(cfg)
-	assert.Len(t, cfg.AllConfigs(), 10)
+	assert.Len(t, cfg.AllConfigs(), 9)
 }
 
 func TestCountPreflights(t *testing.T) {
-	assert.Len(t, getPreflightChecks(true, false, network.DefaultMode), 16)
-	assert.Len(t, getPreflightChecks(true, true, network.DefaultMode), 16)
+	assert.Len(t, getPreflightChecks(true, false, network.DefaultMode), 15)
+	assert.Len(t, getPreflightChecks(true, true, network.DefaultMode), 15)
 
-	assert.Len(t, getPreflightChecks(true, false, network.VSockMode), 15)
-	assert.Len(t, getPreflightChecks(true, true, network.VSockMode), 15)
+	assert.Len(t, getPreflightChecks(true, false, network.VSockMode), 14)
+	assert.Len(t, getPreflightChecks(true, true, network.VSockMode), 14)
 }


### PR DESCRIPTION
This code was introduced to fix crc 1.10 and before (see
https://github.com/code-ready/crc/pull/1350).

---

It removes one more piece of code that requires sudo. It will be easier to include `crc setup` in the .pkg with fewer sudo actions.