### PR TITLE
macOS pkg: check for memory installed

### DIFF
--- a/packaging/darwin/Distribution.in
+++ b/packaging/darwin/Distribution.in
@@ -11,6 +11,13 @@
     <installation-check script="installCheck();"/>
     <script>
 function installCheck() {
+    if (9216000000 > system.sysctl('hw.memsize')) {
+        my.result.title = 'Too few memory installed';
+        my.result.message = 'CodeReady Containers requires at least 9GB of memory to run';
+        my.result.type = 'Fatal';
+        return false;
+    }
+
 	var apps = system.applications.fromIdentifier('com.redhat.codeready.containers');
 	if(apps) {
         my.result.title = 'Update failed';


### PR DESCRIPTION
It will refuse to install if there is less than 9GB of RAM.

<img width="732" alt="Screenshot 2021-04-30 at 22 14 21" src="https://user-images.githubusercontent.com/172624/116749613-7cc66c80-aa01-11eb-9310-b86b7f9d985d.png">

---

I am not sure about the unit but I guess given macbook specs, it only accepts 16GB machines.