### PR TITLE
preflight: Add virsh capabilities fallback

### DIFF
--- a/pkg/crc/preflight/preflight_checks_linux.go
+++ b/pkg/crc/preflight/preflight_checks_linux.go
@@ -90,7 +90,10 @@ func fixKvmEnabled() error {
 func getLibvirtCapabilities() (*libvirtxml.Caps, error) {
 	stdOut, _, err := crcos.RunWithDefaultLocale("virsh", "--readonly", "--connect", "qemu:///system", "capabilities")
 	if err != nil {
-		return nil, fmt.Errorf("Failed to run 'virsh capabilities': %v", err)
+		stdOut, _, err = crcos.RunWithDefaultLocale("virsh", "--connect", "qemu:///session", "capabilities")
+		if err != nil {
+			return nil, fmt.Errorf("Failed to run 'virsh capabilities': %v", err)
+		}
 	}
 	caps := &libvirtxml.Caps{}
 	err = caps.Unmarshal(stdOut)


### PR DESCRIPTION
On some setups, `virsh --read-only -c qemu:///system capabilities` may
not work out of the box.
This commit adds a fallback running
`virsh -c qemu:///session capabilities` when there is a failure. This is
the command which was used before commit 9f83839136

This fixes https://github.com/code-ready/crc/issues/2154