### PR TITLE
macOS pkg: set the list of supported architectures (x86_64, not arm64)

### DIFF
--- a/packaging/darwin/Distribution.in
+++ b/packaging/darwin/Distribution.in
@@ -7,7 +7,7 @@
     <license file="LICENSE.txt"/>
     <options customize="never" allow-external-scripts="no"/>
     <domains enable_localSystem="true" />
-    <options rootVolumeOnly="true"/>
+    <options rootVolumeOnly="true" hostArchitectures="x86_64" />
     <installation-check script="installCheck();"/>
     <script>
 function installCheck() {


### PR DESCRIPTION
This should prevent users from installing the pkg on M1 machines.

(to be tested on a M1 machine...)