### PR TITLE
docs: Fix remote server instructions for rhel7

### DIFF
--- a/docs/source/topics/proc_setting-up-remote-server.adoc
+++ b/docs/source/topics/proc_setting-up-remote-server.adoc
@@ -31,7 +31,7 @@ Ensure that the cluster remains running throughout this procedure.
 . Install the [package]`haproxy` package and other utilities:
 +
 ----
-$ sudo dnf install haproxy policycoreutils-python-utils
+$ sudo dnf install haproxy /usr/sbin/semanage
 ----
 
 . Modify the firewall to allow communication with the cluster:


### PR DESCRIPTION
policycoreutils-python-utils was named policycoreutils-utils in rhel7.
This commit switches to 'dnf install /usr/sbin/semanage' as this will
get resolved to the right package name, and it's also more obvious (I
remember wondering why installing policycoreutils-python-utils was
needed).

This fixes https://github.com/code-ready/crc/issues/2278