### PR TITLE
Remove differences between machine creation and machine start

### DIFF
--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -187,51 +187,51 @@ func (client *client) Start(ctx context.Context, startConfig types.StartConfig) 
 		if err != nil {
 			return nil, errors.Wrap(err, "Error creating machine")
 		}
-	} else { // exists
-		host, err = libMachineAPIClient.Load(client.name)
-		if err != nil {
-			return nil, errors.Wrap(err, "Error loading machine")
-		}
-
-		crcBundleMetadata, err = getBundleMetadataFromDriver(host.Driver)
-		if err != nil {
-			return nil, errors.Wrap(err, "Error loading bundle metadata")
-		}
-		bundleName := crcBundleMetadata.GetBundleName()
-		if bundleName != filepath.Base(startConfig.BundlePath) {
-			logging.Debugf("Bundle '%s' was requested, but the existing VM is using '%s'",
-				filepath.Base(startConfig.BundlePath), bundleName)
-			return nil, fmt.Errorf("Bundle '%s' was requested, but the existing VM is using '%s'",
-				filepath.Base(startConfig.BundlePath),
-				bundleName)
-		}
-		vmState, err := host.Driver.GetState()
-		if err != nil {
-			return nil, errors.Wrap(err, "Error getting the machine state")
-		}
-		if vmState == state.Running {
-			logging.Infof("A CodeReady Containers VM for OpenShift %s is already running", crcBundleMetadata.GetOpenshiftVersion())
-			clusterConfig, err := getClusterConfig(crcBundleMetadata)
-			if err != nil {
-				return nil, errors.Wrap(err, "Cannot create cluster configuration")
-			}
-
-			telemetry.SetStartType(ctx, telemetry.AlreadyRunningStartType)
-			return &types.StartResult{
-				Status:         vmState,
-				ClusterConfig:  *clusterConfig,
-				KubeletStarted: true,
-			}, nil
-		}
-
-		if _, err := bundle.Use(bundleName); err != nil {
-			return nil, err
-		}
-
+	} else {
 		telemetry.SetStartType(ctx, telemetry.StartStartType)
-
-		logging.Infof("Starting CodeReady Containers VM for OpenShift %s...", crcBundleMetadata.GetOpenshiftVersion())
 	}
