### PR TITLE
Remove typos related to crc bundle generate

### DIFF
--- a/pkg/crc/machine/bundle/metadata.go
+++ b/pkg/crc/machine/bundle/metadata.go
@@ -224,5 +224,5 @@ func GetCustomBundleNameWithoutExtension(bundleName string) string {
 }
 
 func GetCustomBundle(bundleNameWithoutExtension string) string {
-	return fmt.Sprintf("%s.%s", bundleNameWithoutExtension, bundleExtension)
+	return fmt.Sprintf("%s%s", bundleNameWithoutExtension, bundleExtension)
 }

--- a/test/e2e/features/basic.feature
+++ b/test/e2e/features/basic.feature
@@ -139,7 +139,7 @@ Feature: Basic test
     Scenario: Bundle generation check
         # This will remove the pull secret from the instance and from the cluster
         # You need to provide pull secret file again if you want to start this cluster
-        # from an stopped state.
+        # from a stopped state.
         Given executing "crc bundle generate" succeeds
 
     @darwin @windows


### PR DESCRIPTION
1. Double `.` in the INFO messages printed to the user (in bundle name). 
```bash
INFO Bundle is generated in /home/jsliacan/github/code-ready/crc/crc_libvirt_4.7.7_1619688289..crcbundle 
INFO You need to perform 'crc delete' and 'crc start -b /home/jsliacan/github/code-ready/crc/crc_libvirt_4.7.7_1619688289..crcbundle' to use this bundle
```
2. Just a petty one in the comment.