### PR TITLE
Add missing states for Hyper-V, remove state.None usage

### DIFF
--- a/pkg/crc/machine/stop.go
+++ b/pkg/crc/machine/stop.go
@@ -12,7 +12,7 @@ func (client *client) Stop() (state.State, error) {
 	host, err := libMachineAPIClient.Load(client.name)
 
 	if err != nil {
-		return state.None, errors.Wrap(err, "Cannot load machine")
+		return state.Error, errors.Wrap(err, "Cannot load machine")
 	}
 
 	logging.Info("Stopping the OpenShift cluster, this may take a few minutes...")

--- a/pkg/drivers/hyperv/hyperv.go
+++ b/pkg/drivers/hyperv/hyperv.go
@@ -96,7 +96,7 @@ func (d *Driver) GetState() (state.State, error) {
 	}
 
 	switch resp[0] {
-	case "Running":
+	case "Starting", "Running", "Stopping":
 		return state.Running, nil
 	case "Off":
 		return state.Stopped, nil

--- a/pkg/drivers/hyperv/hyperv.go
+++ b/pkg/drivers/hyperv/hyperv.go
@@ -87,12 +87,12 @@ func (d *Driver) DriverName() string {
 func (d *Driver) GetState() (state.State, error) {
 	stdout, err := cmdOut("(", "Hyper-V\\Get-VM", d.MachineName, ").state")
 	if err != nil {
-		return state.None, fmt.Errorf("Failed to find the VM status")
+		return state.Error, fmt.Errorf("Failed to find the VM status")
 	}
 
 	resp := parseLines(stdout)
 	if len(resp) < 1 {
-		return state.None, nil
+		return state.Error, fmt.Errorf("unexpected Hyper-V state %s", resp)
 	}
 
 	switch resp[0] {
@@ -101,7 +101,7 @@ func (d *Driver) GetState() (state.State, error) {
 	case "Off":
 		return state.Stopped, nil
 	default:
-		return state.None, nil
+		return state.Error, fmt.Errorf("unexpected Hyper-V state %s", resp[0])
 	}
 }
 


### PR DESCRIPTION
The motivation is still to remove as much as possible the number of possible states.

I found these 2 new Hyper-V states by looking at the Hyper-V manager application and also with an infinite loop polling the crc VM status during start and stop.