### PR TITLE
Update ssh public key to machineconfig resource if used 4.8 cluster

### DIFF
--- a/pkg/crc/cluster/cluster.go
+++ b/pkg/crc/cluster/cluster.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"regexp"
 	"strconv"
 	"strings"
@@ -90,6 +91,33 @@ func GetRootPartitionUsage(sshRunner *ssh.Runner) (int64, int64, error) {
 		return 0, 0, err
 	}
 	return diskSize, diskUsage, nil
+}
+
+func EnsureSSHKeyPresentInTheCluster(ocConfig oc.Config, sshPublicKeyPath string) error {
+	sshPublicKeyByte, err := ioutil.ReadFile(sshPublicKeyPath)
+	if err != nil {
+		return err
+	}
+	sshPublicKey := strings.TrimRight(string(sshPublicKeyByte), "\r\n")
+	if err := WaitForOpenshiftResource(ocConfig, "machineconfigs"); err != nil {
+		return err
+	}
+	stdout, _, err := ocConfig.RunOcCommand("get", "machineconfigs", "99-master-ssh", "-o", `jsonpath='{.spec.config.passwd.users[0].sshAuthorizedKeys[0]}'`)
+	if err != nil {
+		return err
+	}
+	if stdout == string(sshPublicKey) {
+		return nil
+	}
+	logging.Info("Updating SSH key to machine config resource...")
+	cmdArgs := []string{"patch", "machineconfig", "99-master-ssh", "-p",
+		fmt.Sprintf(`'{"spec": {"config": {"passwd": {"users": [{"name": "core", "sshAuthorizedKeys": ["%s"]}]}}}}'`, sshPublicKey),
+		"--type", "merge"}
+	_, stderr, err := ocConfig.RunOcCommand(cmdArgs...)
+	if err != nil {
+		return fmt.Errorf("Failed to update ssh key %v: %s", err, stderr)
+	}
+	return nil
 }
 
 func EnsurePullSecretPresentInTheCluster(ocConfig oc.Config, pullSec PullSecretLoader) error {

--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -388,6 +388,13 @@ func (client *client) Start(ctx context.Context, startConfig types.StartConfig) 
 		return nil, errors.Wrap(err, "Error waiting for apiserver")
 	}
 
+	// Remove this check when we have official 4.8 bundle
+	if strings.HasPrefix(crcBundleMetadata.GetOpenshiftVersion(), "4.8.") {
+		if err := cluster.EnsureSSHKeyPresentInTheCluster(ocConfig, constants.GetPublicKeyPath()); err != nil {
+			return nil, errors.Wrap(err, "Failed to update ssh public key to machine config")
+		}
+	}
+
 	if err := ensureProxyIsConfiguredInOpenShift(ocConfig, sshRunner, proxyConfig, instanceIP); err != nil {
 		return nil, errors.Wrap(err, "Failed to update cluster proxy configuration")
 	}

--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -606,8 +606,9 @@ func updateSSHKeyPair(sshRunner *crcssh.Runner) error {
 	}
 
 	logging.Info("Updating authorized keys...")
-	cmd := fmt.Sprintf("echo '%s' > /home/core/.ssh/authorized_keys; chmod 644 /home/core/.ssh/authorized_keys", publicKey)
-	_, _, err = sshRunner.Run(cmd)
+	// CopyData uses sudo and we need to use it
+	// because of https://bugzilla.redhat.com/show_bug.cgi?id=1956739
+	err = sshRunner.CopyData(publicKey, "/home/core/.ssh/authorized_keys", 0644)
 	if err != nil {
 		return err
 	}

--- a/pkg/crc/machine/stop.go
+++ b/pkg/crc/machine/stop.go
@@ -1,7 +1,11 @@
 package machine
 
 import (
+	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/code-ready/crc/pkg/crc/logging"
+	"github.com/code-ready/crc/pkg/crc/oc"
+	crcssh "github.com/code-ready/crc/pkg/crc/ssh"
+	"github.com/code-ready/crc/pkg/libmachine/host"
 	"github.com/code-ready/machine/libmachine/state"
 	"github.com/pkg/errors"
 )
@@ -14,7 +18,9 @@ func (client *client) Stop() (state.State, error) {
 	if err != nil {
 		return state.Error, errors.Wrap(err, "Cannot load machine")
 	}
-
+	if err := removeMCOPods(host, client); err != nil {
+		return state.Error, err
+	}
 	logging.Info("Stopping the OpenShift cluster, this may take a few minutes...")
 	if err := host.Stop(); err != nil {
 		status, stateErr := host.Driver.GetState()
@@ -24,4 +30,28 @@ func (client *client) Stop() (state.State, error) {
 		return status, errors.Wrap(err, "Cannot stop machine")
 	}
 	return host.Driver.GetState()
+}
+
+// This should be removed after https://bugzilla.redhat.com/show_bug.cgi?id=1965992
+// is fixed. We should also ignore the openshift specific errors because stop
+// operation shouldn't depend on the openshift side. Without this graceful shutdown
+// takes around 6-7 mins.
+func removeMCOPods(host *host.Host, client *client) error {
+	logging.Info("Deleting the pods from openshift-machine-config-operator namespace")
+	instanceIP, err := getIP(host, client.useVSock())
+	if err != nil {
+		return errors.Wrapf(err, "Error getting the IP")
+	}
+	sshRunner, err := crcssh.CreateRunner(instanceIP, getSSHPort(client.useVSock()), constants.GetPrivateKeyPath(), constants.GetRsaPrivateKeyPath())
+	if err != nil {
+		return errors.Wrapf(err, "Error creating the ssh client")
+	}
+	defer sshRunner.Close()
+
+	ocConfig := oc.UseOCWithSSH(sshRunner)
+	_, stderr, err := ocConfig.RunOcCommand("delete", "pods", "--all", "-n openshift-machine-config-operator", "--grace-period=0")
+	if err != nil {
+		logging.Debugf("Error deleting the pods from openshift-machine-config-operator namespace:%v \n StdErr: %s", err, stderr)
+	}
+	return nil
 }


### PR DESCRIPTION
With MCO enabled we need to update the ssh key to machineconfig
so it is become part of cluster and also to instance.
