### PR TITLE
MCO specific changes

### DIFF
--- a/pkg/crc/cluster/cluster.go
+++ b/pkg/crc/cluster/cluster.go
@@ -313,18 +313,6 @@ func (p *PullSecretMemoizer) Value() (string, error) {
 	return val, err
 }
 
-func EnsurePullSecretPresentOnInstanceDisk(sshRunner *ssh.Runner, pullSecret PullSecretLoader) error {
-	if _, _, err := sshRunner.Run(fmt.Sprintf("test -e %s", vmPullSecretPath)); err == nil {
-		return nil
-	}
-	logging.Info("Adding user's pull secret to instance disk...")
-	content, err := pullSecret.Value()
-	if err != nil {
-		return err
-	}
-	return sshRunner.CopyData([]byte(content), vmPullSecretPath, 0600)
-}
-
 func WaitForRequestHeaderClientCaFile(sshRunner *ssh.Runner) error {
 	lookupRequestHeaderClientCa := func() error {
 		expired, err := checkCertValidity(sshRunner, AggregatorClientCert)

--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -394,6 +394,10 @@ func (client *client) Start(ctx context.Context, startConfig types.StartConfig) 
 		return nil, errors.Wrap(err, "Error waiting for apiserver")
 	}
 
+	if err := cluster.UpdateSSHKeyToMachineConfig(ocConfig, constants.GetPublicKeyPath()); err != nil {
+		return nil, errors.Wrap(err, "Failed to update ssh public key to machine config")
+	}
+
 	if err := ensureProxyIsConfiguredInOpenShift(ocConfig, sshRunner, proxyConfig, instanceIP); err != nil {
 		return nil, errors.Wrap(err, "Failed to update cluster proxy configuration")
 	}

--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -366,10 +366,6 @@ func (client *client) Start(ctx context.Context, startConfig types.StartConfig) 
 		logging.Warn(fmt.Sprintf("Failed to query DNS from host: %v", err))
 	}
 
-	if err := cluster.EnsurePullSecretPresentOnInstanceDisk(sshRunner, startConfig.PullSecret); err != nil {
-		return nil, errors.Wrap(err, "Failed to update VM pull secret")
-	}
-
 	if err := ensureKubeletAndCRIOAreConfiguredForProxy(sshRunner, proxyConfig, instanceIP); err != nil {
 		return nil, errors.Wrap(err, "Failed to update proxy configuration of kubelet and crio")
 	}


### PR DESCRIPTION
- Since MCO is now enabled by default, pull secret should be added
automatic to the vm when it starts.
- With MCO enabled we need to update the ssh key to machineconfig
so it is become part of cluster and also to instance.