### PR TITLE
Remove default operator ignore list for status

### DIFF
--- a/pkg/crc/cluster/clusteroperator.go
+++ b/pkg/crc/cluster/clusteroperator.go
@@ -12,8 +12,6 @@ import (
 	openshiftapi "github.com/openshift/api/config/v1"
 )
 
-var defaultIgnoredClusterOperators = []string{"machine-config", "marketplace", "insights"}
-
 // https://github.com/openshift/cluster-version-operator/blob/master/docs/dev/clusteroperator.md#what-should-an-operator-report-with-clusteroperator-custom-resource
 type Status struct {
 	Available   bool
@@ -74,18 +72,14 @@ func (status *Status) IsReady() bool {
 }
 
 func GetClusterOperatorStatus(ocConfig oc.Config, operator string) (*Status, error) {
-	return getStatus(ocConfig, defaultIgnoredClusterOperators, []string{operator})
+	return getStatus(ocConfig, []string{operator})
 }
 
-func GetClusterOperatorsStatus(ocConfig oc.Config, monitoringEnabled bool) (*Status, error) {
-	ignoredOperators := defaultIgnoredClusterOperators
-	if !monitoringEnabled {
-		ignoredOperators = append(ignoredOperators, "monitoring")
-	}
-	return getStatus(ocConfig, ignoredOperators, []string{})
+func GetClusterOperatorsStatus(ocConfig oc.Config) (*Status, error) {
+	return getStatus(ocConfig, []string{})
 }
 
-func getStatus(ocConfig oc.Config, ignoreClusterOperators, selector []string) (*Status, error) {
+func getStatus(ocConfig oc.Config, selector []string) (*Status, error) {
 	cs := &Status{
 		Available: true,
 	}
@@ -102,9 +96,6 @@ func getStatus(ocConfig oc.Config, ignoreClusterOperators, selector []string) (*
 
 	found := false
 	for _, c := range co.Items {
-		if contains(c.ObjectMeta.Name, ignoreClusterOperators) {
-			continue
-		}
 		if len(selector) > 0 && !contains(c.ObjectMeta.Name, selector) {
 			continue
 		}

--- a/pkg/crc/cluster/clusteroperator_test.go
+++ b/pkg/crc/cluster/clusteroperator_test.go
@@ -21,13 +21,13 @@ var (
 )
 
 func TestGetClusterOperatorsStatus(t *testing.T) {
-	status, err := GetClusterOperatorsStatus(ocConfig("co.json"), false)
+	status, err := GetClusterOperatorsStatus(ocConfig("co.json"))
 	assert.NoError(t, err)
 	assert.Equal(t, available, status)
 }
 
 func TestGetClusterOperatorsStatusProgressing(t *testing.T) {
-	status, err := GetClusterOperatorsStatus(ocConfig("co-progressing.json"), false)
+	status, err := GetClusterOperatorsStatus(ocConfig("co-progressing.json"))
 	assert.NoError(t, err)
 	assert.Equal(t, progressing, status)
 }

--- a/pkg/crc/cluster/status.go
+++ b/pkg/crc/cluster/status.go
@@ -24,7 +24,7 @@ func WaitForClusterStable(ctx context.Context, ocConfig oc.Config, monitoringEna
 	var count int // holds num of consecutive matches
 
 	for i := 0; i < retryCount; i++ {
-		status, err := GetClusterOperatorsStatus(ocConfig, monitoringEnabled)
+		status, err := GetClusterOperatorsStatus(ocConfig)
 		if err == nil {
 			// update counter for consecutive matches
 			if status.IsReady() {

--- a/pkg/crc/machine/status.go
+++ b/pkg/crc/machine/status.go
@@ -58,15 +58,15 @@ func (client *client) Status() (*types.ClusterStatusResult, error) {
 	}
 	return &types.ClusterStatusResult{
 		CrcStatus:        state.Running,
-		OpenshiftStatus:  getOpenShiftStatus(sshRunner, client.monitoringEnabled()),
+		OpenshiftStatus:  getOpenShiftStatus(sshRunner),
 		OpenshiftVersion: crcBundleMetadata.GetOpenshiftVersion(),
 		DiskUse:          diskUse,
 		DiskSize:         diskSize,
 	}, nil
 }
 
-func getOpenShiftStatus(sshRunner *crcssh.Runner, monitoringEnabled bool) types.OpenshiftStatus {
-	status, err := cluster.GetClusterOperatorsStatus(oc.UseOCWithSSH(sshRunner), monitoringEnabled)
+func getOpenShiftStatus(sshRunner *crcssh.Runner) types.OpenshiftStatus {
+	status, err := cluster.GetClusterOperatorsStatus(oc.UseOCWithSSH(sshRunner))
 	if err != nil {
 		logging.Debugf("cannot get OpenShift status: %v", err)
 		return types.OpenshiftUnreachable


### PR DESCRIPTION
From 4.7 we are already removing operators from being part of
final bundle as part of snc so we don't need any list of ignore
operators. All the operators which are part of bundle should be
available and working as expected.