### PR TITLE
Use more explicit names for the 'network-mode' options

### DIFF
--- a/cmd/crc/cmd/config/config.go
+++ b/cmd/crc/cmd/config/config.go
@@ -3,117 +3,13 @@ package config
 import (
 	"bytes"
 	"fmt"
-	"runtime"
 	"sort"
 	"strings"
 	"text/tabwriter"
 
 	"github.com/code-ready/crc/pkg/crc/config"
-	"github.com/code-ready/crc/pkg/crc/constants"
-	"github.com/code-ready/crc/pkg/crc/network"
-	"github.com/code-ready/crc/pkg/crc/version"
-	"github.com/spf13/cast"
 	"github.com/spf13/cobra"
 )
-
-const (
-	Bundle                  = "bundle"
-	CPUs                    = "cpus"
-	Memory                  = "memory"
-	DiskSize                = "disk-size"
-	NameServer              = "nameserver"
-	PullSecretFile          = "pull-secret-file"
-	DisableUpdateCheck      = "disable-update-check"
-	ExperimentalFeatures    = "enable-experimental-features"
-	NetworkMode             = "network-mode"
-	HostNetworkAccess       = "host-network-access"
-	HTTPProxy               = "http-proxy"
-	HTTPSProxy              = "https-proxy"
-	NoProxy                 = "no-proxy"
-	ProxyCAFile             = "proxy-ca-file"
-	ConsentTelemetry        = "consent-telemetry"
-	EnableClusterMonitoring = "enable-cluster-monitoring"
-	AutostartTray           = "autostart-tray"
-)
-
-func RegisterSettings(cfg *config.Config) {
-	validateTrayAutostart := func(value interface{}) (bool, string) {
-		if runtime.GOOS != "darwin" {
-			return false, "Tray autostart is only supported on macOS"
-		}
-		return config.ValidateBool(value)
-	}
-
-	validateHostNetworkAccess := func(value interface{}) (bool, string) {
-		mode := network.ParseMode(cfg.Get(NetworkMode).AsString())
-		if mode != network.UserNetworkingMode {
-			return false, fmt.Sprintf("%s can only be used with %s set to '%s'",
-				HostNetworkAccess, NetworkMode, network.UserNetworkingMode)
-		}
-		return config.ValidateBool(value)
-	}
-
-	disableEnableTrayAutostart := func(key string, value interface{}) string {
-		if cast.ToBool(value) {
-			return fmt.Sprintf(
-				"Successfully configured '%s' to '%s'. Run 'crc setup' for it to take effect.",
-				key, cast.ToString(value),
-			)
-		}
-		return fmt.Sprintf(
-			"Successfully configured '%s' to '%s'. Run 'crc cleanup' and then 'crc setup' for it to take effect.",
-			key, cast.ToString(value),
-		)
-	}
-
-	// Start command settings in config
-	cfg.AddSetting(Bundle, constants.DefaultBundlePath, config.ValidateBundlePath, config.SuccessfullyApplied,
-		fmt.Sprintf("Bundle path (string, default '%s')", constants.DefaultBundlePath))
-	cfg.AddSetting(CPUs, constants.DefaultCPUs, config.ValidateCPUs, config.RequiresRestartMsg,
-		fmt.Sprintf("Number of CPU cores (must be greater than or equal to '%d')", constants.DefaultCPUs))
-	cfg.AddSetting(Memory, constants.DefaultMemory, config.ValidateMemory, config.RequiresRestartMsg,
-		fmt.Sprintf("Memory size in MiB (must be greater than or equal to '%d')", constants.DefaultMemory))
-	cfg.AddSetting(DiskSize, constants.DefaultDiskSize, config.ValidateDiskSize, config.RequiresRestartMsg,
-		fmt.Sprintf("Total size in GiB of the disk (must be greater than or equal to '%d')", constants.DefaultDiskSize))
-	cfg.AddSetting(NameServer, "", config.ValidateIPAddress, config.SuccessfullyApplied,
-		"IPv4 address of nameserver (string, like '1.1.1.1 or 8.8.8.8')")
-	cfg.AddSetting(PullSecretFile, "", config.ValidatePath, config.SuccessfullyApplied,
-		fmt.Sprintf("Path of image pull secret (download from %s)", constants.CrcLandingPageURL))
-	cfg.AddSetting(DisableUpdateCheck, false, config.ValidateBool, config.SuccessfullyApplied,
-		"Disable update check (true/false, default: false)")
-	cfg.AddSetting(ExperimentalFeatures, false, config.ValidateBool, config.SuccessfullyApplied,
-		"Enable experimental features (true/false, default: false)")
-	cfg.AddSetting(NetworkMode, string(defaultNetworkMode()), network.ValidateMode, network.SuccessfullyAppliedMode,
-		"Network mode (default or vsock)")
-	cfg.AddSetting(HostNetworkAccess, false, validateHostNetworkAccess, config.SuccessfullyApplied,
-		"Allow TCP/IP connections from the CodeReady Containers VM to services running on the host (true/false, default: false)")
-	// System tray auto-start config
-	cfg.AddSetting(AutostartTray, true, validateTrayAutostart, disableEnableTrayAutostart,
-		"Automatically start the tray (true/false, default: true)")
-	// Proxy Configuration
-	cfg.AddSetting(HTTPProxy, "", config.ValidateURI, config.SuccessfullyApplied,
-		"HTTP proxy URL (string, like 'http://my-proxy.com:8443')")
-	cfg.AddSetting(HTTPSProxy, "", config.ValidateURI, config.SuccessfullyApplied,
-		"HTTPS proxy URL (string, like 'https://my-proxy.com:8443')")
-	cfg.AddSetting(NoProxy, "", config.ValidateNoProxy, config.SuccessfullyApplied,
-		"Hosts, ipv4 addresses or CIDR which do not use a proxy (string, comma-separated list such as '127.0.0.1,192.168.100.1/24')")
-	cfg.AddSetting(ProxyCAFile, "", config.ValidatePath, config.SuccessfullyApplied,
-		"Path to an HTTPS proxy certificate authority (CA)")
-
-	cfg.AddSetting(EnableClusterMonitoring, false, config.ValidateBool, config.SuccessfullyApplied,
-		"Enable cluster monitoring Operator (true/false, default: false)")
-
-	// Telemeter Configuration
-	cfg.AddSetting(ConsentTelemetry, "", config.ValidateYesNo, config.SuccessfullyApplied,
-		"Consent to collection of anonymous usage data (yes/no)")
-}
-
-func defaultNetworkMode() network.Mode {
-	if runtime.GOOS == "darwin" && version.IsMacosInstallPathSet() {
-		return network.UserNetworkingMode
-	}
-	return network.SystemNetworkingMode
-}
 
 func isPreflightKey(key string) bool {
 	return strings.HasPrefix(key, "skip-")

--- a/cmd/crc/cmd/config/config.go
+++ b/cmd/crc/cmd/config/config.go
@@ -46,9 +46,9 @@ func RegisterSettings(cfg *config.Config) {
 
 	validateHostNetworkAccess := func(value interface{}) (bool, string) {
 		mode := network.ParseMode(cfg.Get(NetworkMode).AsString())
-		if mode != network.VSockMode {
+		if mode != network.UserNetworkingMode {
 			return false, fmt.Sprintf("%s can only be used with %s set to '%s'",
-				HostNetworkAccess, NetworkMode, network.VSockMode)
+				HostNetworkAccess, NetworkMode, network.UserNetworkingMode)
 		}
 		return config.ValidateBool(value)
 	}
@@ -110,9 +110,9 @@ func RegisterSettings(cfg *config.Config) {
 
 func defaultNetworkMode() network.Mode {
 	if runtime.GOOS == "darwin" && version.IsMacosInstallPathSet() {
-		return network.VSockMode
+		return network.UserNetworkingMode
 	}
-	return network.DefaultMode
+	return network.SystemNetworkingMode
 }
 
 func isPreflightKey(key string) bool {

--- a/cmd/crc/cmd/daemon.go
+++ b/cmd/crc/cmd/daemon.go
@@ -14,9 +14,9 @@ import (
 	"syscall"
 	"time"
 
-	cmdConfig "github.com/code-ready/crc/cmd/crc/cmd/config"
 	"github.com/code-ready/crc/pkg/crc/adminhelper"
 	"github.com/code-ready/crc/pkg/crc/api"
+	crcConfig "github.com/code-ready/crc/pkg/crc/config"
 	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/code-ready/crc/pkg/crc/daemonclient"
 	"github.com/code-ready/crc/pkg/crc/logging"
@@ -90,7 +90,7 @@ var daemonCmd = &cobra.Command{
 				},
 			},
 		}
-		if config.Get(cmdConfig.HostNetworkAccess).AsBool() {
+		if config.Get(crcConfig.HostNetworkAccess).AsBool() {
 			log.Debugf("Enabling host network access")
 			for i := range virtualNetworkConfig.DNS {
 				zone := &virtualNetworkConfig.DNS[i]

--- a/cmd/crc/cmd/root.go
+++ b/cmd/crc/cmd/root.go
@@ -126,10 +126,10 @@ func checkIfMachineMissing(client machine.Client) error {
 }
 
 func setProxyDefaults() error {
-	httpProxy := config.Get(cmdConfig.HTTPProxy).AsString()
-	httpsProxy := config.Get(cmdConfig.HTTPSProxy).AsString()
-	noProxy := config.Get(cmdConfig.NoProxy).AsString()
-	proxyCAFile := config.Get(cmdConfig.ProxyCAFile).AsString()
+	httpProxy := config.Get(crcConfig.HTTPProxy).AsString()
+	httpsProxy := config.Get(crcConfig.HTTPSProxy).AsString()
+	noProxy := config.Get(crcConfig.NoProxy).AsString()
+	proxyCAFile := config.Get(crcConfig.ProxyCAFile).AsString()
 
 	proxyCAData, err := getProxyCAData(proxyCAFile)
 	if err != nil {
@@ -171,7 +171,7 @@ func newViperConfig() (*crcConfig.Config, *crcConfig.ViperStorage, error) {
 		return nil, nil, err
 	}
 	cfg := crcConfig.New(viper)
-	cmdConfig.RegisterSettings(cfg)
+	crcConfig.RegisterSettings(cfg)
 	preflight.RegisterSettings(cfg)
 	return cfg, viper, nil
 }

--- a/cmd/crc/cmd/setup.go
+++ b/cmd/crc/cmd/setup.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"os"
 
-	cmdConfig "github.com/code-ready/crc/cmd/crc/cmd/config"
+	crcConfig "github.com/code-ready/crc/pkg/crc/config"
 	"github.com/code-ready/crc/pkg/crc/constants"
 	crcErrors "github.com/code-ready/crc/pkg/crc/errors"
 	"github.com/code-ready/crc/pkg/crc/input"
@@ -20,7 +20,7 @@ var (
 )
 
 func init() {
-	setupCmd.Flags().Bool(cmdConfig.ExperimentalFeatures, false, "Allow the use of experimental features")
+	setupCmd.Flags().Bool(crcConfig.ExperimentalFeatures, false, "Allow the use of experimental features")
 	setupCmd.Flags().BoolVar(&checkOnly, "check-only", false, "Only run the preflight checks, don't try to fix any misconfiguration")
 	addOutputFormatFlag(setupCmd)
 	rootCmd.AddCommand(setupCmd)
@@ -39,19 +39,19 @@ var setupCmd = &cobra.Command{
 }
 
 func runSetup(arguments []string) error {
-	if config.Get(cmdConfig.ConsentTelemetry).AsString() == "" {
+	if config.Get(crcConfig.ConsentTelemetry).AsString() == "" {
 		fmt.Println("CodeReady Containers is constantly improving and we would like to know more about usage (more details at https://developers.redhat.com/article/tool-data-collection)")
 		fmt.Println("Your preference can be changed manually if desired using 'crc config set consent-telemetry <yes/no>'")
 		if input.PromptUserForYesOrNo("Would you like to contribute anonymous usage statistics", false) {
-			if _, err := config.Set(cmdConfig.ConsentTelemetry, "yes"); err != nil {
+			if _, err := config.Set(crcConfig.ConsentTelemetry, "yes"); err != nil {
 				return err
 			}
-			fmt.Printf("Thanks for helping us! You can disable telemetry with the command 'crc config set %s no'.\n", cmdConfig.ConsentTelemetry)
+			fmt.Printf("Thanks for helping us! You can disable telemetry with the command 'crc config set %s no'.\n", crcConfig.ConsentTelemetry)
 		} else {
-			if _, err := config.Set(cmdConfig.ConsentTelemetry, "no"); err != nil {
+			if _, err := config.Set(crcConfig.ConsentTelemetry, "no"); err != nil {
 				return err
 			}
-			fmt.Printf("No worry, you can still enable telemetry manually with the command 'crc config set %s yes'.\n", cmdConfig.ConsentTelemetry)
+			fmt.Printf("No worry, you can still enable telemetry manually with the command 'crc config set %s yes'.\n", crcConfig.ConsentTelemetry)
 		}
 	}
 

--- a/cmd/crc/cmd/start.go
+++ b/cmd/crc/cmd/start.go
@@ -258,7 +258,7 @@ func commandLinePrefix(shell string) string {
 }
 
 func checkDaemonStarted() error {
-	if config.Get(cmdConfig.NetworkMode).AsString() == string(network.DefaultMode) {
+	if config.Get(cmdConfig.NetworkMode).AsString() == string(network.SystemNetworkingMode) {
 		return nil
 	}
 	daemonClient := daemonclient.New()

--- a/cmd/crc/cmd/start.go
+++ b/cmd/crc/cmd/start.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 	"text/template"
 
-	cmdConfig "github.com/code-ready/crc/cmd/crc/cmd/config"
 	"github.com/code-ready/crc/pkg/crc/cluster"
+	crcConfig "github.com/code-ready/crc/pkg/crc/config"
 	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/code-ready/crc/pkg/crc/daemonclient"
 	crcErrors "github.com/code-ready/crc/pkg/crc/errors"
@@ -32,13 +32,13 @@ func init() {
 	addOutputFormatFlag(startCmd)
 
 	flagSet := pflag.NewFlagSet("start", pflag.ExitOnError)
-	flagSet.StringP(cmdConfig.Bundle, "b", constants.DefaultBundlePath, "The system bundle used for deployment of the OpenShift cluster")
-	flagSet.StringP(cmdConfig.PullSecretFile, "p", "", fmt.Sprintf("File path of image pull secret (download from %s)", constants.CrcLandingPageURL))
-	flagSet.IntP(cmdConfig.CPUs, "c", constants.DefaultCPUs, "Number of CPU cores to allocate to the OpenShift cluster")
-	flagSet.IntP(cmdConfig.Memory, "m", constants.DefaultMemory, "MiB of memory to allocate to the OpenShift cluster")
-	flagSet.UintP(cmdConfig.DiskSize, "d", constants.DefaultDiskSize, "Total size in GiB of the disk used by the OpenShift cluster")
-	flagSet.StringP(cmdConfig.NameServer, "n", "", "IPv4 address of nameserver to use for the OpenShift cluster")
-	flagSet.Bool(cmdConfig.DisableUpdateCheck, false, "Don't check for update")
+	flagSet.StringP(crcConfig.Bundle, "b", constants.DefaultBundlePath, "The system bundle used for deployment of the OpenShift cluster")
+	flagSet.StringP(crcConfig.PullSecretFile, "p", "", fmt.Sprintf("File path of image pull secret (download from %s)", constants.CrcLandingPageURL))
+	flagSet.IntP(crcConfig.CPUs, "c", constants.DefaultCPUs, "Number of CPU cores to allocate to the OpenShift cluster")
+	flagSet.IntP(crcConfig.Memory, "m", constants.DefaultMemory, "MiB of memory to allocate to the OpenShift cluster")
+	flagSet.UintP(crcConfig.DiskSize, "d", constants.DefaultDiskSize, "Total size in GiB of the disk used by the OpenShift cluster")
+	flagSet.StringP(crcConfig.NameServer, "n", "", "IPv4 address of nameserver to use for the OpenShift cluster")
+	flagSet.Bool(crcConfig.DisableUpdateCheck, false, "Don't check for update")
 
 	startCmd.Flags().AddFlagSet(flagSet)
 }
@@ -63,14 +63,14 @@ func runStart(ctx context.Context) (*types.StartResult, error) {
 		return nil, err
 	}
 
-	checkIfNewVersionAvailable(config.Get(cmdConfig.DisableUpdateCheck).AsBool())
+	checkIfNewVersionAvailable(config.Get(crcConfig.DisableUpdateCheck).AsBool())
 
 	startConfig := types.StartConfig{
-		BundlePath: config.Get(cmdConfig.Bundle).AsString(),
-		Memory:     config.Get(cmdConfig.Memory).AsInt(),
-		DiskSize:   config.Get(cmdConfig.DiskSize).AsInt(),
-		CPUs:       config.Get(cmdConfig.CPUs).AsInt(),
-		NameServer: config.Get(cmdConfig.NameServer).AsString(),
+		BundlePath: config.Get(crcConfig.Bundle).AsString(),
+		Memory:     config.Get(crcConfig.Memory).AsInt(),
+		DiskSize:   config.Get(crcConfig.DiskSize).AsInt(),
+		CPUs:       config.Get(crcConfig.CPUs).AsInt(),
+		NameServer: config.Get(crcConfig.NameServer).AsString(),
 		PullSecret: cluster.NewInteractivePullSecretLoader(config),
 	}
 
@@ -170,20 +170,20 @@ func isDebugLog() bool {
 }
 
 func validateStartFlags() error {
-	if err := validation.ValidateMemory(config.Get(cmdConfig.Memory).AsInt()); err != nil {
+	if err := validation.ValidateMemory(config.Get(crcConfig.Memory).AsInt()); err != nil {
 		return err
 	}
-	if err := validation.ValidateCPUs(config.Get(cmdConfig.CPUs).AsInt()); err != nil {
+	if err := validation.ValidateCPUs(config.Get(crcConfig.CPUs).AsInt()); err != nil {
 		return err
 	}
-	if err := validation.ValidateDiskSize(config.Get(cmdConfig.DiskSize).AsInt()); err != nil {
+	if err := validation.ValidateDiskSize(config.Get(crcConfig.DiskSize).AsInt()); err != nil {
 		return err
 	}
-	if err := validation.ValidateBundle(config.Get(cmdConfig.Bundle).AsString()); err != nil {
+	if err := validation.ValidateBundle(config.Get(crcConfig.Bundle).AsString()); err != nil {
 		return err
 	}
-	if config.Get(cmdConfig.NameServer).AsString() != "" {
-		if err := validation.ValidateIPAddress(config.Get(cmdConfig.NameServer).AsString()); err != nil {
+	if config.Get(crcConfig.NameServer).AsString() != "" {
+		if err := validation.ValidateIPAddress(config.Get(crcConfig.NameServer).AsString()); err != nil {
 			return err
 		}
 	}
@@ -258,7 +258,7 @@ func commandLinePrefix(shell string) string {
 }
 
 func checkDaemonStarted() error {
-	if config.Get(cmdConfig.NetworkMode).AsString() == string(network.SystemNetworkingMode) {
+	if config.Get(crcConfig.NetworkMode).AsString() == string(network.SystemNetworkingMode) {
 		return nil
 	}
 	daemonClient := daemonclient.New()

--- a/cmd/crc/cmd/start.go
+++ b/cmd/crc/cmd/start.go
@@ -258,7 +258,7 @@ func commandLinePrefix(shell string) string {
 }
 
 func checkDaemonStarted() error {
-	if config.Get(crcConfig.NetworkMode).AsString() == string(network.SystemNetworkingMode) {
+	if crcConfig.GetNetworkMode(config) == network.SystemNetworkingMode {
 		return nil
 	}
 	daemonClient := daemonclient.New()

--- a/cmd/crc/cmd/version.go
+++ b/cmd/crc/cmd/version.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"os"
 
-	cmdConfig "github.com/code-ready/crc/cmd/crc/cmd/config"
+	crcConfig "github.com/code-ready/crc/pkg/crc/config"
 	"github.com/code-ready/crc/pkg/crc/constants"
 	crcversion "github.com/code-ready/crc/pkg/crc/version"
 	"github.com/spf13/cobra"
@@ -26,7 +26,7 @@ var versionCmd = &cobra.Command{
 }
 
 func runPrintVersion(writer io.Writer, version *version, outputFormat string) error {
-	checkIfNewVersionAvailable(config.Get(cmdConfig.DisableUpdateCheck).AsBool())
+	checkIfNewVersionAvailable(config.Get(crcConfig.DisableUpdateCheck).AsBool())
 	return render(version, writer, outputFormat)
 }
 

--- a/pkg/crc/api/handlers.go
+++ b/pkg/crc/api/handlers.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/code-ready/crc/cmd/crc/cmd/config"
 	"github.com/code-ready/crc/pkg/crc/api/client"
 	"github.com/code-ready/crc/pkg/crc/cluster"
 	crcConfig "github.com/code-ready/crc/pkg/crc/config"
@@ -99,10 +98,10 @@ func parseStartArgs(args json.RawMessage) (startArgs, error) {
 
 func getStartConfig(cfg crcConfig.Storage, args startArgs) types.StartConfig {
 	return types.StartConfig{
-		BundlePath: cfg.Get(config.Bundle).AsString(),
-		Memory:     cfg.Get(config.Memory).AsInt(),
-		CPUs:       cfg.Get(config.CPUs).AsInt(),
-		NameServer: cfg.Get(config.NameServer).AsString(),
+		BundlePath: cfg.Get(crcConfig.Bundle).AsString(),
+		Memory:     cfg.Get(crcConfig.Memory).AsInt(),
+		CPUs:       cfg.Get(crcConfig.CPUs).AsInt(),
+		NameServer: cfg.Get(crcConfig.NameServer).AsString(),
 		PullSecret: cluster.NewNonInteractivePullSecretLoader(cfg, args.PullSecretFile),
 	}
 }

--- a/pkg/crc/api/helpers_test.go
+++ b/pkg/crc/api/helpers_test.go
@@ -3,7 +3,6 @@ package api
 import (
 	"strings"
 
-	cmdConfig "github.com/code-ready/crc/cmd/crc/cmd/config"
 	"github.com/code-ready/crc/pkg/crc/config"
 	"github.com/code-ready/crc/pkg/crc/preflight"
 )
@@ -13,7 +12,7 @@ func setupNewInMemoryConfig() config.Storage {
 	cfg := config.New(&skipPreflights{
 		storage: storage,
 	})
-	cmdConfig.RegisterSettings(cfg)
+	config.RegisterSettings(cfg)
 	preflight.RegisterSettings(cfg)
 
 	return cfg

--- a/pkg/crc/cluster/pullsecret.go
+++ b/pkg/crc/cluster/pullsecret.go
@@ -10,7 +10,6 @@ import (
 	"io/ioutil"
 	"strings"
 
-	cmdConfig "github.com/code-ready/crc/cmd/crc/cmd/config"
 	crcConfig "github.com/code-ready/crc/pkg/crc/config"
 	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/code-ready/crc/pkg/crc/logging"
@@ -89,7 +88,7 @@ func (loader *nonInteractivePullSecretLoader) Value() (string, error) {
 		}
 		logging.Debugf("Cannot load secret from path %q: %v", loader.path, err)
 	}
-	fromConfig, err := loadFile(loader.config.Get(cmdConfig.PullSecretFile).AsString())
+	fromConfig, err := loadFile(loader.config.Get(crcConfig.PullSecretFile).AsString())
 	if err == nil {
 		logging.Debugf("Using secret from configuration")
 		return fromConfig, nil

--- a/pkg/crc/cluster/pullsecret_test.go
+++ b/pkg/crc/cluster/pullsecret_test.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	cmdConfig "github.com/code-ready/crc/cmd/crc/cmd/config"
 	"github.com/code-ready/crc/pkg/crc/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/zalando/go-keyring"
@@ -26,7 +25,7 @@ func TestLoadPullSecret(t *testing.T) {
 	defer os.RemoveAll(dir)
 
 	cfg := config.New(config.NewEmptyInMemoryStorage())
-	cmdConfig.RegisterSettings(cfg)
+	config.RegisterSettings(cfg)
 
 	loader := &nonInteractivePullSecretLoader{
 		config: cfg,
@@ -43,7 +42,7 @@ func TestLoadPullSecret(t *testing.T) {
 	assert.Equal(t, secret3, val)
 
 	assert.NoError(t, ioutil.WriteFile(filepath.Join(dir, "file2"), []byte(secret2), 0600))
-	_, err = cfg.Set(cmdConfig.PullSecretFile, filepath.Join(dir, "file2"))
+	_, err = cfg.Set(config.PullSecretFile, filepath.Join(dir, "file2"))
 	assert.NoError(t, err)
 
 	val, err = loader.Value()

--- a/pkg/crc/config/settings.go
+++ b/pkg/crc/config/settings.go
@@ -1,0 +1,111 @@
+package config
+
+import (
+	"fmt"
+	"runtime"
+
+	"github.com/code-ready/crc/pkg/crc/constants"
+	"github.com/code-ready/crc/pkg/crc/network"
+	"github.com/code-ready/crc/pkg/crc/version"
+
+	"github.com/spf13/cast"
+)
+
+const (
+	Bundle                  = "bundle"
+	CPUs                    = "cpus"
+	Memory                  = "memory"
+	DiskSize                = "disk-size"
+	NameServer              = "nameserver"
+	PullSecretFile          = "pull-secret-file"
+	DisableUpdateCheck      = "disable-update-check"
+	ExperimentalFeatures    = "enable-experimental-features"
+	NetworkMode             = "network-mode"
+	HostNetworkAccess       = "host-network-access"
+	HTTPProxy               = "http-proxy"
+	HTTPSProxy              = "https-proxy"
+	NoProxy                 = "no-proxy"
+	ProxyCAFile             = "proxy-ca-file"
+	ConsentTelemetry        = "consent-telemetry"
+	EnableClusterMonitoring = "enable-cluster-monitoring"
+	AutostartTray           = "autostart-tray"
+)
+
+func RegisterSettings(cfg *Config) {
+	validateTrayAutostart := func(value interface{}) (bool, string) {
+		if runtime.GOOS != "darwin" {
+			return false, "Tray autostart is only supported on macOS"
+		}
+		return ValidateBool(value)
+	}
+
+	validateHostNetworkAccess := func(value interface{}) (bool, string) {
+		mode := network.ParseMode(cfg.Get(NetworkMode).AsString())
+		if mode != network.UserNetworkingMode {
+			return false, fmt.Sprintf("%s can only be used with %s set to '%s'",
+				HostNetworkAccess, NetworkMode, network.UserNetworkingMode)
+		}
+		return ValidateBool(value)
+	}
+
+	disableEnableTrayAutostart := func(key string, value interface{}) string {
+		if cast.ToBool(value) {
+			return fmt.Sprintf(
+				"Successfully configured '%s' to '%s'. Run 'crc setup' for it to take effect.",
+				key, cast.ToString(value),
+			)
+		}
+		return fmt.Sprintf(
+			"Successfully configured '%s' to '%s'. Run 'crc cleanup' and then 'crc setup' for it to take effect.",
+			key, cast.ToString(value),
+		)
+	}
+
+	// Start command settings in config
+	cfg.AddSetting(Bundle, constants.DefaultBundlePath, ValidateBundlePath, SuccessfullyApplied,
+		fmt.Sprintf("Bundle path (string, default '%s')", constants.DefaultBundlePath))
+	cfg.AddSetting(CPUs, constants.DefaultCPUs, ValidateCPUs, RequiresRestartMsg,
+		fmt.Sprintf("Number of CPU cores (must be greater than or equal to '%d')", constants.DefaultCPUs))
+	cfg.AddSetting(Memory, constants.DefaultMemory, ValidateMemory, RequiresRestartMsg,
+		fmt.Sprintf("Memory size in MiB (must be greater than or equal to '%d')", constants.DefaultMemory))
+	cfg.AddSetting(DiskSize, constants.DefaultDiskSize, ValidateDiskSize, RequiresRestartMsg,
+		fmt.Sprintf("Total size in GiB of the disk (must be greater than or equal to '%d')", constants.DefaultDiskSize))
+	cfg.AddSetting(NameServer, "", ValidateIPAddress, SuccessfullyApplied,
+		"IPv4 address of nameserver (string, like '1.1.1.1 or 8.8.8.8')")
+	cfg.AddSetting(PullSecretFile, "", ValidatePath, SuccessfullyApplied,
+		fmt.Sprintf("Path of image pull secret (download from %s)", constants.CrcLandingPageURL))
+	cfg.AddSetting(DisableUpdateCheck, false, ValidateBool, SuccessfullyApplied,
+		"Disable update check (true/false, default: false)")
+	cfg.AddSetting(ExperimentalFeatures, false, ValidateBool, SuccessfullyApplied,
+		"Enable experimental features (true/false, default: false)")
+	cfg.AddSetting(NetworkMode, string(defaultNetworkMode()), network.ValidateMode, network.SuccessfullyAppliedMode,
+		"Network mode (default or vsock)")
+	cfg.AddSetting(HostNetworkAccess, false, validateHostNetworkAccess, SuccessfullyApplied,
+		"Allow TCP/IP connections from the CodeReady Containers VM to services running on the host (true/false, default: false)")
+	// System tray auto-start config
+	cfg.AddSetting(AutostartTray, true, validateTrayAutostart, disableEnableTrayAutostart,
+		"Automatically start the tray (true/false, default: true)")
+	// Proxy Configuration
+	cfg.AddSetting(HTTPProxy, "", ValidateURI, SuccessfullyApplied,
+		"HTTP proxy URL (string, like 'http://my-proxy.com:8443')")
+	cfg.AddSetting(HTTPSProxy, "", ValidateURI, SuccessfullyApplied,
+		"HTTPS proxy URL (string, like 'https://my-proxy.com:8443')")
+	cfg.AddSetting(NoProxy, "", ValidateNoProxy, SuccessfullyApplied,
+		"Hosts, ipv4 addresses or CIDR which do not use a proxy (string, comma-separated list such as '127.0.0.1,192.168.100.1/24')")
+	cfg.AddSetting(ProxyCAFile, "", ValidatePath, SuccessfullyApplied,
+		"Path to an HTTPS proxy certificate authority (CA)")
+
+	cfg.AddSetting(EnableClusterMonitoring, false, ValidateBool, SuccessfullyApplied,
+		"Enable cluster monitoring Operator (true/false, default: false)")
+
+	// Telemeter Configuration
+	cfg.AddSetting(ConsentTelemetry, "", ValidateYesNo, SuccessfullyApplied,
+		"Consent to collection of anonymous usage data (yes/no)")
+}
+
+func defaultNetworkMode() network.Mode {
+	if runtime.GOOS == "darwin" && version.IsMacosInstallPathSet() {
+		return network.UserNetworkingMode
+	}
+	return network.SystemNetworkingMode
+}

--- a/pkg/crc/config/settings.go
+++ b/pkg/crc/config/settings.go
@@ -40,7 +40,7 @@ func RegisterSettings(cfg *Config) {
 	}
 
 	validateHostNetworkAccess := func(value interface{}) (bool, string) {
-		mode := network.ParseMode(cfg.Get(NetworkMode).AsString())
+		mode := GetNetworkMode(cfg)
 		if mode != network.UserNetworkingMode {
 			return false, fmt.Sprintf("%s can only be used with %s set to '%s'",
 				HostNetworkAccess, NetworkMode, network.UserNetworkingMode)
@@ -108,4 +108,8 @@ func defaultNetworkMode() network.Mode {
 		return network.UserNetworkingMode
 	}
 	return network.SystemNetworkingMode
+}
+
+func GetNetworkMode(config Storage) network.Mode {
+	return network.ParseMode(config.Get(NetworkMode).AsString())
 }

--- a/pkg/crc/config/viper_config_test.go
+++ b/pkg/crc/config/viper_config_test.go
@@ -12,8 +12,8 @@ import (
 )
 
 const (
-	CPUs       = "cpus"
-	NameServer = "nameservers"
+	cpus       = "cpus"
+	nameServer = "nameservers"
 )
 
 func newTestConfig(configFile, envPrefix string) (*Config, error) {
@@ -22,8 +22,8 @@ func newTestConfig(configFile, envPrefix string) (*Config, error) {
 		return nil, err
 	}
 	config := New(storage)
-	config.AddSetting(CPUs, 4, ValidateCPUs, RequiresRestartMsg, "")
-	config.AddSetting(NameServer, "", ValidateIPAddress, SuccessfullyApplied, "")
+	config.AddSetting(cpus, 4, ValidateCPUs, RequiresRestartMsg, "")
+	config.AddSetting(nameServer, "", ValidateIPAddress, SuccessfullyApplied, "")
 	return config, nil
 }
 
@@ -50,13 +50,13 @@ func TestViperConfigSetAndGet(t *testing.T) {
 	config, err := newTestConfig(configFile, "CRC")
 	require.NoError(t, err)
 
-	_, err = config.Set(CPUs, 5)
+	_, err = config.Set(cpus, 5)
 	assert.NoError(t, err)
 
 	assert.Equal(t, SettingValue{
 		Value:     5,
 		IsDefault: false,
-	}, config.Get(CPUs))
+	}, config.Get(cpus))
 
 	bin, err := ioutil.ReadFile(configFile)
 	assert.NoError(t, err)
@@ -73,13 +73,13 @@ func TestViperConfigUnsetAndGet(t *testing.T) {
 	config, err := newTestConfig(configFile, "CRC")
 	require.NoError(t, err)
 
-	_, err = config.Unset(CPUs)
+	_, err = config.Unset(cpus)
 	assert.NoError(t, err)
 
 	assert.Equal(t, SettingValue{
 		Value:     4,
 		IsDefault: true,
-	}, config.Get(CPUs))
+	}, config.Get(cpus))
 
 	bin, err := ioutil.ReadFile(configFile)
 	assert.NoError(t, err)
@@ -95,7 +95,7 @@ func TestViperConfigSetReloadAndGet(t *testing.T) {
 	config, err := newTestConfig(configFile, "CRC")
 	require.NoError(t, err)
 
-	_, err = config.Set(CPUs, 5)
+	_, err = config.Set(cpus, 5)
 	require.NoError(t, err)
 
 	config, err = newTestConfig(configFile, "CRC")
@@ -104,7 +104,7 @@ func TestViperConfigSetReloadAndGet(t *testing.T) {
 	assert.Equal(t, SettingValue{
 		Value:     5,
 		IsDefault: false,
-	}, config.Get(CPUs))
+	}, config.Get(cpus))
 }
 
 func TestViperConfigLoadDefaultValue(t *testing.T) {
@@ -119,9 +119,9 @@ func TestViperConfigLoadDefaultValue(t *testing.T) {
 	assert.Equal(t, SettingValue{
 		Value:     4,
 		IsDefault: true,
-	}, config.Get(CPUs))
+	}, config.Get(cpus))
 
-	_, err = config.Set(CPUs, 4)
+	_, err = config.Set(cpus, 4)
 	assert.NoError(t, err)
 
 	bin, err := ioutil.ReadFile(configFile)
@@ -131,7 +131,7 @@ func TestViperConfigLoadDefaultValue(t *testing.T) {
 	assert.Equal(t, SettingValue{
 		Value:     4,
 		IsDefault: true,
-	}, config.Get(CPUs))
+	}, config.Get(cpus))
 
 	config, err = newTestConfig(configFile, "CRC")
 	require.NoError(t, err)
@@ -139,7 +139,7 @@ func TestViperConfigLoadDefaultValue(t *testing.T) {
 	assert.Equal(t, SettingValue{
 		Value:     4,
 		IsDefault: true,
-	}, config.Get(CPUs))
+	}, config.Get(cpus))
 }
 
 func TestViperConfigBindFlagSet(t *testing.T) {
@@ -151,12 +151,12 @@ func TestViperConfigBindFlagSet(t *testing.T) {
 	storage, err := NewViperStorage(configFile, "CRC")
 	require.NoError(t, err)
 	config := New(storage)
-	config.AddSetting(CPUs, 4, ValidateCPUs, RequiresRestartMsg, "")
-	config.AddSetting(NameServer, "", ValidateIPAddress, SuccessfullyApplied, "")
+	config.AddSetting(cpus, 4, ValidateCPUs, RequiresRestartMsg, "")
+	config.AddSetting(nameServer, "", ValidateIPAddress, SuccessfullyApplied, "")
 
 	flagSet := pflag.NewFlagSet("start", pflag.ExitOnError)
-	flagSet.IntP(CPUs, "c", 4, "")
-	flagSet.StringP(NameServer, "n", "", "")
+	flagSet.IntP(cpus, "c", 4, "")
+	flagSet.StringP(nameServer, "n", "", "")
 	flagSet.StringP("extra", "e", "", "")
 
 	_ = storage.BindFlagSet(flagSet)
@@ -164,20 +164,20 @@ func TestViperConfigBindFlagSet(t *testing.T) {
 	assert.Equal(t, SettingValue{
 		Value:     4,
 		IsDefault: true,
-	}, config.Get(CPUs))
+	}, config.Get(cpus))
 	assert.Equal(t, SettingValue{
 		Value:     "",
 		IsDefault: true,
-	}, config.Get(NameServer))
+	}, config.Get(nameServer))
 
-	assert.NoError(t, flagSet.Set(CPUs, "5"))
+	assert.NoError(t, flagSet.Set(cpus, "5"))
 
 	assert.Equal(t, SettingValue{
 		Value:     5,
 		IsDefault: false,
-	}, config.Get(CPUs))
+	}, config.Get(cpus))
 
-	_, err = config.Set(CPUs, "6")
+	_, err = config.Set(cpus, "6")
 	assert.NoError(t, err)
 
 	bin, err := ioutil.ReadFile(configFile)
@@ -194,7 +194,7 @@ func TestViperConfigCastSet(t *testing.T) {
 	config, err := newTestConfig(configFile, "CRC")
 	require.NoError(t, err)
 
-	_, err = config.Set(CPUs, "5")
+	_, err = config.Set(cpus, "5")
 	require.NoError(t, err)
 
 	config, err = newTestConfig(configFile, "CRC")
@@ -203,7 +203,7 @@ func TestViperConfigCastSet(t *testing.T) {
 	assert.Equal(t, SettingValue{
 		Value:     5,
 		IsDefault: false,
-	}, config.Get(CPUs))
+	}, config.Get(cpus))
 
 	bin, err := ioutil.ReadFile(configFile)
 	assert.NoError(t, err)
@@ -219,7 +219,7 @@ func TestCannotSetWithWrongType(t *testing.T) {
 	config, err := newTestConfig(configFile, "CRC")
 	require.NoError(t, err)
 
-	_, err = config.Set(CPUs, "helloworld")
+	_, err = config.Set(cpus, "helloworld")
 	assert.EqualError(t, err, "Value 'helloworld' for configuration property 'cpus' is invalid, reason: requires integer value >= 4")
 }
 
@@ -233,7 +233,7 @@ func TestCannotGetWithWrongType(t *testing.T) {
 	config, err := newTestConfig(configFile, "CRC")
 	require.NoError(t, err)
 
-	assert.True(t, config.Get(CPUs).Invalid)
+	assert.True(t, config.Get(cpus).Invalid)
 }
 
 func TestTwoInstancesSharingSameConfiguration(t *testing.T) {
@@ -248,7 +248,7 @@ func TestTwoInstancesSharingSameConfiguration(t *testing.T) {
 	config2, err := newTestConfig(configFile, "CRC")
 	require.NoError(t, err)
 
-	_, err = config1.Set(CPUs, 5)
+	_, err = config1.Set(cpus, 5)
 	require.NoError(t, err)
 
 	bin, err := ioutil.ReadFile(configFile)
@@ -258,11 +258,11 @@ func TestTwoInstancesSharingSameConfiguration(t *testing.T) {
 	assert.Equal(t, SettingValue{
 		Value:     5,
 		IsDefault: false,
-	}, config2.Get(CPUs))
+	}, config2.Get(cpus))
 	assert.Equal(t, SettingValue{
 		Value:     5,
 		IsDefault: false,
-	}, config1.Get(CPUs))
+	}, config1.Get(cpus))
 }
 
 func TestTwoInstancesWriteSameConfiguration(t *testing.T) {
@@ -277,21 +277,21 @@ func TestTwoInstancesWriteSameConfiguration(t *testing.T) {
 	config2, err := newTestConfig(configFile, "CRC")
 	require.NoError(t, err)
 
-	_, err = config1.Set(CPUs, 5)
+	_, err = config1.Set(cpus, 5)
 	require.NoError(t, err)
 
-	_, err = config2.Set(NameServer, "1.1.1.1")
+	_, err = config2.Set(nameServer, "1.1.1.1")
 	require.NoError(t, err)
 
 	bin, err := ioutil.ReadFile(configFile)
 	assert.NoError(t, err)
 	assert.JSONEq(t, `{"cpus":5, "nameservers":"1.1.1.1"}`, string(bin))
 
-	assert.Equal(t, 5, config2.Get(CPUs).Value)
-	assert.Equal(t, 5, config1.Get(CPUs).Value)
+	assert.Equal(t, 5, config2.Get(cpus).Value)
+	assert.Equal(t, 5, config1.Get(cpus).Value)
 
-	assert.Equal(t, "1.1.1.1", config2.Get(NameServer).Value)
-	assert.Equal(t, "1.1.1.1", config1.Get(NameServer).Value)
+	assert.Equal(t, "1.1.1.1", config2.Get(nameServer).Value)
+	assert.Equal(t, "1.1.1.1", config1.Get(nameServer).Value)
 }
 
 func TestTwoInstancesSetAndUnsetSameConfiguration(t *testing.T) {
@@ -306,16 +306,16 @@ func TestTwoInstancesSetAndUnsetSameConfiguration(t *testing.T) {
 	config2, err := newTestConfig(configFile, "CRC")
 	require.NoError(t, err)
 
-	_, err = config1.Set(CPUs, 5)
+	_, err = config1.Set(cpus, 5)
 	require.NoError(t, err)
 
-	_, err = config2.Unset(CPUs)
+	_, err = config2.Unset(cpus)
 	require.NoError(t, err)
 
 	bin, err := ioutil.ReadFile(configFile)
 	assert.NoError(t, err)
 	assert.JSONEq(t, `{}`, string(bin))
 
-	assert.Equal(t, 4, config2.Get(CPUs).Value)
-	assert.Equal(t, 4, config1.Get(CPUs).Value)
+	assert.Equal(t, 4, config2.Get(cpus).Value)
+	assert.Equal(t, 4, config1.Get(cpus).Value)
 }

--- a/pkg/crc/machine/client.go
+++ b/pkg/crc/machine/client.go
@@ -47,7 +47,7 @@ func (client *client) useVSock() bool {
 }
 
 func (client *client) networkMode() network.Mode {
-	return network.ParseMode(client.config.Get(crcConfig.NetworkMode).AsString())
+	return crcConfig.GetNetworkMode(client.config)
 }
 
 func (client *client) monitoringEnabled() bool {

--- a/pkg/crc/machine/client.go
+++ b/pkg/crc/machine/client.go
@@ -44,7 +44,7 @@ func (client *client) GetName() string {
 }
 
 func (client *client) useVSock() bool {
-	return client.networkMode() == network.VSockMode
+	return client.networkMode() == network.UserNetworkingMode
 }
 
 func (client *client) networkMode() network.Mode {

--- a/pkg/crc/machine/client.go
+++ b/pkg/crc/machine/client.go
@@ -3,7 +3,6 @@ package machine
 import (
 	"context"
 
-	cmdConfig "github.com/code-ready/crc/cmd/crc/cmd/config"
 	crcConfig "github.com/code-ready/crc/pkg/crc/config"
 	"github.com/code-ready/crc/pkg/crc/machine/types"
 	"github.com/code-ready/crc/pkg/crc/network"
@@ -48,9 +47,9 @@ func (client *client) useVSock() bool {
 }
 
 func (client *client) networkMode() network.Mode {
-	return network.ParseMode(client.config.Get(cmdConfig.NetworkMode).AsString())
+	return network.ParseMode(client.config.Get(crcConfig.NetworkMode).AsString())
 }
 
 func (client *client) monitoringEnabled() bool {
-	return client.config.Get(cmdConfig.EnableClusterMonitoring).AsBool()
+	return client.config.Get(crcConfig.EnableClusterMonitoring).AsBool()
 }

--- a/pkg/crc/machine/hyperkit/driver_darwin.go
+++ b/pkg/crc/machine/hyperkit/driver_darwin.go
@@ -20,7 +20,7 @@ func CreateHost(machineConfig config.MachineConfig) *hyperkit.Driver {
 	hyperkitDriver.InitrdPath = machineConfig.Initramfs
 	hyperkitDriver.HyperKitPath = filepath.Join(constants.BinDir(), HyperKitCommand)
 
-	hyperkitDriver.VMNet = machineConfig.NetworkMode == network.DefaultMode
+	hyperkitDriver.VMNet = machineConfig.NetworkMode == network.SystemNetworkingMode
 
 	return hyperkitDriver
 }

--- a/pkg/crc/machine/hyperv/driver_windows.go
+++ b/pkg/crc/machine/hyperv/driver_windows.go
@@ -15,7 +15,7 @@ func CreateHost(machineConfig config.MachineConfig) *hyperv.Driver {
 
 	hypervDriver.DisableDynamicMemory = true
 
-	if machineConfig.NetworkMode == network.VSockMode {
+	if machineConfig.NetworkMode == network.UserNetworkingMode {
 
 		hypervDriver.VirtualSwitch = ""
 	} else {

--- a/pkg/crc/machine/libvirt/driver_linux.go
+++ b/pkg/crc/machine/libvirt/driver_linux.go
@@ -12,7 +12,7 @@ func CreateHost(machineConfig config.MachineConfig) *libvirt.Driver {
 
 	config.InitVMDriverFromMachineConfig(machineConfig, libvirtDriver.VMDriver)
 
-	if machineConfig.NetworkMode == network.VSockMode {
+	if machineConfig.NetworkMode == network.UserNetworkingMode {
 		libvirtDriver.Network = "" // don't need to attach a network interface
 		libvirtDriver.VSock = true
 	} else {

--- a/pkg/crc/network/types.go
+++ b/pkg/crc/network/types.go
@@ -23,15 +23,15 @@ type ResolvFileValues struct {
 type Mode string
 
 const (
-	SystemNetworkingMode Mode = "default"
-	UserNetworkingMode   Mode = "vsock"
+	SystemNetworkingMode Mode = "system"
+	UserNetworkingMode   Mode = "user"
 )
 
 func parseMode(input string) (Mode, error) {
 	switch input {
-	case string(UserNetworkingMode):
+	case string(UserNetworkingMode), "vsock":
 		return UserNetworkingMode, nil
-	case string(SystemNetworkingMode):
+	case string(SystemNetworkingMode), "default":
 		return SystemNetworkingMode, nil
 	default:
 		return SystemNetworkingMode, fmt.Errorf("Cannot parse mode '%s'", input)

--- a/pkg/crc/network/types.go
+++ b/pkg/crc/network/types.go
@@ -23,25 +23,25 @@ type ResolvFileValues struct {
 type Mode string
 
 const (
-	DefaultMode Mode = "default"
-	VSockMode   Mode = "vsock"
+	SystemNetworkingMode Mode = "default"
+	UserNetworkingMode   Mode = "vsock"
 )
 
 func parseMode(input string) (Mode, error) {
 	switch input {
-	case string(VSockMode):
-		return VSockMode, nil
-	case string(DefaultMode):
-		return DefaultMode, nil
+	case string(UserNetworkingMode):
+		return UserNetworkingMode, nil
+	case string(SystemNetworkingMode):
+		return SystemNetworkingMode, nil
 	default:
-		return DefaultMode, fmt.Errorf("Cannot parse mode '%s'", input)
+		return SystemNetworkingMode, fmt.Errorf("Cannot parse mode '%s'", input)
 	}
 }
 func ParseMode(input string) Mode {
 	mode, err := parseMode(input)
 	if err != nil {
 		logging.Errorf("unexpected network mode %s, using default", input)
-		return DefaultMode
+		return SystemNetworkingMode
 	}
 	return mode
 }
@@ -49,7 +49,7 @@ func ParseMode(input string) Mode {
 func ValidateMode(val interface{}) (bool, string) {
 	_, err := parseMode(cast.ToString(val))
 	if err != nil {
-		return false, fmt.Sprintf("network mode should be either %s or %s", DefaultMode, VSockMode)
+		return false, fmt.Sprintf("network mode should be either %s or %s", SystemNetworkingMode, UserNetworkingMode)
 	}
 	return true, ""
 }

--- a/pkg/crc/network/types.go
+++ b/pkg/crc/network/types.go
@@ -27,23 +27,31 @@ const (
 	VSockMode   Mode = "vsock"
 )
 
-func ParseMode(input string) Mode {
+func parseMode(input string) (Mode, error) {
 	switch input {
 	case string(VSockMode):
-		return VSockMode
+		return VSockMode, nil
 	case string(DefaultMode):
-		return DefaultMode
+		return DefaultMode, nil
 	default:
+		return DefaultMode, fmt.Errorf("Cannot parse mode '%s'", input)
+	}
+}
+func ParseMode(input string) Mode {
+	mode, err := parseMode(input)
+	if err != nil {
 		logging.Errorf("unexpected network mode %s, using default", input)
 		return DefaultMode
 	}
+	return mode
 }
 
 func ValidateMode(val interface{}) (bool, string) {
-	if cast.ToString(val) == string(DefaultMode) || cast.ToString(val) == string(VSockMode) {
-		return true, ""
+	_, err := parseMode(cast.ToString(val))
+	if err != nil {
+		return false, fmt.Sprintf("network mode should be either %s or %s", DefaultMode, VSockMode)
 	}
-	return false, fmt.Sprintf("network mode should be either %s or %s", DefaultMode, VSockMode)
+	return true, ""
 }
 
 func SuccessfullyAppliedMode(_ string, _ interface{}) string {

--- a/pkg/crc/preflight/preflight.go
+++ b/pkg/crc/preflight/preflight.go
@@ -3,8 +3,7 @@ package preflight
 import (
 	"fmt"
 
-	cmdConfig "github.com/code-ready/crc/cmd/crc/cmd/config"
-	"github.com/code-ready/crc/pkg/crc/config"
+	crcConfig "github.com/code-ready/crc/pkg/crc/config"
 	"github.com/code-ready/crc/pkg/crc/errors"
 	"github.com/code-ready/crc/pkg/crc/logging"
 	"github.com/code-ready/crc/pkg/crc/network"
@@ -41,14 +40,14 @@ func (check *Check) getSkipConfigName() string {
 	return "skip-" + check.configKeySuffix
 }
 
-func (check *Check) shouldSkip(config config.Storage) bool {
+func (check *Check) shouldSkip(config crcConfig.Storage) bool {
 	if check.configKeySuffix == "" {
 		return false
 	}
 	return config.Get(check.getSkipConfigName()).AsBool()
 }
 
-func (check *Check) doCheck(config config.Storage) error {
+func (check *Check) doCheck(config crcConfig.Storage) error {
 	if check.checkDescription == "" {
 		panic(fmt.Sprintf("Should not happen, empty description for check '%s'", check.configKeySuffix))
 	} else {
@@ -89,7 +88,7 @@ func (check *Check) doCleanUp() error {
 	return check.cleanup()
 }
 
-func doPreflightChecks(config config.Storage, checks []Check) error {
+func doPreflightChecks(config crcConfig.Storage, checks []Check) error {
 	for _, check := range checks {
 		if check.flags&SetupOnly == SetupOnly || check.flags&CleanUpOnly == CleanUpOnly {
 			continue
@@ -101,7 +100,7 @@ func doPreflightChecks(config config.Storage, checks []Check) error {
 	return nil
 }
 
-func doFixPreflightChecks(config config.Storage, checks []Check, checkOnly bool) error {
+func doFixPreflightChecks(config crcConfig.Storage, checks []Check, checkOnly bool) error {
 	for _, check := range checks {
 		if check.flags&CleanUpOnly == CleanUpOnly {
 			continue
@@ -141,20 +140,20 @@ func doCleanUpPreflightChecks(checks []Check) error {
 	return mErr
 }
 
-func doRegisterSettings(cfg config.Schema, checks []Check) {
+func doRegisterSettings(cfg crcConfig.Schema, checks []Check) {
 	for _, check := range checks {
 		if check.configKeySuffix != "" {
-			cfg.AddSetting(check.getSkipConfigName(), false, config.ValidateBool, config.SuccessfullyApplied,
+			cfg.AddSetting(check.getSkipConfigName(), false, crcConfig.ValidateBool, crcConfig.SuccessfullyApplied,
 				"Skip preflight check (true/false, default: false)")
 		}
 	}
 }
 
 // StartPreflightChecks performs the preflight checks before starting the cluster
-func StartPreflightChecks(config config.Storage) error {
-	experimentalFeatures := config.Get(cmdConfig.ExperimentalFeatures).AsBool()
-	mode := network.ParseMode(config.Get(cmdConfig.NetworkMode).AsString())
-	trayAutostart := config.Get(cmdConfig.AutostartTray).AsBool()
+func StartPreflightChecks(config crcConfig.Storage) error {
+	experimentalFeatures := config.Get(crcConfig.ExperimentalFeatures).AsBool()
+	mode := network.ParseMode(config.Get(crcConfig.NetworkMode).AsString())
+	trayAutostart := config.Get(crcConfig.AutostartTray).AsBool()
 	if err := doPreflightChecks(config, getPreflightChecks(experimentalFeatures, trayAutostart, mode)); err != nil {
 		return &errors.PreflightError{Err: err}
 	}
@@ -162,14 +161,14 @@ func StartPreflightChecks(config config.Storage) error {
 }
 
 // SetupHost performs the prerequisite checks and setups the host to run the cluster
-func SetupHost(config config.Storage, checkOnly bool) error {
-	experimentalFeatures := config.Get(cmdConfig.ExperimentalFeatures).AsBool()
-	mode := network.ParseMode(config.Get(cmdConfig.NetworkMode).AsString())
-	trayAutostart := config.Get(cmdConfig.AutostartTray).AsBool()
+func SetupHost(config crcConfig.Storage, checkOnly bool) error {
+	experimentalFeatures := config.Get(crcConfig.ExperimentalFeatures).AsBool()
+	mode := network.ParseMode(config.Get(crcConfig.NetworkMode).AsString())
+	trayAutostart := config.Get(crcConfig.AutostartTray).AsBool()
 	return doFixPreflightChecks(config, getPreflightChecks(experimentalFeatures, trayAutostart, mode), checkOnly)
 }
 
-func RegisterSettings(config config.Schema) {
+func RegisterSettings(config crcConfig.Schema) {
 	doRegisterSettings(config, getAllPreflightChecks())
 }
 

--- a/pkg/crc/preflight/preflight.go
+++ b/pkg/crc/preflight/preflight.go
@@ -6,7 +6,6 @@ import (
 	crcConfig "github.com/code-ready/crc/pkg/crc/config"
 	"github.com/code-ready/crc/pkg/crc/errors"
 	"github.com/code-ready/crc/pkg/crc/logging"
-	"github.com/code-ready/crc/pkg/crc/network"
 )
 
 type Flags uint32
@@ -152,7 +151,7 @@ func doRegisterSettings(cfg crcConfig.Schema, checks []Check) {
 // StartPreflightChecks performs the preflight checks before starting the cluster
 func StartPreflightChecks(config crcConfig.Storage) error {
 	experimentalFeatures := config.Get(crcConfig.ExperimentalFeatures).AsBool()
-	mode := network.ParseMode(config.Get(crcConfig.NetworkMode).AsString())
+	mode := crcConfig.GetNetworkMode(config)
 	trayAutostart := config.Get(crcConfig.AutostartTray).AsBool()
 	if err := doPreflightChecks(config, getPreflightChecks(experimentalFeatures, trayAutostart, mode)); err != nil {
 		return &errors.PreflightError{Err: err}
@@ -163,7 +162,7 @@ func StartPreflightChecks(config crcConfig.Storage) error {
 // SetupHost performs the prerequisite checks and setups the host to run the cluster
 func SetupHost(config crcConfig.Storage, checkOnly bool) error {
 	experimentalFeatures := config.Get(crcConfig.ExperimentalFeatures).AsBool()
-	mode := network.ParseMode(config.Get(crcConfig.NetworkMode).AsString())
+	mode := crcConfig.GetNetworkMode(config)
 	trayAutostart := config.Get(crcConfig.AutostartTray).AsBool()
 	return doFixPreflightChecks(config, getPreflightChecks(experimentalFeatures, trayAutostart, mode), checkOnly)
 }

--- a/pkg/crc/preflight/preflight_checks_darwin.go
+++ b/pkg/crc/preflight/preflight_checks_darwin.go
@@ -51,7 +51,7 @@ func checkHyperKitInstalled(networkMode network.Mode) func() error {
 		if err := h.CheckVersion(); err != nil {
 			return err
 		}
-		if networkMode == network.VSockMode {
+		if networkMode == network.UserNetworkingMode {
 			return nil
 		}
 		return checkSuid(hyperkitPath)
@@ -71,7 +71,7 @@ func fixHyperKitInstallation(networkMode network.Mode) func() error {
 		if err := h.EnsureIsCached(); err != nil {
 			return fmt.Errorf("Unable to download %s : %v", h.GetExecutableName(), err)
 		}
-		if networkMode == network.VSockMode {
+		if networkMode == network.UserNetworkingMode {
 			return nil
 		}
 		return setSuid(h.GetExecutablePath())
@@ -94,7 +94,7 @@ func checkMachineDriverHyperKitInstalled(networkMode network.Mode) func() error 
 		if err := hyperkitDriver.CheckVersion(); err != nil {
 			return err
 		}
-		if networkMode == network.VSockMode {
+		if networkMode == network.UserNetworkingMode {
 			return nil
 		}
 		return checkSuid(hyperkitDriver.GetExecutablePath())
@@ -114,7 +114,7 @@ func fixMachineDriverHyperKitInstalled(networkMode network.Mode) func() error {
 		if err := hyperkitDriver.EnsureIsCached(); err != nil {
 			return fmt.Errorf("Unable to download %s : %v", hyperkitDriver.GetExecutableName(), err)
 		}
-		if networkMode == network.VSockMode {
+		if networkMode == network.UserNetworkingMode {
 			return nil
 		}
 		return setSuid(hyperkitDriver.GetExecutablePath())

--- a/pkg/crc/preflight/preflight_darwin.go
+++ b/pkg/crc/preflight/preflight_darwin.go
@@ -85,7 +85,7 @@ var traySetupChecks = [...]Check{
 }
 
 func getAllPreflightChecks() []Check {
-	return getPreflightChecks(true, true, network.DefaultMode)
+	return getPreflightChecks(true, true, network.SystemNetworkingMode)
 }
 
 func getPreflightChecks(experimentalFeatures bool, trayAutostart bool, mode network.Mode) []Check {
@@ -96,7 +96,7 @@ func getPreflightChecks(experimentalFeatures bool, trayAutostart bool, mode netw
 	checks = append(checks, hyperkitPreflightChecks(mode)...)
 	checks = append(checks, daemonSetupChecks[:]...)
 
-	if mode == network.DefaultMode {
+	if mode == network.SystemNetworkingMode {
 		checks = append(checks, resolverPreflightChecks[:]...)
 	}
 

--- a/pkg/crc/preflight/preflight_darwin_test.go
+++ b/pkg/crc/preflight/preflight_darwin_test.go
@@ -16,9 +16,9 @@ func TestCountConfigurationOptions(t *testing.T) {
 }
 
 func TestCountPreflights(t *testing.T) {
-	assert.Len(t, getPreflightChecks(true, false, network.DefaultMode), 15)
-	assert.Len(t, getPreflightChecks(true, true, network.DefaultMode), 15)
+	assert.Len(t, getPreflightChecks(true, false, network.SystemNetworkingMode), 15)
+	assert.Len(t, getPreflightChecks(true, true, network.SystemNetworkingMode), 15)
 
-	assert.Len(t, getPreflightChecks(true, false, network.VSockMode), 14)
-	assert.Len(t, getPreflightChecks(true, true, network.VSockMode), 14)
+	assert.Len(t, getPreflightChecks(true, false, network.UserNetworkingMode), 14)
+	assert.Len(t, getPreflightChecks(true, true, network.UserNetworkingMode), 14)
 }

--- a/pkg/crc/preflight/preflight_linux.go
+++ b/pkg/crc/preflight/preflight_linux.go
@@ -219,7 +219,7 @@ func removeVsockCrcSettings() error {
 
 func getAllPreflightChecks() []Check {
 	usingSystemdResolved := checkSystemdResolvedIsRunning()
-	checks := getPreflightChecksForDistro(distro(), network.DefaultMode, usingSystemdResolved == nil)
+	checks := getPreflightChecksForDistro(distro(), network.SystemNetworkingMode, usingSystemdResolved == nil)
 	checks = append(checks, vsockPreflightChecks)
 	return checks
 }
@@ -232,7 +232,7 @@ func getPreflightChecks(_ bool, _ bool, networkMode network.Mode) []Check {
 func getNetworkChecks(networkMode network.Mode, systemdResolved bool) []Check {
 	var checks []Check
 
-	if networkMode == network.VSockMode {
+	if networkMode == network.UserNetworkingMode {
 		return append(checks, vsockPreflightChecks)
 	}
 
@@ -253,7 +253,7 @@ func getPreflightChecksForDistro(distro *linux.OsRelease, networkMode network.Mo
 	checks = append(checks, libvirtPreflightChecks(distro)...)
 	networkChecks := getNetworkChecks(networkMode, systemdResolved)
 	checks = append(checks, networkChecks...)
-	if networkMode == network.DefaultMode {
+	if networkMode == network.SystemNetworkingMode {
 		checks = append(checks, libvirtNetworkPreflightChecks[:]...)
 	}
 	checks = append(checks, bundleCheck)

--- a/pkg/crc/preflight/preflight_linux_test.go
+++ b/pkg/crc/preflight/preflight_linux_test.go
@@ -59,7 +59,7 @@ type checkListForDistro struct {
 var checkListForDistros = []checkListForDistro{
 	{
 		distro:          &fedora,
-		networkMode:     network.DefaultMode,
+		networkMode:     network.SystemNetworkingMode,
 		systemdResolved: true,
 		checks: []Check{
 			{check: checkIfRunningAsNormalUser},
@@ -92,7 +92,7 @@ var checkListForDistros = []checkListForDistro{
 	},
 	{
 		distro:          &fedora,
-		networkMode:     network.DefaultMode,
+		networkMode:     network.SystemNetworkingMode,
 		systemdResolved: false,
 		checks: []Check{
 			{check: checkIfRunningAsNormalUser},
@@ -124,7 +124,7 @@ var checkListForDistros = []checkListForDistro{
 	},
 	{
 		distro:          &fedora,
-		networkMode:     network.VSockMode,
+		networkMode:     network.UserNetworkingMode,
 		systemdResolved: false,
 		checks: []Check{
 			{check: checkIfRunningAsNormalUser},
@@ -150,7 +150,7 @@ var checkListForDistros = []checkListForDistro{
 	},
 	{
 		distro:          &rhel,
-		networkMode:     network.DefaultMode,
+		networkMode:     network.SystemNetworkingMode,
 		systemdResolved: true,
 		checks: []Check{
 			{check: checkIfRunningAsNormalUser},
@@ -183,7 +183,7 @@ var checkListForDistros = []checkListForDistro{
 	},
 	{
 		distro:          &rhel,
-		networkMode:     network.DefaultMode,
+		networkMode:     network.SystemNetworkingMode,
 		systemdResolved: false,
 		checks: []Check{
 			{check: checkIfRunningAsNormalUser},
@@ -215,7 +215,7 @@ var checkListForDistros = []checkListForDistro{
 	},
 	{
 		distro:          &rhel,
-		networkMode:     network.VSockMode,
+		networkMode:     network.UserNetworkingMode,
 		systemdResolved: false,
 		checks: []Check{
 			{check: checkIfRunningAsNormalUser},
@@ -241,7 +241,7 @@ var checkListForDistros = []checkListForDistro{
 	},
 	{
 		distro:          &unexpected,
-		networkMode:     network.DefaultMode,
+		networkMode:     network.SystemNetworkingMode,
 		systemdResolved: true,
 		checks: []Check{
 			{check: checkIfRunningAsNormalUser},
@@ -274,7 +274,7 @@ var checkListForDistros = []checkListForDistro{
 	},
 	{
 		distro:          &unexpected,
-		networkMode:     network.DefaultMode,
+		networkMode:     network.SystemNetworkingMode,
 		systemdResolved: false,
 		checks: []Check{
 			{check: checkIfRunningAsNormalUser},
@@ -306,7 +306,7 @@ var checkListForDistros = []checkListForDistro{
 	},
 	{
 		distro:          &unexpected,
-		networkMode:     network.VSockMode,
+		networkMode:     network.UserNetworkingMode,
 		systemdResolved: false,
 		checks: []Check{
 			{check: checkIfRunningAsNormalUser},
@@ -332,7 +332,7 @@ var checkListForDistros = []checkListForDistro{
 	},
 	{
 		distro:          &ubuntu,
-		networkMode:     network.DefaultMode,
+		networkMode:     network.SystemNetworkingMode,
 		systemdResolved: true,
 		checks: []Check{
 			{check: checkIfRunningAsNormalUser},
@@ -366,7 +366,7 @@ var checkListForDistros = []checkListForDistro{
 	},
 	{
 		distro:          &ubuntu,
-		networkMode:     network.DefaultMode,
+		networkMode:     network.SystemNetworkingMode,
 		systemdResolved: false,
 		checks: []Check{
 			{check: checkIfRunningAsNormalUser},
@@ -399,7 +399,7 @@ var checkListForDistros = []checkListForDistro{
 	},
 	{
 		distro:          &ubuntu,
-		networkMode:     network.VSockMode,
+		networkMode:     network.UserNetworkingMode,
 		systemdResolved: false,
 		checks: []Check{
 			{check: checkIfRunningAsNormalUser},
@@ -463,19 +463,19 @@ func assertExpectedPreflights(t *testing.T, distro *crcos.OsRelease, networkMode
 }
 
 func TestCountPreflights(t *testing.T) {
-	assertExpectedPreflights(t, &fedora, network.DefaultMode, true)
-	assertExpectedPreflights(t, &fedora, network.DefaultMode, false)
-	assertExpectedPreflights(t, &fedora, network.VSockMode, false)
+	assertExpectedPreflights(t, &fedora, network.SystemNetworkingMode, true)
+	assertExpectedPreflights(t, &fedora, network.SystemNetworkingMode, false)
+	assertExpectedPreflights(t, &fedora, network.UserNetworkingMode, false)
 
-	assertExpectedPreflights(t, &rhel, network.DefaultMode, true)
-	assertExpectedPreflights(t, &rhel, network.DefaultMode, false)
-	assertExpectedPreflights(t, &rhel, network.VSockMode, false)
+	assertExpectedPreflights(t, &rhel, network.SystemNetworkingMode, true)
+	assertExpectedPreflights(t, &rhel, network.SystemNetworkingMode, false)
+	assertExpectedPreflights(t, &rhel, network.UserNetworkingMode, false)
 
-	assertExpectedPreflights(t, &unexpected, network.DefaultMode, true)
-	assertExpectedPreflights(t, &unexpected, network.DefaultMode, false)
-	assertExpectedPreflights(t, &unexpected, network.VSockMode, false)
+	assertExpectedPreflights(t, &unexpected, network.SystemNetworkingMode, true)
+	assertExpectedPreflights(t, &unexpected, network.SystemNetworkingMode, false)
+	assertExpectedPreflights(t, &unexpected, network.UserNetworkingMode, false)
 
-	assertExpectedPreflights(t, &ubuntu, network.DefaultMode, true)
-	assertExpectedPreflights(t, &ubuntu, network.DefaultMode, false)
-	assertExpectedPreflights(t, &ubuntu, network.VSockMode, false)
+	assertExpectedPreflights(t, &ubuntu, network.SystemNetworkingMode, true)
+	assertExpectedPreflights(t, &ubuntu, network.SystemNetworkingMode, false)
+	assertExpectedPreflights(t, &ubuntu, network.UserNetworkingMode, false)
 }

--- a/pkg/crc/preflight/preflight_windows.go
+++ b/pkg/crc/preflight/preflight_windows.go
@@ -138,7 +138,7 @@ func fixVsock() error {
 }
 
 func getAllPreflightChecks() []Check {
-	return getPreflightChecks(true, true, network.VSockMode)
+	return getPreflightChecks(true, true, network.UserNetworkingMode)
 }
 
 func getPreflightChecks(experimentalFeatures bool, _ bool, networkMode network.Mode) []Check {
@@ -146,7 +146,7 @@ func getPreflightChecks(experimentalFeatures bool, _ bool, networkMode network.M
 	checks = append(checks, genericPreflightChecks[:]...)
 	checks = append(checks, hypervPreflightChecks[:]...)
 
-	if networkMode == network.VSockMode {
+	if networkMode == network.UserNetworkingMode {
 		checks = append(checks, vsockChecks[:]...)
 	}
 

--- a/pkg/crc/preflight/preflight_windows_test.go
+++ b/pkg/crc/preflight/preflight_windows_test.go
@@ -15,9 +15,9 @@ func TestCountConfigurationOptions(t *testing.T) {
 }
 
 func TestCountPreflights(t *testing.T) {
-	assert.Len(t, getPreflightChecks(false, false, network.DefaultMode), 17)
-	assert.Len(t, getPreflightChecks(true, true, network.DefaultMode), 20)
+	assert.Len(t, getPreflightChecks(false, false, network.SystemNetworkingMode), 17)
+	assert.Len(t, getPreflightChecks(true, true, network.SystemNetworkingMode), 20)
 
-	assert.Len(t, getPreflightChecks(false, false, network.VSockMode), 18)
-	assert.Len(t, getPreflightChecks(true, true, network.VSockMode), 21)
+	assert.Len(t, getPreflightChecks(false, false, network.UserNetworkingMode), 18)
+	assert.Len(t, getPreflightChecks(true, true, network.UserNetworkingMode), 21)
 }

--- a/pkg/crc/segment/segment.go
+++ b/pkg/crc/segment/segment.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/code-ready/crc/cmd/crc/cmd/config"
 	crcConfig "github.com/code-ready/crc/pkg/crc/config"
 	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/code-ready/crc/pkg/crc/logging"
@@ -69,7 +68,7 @@ func (c *Client) UploadCmd(ctx context.Context, action string, duration time.Dur
 }
 
 func (c *Client) upload(action string, a analytics.Properties) error {
-	if c.config.Get(config.ConsentTelemetry).AsString() != "yes" {
+	if c.config.Get(crcConfig.ConsentTelemetry).AsString() != "yes" {
 		return nil
 	}
 
@@ -119,9 +118,9 @@ func properties(ctx context.Context, err error, duration time.Duration) analytic
 func addConfigTraits(c *crcConfig.Config, in analytics.Traits) analytics.Traits {
 	return in.
 		Set("proxy", isProxyUsed()).
-		Set(config.NetworkMode, c.Get(config.NetworkMode).AsString()).
-		Set(config.EnableClusterMonitoring, c.Get(config.EnableClusterMonitoring).AsBool()).
-		Set(config.ExperimentalFeatures, c.Get(config.ExperimentalFeatures).AsBool())
+		Set(crcConfig.NetworkMode, c.Get(crcConfig.NetworkMode).AsString()).
+		Set(crcConfig.EnableClusterMonitoring, c.Get(crcConfig.EnableClusterMonitoring).AsBool()).
+		Set(crcConfig.ExperimentalFeatures, c.Get(crcConfig.ExperimentalFeatures).AsBool())
 }
 
 func isProxyUsed() bool {

--- a/pkg/crc/segment/segment.go
+++ b/pkg/crc/segment/segment.go
@@ -118,7 +118,7 @@ func properties(ctx context.Context, err error, duration time.Duration) analytic
 func addConfigTraits(c *crcConfig.Config, in analytics.Traits) analytics.Traits {
 	return in.
 		Set("proxy", isProxyUsed()).
-		Set(crcConfig.NetworkMode, c.Get(crcConfig.NetworkMode).AsString()).
+		Set(crcConfig.NetworkMode, crcConfig.GetNetworkMode(c)).
 		Set(crcConfig.EnableClusterMonitoring, c.Get(crcConfig.EnableClusterMonitoring).AsBool()).
 		Set(crcConfig.ExperimentalFeatures, c.Get(crcConfig.ExperimentalFeatures).AsBool())
 }

--- a/pkg/crc/segment/segment_test.go
+++ b/pkg/crc/segment/segment_test.go
@@ -13,7 +13,6 @@ import (
 	"testing"
 	"time"
 
-	cmdConfig "github.com/code-ready/crc/cmd/crc/cmd/config"
 	crcConfig "github.com/code-ready/crc/pkg/crc/config"
 	crcErr "github.com/code-ready/crc/pkg/crc/errors"
 	"github.com/code-ready/crc/pkg/crc/logging"
@@ -61,12 +60,12 @@ func mockServer() (chan []byte, *httptest.Server) {
 func newTestConfig(value string) (*crcConfig.Config, error) {
 	storage := crcConfig.NewEmptyInMemoryStorage()
 	config := crcConfig.New(storage)
-	cmdConfig.RegisterSettings(config)
+	crcConfig.RegisterSettings(config)
 
-	if _, err := config.Set(cmdConfig.ConsentTelemetry, value); err != nil {
+	if _, err := config.Set(crcConfig.ConsentTelemetry, value); err != nil {
 		return nil, err
 	}
-	if _, err := config.Set(cmdConfig.ExperimentalFeatures, true); err != nil {
+	if _, err := config.Set(crcConfig.ExperimentalFeatures, true); err != nil {
 		return nil, err
 	}
 	return config, nil

--- a/pkg/crc/services/dns/dns.go
+++ b/pkg/crc/services/dns/dns.go
@@ -40,7 +40,7 @@ func RunPostStart(serviceConfig services.ServicePostStartConfig) error {
 }
 
 func setupDnsmasq(serviceConfig services.ServicePostStartConfig) error {
-	if serviceConfig.NetworkMode == network.VSockMode {
+	if serviceConfig.NetworkMode == network.UserNetworkingMode {
 		return nil
 	}
 
@@ -81,7 +81,7 @@ func getResolvFileValues(serviceConfig services.ServicePostStartConfig) (network
 }
 
 func dnsServers(serviceConfig services.ServicePostStartConfig) ([]network.NameServer, error) {
-	if serviceConfig.NetworkMode == network.VSockMode {
+	if serviceConfig.NetworkMode == network.UserNetworkingMode {
 		return []network.NameServer{
 			{
 				IPAddress: constants.VSockGateway,

--- a/pkg/crc/services/dns/dns_darwin.go
+++ b/pkg/crc/services/dns/dns_darwin.go
@@ -36,7 +36,7 @@ func runPostStartForOS(serviceConfig services.ServicePostStartConfig) error {
 		return err
 	}
 
-	if serviceConfig.NetworkMode == network.VSockMode {
+	if serviceConfig.NetworkMode == network.UserNetworkingMode {
 		return nil
 	}
 

--- a/pkg/crc/services/dns/dns_windows.go
+++ b/pkg/crc/services/dns/dns_windows.go
@@ -19,7 +19,7 @@ const (
 )
 
 func runPostStartForOS(serviceConfig services.ServicePostStartConfig) error {
-	if serviceConfig.NetworkMode == network.VSockMode {
+	if serviceConfig.NetworkMode == network.UserNetworkingMode {
 		return addOpenShiftHosts(serviceConfig)
 	}
 


### PR DESCRIPTION
I went with `user` and `system` (`kernel`?) but I expect this is going to be discussed/changed.
The old options are still supported for backwards compatibility (in particular when they were written to the config file).
For testing, `vsock`/`user` should be usable interchangeably, and same for `default`/`system`.
Behaviour should be exactly the same regardless of what value the option is set to.