### PR TITLE
telemetry: send the status of the cluster with action

### DIFF
--- a/pkg/crc/api/client/types.go
+++ b/pkg/crc/api/client/types.go
@@ -70,4 +70,5 @@ type getOrUnsetConfigRequest struct {
 type TelemetryRequest struct {
 	Action string `json:"action"`
 	Source string `json:"source"`
+	Status string `json:"status"`
 }

--- a/pkg/crc/api/handlers.go
+++ b/pkg/crc/api/handlers.go
@@ -29,7 +29,7 @@ type Logger interface {
 }
 
 type Telemetry interface {
-	UploadAction(action, source string) error
+	UploadAction(action, source, status string) error
 }
 
 func (h *Handler) Logs() string {
@@ -249,7 +249,7 @@ func (h *Handler) UploadTelemetry(args json.RawMessage) string {
 	if err := json.Unmarshal(args, &req); err != nil {
 		return encodeErrorToJSON(err.Error())
 	}
-	if err := h.Telemetry.UploadAction(req.Action, req.Source); err != nil {
+	if err := h.Telemetry.UploadAction(req.Action, req.Source, req.Status); err != nil {
 		return encodeErrorToJSON(err.Error())
 	}
 	return encodeStructToJSON(client.Result{

--- a/pkg/crc/api/helpers_test.go
+++ b/pkg/crc/api/helpers_test.go
@@ -48,7 +48,7 @@ type mockTelemetry struct {
 	actions []string
 }
 
-func (m *mockTelemetry) UploadAction(action, _ string) error {
+func (m *mockTelemetry) UploadAction(action, _, _ string) error {
 	m.actions = append(m.actions, action)
 	return nil
 }

--- a/pkg/crc/segment/segment.go
+++ b/pkg/crc/segment/segment.go
@@ -59,8 +59,9 @@ func (c *Client) Close() error {
 	return c.segmentClient.Close()
 }
 
-func (c *Client) UploadAction(action, source string) error {
-	return c.upload(action, baseProperties(source))
+func (c *Client) UploadAction(action, source, status string) error {
+	return c.upload(action, baseProperties(source).
+		Set("status", status))
 }
 
 func (c *Client) UploadCmd(ctx context.Context, action string, duration time.Duration, err error) error {


### PR DESCRIPTION
It allows to us to understand why a user clicked on a particular button.

Example:
action="click start" status="stopped"
action="click stop" status="starting" // aborting

It also allows new event "status changed". For each cluster status
change, we can receive an event like:

action="status changed" status="starting"
action="status changed" status="running"

