### PR TITLE
[E2E] Remove e2e test for skip-check-hosts-file-permissions 

### DIFF
--- a/test/e2e/features/config.feature
+++ b/test/e2e/features/config.feature
@@ -74,7 +74,6 @@ Feature: Test configuration settings
         Examples:
             | property                             | value1 | value2 |
             | skip-check-bundle-extracted          | true   | false  |
-            | skip-check-hosts-file-permissions    | true   | false  |
             | skip-check-hyperkit-driver           | true   | false  |
             | skip-check-hyperkit-installed        | true   | false  |
             | skip-check-resolver-file-permissions | true   | false  |


### PR DESCRIPTION
This options was recently removed on #2282.

This PR fixes the e2e which was testing that property.