### PR TITLE
Don't use kubeadmin-passwd file from the bundle

### DIFF
--- a/pkg/crc/cluster/kubeadmin_password.go
+++ b/pkg/crc/cluster/kubeadmin_password.go
@@ -3,16 +3,13 @@ package cluster
 import (
 	"crypto/rand"
 	"encoding/base64"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"math/big"
-	"os"
 	"strings"
 
 	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/code-ready/crc/pkg/crc/logging"
-	"github.com/code-ready/crc/pkg/crc/machine/bundle"
 	"github.com/code-ready/crc/pkg/crc/oc"
 	crcos "github.com/code-ready/crc/pkg/os"
 	"golang.org/x/crypto/bcrypt"
@@ -57,13 +54,10 @@ func UpdateKubeAdminUserPassword(ocConfig oc.Config) error {
 	return ioutil.WriteFile(kubeAdminPasswordFile, []byte(kubeAdminPassword), 0600)
 }
 
-func GetKubeadminPassword(bundle *bundle.CrcBundleInfo) (string, error) {
+func GetKubeadminPassword() (string, error) {
 	kubeAdminPasswordFile := constants.GetKubeAdminPasswordPath()
 	rawData, err := ioutil.ReadFile(kubeAdminPasswordFile)
 	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return bundle.GetKubeadminPassword()
-		}
 		return "", err
 	}
 	return strings.TrimSpace(string(rawData)), nil

--- a/pkg/crc/machine/bundle/copier.go
+++ b/pkg/crc/machine/bundle/copier.go
@@ -63,12 +63,6 @@ func (copier *Copier) CopyPrivateSSHKey(srcPath string) error {
 	return crcos.CopyFileContents(srcPath, destPath, 0400)
 }
 
-func (copier *Copier) SetKubeAdminPassword(kubePassword string) error {
-	kubeAdminPasswordFileName := copier.srcBundle.ClusterInfo.KubeadminPasswordFile
-	path := copier.resolvePath(kubeAdminPasswordFileName)
-	return ioutil.WriteFile(path, []byte(kubePassword), 0600)
-}
-
 func (copier *Copier) CopyKubeConfig() error {
 	kubeConfigFileName := filepath.Base(copier.srcBundle.GetKubeConfigPath())
 	srcPath := copier.srcBundle.GetKubeConfigPath()

--- a/pkg/crc/machine/bundle/copier_test.go
+++ b/pkg/crc/machine/bundle/copier_test.go
@@ -36,7 +36,6 @@ func TestGenerateBundle(t *testing.T) {
 
 	assert.NoError(t, copier.CopyKubeConfig())
 
-	assert.NoError(t, copier.SetKubeAdminPassword("****-****-****"))
 	assert.NoError(t, copier.CopyPrivateSSHKey(copier.srcBundle.GetSSHKeyPath()))
 	assert.NoError(t, copier.CopyFilesFromFileList())
 
@@ -53,7 +52,6 @@ func createDummyBundleFiles(t *testing.T, bundle *CrcBundleInfo) {
 
 	files := []string{
 		bundle.GetOcPath(),
-		bundle.resolvePath(bundle.ClusterInfo.KubeadminPasswordFile),
 		bundle.GetKubeConfigPath(),
 		bundle.GetSSHKeyPath(),
 		bundle.GetDiskImagePath(),

--- a/pkg/crc/machine/bundle/metadata.go
+++ b/pkg/crc/machine/bundle/metadata.go
@@ -2,7 +2,6 @@ package bundle
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -32,14 +31,13 @@ type BuildInfo struct {
 }
 
 type ClusterInfo struct {
-	OpenShiftVersion      string `json:"openshiftVersion"`
-	ClusterName           string `json:"clusterName"`
-	BaseDomain            string `json:"baseDomain"`
-	AppsDomain            string `json:"appsDomain"`
-	SSHPrivateKeyFile     string `json:"sshPrivateKeyFile"`
-	KubeConfig            string `json:"kubeConfig"`
-	KubeadminPasswordFile string `json:"kubeadminPasswordFile"`
-	OpenshiftPullSecret   string `json:"openshiftPullSecret,omitempty"`
+	OpenShiftVersion    string `json:"openshiftVersion"`
+	ClusterName         string `json:"clusterName"`
+	BaseDomain          string `json:"baseDomain"`
+	AppsDomain          string `json:"appsDomain"`
+	SSHPrivateKeyFile   string `json:"sshPrivateKeyFile"`
+	KubeConfig          string `json:"kubeConfig"`
+	OpenshiftPullSecret string `json:"openshiftPullSecret,omitempty"`
 }
 
 type Node struct {
@@ -154,14 +152,6 @@ func (bundle *CrcBundleInfo) GetKernelCommandLine() string {
 	return bundle.Nodes[0].KernelCmdLine
 }
 
-func (bundle *CrcBundleInfo) GetKubeadminPassword() (string, error) {
-	rawData, err := ioutil.ReadFile(bundle.resolvePath(bundle.ClusterInfo.KubeadminPasswordFile))
-	if err != nil {
-		return "", err
-	}
-	return strings.TrimSpace(string(rawData)), nil
-}
-
 func (bundle *CrcBundleInfo) GetBundleBuildTime() (time.Time, error) {
 	return time.Parse(time.RFC3339, strings.TrimSpace(bundle.BuildInfo.BuildTime))
 }
@@ -177,7 +167,6 @@ func (bundle *CrcBundleInfo) GetBundleNameWithoutExtension() string {
 func (bundle *CrcBundleInfo) verify() error {
 	files := []string{
 		bundle.GetOcPath(),
-		bundle.resolvePath(bundle.ClusterInfo.KubeadminPasswordFile),
 		bundle.GetKubeConfigPath(),
 		bundle.GetSSHKeyPath(),
 		bundle.GetDiskImagePath(),

--- a/pkg/crc/machine/bundle/metadata_test.go
+++ b/pkg/crc/machine/bundle/metadata_test.go
@@ -27,8 +27,7 @@ const reference = `{
     "baseDomain": "testing",
     "appsDomain": "apps-crc.testing",
     "sshPrivateKeyFile": "id_ecdsa_crc",
-    "kubeConfig": "kubeconfig",
-    "kubeadminPasswordFile": "kubeadmin-password"
+    "kubeConfig": "kubeconfig"
   },
   "nodes": [
     {
@@ -73,13 +72,12 @@ var parsedReference = CrcBundleInfo{
 		SncVersion:                "git4.1.14-137-g14e7",
 	},
 	ClusterInfo: ClusterInfo{
-		OpenShiftVersion:      "4.6.1",
-		ClusterName:           "crc",
-		BaseDomain:            "testing",
-		AppsDomain:            "apps-crc.testing",
-		SSHPrivateKeyFile:     "id_ecdsa_crc",
-		KubeConfig:            "kubeconfig",
-		KubeadminPasswordFile: "kubeadmin-password",
+		OpenShiftVersion:  "4.6.1",
+		ClusterName:       "crc",
+		BaseDomain:        "testing",
+		AppsDomain:        "apps-crc.testing",
+		SSHPrivateKeyFile: "id_ecdsa_crc",
+		KubeConfig:        "kubeconfig",
 	}, Nodes: []Node{
 		{
 			Kind:       []string{"master", "worker"},

--- a/pkg/crc/machine/generate_bundle.go
+++ b/pkg/crc/machine/generate_bundle.go
@@ -58,14 +58,6 @@ func (client *client) GenerateBundle() error {
 		return err
 	}
 
-	kubePassword, err := cluster.GetKubeadminPassword(bundleMetadata)
-	if err != nil {
-		return err
-	}
-	if err := copier.SetKubeAdminPassword(kubePassword); err != nil {
-		return err
-	}
-
 	if err := copier.CopyPrivateSSHKey(constants.GetPrivateKeyPath()); err != nil {
 		return err
 	}

--- a/pkg/crc/machine/machine.go
+++ b/pkg/crc/machine/machine.go
@@ -15,7 +15,7 @@ import (
 )
 
 func getClusterConfig(bundleInfo *bundle.CrcBundleInfo) (*types.ClusterConfig, error) {
-	kubeadminPassword, err := cluster.GetKubeadminPassword(bundleInfo)
+	kubeadminPassword, err := cluster.GetKubeadminPassword()
 	if err != nil {
 		return nil, fmt.Errorf("Error reading kubeadmin password from bundle %v", err)
 	}

--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -249,11 +249,6 @@ func (client *client) Start(ctx context.Context, startConfig types.StartConfig) 
 		}
 	}
 
-	clusterConfig, err := getClusterConfig(crcBundleMetadata)
-	if err != nil {
-		return nil, errors.Wrap(err, "Cannot create cluster configuration")
-	}
-
 	// Post-VM start
 	vmState, err = host.Driver.GetState()
 	if err != nil {
@@ -396,10 +391,6 @@ func (client *client) Start(ctx context.Context, startConfig types.StartConfig) 
 	if err := cluster.UpdateKubeAdminUserPassword(ocConfig); err != nil {
 		return nil, errors.Wrap(err, "Failed to update kubeadmin user password")
 	}
-	clusterConfig.KubeAdminPass, err = cluster.GetKubeadminPassword(crcBundleMetadata)
-	if err != nil {
-		return nil, errors.Wrap(err, "Failed to get kubeadmin user password")
-	}
 
 	if err := cluster.EnsureClusterIDIsNotEmpty(ocConfig); err != nil {
 		return nil, errors.Wrap(err, "Failed to update cluster ID")
@@ -448,6 +439,11 @@ func (client *client) Start(ctx context.Context, startConfig types.StartConfig) 
 	}
 
 	waitForProxyPropagation(ctx, ocConfig, proxyConfig)
+
+	clusterConfig, err := getClusterConfig(crcBundleMetadata)
+	if err != nil {
+		return nil, errors.Wrap(err, "Cannot get cluster configuration")
+	}
 
 	logging.Info("Adding crc-admin and crc-developer contexts to kubeconfig...")
 	if err := writeKubeconfig(instanceIP, clusterConfig); err != nil {


### PR DESCRIPTION
This patch will remove all the occurance where we are trying to use
the kubeadmin-passwd file for `kubeadmin` user because now every crc
start generate a new passwd and stored in
`~/.crc/machine/crc/kubeadmin-passwd` file.

