### PR TITLE
`crc bundle generate` improvements

### DIFF
--- a/pkg/crc/machine/bundle/metadata.go
+++ b/pkg/crc/machine/bundle/metadata.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -219,6 +220,8 @@ func GetBundleNameWithoutExtension(bundleName string) string {
 	return strings.TrimSuffix(bundleName, bundleExtension)
 }
 
-func GetCustomBundleName(bundleName string) string {
-	return fmt.Sprintf("%s_%d%s", GetBundleNameWithoutExtension(bundleName), time.Now().Unix(), bundleExtension)
+func GetCustomBundleName(bundleFilename string) string {
+	re := regexp.MustCompile(`(?:_[0-9]+)*.crcbundle$`)
+	baseName := re.ReplaceAllLiteralString(bundleFilename, "")
+	return fmt.Sprintf("%s_%d%s", baseName, time.Now().Unix(), bundleExtension)
 }

--- a/pkg/crc/machine/bundle/metadata.go
+++ b/pkg/crc/machine/bundle/metadata.go
@@ -219,10 +219,6 @@ func GetBundleNameWithoutExtension(bundleName string) string {
 	return strings.TrimSuffix(bundleName, bundleExtension)
 }
 
-func GetCustomBundleNameWithoutExtension(bundleName string) string {
-	return fmt.Sprintf("%s_%d", GetBundleNameWithoutExtension(bundleName), time.Now().Unix())
-}
-
-func GetCustomBundle(bundleNameWithoutExtension string) string {
-	return fmt.Sprintf("%s%s", bundleNameWithoutExtension, bundleExtension)
+func GetCustomBundleName(bundleName string) string {
+	return fmt.Sprintf("%s_%d%s", GetBundleNameWithoutExtension(bundleName), time.Now().Unix(), bundleExtension)
 }

--- a/pkg/crc/machine/generate_bundle.go
+++ b/pkg/crc/machine/generate_bundle.go
@@ -77,7 +77,7 @@ func (client *client) GenerateBundle() error {
 	// Copy disk image
 	logging.Infof("Copying the disk image to %s", customBundleNameWithoutExtension)
 	logging.Debugf("Absolute path of custom bundle directory: %s", customBundleDir)
-	diskPath, diskFormat, err := copyDiskImage(customBundleDir, bundleMetadata.GetDiskImagePath())
+	diskPath, diskFormat, err := copyDiskImage(customBundleDir)
 	if err != nil {
 		return err
 	}

--- a/pkg/crc/machine/generate_bundle.go
+++ b/pkg/crc/machine/generate_bundle.go
@@ -44,7 +44,8 @@ func (client *client) GenerateBundle() error {
 	defer os.RemoveAll(tmpBaseDir)
 
 	// Create the custom bundle directory which is used as top level directory for tarball during compression
-	customBundleNameWithoutExtension := bundle.GetCustomBundleNameWithoutExtension(bundleMetadata.GetBundleName())
+	customBundleName := bundle.GetCustomBundleName(bundleMetadata.GetBundleName())
+	customBundleNameWithoutExtension := bundle.GetBundleNameWithoutExtension(customBundleName)
 
 	copier, err := bundle.NewCopier(bundleMetadata, tmpBaseDir, customBundleNameWithoutExtension)
 	if err != nil {
@@ -92,8 +93,8 @@ func (client *client) GenerateBundle() error {
 	if err != nil {
 		return err
 	}
-	logging.Infof("Bundle is generated in %s", filepath.Join(cwd, bundle.GetCustomBundle(customBundleNameWithoutExtension)))
-	logging.Infof("You need to perform 'crc delete' and 'crc start -b %s' to use this bundle", filepath.Join(cwd, bundle.GetCustomBundle(customBundleNameWithoutExtension)))
+	logging.Infof("Bundle is generated in %s", filepath.Join(cwd, customBundleName))
+	logging.Infof("You need to perform 'crc delete' and 'crc start -b %s' to use this bundle", filepath.Join(cwd, customBundleName))
 	return nil
 }
 

--- a/pkg/crc/machine/generate_bundle_linux.go
+++ b/pkg/crc/machine/generate_bundle_linux.go
@@ -1,50 +1,25 @@
 package machine
 
 import (
-	"os"
+	"fmt"
 	"path/filepath"
 
 	"github.com/code-ready/crc/pkg/crc/constants"
 	crcos "github.com/code-ready/crc/pkg/os"
 )
 
-func copyDiskImage(destDir string, srcDir string) (string, string, error) {
-	tmpDir := filepath.Join(constants.MachineCacheDir, "image-rebase")
-	_ = os.RemoveAll(tmpDir) // clean up before using it
-	if err := os.Mkdir(tmpDir, 0700); err != nil {
-		return "", "", err
-	}
-	defer func() {
-		_ = os.RemoveAll(tmpDir) // clean up after using it
-	}()
+func copyDiskImage(destDir string) (string, string, error) {
+	const destFormat = "qcow2"
 
-	// We copy the overlay file because before doing the commit, we need to adjust the backing file.
-	baseImageName := filepath.Base(srcDir)
-	srcOverlayDiskPath := filepath.Join(constants.MachineInstanceDir, constants.DefaultName, baseImageName)
-	destOverlayDiskPath := filepath.Join(tmpDir, "overlayImage.qcow2")
-	if err := crcos.CopyFileContents(srcOverlayDiskPath, destOverlayDiskPath, 0644); err != nil {
+	imageName := fmt.Sprintf("%s.qcow2", constants.DefaultName)
+
+	srcPath := filepath.Join(constants.MachineInstanceDir, constants.DefaultName, imageName)
+	destPath := filepath.Join(destDir, imageName)
+
+	_, _, err := crcos.RunWithDefaultLocale("qemu-img", "convert", "-f", "qcow2", "-O", destFormat, srcPath, destPath)
+	if err != nil {
 		return "", "", err
 	}
 
-	// We copy the base image because this is where we are going to commit the changes which were made to the VM
-	if err := crcos.CopyFileContents(srcDir,
-		filepath.Join(tmpDir, baseImageName), 0644); err != nil {
-		return "", "", err
-	}
-
-	// Use qemu-img commands to rebase and commit it.
-	format := "qcow2"
-	if _, _, err := crcos.RunWithDefaultLocale("qemu-img", "rebase", "-F", format, "-b",
-		filepath.Join(tmpDir, baseImageName), destOverlayDiskPath); err != nil {
-		return "", "", err
-	}
-	if _, _, err := crcos.RunWithDefaultLocale("qemu-img", "commit", destOverlayDiskPath); err != nil {
-		return "", "", err
-	}
-
-	// Copy the final image to destination dir
-	if err := crcos.CopyFileContents(filepath.Join(tmpDir, baseImageName), filepath.Join(destDir, baseImageName), 0644); err != nil {
-		return "", "", err
-	}
-	return filepath.Join(destDir, baseImageName), format, nil
+	return destPath, destFormat, nil
 }

--- a/pkg/crc/machine/generate_bundle_nonlinux.go
+++ b/pkg/crc/machine/generate_bundle_nonlinux.go
@@ -7,6 +7,6 @@ import (
 	"runtime"
 )
 
-func copyDiskImage(dirName string, srcDir string) (string, string, error) {
+func copyDiskImage(dirName string) (string, string, error) {
 	return "", "", fmt.Errorf("Not implemented for %s", runtime.GOOS)
 }


### PR DESCRIPTION
This PR has 2 main changes to the 'crc bundle generate' code:
- it uses a simpler/faster method to copy the disk image to the new bundle
- it fixes the name of custom bundles when the source bundle is already a custom bundle

The only user visible changes is the name of the bundle which will always be like `crc_libvirt_4.8.8_11111111.crcbundle`,
while in current master we can have repeated suffixes (`crc_libvirt_4.8.8_11111111_11111111_11111111.crcbundle`).