### PR TITLE
[msi] Don't use embedded crc binary and use helper binaries from install location

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -323,7 +323,7 @@ endif
 	rm $(PACKAGE_DIR)/product.wxs
 
 $(BUILD_DIR)/windows-amd64/crc-windows-amd64.msi: msidir
-	candle.exe -arch x64 -o $(PACKAGE_DIR)/msi/ $(PACKAGE_DIR)/msi/*.wxs
+	candle.exe -arch x64 -ext WixUtilExtension -o $(PACKAGE_DIR)/msi/ $(PACKAGE_DIR)/msi/*.wxs
 	cd $(PACKAGE_DIR)/msi && light.exe -ext WixUIExtension -ext WixUtilExtension -sacl -spdb -sice:ICE61 -out ../../../$@ *.wixobj
 
 CABS_MSI = "cab1.cab,cab2.cab,cab3.cab,crc-windows-amd64.msi"

--- a/Makefile
+++ b/Makefile
@@ -301,18 +301,21 @@ $(GOPATH)/bin/gomod2rpmdeps:
 $(HOST_BUILD_DIR)/split: packaging/windows/split.go
 	go build -o $(HOST_BUILD_DIR)/split packaging/windows/split.go
 
+CRC_EXE=crc.exe
+BUNDLE_NAME=crc_hyperv_$(BUNDLE_VERSION).$(BUNDLE_EXTENSION)
+
 .PHONY: msidir
-msidir: CRC_EXE = crc.exe
 msidir: clean $(HOST_BUILD_DIR)/crc-embedder $(HOST_BUILD_DIR)/split $(BUILD_DIR)/windows-amd64/crc.exe check_bundledir $(PACKAGE_DIR)/product.wxs
 	mkdir -p $(PACKAGE_DIR)/msi
-	$(HOST_BUILD_DIR)/crc-embedder embed --goos windows --log-level debug --bundle-dir $(BUNDLE_DIR) $(BUILD_DIR)/windows-amd64/crc.exe
+	$(HOST_BUILD_DIR)/crc-embedder download $(PACKAGE_DIR)/msi 
 	cp $(HOST_BUILD_DIR)/crc.exe $(PACKAGE_DIR)/msi/$(CRC_EXE)
+	pwsh -NoProfile -Command "cd $(PACKAGE_DIR)/msi; Expand-Archive crc-tray-windows.zip -DestinationPath .\; Remove-Item crc-tray-windows.zip"
 ifeq ($(MOCK_BUNDLE),true)
-	mv $(PACKAGE_DIR)/msi/$(CRC_EXE) $(PACKAGE_DIR)/msi/$(CRC_EXE).0
-	touch $(PACKAGE_DIR)/msi/$(CRC_EXE).1 $(PACKAGE_DIR)/msi/$(CRC_EXE).2
+	touch $(PACKAGE_DIR)/msi/$(BUNDLE_NAME).0 $(PACKAGE_DIR)/msi/$(BUNDLE_NAME).1 $(PACKAGE_DIR)/msi/$(BUNDLE_NAME).2
 else
-	$(HOST_BUILD_DIR)/split $(PACKAGE_DIR)/msi/$(CRC_EXE)
-	rm $(PACKAGE_DIR)/msi/$(CRC_EXE)
+	cp $(HYPERV_BUNDLENAME) $(PACKAGE_DIR)/msi
+	$(HOST_BUILD_DIR)/split $(PACKAGE_DIR)/msi/$(BUNDLE_NAME)
+	rm $(PACKAGE_DIR)/msi/$(BUNDLE_NAME)
 endif
 	cp -r $(PACKAGE_DIR)/Resources $(PACKAGE_DIR)/msi/
 	cp $(PACKAGE_DIR)/*.wxs $(PACKAGE_DIR)/msi

--- a/Makefile
+++ b/Makefile
@@ -326,8 +326,8 @@ $(BUILD_DIR)/windows-amd64/crc-windows-amd64.msi: msidir
 	cd $(PACKAGE_DIR)/msi && light.exe -ext WixUIExtension -ext WixUtilExtension -sacl -spdb -sice:ICE61 -out ../../../$@ *.wixobj
 
 CABS_MSI = "cab1.cab,cab2.cab,cab3.cab,crc-windows-amd64.msi"
-$(BUILD_DIR)/windows-amd64/crc-installer.zip: $(BUILD_DIR)/windows-amd64/crc-windows-amd64.msi
+$(BUILD_DIR)/windows-amd64/crc-windows-installer.zip: $(BUILD_DIR)/windows-amd64/crc-windows-amd64.msi
 	rm -f $(HOST_BUILD_DIR)/crc.exe
 	rm -f $(HOST_BUILD_DIR)/crc-embedder
 	rm -f $(HOST_BUILD_DIR)/split
-	pwsh -NoProfile -Command "cd $(HOST_BUILD_DIR); Compress-Archive -LiteralPath $(CABS_MSI) -DestinationPath crc-installer.zip"
+	pwsh -NoProfile -Command "cd $(HOST_BUILD_DIR); Compress-Archive -LiteralPath $(CABS_MSI) -DestinationPath crc-windows-installer.zip"

--- a/Makefile
+++ b/Makefile
@@ -305,6 +305,7 @@ CRC_EXE=crc.exe
 BUNDLE_NAME=crc_hyperv_$(BUNDLE_VERSION).$(BUNDLE_EXTENSION)
 
 .PHONY: msidir
+msidir: LDFLAGS+= -X '$(REPOPATH)/pkg/crc/version.msiBuild=true' $(RELEASE_VERSION_VARIABLES)
 msidir: clean $(HOST_BUILD_DIR)/crc-embedder $(HOST_BUILD_DIR)/split $(BUILD_DIR)/windows-amd64/crc.exe check_bundledir $(PACKAGE_DIR)/product.wxs
 	mkdir -p $(PACKAGE_DIR)/msi
 	$(HOST_BUILD_DIR)/crc-embedder download $(PACKAGE_DIR)/msi 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,7 @@ before_test:
   - choco install make
   - choco install wixtoolset
   - set PATH=%PATH%;"C:\Program Files (x86)\WiX Toolset v3.11\bin"
-  - make MOCK_BUNDLE=true BUNDLE_DIR=./ out/windows-amd64/crc-installer.zip
+  - make MOCK_BUNDLE=true BUNDLE_DIR=./ out/windows-amd64/crc-windows-installer.zip
   - make cross
 test_script:
   - make test
@@ -23,6 +23,6 @@ artifacts:
   - path: out\windows-amd64\crc.exe
     name: crc windows executable
     type: File
-  - path: out\windows-amd64\crc-installer.zip
+  - path: out\windows-amd64\crc-windows-installer.zip
     name: crc windows installer
     type: Zip

--- a/packaging/windows/product.wxs.in
+++ b/packaging/windows/product.wxs.in
@@ -1,88 +1,91 @@
 <?xml version="1.0"?>
-
-<?define crcPart0="crc.exe.0"?>
-<?define crcPart1="crc.exe.1"?>
-<?define crcPart2="crc.exe.2"?>
-<?define crcExeName="crc.exe"?>
-
+<?define crcBundlePart0="crc_hyperv___OPENSHIFT_VERSION__.crcbundle.0"?>
+<?define crcBundlePart1="crc_hyperv___OPENSHIFT_VERSION__.crcbundle.1"?>
+<?define crcBundlePart2="crc_hyperv___OPENSHIFT_VERSION__.crcbundle.2"?>
+<?define crcBundleName="crc_hyperv___OPENSHIFT_VERSION__.crcbundle"?>
 <Wix
-	xmlns="http://schemas.microsoft.com/wix/2006/wi">
-	<Product Id="*" UpgradeCode="53DE5BFA-0E53-44E7-8D4F-07E37E59A9AB"
+    xmlns="http://schemas.microsoft.com/wix/2006/wi">
+    <Product Id="*" UpgradeCode="53DE5BFA-0E53-44E7-8D4F-07E37E59A9AB"
             Name="CodeReady Containers"
             Version="__VERSION__"
             Manufacturer="Red Hat Inc."
             Language="1033">
-		<Package Id ="*" InstallerVersion="300" 
+        <Package Id ="*" InstallerVersion="300" 
 			Compressed="yes" 
 			Description="CodeReady Containers __VERSION__"
             Comments="This installs CodeReady Containers __VERSION__" 
 			InstallScope="perMachine" />
-		
-		<Media Id="1" EmbedCab="no" Cabinet="cab1.cab" />
-		<Media Id="2" EmbedCab="no" Cabinet="cab2.cab" />
-		<Media Id="3" EmbedCab="no" Cabinet="cab3.cab" />
-
-		<MajorUpgrade AllowDowngrades="yes" />
-		<WixVariable Id="WixUIBannerBmp" Value=".\Resources\banner.png"/>
-		<WixVariable Id="WixUIDialogBmp" Value=".\Resources\background.png"/>
-		<Icon Id="crcicon.ico" SourceFile=".\Resources\icon.ico"/>
-		<Property Id="ARPPRODUCTICON" Value="crcicon.ico"/>
-		<Property Id="CURRENTBUILD">
-			<RegistrySearch Id="CURRENTBUILDSearch" Root="HKLM" Key="SOFTWARE\Microsoft\Windows NT\CurrentVersion"
+        <Media Id="1" EmbedCab="no" Cabinet="cab1.cab" />
+        <Media Id="2" EmbedCab="no" Cabinet="cab2.cab" />
+        <Media Id="3" EmbedCab="no" Cabinet="cab3.cab" />
+        <MajorUpgrade AllowDowngrades="yes" />
+        <WixVariable Id="WixUIBannerBmp" Value=".\Resources\banner.png"/>
+        <WixVariable Id="WixUIDialogBmp" Value=".\Resources\background.png"/>
+        <Icon Id="crcicon.ico" SourceFile=".\Resources\icon.ico"/>
+        <Property Id="ARPPRODUCTICON" Value="crcicon.ico"/>
+        <Property Id="CURRENTBUILD">
+            <RegistrySearch Id="CURRENTBUILDSearch" Root="HKLM" Key="SOFTWARE\Microsoft\Windows NT\CurrentVersion"
              Name="CurrentBuild"  Type="raw"/>
-		</Property>
-		<Property Id="MINIMUMBUILD" Value="1709" Secure="yes"></Property>
-		<Condition Message="CodeReady Containers requires the Windows 10 Fall Creators Update (version 1709) or newer.">
-			<![CDATA[Installed OR (CURRENTBUILD > MINIMUMBUILD)]]>
-		</Condition>
-		<Directory Id="TARGETDIR" Name="SourceDir">
-			<Directory Id="ProgramFiles64Folder">
-				<Directory Id="INSTALLDIR" Name="CodeReady Containers">
-                    <Component Id="CrcExePart1" Guid="*">
-                        <File Id="CrcExePart1" Source="$(var.crcPart0)" KeyPath="yes" DiskId="1" />
+        </Property>
+        <Property Id="MINIMUMBUILD" Value="1709" Secure="yes"></Property>
+        <Condition Message="CodeReady Containers requires the Windows 10 Fall Creators Update (version 1709) or newer.">
+            <![CDATA[Installed OR (CURRENTBUILD > MINIMUMBUILD)]]>
+        </Condition>
+        <Directory Id="TARGETDIR" Name="SourceDir">
+            <Directory Id="ProgramFiles64Folder">
+                <Directory Id="INSTALLDIR" Name="CodeReady Containers">
+                    <Component Id="CrcBundlePart1" Guid="*">
+                        <File Id="CrcBundlePart1" Source="SourceDir\$(var.crcBundlePart0)" KeyPath="yes" DiskId="1" />
                     </Component>
-                    <Component Id="CrcExePart2" Guid="*">
-                        <File Id="CrcExePart2" Source="$(var.crcPart1)" KeyPath="yes" DiskId="2" />
+                    <Component Id="CrcBundlePart2" Guid="*">
+                        <File Id="CrcBundlePart2" Source="SourceDir\$(var.crcBundlePart1)" KeyPath="yes" DiskId="2" />
                     </Component>
-                    <Component Id="CrcExePart3" Guid="*">
-                        <File Id="CrcExePart3" Source="$(var.crcPart2)" KeyPath="yes" DiskId="3" />
+                    <Component Id="CrcBundlePart3" Guid="*">
+                        <File Id="CrcBundlePart3" Source="SourceDir\$(var.crcBundlePart2)" KeyPath="yes" DiskId="3" />
+                    </Component>
+                    <Component Id="CrcExe" Guid="*">
+                        <File Id="CrcExe" Source="SourceDir\crc.exe" KeyPath="yes" DiskId="3" />
+                    </Component>
+                    <Component Id="AdminHelper" Guid="*">
+                        <File Id="AdminHelper" Source="SourceDir\admin-helper-windows.exe" KeyPath="yes" DiskId="3" />
+                    </Component>
+                    <Component Id="CrcTray" Guid="*">
+                        <File Id="CrcTray" Source="SourceDir\crc-tray.exe" KeyPath="yes" DiskId="3" />
                     </Component>
                     <Component Id="AddToPath" Guid="09C1E713-44DE-44C3-BDAD-72BE10C10542">
                         <CreateFolder />
                         <Environment Id="PATH" Name="PATH" Value="[INSTALLDIR]" Permanent="no" Part="last" Action="set" />
                     </Component>
-				</Directory>
-			</Directory>
-		</Directory>
-		
-		<SetProperty Action="CAJoinCrc"  Id="JoinCrc"  Value='"[WindowsFolder]\System32\cmd.exe" /c cd "[INSTALLDIR]" &amp;&amp; copy /b $(var.crcPart0)+$(var.crcPart1)+$(var.crcPart2) $(var.crcExeName)' Before="JoinCrc" Sequence="execute"/>
-		<CustomAction Id="JoinCrc" BinaryKey="WixCA" DllEntry="WixQuietExec" Execute="deferred" Impersonate="no" />
-
-		<SetProperty Action="CARemoveParts"  Id="RemoveParts"  Value='"[WindowsFolder]\System32\cmd.exe" /c cd "[INSTALLDIR]" &amp;&amp; del /f /q $(var.crcPart0) $(var.crcPart1) $(var.crcPart2)' Before="RemoveParts" Sequence="execute"/>
-		<CustomAction Id="RemoveParts" BinaryKey="WixCA" DllEntry="WixQuietExec" Execute="deferred" Impersonate="no" />
-
-		<SetProperty Action="CAUninstall"  Id="Uninstall"  Value='"[WindowsFolder]\System32\cmd.exe" /c rmdir /S /Q "[INSTALLDIR]"' Before="Uninstall" Sequence="execute"/>
-		<CustomAction Id="Uninstall" BinaryKey="WixCA" DllEntry="WixQuietExec" Execute="deferred" Impersonate="no" />
-
-		<InstallExecuteSequence>
-			<Custom Action="JoinCrc"  After="InstallFiles" >NOT Installed AND NOT PATCH</Custom>
-			<Custom Action="RemoveParts"  After="JoinCrc" >NOT Installed AND NOT PATCH</Custom>
-			<Custom Action="Uninstall"  After="RemoveFolders" >REMOVE~="ALL"</Custom>
-		</InstallExecuteSequence>
-		
-		<Feature Id="DefaultFeature" Level="1">
-			<ComponentRef Id="CrcExePart1"/>
-            <ComponentRef Id="CrcExePart2"/>
-            <ComponentRef Id="CrcExePart3"/>
+                </Directory>
+            </Directory>
+        </Directory>
+        <SetProperty Action="CAJoinBundle"  Id="JoinBundle"  Value='"[WindowsFolder]\System32\cmd.exe" /c cd "[INSTALLDIR]" &amp;&amp; copy /b $(var.crcBundlePart0)+$(var.crcBundlePart1)+$(var.crcBundlePart2) $(var.crcBundleName)' Before="JoinBundle" Sequence="execute"/>
+        <CustomAction Id="JoinBundle" BinaryKey="WixCA" DllEntry="WixQuietExec" Execute="deferred" Impersonate="no" />
+        <SetProperty Action="CARemoveParts"  Id="RemoveParts"  Value='"[WindowsFolder]\System32\cmd.exe" /c cd "[INSTALLDIR]" &amp;&amp; del /f /q $(var.crcBundlePart0) $(var.crcBundlePart1) $(var.crcBundlePart2)' Before="RemoveParts" Sequence="execute"/>
+        <CustomAction Id="RemoveParts" BinaryKey="WixCA" DllEntry="WixQuietExec" Execute="deferred" Impersonate="no" />
+        <SetProperty Action="CAUninstall"  Id="Uninstall"  Value='"[WindowsFolder]\System32\cmd.exe" /c rmdir /S /Q "[INSTALLDIR]"' Before="Uninstall" Sequence="execute"/>
+        <CustomAction Id="Uninstall" BinaryKey="WixCA" DllEntry="WixQuietExec" Execute="deferred" Impersonate="no" />
+        <InstallExecuteSequence>
+            <Custom Action="JoinBundle"  After="InstallFiles" >NOT Installed AND NOT PATCH</Custom>
+            <Custom Action="RemoveParts"  After="JoinBundle" >NOT Installed AND NOT PATCH</Custom>
+            <Custom Action="Uninstall"  After="RemoveFolders" >REMOVE~="ALL"</Custom>
+        </InstallExecuteSequence>
+        <Feature Id="DefaultFeature" Level="1">
+            <ComponentRef Id="CrcBundlePart1"/>
+            <ComponentRef Id="CrcBundlePart2"/>
+            <ComponentRef Id="CrcBundlePart3"/>
+            <ComponentRef Id="CrcExe" />
+            <ComponentRef Id="CrcTray" />
+            <ComponentRef Id="AdminHelper" />
             <ComponentRef Id="AddToPath"/>
-		</Feature>
-		<UI>
-			<UIRef Id="WixUI_ErrorProgressText"/>
-			<!-- Define the installer UI -->
-			<UIRef Id="WixUI_HK"/>
-		</UI>
-		<Property Id="WIXUI_INSTALLDIR" Value="INSTALLDIR" />
-		<!-- this should help to propagate env var changes -->
-		<CustomActionRef Id="WixBroadcastEnvironmentChange" />
-	</Product>
+        </Feature>
+        <UI>
+            <UIRef Id="WixUI_ErrorProgressText"/>
+            <!-- Define the installer UI -->
+            <UIRef Id="WixUI_HK"/>
+        </UI>
+        <Property Id="WIXUI_INSTALLDIR" Value="INSTALLDIR" />
+        <!-- this should help to propagate env var changes -->
+        <CustomActionRef Id="WixBroadcastEnvironmentChange" />
+    </Product>
 </Wix>

--- a/packaging/windows/product.wxs.in
+++ b/packaging/windows/product.wxs.in
@@ -4,7 +4,7 @@
 <?define crcBundlePart2="crc_hyperv___OPENSHIFT_VERSION__.crcbundle.2"?>
 <?define crcBundleName="crc_hyperv___OPENSHIFT_VERSION__.crcbundle"?>
 <Wix
-    xmlns="http://schemas.microsoft.com/wix/2006/wi">
+    xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
     <Product Id="*" UpgradeCode="53DE5BFA-0E53-44E7-8D4F-07E37E59A9AB"
             Name="CodeReady Containers"
             Version="__VERSION__"
@@ -65,6 +65,11 @@
         <CustomAction Id="RemoveParts" BinaryKey="WixCA" DllEntry="WixQuietExec" Execute="deferred" Impersonate="no" />
         <SetProperty Action="CAUninstall"  Id="Uninstall"  Value='"[WindowsFolder]\System32\cmd.exe" /c rmdir /S /Q "[INSTALLDIR]"' Before="Uninstall" Sequence="execute"/>
         <CustomAction Id="Uninstall" BinaryKey="WixCA" DllEntry="WixQuietExec" Execute="deferred" Impersonate="no" />
+
+        <util:CloseApplication Id = "TrayRunning" Description="Please exit CodeReady Containers from tray and run the installation again."
+            Target="crc-tray.exe" RebootPrompt="no"
+            PromptToContinue="yes" />
+
         <InstallExecuteSequence>
             <Custom Action="JoinBundle"  After="InstallFiles" >NOT Installed AND NOT PATCH</Custom>
             <Custom Action="RemoveParts"  After="JoinBundle" >NOT Installed AND NOT PATCH</Custom>

--- a/pkg/crc/constants/constants.go
+++ b/pkg/crc/constants/constants.go
@@ -97,12 +97,21 @@ func defaultBundlePath() string {
 			return path
 		}
 	}
+	if runtime.GOOS == "windows" && version.IsMsiBuild() {
+		path := filepath.Join(GetMsiInstallPath(), GetDefaultBundle())
+		if _, err := os.Stat(path); err == nil {
+			return path
+		}
+	}
 	return filepath.Join(MachineCacheDir, GetDefaultBundle())
 }
 
 func BinDir() string {
 	if runtime.GOOS == "darwin" && version.IsMacosInstallPathSet() {
 		return version.GetMacosInstallPath()
+	}
+	if runtime.GOOS == "windows" && version.IsMsiBuild() {
+		return GetMsiInstallPath()
 	}
 	return CrcBinDir
 }
@@ -144,7 +153,7 @@ func BundleEmbedded() bool {
 }
 
 func IsRelease() bool {
-	return BundleEmbedded() || version.IsMacosInstallPathSet()
+	return BundleEmbedded() || version.IsMacosInstallPathSet() || version.IsMsiBuild()
 }
 
 func contains(arr []string, str string) bool {
@@ -180,4 +189,8 @@ func GetCRCMacTrayDownloadURL() string {
 
 func GetCRCWindowsTrayDownloadURL() string {
 	return fmt.Sprintf(CRCWindowsTrayDownloadURL, version.GetCRCWindowsTrayVersion())
+}
+
+func GetMsiInstallPath() string {
+	return filepath.Join(os.Getenv("PROGRAMFILES"), "CodeReady Containers")
 }

--- a/pkg/crc/preflight/preflight_checks_common.go
+++ b/pkg/crc/preflight/preflight_checks_common.go
@@ -135,7 +135,7 @@ func fixBundleExtracted() error {
 
 // Check if helper executable is cached or not
 func checkAdminHelperExecutableCached() error {
-	if version.IsMacosInstallPathSet() {
+	if version.IsMacosInstallPathSet() || version.IsMsiBuild() {
 		return nil
 	}
 
@@ -151,7 +151,7 @@ func checkAdminHelperExecutableCached() error {
 }
 
 func fixAdminHelperExecutableCached() error {
-	if version.IsMacosInstallPathSet() {
+	if version.IsMacosInstallPathSet() || version.IsMsiBuild() {
 		return nil
 	}
 

--- a/pkg/crc/version/version.go
+++ b/pkg/crc/version/version.go
@@ -24,6 +24,8 @@ var (
 	okdBuild = "false"
 
 	macosInstallPath = "/unset"
+
+	msiBuild = "false"
 )
 
 const (
@@ -70,6 +72,10 @@ func GetMacosInstallPath() string {
 
 func IsMacosInstallPathSet() bool {
 	return macosInstallPath != "/unset"
+}
+
+func IsMsiBuild() bool {
+	return msiBuild != "false"
 }
 
 func getCRCLatestVersionFromMirror() (*semver.Version, error) {

--- a/pkg/embed/embed.go
+++ b/pkg/embed/embed.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 
 	"github.com/YourFin/binappend"
+	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/code-ready/crc/pkg/crc/logging"
 	"github.com/code-ready/crc/pkg/crc/version"
 )
@@ -15,6 +16,13 @@ import (
 func openEmbeddedFile(executablePath, embedName string) (io.ReadCloser, error) {
 	if runtime.GOOS == "darwin" && version.IsMacosInstallPathSet() {
 		path := filepath.Join(version.GetMacosInstallPath(), embedName)
+		if _, err := os.Stat(path); err == nil {
+			return os.Open(path)
+		}
+	}
+
+	if runtime.GOOS == "windows" && version.IsMsiBuild() {
+		path := filepath.Join(constants.GetMsiInstallPath(), embedName)
 		if _, err := os.Stat(path); err == nil {
 			return os.Open(path)
 		}


### PR DESCRIPTION
- Don't use embedded `crc` binary for building the msi
- use the bundle and helper binaries directly from `Program Files\CodeReady Containers` and don;t copy them to `~\.crc` 
- prompt user to exit the running tray if one is running during installation (this not similar to the macOS installer, as this would not exit the installation but presents user with a dialog to continue even if the tray is running), [screenshot below]
<img src="https://user-images.githubusercontent.com/8885742/117652530-e76d6a00-b1b0-11eb-8c5e-99949dc04538.PNG" width="500">


Fixes #2205 
Fixes #2206 
