### PR TITLE
Add an enum for OpenShift status. Ensure it doesn't change.

### DIFF
--- a/cmd/crc/cmd/status.go
+++ b/cmd/crc/cmd/status.go
@@ -10,6 +10,7 @@ import (
 	"github.com/code-ready/crc/pkg/crc/constants"
 	crcErrors "github.com/code-ready/crc/pkg/crc/errors"
 	"github.com/code-ready/crc/pkg/crc/machine"
+	"github.com/code-ready/crc/pkg/crc/machine/types"
 	"github.com/docker/go-units"
 	"github.com/spf13/cobra"
 )
@@ -32,7 +33,7 @@ type status struct {
 	Success          bool                         `json:"success"`
 	Error            *crcErrors.SerializableError `json:"error,omitempty"`
 	CrcStatus        string                       `json:"crcStatus,omitempty"`
-	OpenShiftStatus  string                       `json:"openshiftStatus,omitempty"`
+	OpenShiftStatus  types.OpenshiftStatus        `json:"openshiftStatus,omitempty"`
 	OpenShiftVersion string                       `json:"openshiftVersion,omitempty"`
 	DiskUsage        int64                        `json:"diskUsage,omitempty"`
 	DiskSize         int64                        `json:"diskSize,omitempty"`
@@ -107,7 +108,7 @@ func openshiftStatus(status *status) string {
 	if status.OpenShiftVersion != "" {
 		return fmt.Sprintf("%s (v%s)", status.OpenShiftStatus, status.OpenShiftVersion)
 	}
-	return status.OpenShiftStatus
+	return string(status.OpenShiftStatus)
 }
 
 func printLine(w *tabwriter.Writer, left string, right string) error {

--- a/pkg/crc/api/adapter.go
+++ b/pkg/crc/api/adapter.go
@@ -88,7 +88,7 @@ func (a *Adapter) Status() client.ClusterStatusResult {
 	return client.ClusterStatusResult{
 		Name:             a.Underlying.GetName(),
 		CrcStatus:        res.CrcStatus.String(),
-		OpenshiftStatus:  res.OpenshiftStatus,
+		OpenshiftStatus:  string(res.OpenshiftStatus),
 		OpenshiftVersion: res.OpenshiftVersion,
 		DiskUse:          res.DiskUse,
 		DiskSize:         res.DiskSize,

--- a/pkg/crc/machine/fakemachine/client.go
+++ b/pkg/crc/machine/fakemachine/client.go
@@ -95,7 +95,7 @@ func (c *Client) Status() (*types.ClusterStatusResult, error) {
 	}
 	return &types.ClusterStatusResult{
 		CrcStatus:        state.Running,
-		OpenshiftStatus:  "Running",
+		OpenshiftStatus:  types.OpenshiftRunning,
 		OpenshiftVersion: "4.5.1",
 		DiskUse:          10_000_000_000,
 		DiskSize:         20_000_000_000,

--- a/pkg/crc/machine/status.go
+++ b/pkg/crc/machine/status.go
@@ -37,7 +37,7 @@ func (client *client) Status() (*types.ClusterStatusResult, error) {
 	if vmStatus != state.Running {
 		return &types.ClusterStatusResult{
 			CrcStatus:        vmStatus,
-			OpenshiftStatus:  "Stopped",
+			OpenshiftStatus:  types.OpenshiftStopped,
 			OpenshiftVersion: crcBundleMetadata.GetOpenshiftVersion(),
 		}, nil
 	}
@@ -65,19 +65,19 @@ func (client *client) Status() (*types.ClusterStatusResult, error) {
 	}, nil
 }
 
-func getOpenShiftStatus(sshRunner *crcssh.Runner, monitoringEnabled bool) string {
+func getOpenShiftStatus(sshRunner *crcssh.Runner, monitoringEnabled bool) types.OpenshiftStatus {
 	status, err := cluster.GetClusterOperatorsStatus(oc.UseOCWithSSH(sshRunner), monitoringEnabled)
 	if err != nil {
 		logging.Debugf("cannot get OpenShift status: %v", err)
-		return "Unreachable"
+		return types.OpenshiftUnreachable
 	}
 	switch {
 	case status.Progressing:
-		return "Starting"
+		return types.OpenshiftStarting
 	case status.Degraded:
-		return "Degraded"
+		return types.OpenshiftDegraded
 	case status.Available:
-		return "Running"
+		return types.OpenshiftRunning
 	}
-	return "Stopped"
+	return types.OpenshiftStopped
 }

--- a/pkg/crc/machine/types/types.go
+++ b/pkg/crc/machine/types/types.go
@@ -46,11 +46,21 @@ type StopResult struct {
 
 type ClusterStatusResult struct {
 	CrcStatus        state.State
-	OpenshiftStatus  string
+	OpenshiftStatus  OpenshiftStatus
 	OpenshiftVersion string
 	DiskUse          int64
 	DiskSize         int64
 }
+
+type OpenshiftStatus string
+
+const (
+	OpenshiftUnreachable OpenshiftStatus = "Unreachable"
+	OpenshiftStarting    OpenshiftStatus = "Starting"
+	OpenshiftRunning     OpenshiftStatus = "Running"
+	OpenshiftDegraded    OpenshiftStatus = "Degraded"
+	OpenshiftStopped     OpenshiftStatus = "Stopped"
+)
 
 type ConsoleResult struct {
 	ClusterConfig ClusterConfig


### PR DESCRIPTION
These values are used in various clients (consumers of the json output
of the CLI, tray, etc.). It is better to highlight this with an enum.

The goal is after to consolidate the 3 enums:

``` 
// State represents the state of a host
type State int

const (
	None State = iota
	Running
	Paused
	Saved
	Stopped
	Stopping
	Starting
	Error
	Timeout
)

type State string

const (
	Idle     State = "Idle"
	Deleting State = "Deleting"
	Stopping State = "Stopping"
	Starting State = "Starting"
)

type OpenshiftStatus string

const (
	OpenshiftUnreachable OpenshiftStatus = "Unreachable"
	OpenshiftStarting    OpenshiftStatus = "Starting"
	OpenshiftRunning     OpenshiftStatus = "Running"
	OpenshiftDegraded    OpenshiftStatus = "Degraded"
	OpenshiftStopped     OpenshiftStatus = "Stopped"
)
```