### PR TITLE
Run all setup preflights when --check-only is used

### DIFF
--- a/cmd/crc/cmd/setup.go
+++ b/cmd/crc/cmd/setup.go
@@ -54,17 +54,13 @@ func runSetup(arguments []string) error {
 			fmt.Printf("No worry, you can still enable telemetry manually with the command 'crc config set %s yes'.\n", cmdConfig.ConsentTelemetry)
 		}
 	}
-	var err error
-	if checkOnly {
-		err = preflight.StartPreflightChecks(config)
-		if err != nil {
-			err = exec.CodeExitError{
-				Err:  err,
-				Code: preflightFailedExitCode,
-			}
+
+	err := preflight.SetupHost(config, checkOnly)
+	if err != nil && checkOnly {
+		err = exec.CodeExitError{
+			Err:  err,
+			Code: preflightFailedExitCode,
 		}
-	} else {
-		err = preflight.SetupHost(config)
 	}
 
 	return render(&setupResult{

--- a/pkg/crc/preflight/preflight.go
+++ b/pkg/crc/preflight/preflight.go
@@ -101,7 +101,7 @@ func doPreflightChecks(config config.Storage, checks []Check) error {
 	return nil
 }
 
-func doFixPreflightChecks(config config.Storage, checks []Check) error {
+func doFixPreflightChecks(config config.Storage, checks []Check, checkOnly bool) error {
 	for _, check := range checks {
 		if check.flags&CleanUpOnly == CleanUpOnly {
 			continue
@@ -109,6 +109,8 @@ func doFixPreflightChecks(config config.Storage, checks []Check) error {
 		err := check.doCheck(config)
 		if err == nil {
 			continue
+		} else if checkOnly {
+			return err
 		}
 		if err = check.doFix(); err != nil {
 			return err
@@ -160,11 +162,11 @@ func StartPreflightChecks(config config.Storage) error {
 }
 
 // SetupHost performs the prerequisite checks and setups the host to run the cluster
-func SetupHost(config config.Storage) error {
+func SetupHost(config config.Storage, checkOnly bool) error {
 	experimentalFeatures := config.Get(cmdConfig.ExperimentalFeatures).AsBool()
 	mode := network.ParseMode(config.Get(cmdConfig.NetworkMode).AsString())
 	trayAutostart := config.Get(cmdConfig.AutostartTray).AsBool()
-	return doFixPreflightChecks(config, getPreflightChecks(experimentalFeatures, trayAutostart, mode))
+	return doFixPreflightChecks(config, getPreflightChecks(experimentalFeatures, trayAutostart, mode), checkOnly)
 }
 
 func RegisterSettings(config config.Schema) {

--- a/pkg/crc/preflight/preflight_test.go
+++ b/pkg/crc/preflight/preflight_test.go
@@ -34,9 +34,19 @@ func TestFixPreflight(t *testing.T) {
 	cfg := config.New(config.NewEmptyInMemoryStorage())
 	doRegisterSettings(cfg, []Check{*check})
 
-	assert.NoError(t, doFixPreflightChecks(cfg, []Check{*check}))
+	assert.NoError(t, doFixPreflightChecks(cfg, []Check{*check}, false))
 	assert.True(t, calls.checked)
 	assert.True(t, calls.fixed)
+}
+
+func TestFixPreflightCheckOnly(t *testing.T) {
+	check, calls := sampleCheck(errors.New("check failed"), nil)
+	cfg := config.New(config.NewEmptyInMemoryStorage())
+	doRegisterSettings(cfg, []Check{*check})
+
+	assert.Error(t, doFixPreflightChecks(cfg, []Check{*check}, true))
+	assert.True(t, calls.checked)
+	assert.False(t, calls.fixed)
 }
 
 func sampleCheck(checkErr, fixErr error) (*Check, *status) {


### PR DESCRIPTION
Previous attempt in commit e07d23985fa missed some checks as it is
running the checks which are run at crc start time, and thus it ignores
the ones marked as SetupOnly. In particular, it does not report properly
if the bundle needs to be extracted or not, which is one of the last
preflights ran by `crc setup`

This commit adds a checkOnly parameter to SetupHost() so that it can
error out when a preflight check fails rather than trying to fix it.

This should fix https://github.com/code-ready/crc/issues/2225