+
+	host, err = libMachineAPIClient.Load(client.name)
+	if err != nil {
+		return nil, errors.Wrap(err, "Error loading machine")
+	}
+
+	crcBundleMetadata, err = getBundleMetadataFromDriver(host.Driver)
+	if err != nil {
+		return nil, errors.Wrap(err, "Error loading bundle metadata")
+	}
+	bundleName := crcBundleMetadata.GetBundleName()
+	if bundleName != filepath.Base(startConfig.BundlePath) {
+		logging.Debugf("Bundle '%s' was requested, but the existing VM is using '%s'",
+			filepath.Base(startConfig.BundlePath), bundleName)
+		return nil, fmt.Errorf("Bundle '%s' was requested, but the existing VM is using '%s'",
+			filepath.Base(startConfig.BundlePath),
+			bundleName)
+	}
+	vmState, err := host.Driver.GetState()
+	if err != nil {
+		return nil, errors.Wrap(err, "Error getting the machine state")
+	}
+	if vmState == state.Running {
+		logging.Infof("A CodeReady Containers VM for OpenShift %s is already running", crcBundleMetadata.GetOpenshiftVersion())
+		clusterConfig, err := getClusterConfig(crcBundleMetadata)
+		if err != nil {
+			return nil, errors.Wrap(err, "Cannot create cluster configuration")
+		}
+
+		telemetry.SetStartType(ctx, telemetry.AlreadyRunningStartType)
+		return &types.StartResult{
+			Status:         vmState,
+			ClusterConfig:  *clusterConfig,
+			KubeletStarted: true,
+		}, nil
+	}
+
+	if _, err := bundle.Use(bundleName); err != nil {
+		return nil, err
+	}
+
+	logging.Infof("Starting CodeReady Containers VM for OpenShift %s...", crcBundleMetadata.GetOpenshiftVersion())
 
 	if client.useVSock() {
 		if err := exposePorts(); err != nil {
@@ -259,7 +259,7 @@ func (client *client) Start(ctx context.Context, startConfig types.StartConfig) 
 	}
 
 	// Post-VM start
-	vmState, err := host.Driver.GetState()
+	vmState, err = host.Driver.GetState()
 	if err != nil {
 		return nil, errors.Wrap(err, "Error getting the state")
 	}

--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -192,9 +192,12 @@ func (client *client) Start(ctx context.Context, startConfig types.StartConfig) 
 		machineConfig.Initramfs = crcBundleMetadata.GetInitramfsPath()
 		machineConfig.Kernel = crcBundleMetadata.GetKernelPath()
 
-		host, err = createHost(ctx, libMachineAPIClient, machineConfig)
+		host, err = createHost(libMachineAPIClient, machineConfig)
 		if err != nil {
 			return nil, errors.Wrap(err, "Error creating machine")
+		}
+		if err := startHost(ctx, libMachineAPIClient, host); err != nil {
+			return nil, errors.Wrap(err, "Error starting machine")
 		}
 	} else { // exists
 		host, err = libMachineAPIClient.Load(client.name)
@@ -521,52 +524,49 @@ func makeDaemonVisibleToHyperkit(name string) error {
 	return nil
 }
 
-func createHost(ctx context.Context, api *libmachine.Client, machineConfig config.MachineConfig) (*host.Host, error) {
+func createHost(api *libmachine.Client, machineConfig config.MachineConfig) (*host.Host, error) {
 	vm, err := newHost(api, machineConfig)
 	if err != nil {
 		return nil, fmt.Errorf("Error creating new host: %s", err)
 	}
-	if err := createAndStartHost(ctx, api, vm); err != nil {
-		return nil, fmt.Errorf("Error creating the VM: %s", err)
-	}
-	return vm, nil
-}
 
-// Create is the wrapper method which covers all of the boilerplate around
-// actually creating, provisioning, and persisting an instance in the store.
-func createAndStartHost(ctx context.Context, api *libmachine.Client, h *host.Host) error {
 	logging.Debug("Running pre-create checks...")
 
-	if err := h.Driver.PreCreateCheck(); err != nil {
-		return errors.Wrap(err, "error with pre-create check")
+	if err := vm.Driver.PreCreateCheck(); err != nil {
+		return nil, errors.Wrap(err, "error with pre-create check")
 	}
 
-	if err := api.Save(h); err != nil {
-		return fmt.Errorf("Error saving host to store before attempting creation: %s", err)
+	if err := api.Save(vm); err != nil {
+		return nil, fmt.Errorf("Error saving host to store before attempting creation: %s", err)
 	}
 
 	logging.Debug("Creating machine...")
 
-	if err := h.Driver.Create(); err != nil {
-		return fmt.Errorf("Error in driver during machine creation: %s", err)
+	if err := vm.Driver.Create(); err != nil {
+		return nil, fmt.Errorf("Error in driver during machine creation: %s", err)
 	}
 
-	if err := h.Driver.Start(); err != nil {
+	logging.Debug("Machine successfully created")
+	return vm, nil
+}
+
+func startHost(ctx context.Context, api *libmachine.Client, vm *host.Host) error {
+	if err := vm.Driver.Start(); err != nil {
 		return fmt.Errorf("Error in driver during machine start: %s", err)
 	}
 
-	if err := api.Save(h); err != nil {
+	if err := api.Save(vm); err != nil {
 		return fmt.Errorf("Error saving host to store after attempting creation: %s", err)
 	}
 
 	logging.Debug("Waiting for machine to be running, this may take a few minutes...")
-	if err := crcerrors.RetryAfterWithContext(ctx, 3*time.Minute, host.MachineInState(h.Driver, state.Running), 3*time.Second); err != nil {
+	if err := crcerrors.RetryAfterWithContext(ctx, 3*time.Minute, host.MachineInState(vm.Driver, state.Running), 3*time.Second); err != nil {
 		return fmt.Errorf("Error waiting for machine to be running: %s", err)
 	}
 
 	logging.Debug("Machine is up and running!")
 
-	if err := api.SetExists(h.Name); err != nil {
+	if err := api.SetExists(vm.Name); err != nil {
 		logging.Debug("Failed to record VM existence")
 	}
 

--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -254,8 +254,8 @@ func (client *client) Start(ctx context.Context, startConfig types.StartConfig) 
 			return nil, errors.Wrap(err, "Could not update CRC VM configuration")
 		}
 
-		if err := host.Driver.Start(); err != nil {
-			return nil, errors.Wrap(err, "Error starting stopped VM")
+		if err := startHost(ctx, libMachineAPIClient, host); err != nil {
+			return nil, errors.Wrap(err, "Error starting machine")
 		}
 	}
 

--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -162,15 +162,6 @@ func (client *client) Start(ctx context.Context, startConfig types.StartConfig) 
 			return nil, errors.Wrap(err, "Failed to ask for pull secret")
 		}
 
-		machineConfig := config.MachineConfig{
-			Name:        client.name,
-			BundleName:  filepath.Base(startConfig.BundlePath),
-			CPUs:        startConfig.CPUs,
-			Memory:      startConfig.Memory,
-			DiskSize:    startConfig.DiskSize,
-			NetworkMode: client.networkMode(),
-		}
-
 		crcBundleMetadata, err = getCrcBundleInfo(startConfig.BundlePath)
 		if err != nil {
 			return nil, errors.Wrap(err, "Error getting bundle metadata")
@@ -184,14 +175,20 @@ func (client *client) Start(ctx context.Context, startConfig types.StartConfig) 
 
 		logging.Infof("Creating CodeReady Containers VM for OpenShift %s...", crcBundleMetadata.GetOpenshiftVersion())
 
-		// Retrieve metadata info
-		machineConfig.ImageSourcePath = crcBundleMetadata.GetDiskImagePath()
-		machineConfig.ImageFormat = crcBundleMetadata.GetDiskImageFormat()
-		machineConfig.SSHKeyPath = crcBundleMetadata.GetSSHKeyPath()
-		machineConfig.KernelCmdLine = crcBundleMetadata.GetKernelCommandLine()
-		machineConfig.Initramfs = crcBundleMetadata.GetInitramfsPath()
-		machineConfig.Kernel = crcBundleMetadata.GetKernelPath()
-
+		machineConfig := config.MachineConfig{
+			Name:            client.name,
+			BundleName:      filepath.Base(startConfig.BundlePath),
+			CPUs:            startConfig.CPUs,
+			Memory:          startConfig.Memory,
+			DiskSize:        startConfig.DiskSize,
+			NetworkMode:     client.networkMode(),
+			ImageSourcePath: crcBundleMetadata.GetDiskImagePath(),
+			ImageFormat:     crcBundleMetadata.GetDiskImageFormat(),
+			SSHKeyPath:      crcBundleMetadata.GetSSHKeyPath(),
+			KernelCmdLine:   crcBundleMetadata.GetKernelCommandLine(),
+			Initramfs:       crcBundleMetadata.GetInitramfsPath(),
+			Kernel:          crcBundleMetadata.GetKernelPath(),
+		}
 		host, err = createHost(libMachineAPIClient, machineConfig)
 		if err != nil {
 			return nil, errors.Wrap(err, "Error creating machine")

--- a/pkg/libmachine/host/host.go
+++ b/pkg/libmachine/host/host.go
@@ -43,17 +43,6 @@ func (h *Host) runActionForState(action func() error, desiredState state.State) 
 	return crcerrors.RetryAfter(3*time.Minute, MachineInState(h.Driver, desiredState), 3*time.Second)
 }
 
-func (h *Host) Start() error {
-	log.Debugf("Starting %q...", h.Name)
-	if err := h.runActionForState(h.Driver.Start, state.Running); err != nil {
-		return err
-	}
-
-	log.Debugf("Machine %q was started.", h.Name)
-
-	return nil
-}
-
 func (h *Host) Stop() error {
 	log.Debugf("Stopping %q...", h.Name)
 	if err := h.runActionForState(h.Driver.Stop, state.Stopped); err != nil {

--- a/pkg/libmachine/libmachine.go
+++ b/pkg/libmachine/libmachine.go
@@ -1,27 +1,19 @@
 package libmachine
 
 import (
-	"context"
 	"encoding/json"
-	"fmt"
 	"io"
-	"time"
 
-	crcerrors "github.com/code-ready/crc/pkg/crc/errors"
-	log "github.com/code-ready/crc/pkg/crc/logging"
 	"github.com/code-ready/crc/pkg/drivers/hyperv"
 	"github.com/code-ready/crc/pkg/libmachine/host"
 	"github.com/code-ready/crc/pkg/libmachine/persist"
 	"github.com/code-ready/machine/libmachine/drivers"
 	rpcdriver "github.com/code-ready/machine/libmachine/drivers/rpc"
-	"github.com/code-ready/machine/libmachine/state"
-	"github.com/pkg/errors"
 )
 
 type API interface {
 	io.Closer
 	NewHost(driverName string, driverPath string, rawDriver []byte) (*host.Host, error)
-	Create(ctx context.Context, h *host.Host) error
 	persist.Store
 }
 
@@ -83,47 +75,6 @@ func (api *Client) Load(name string) (*host.Host, error) {
 	}
 	h.Driver = d
 	return h, nil
-}
-
-// Create is the wrapper method which covers all of the boilerplate around
-// actually creating, provisioning, and persisting an instance in the store.
-func (api *Client) Create(ctx context.Context, h *host.Host) error {
-	log.Debug("Running pre-create checks...")
-
-	if err := h.Driver.PreCreateCheck(); err != nil {
-		return errors.Wrap(err, "error with pre-create check")
-	}
-
-	if err := api.Save(h); err != nil {
-		return fmt.Errorf("Error saving host to store before attempting creation: %s", err)
-	}
-
-	log.Debug("Creating machine...")
-
-	if err := h.Driver.Create(); err != nil {
-		return fmt.Errorf("Error in driver during machine creation: %s", err)
-	}
-
-	if err := h.Driver.Start(); err != nil {
-		return fmt.Errorf("Error in driver during machine start: %s", err)
-	}
-
-	if err := api.Save(h); err != nil {
-		return fmt.Errorf("Error saving host to store after attempting creation: %s", err)
-	}
-
-	log.Debug("Waiting for machine to be running, this may take a few minutes...")
-	if err := crcerrors.RetryAfterWithContext(ctx, 3*time.Minute, host.MachineInState(h.Driver, state.Running), 3*time.Second); err != nil {
-		return fmt.Errorf("Error waiting for machine to be running: %s", err)
-	}
-
-	log.Debug("Machine is up and running!")
-
-	if err := api.SetExists(h.Name); err != nil {
-		log.Debug("Failed to record VM existence")
-	}
-
-	return nil
 }
 
 func (api *Client) Close() error {

--- a/pkg/libmachine/libmachine.go
+++ b/pkg/libmachine/libmachine.go
@@ -100,19 +100,6 @@ func (api *Client) Create(ctx context.Context, h *host.Host) error {
 
 	log.Debug("Creating machine...")
 
-	if err := api.performCreate(ctx, h); err != nil {
-		return fmt.Errorf("Error creating machine: %s", err)
-	}
-
-	log.Debug("Machine successfully created")
-	if err := api.SetExists(h.Name); err != nil {
-		log.Debug("Failed to record VM existence")
-	}
-
-	return nil
-}
-
-func (api *Client) performCreate(ctx context.Context, h *host.Host) error {
 	if err := h.Driver.Create(); err != nil {
 		return fmt.Errorf("Error in driver during machine creation: %s", err)
 	}
@@ -131,6 +118,11 @@ func (api *Client) performCreate(ctx context.Context, h *host.Host) error {
 	}
 
 	log.Debug("Machine is up and running!")
+
+	if err := api.SetExists(h.Name); err != nil {
+		log.Debug("Failed to record VM existence")
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
This removes the branch `if !exists { start the VM this way } else { start the VM this other way }` in machine.Start.

It simplifies the code but also ensures a just created VM can be launched again. 
In the future, we could add a `machine.Create` method that can be call at setup time. It would radically change the UX: no more error like `Machine doesnt not exist. Use 'crc start' to create it`