### PR TITLE
Update the cluster name as per oc norms

### DIFF
--- a/pkg/crc/machine/kubeconfig.go
+++ b/pkg/crc/machine/kubeconfig.go
@@ -16,6 +16,7 @@ import (
 	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/code-ready/crc/pkg/crc/machine/types"
 	"github.com/openshift/oc/pkg/helpers/tokencmd"
+	"k8s.io/apimachinery/third_party/forked/golang/netutil"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/clientcmd/api"
@@ -79,12 +80,14 @@ func certificateAuthority(kubeconfigFile string) ([]byte, error) {
 	return cluster.CertificateAuthorityData, nil
 }
 
+// https://github.com/openshift/oc/blob/f94afb52dc8a3185b3b9eacaf92ec34d80f8708d/pkg/helpers/kubeconfig/smart_merge.go#L21
 func hostname(clusterAPI string) (string, error) {
 	p, err := url.Parse(clusterAPI)
 	if err != nil {
 		return "", err
 	}
-	return p.Host, nil
+	h := netutil.CanonicalAddr(p)
+	return strings.ReplaceAll(h, ".", "-"), nil
 }
 
 func addContext(cfg *api.Config, ip string, clusterConfig *types.ClusterConfig, ca []byte, context, username, password string) error {


### PR DESCRIPTION
This patch fixes following issue
```
$ crc start
$ crc whoami
kubeadmin
$ oc config get-contexts
$ oc config get-contexts
CURRENT   NAME
CLUSTER                AUTHINFO                         NAMESPACE
*         crc-admin
	  api.crc.testing:6443   kubeadmin
default
          crc-developer
api.crc.testing:6443   developer                        default
$ oc config get-clusters
NAME
api.crc.testing:6443

$ oc project openshift-machine-config-operator
$ oc config get-contexts
CURRENT   NAME
CLUSTER                AUTHINFO                         NAMESPACE
          crc-admin
api.crc.testing:6443   kubeadmin                        default
          crc-developer
api.crc.testing:6443   developer                        default
*
openshift-machine-config-operator/api-crc-testing:6443/kubeadmin
api-crc-testing:6443   kubeadmin/api-crc-testing:6443
openshift-machine-config-operator
$ oc config get-clusters
NAME
api-crc-testing:6443
api.crc.testing:6443

$ crc delete && crc start
$ oc whoami
Unable to connect to the server: x509: certificate signed by unknown
authority (possibly because of "crypto/rsa: verification error" while
trying to verify candidate authority certificate
"kube-apiserver-lb-signer")
```

Which is happen 2 different cluster having same
certificate-authority but after delete and start the `api.crc.testing`
server is only updated and not the `api-crc-testing` one which cause this issue.

fixes: #2332