### PR TITLE
windows daemon installation removal from `crc setup`

### DIFF
--- a/pkg/crc/preflight/preflight_checks_tray_windows.go
+++ b/pkg/crc/preflight/preflight_checks_tray_windows.go
@@ -14,6 +14,8 @@ import (
 	"github.com/code-ready/crc/pkg/os/windows/powershell"
 )
 
+var daemonBatchFileShortcutPath = filepath.Join(constants.StartupFolder, constants.DaemonBatchFileShortcutName)
+
 func checkIfTrayInstalled() error {
 	if os.FileExists(filepath.Join(constants.StartupFolder, constants.TrayShortcutName)) && checkTrayVersion() {
 		return nil
@@ -25,7 +27,7 @@ func checkIfDaemonInstalled() error {
 	if os.FileExists(constants.DaemonBatchFilePath) || os.FileExists(constants.DaemonPSScriptPath) {
 		return fmt.Errorf("Daemon should not be installed")
 	}
-	if os.FileExists(filepath.Join(constants.StartupFolder, constants.DaemonBatchFileShortcutName)) {
+	if os.FileExists(daemonBatchFileShortcutPath) {
 		return fmt.Errorf("Daemon should not be installed")
 	}
 	return nil
@@ -84,6 +86,9 @@ func removeDaemon() error {
 		mErr.Collect(err)
 	}
 	if err := os.RemoveFileIfExists(constants.DaemonPSScriptPath); err != nil {
+		mErr.Collect(err)
+	}
+	if err := os.RemoveFileIfExists(daemonBatchFileShortcutPath); err != nil {
 		mErr.Collect(err)
 	}
 	if len(mErr.Errors) == 0 {

--- a/pkg/crc/preflight/preflight_checks_tray_windows.go
+++ b/pkg/crc/preflight/preflight_checks_tray_windows.go
@@ -93,15 +93,10 @@ func removeDaemon() error {
 }
 
 func stopDaemon() error {
-	executablePath, err := goos.Executable()
-	if err != nil {
-		return fmt.Errorf("Failed to find current executable's path: %w", err)
-	}
 	// get the PID of the process running command 'crc daemon --log-level debug'
 	getCrcProcessCmd := `(Get-WmiObject Win32_Process -Filter "name = 'crc.exe'")`
-	cmd := fmt.Sprintf(`(%s | Where-Object -Property CommandLine -Eq '"%s" daemon --log-level debug').ProcessId`,
+	cmd := fmt.Sprintf(`(%s | Where-Object -Property CommandLine -Like '* daemon --log-level debug').ProcessId`,
 		getCrcProcessCmd,
-		executablePath,
 	)
 	stdOut, _, err := powershell.Execute(cmd)
 	if err != nil {

--- a/pkg/crc/preflight/preflight_windows.go
+++ b/pkg/crc/preflight/preflight_windows.go
@@ -73,20 +73,20 @@ var hypervPreflightChecks = [...]Check{
 
 var traySetupChecks = [...]Check{
 	{
+		checkDescription:   "Checking if CodeReady Containers daemon is installed",
+		check:              checkIfDaemonInstalled,
+		fixDescription:     "Removing CodeReady Containers daemon",
+		fix:                removeDaemon,
+		cleanupDescription: "Uninstalling daemon if installed",
+		cleanup:            removeDaemon,
+		flags:              SetupOnly,
+	},
+	{
 		checkDescription: "Checking if tray executable is present",
 		check:            checkTrayExecutableExists,
 		fixDescription:   "Caching tray executable",
 		fix:              fixTrayExecutableExists,
 		flags:            SetupOnly,
-	},
-	{
-		checkDescription:   "Checking if CodeReady Containers daemon is installed",
-		check:              checkIfDaemonInstalled,
-		fixDescription:     "Installing CodeReady Containers daemon",
-		fix:                fixDaemonInstalled,
-		cleanupDescription: "Uninstalling daemon if installed",
-		cleanup:            removeDaemon,
-		flags:              SetupOnly,
 	},
 	{
 		checkDescription:   "Checking if tray is installed",


### PR DESCRIPTION
This is related to https://github.com/code-ready/tray-windows/pull/70
- Remove installation of daemon during crc setup. The daemon is ran from the tray this is similar to how the tray and daemon is setup on macOS, during the setup(with `--enable-experimental-features`) if an old daemon was found installed, it will be removed.
- remove the `crc-daemon-autostart.bat` file from the start-up folder during `crc cleanup`