### PR TITLE
Display the same error message for all commands if the machine is missing

### DIFF
--- a/cmd/crc/cmd/oc_env.go
+++ b/cmd/crc/cmd/oc_env.go
@@ -28,6 +28,10 @@ func runOcEnv(args []string) error {
 	}
 
 	client := newMachine()
+	if err := checkIfMachineMissing(client); err != nil {
+		return err
+	}
+
 	consoleResult, err := client.GetConsoleURL()
 	if err != nil {
 		return err


### PR DESCRIPTION
Before
Cannot load machine: machine crc does not exist

After
Machine does not exist. Use 'crc start' to create it
