### PR TITLE
http api: return only the error instead of a full object

### DIFF
--- a/pkg/crc/api/adapter.go
+++ b/pkg/crc/api/adapter.go
@@ -11,7 +11,6 @@ import (
 )
 
 type AdaptedClient interface {
-	GetName() string
 	Delete() client.Result
 	GetConsoleURL() client.ConsoleResult
 	Start(ctx context.Context, startConfig types.StartConfig) client.StartResult
@@ -23,22 +22,16 @@ type Adapter struct {
 	Underlying machine.Client
 }
 
-func (a *Adapter) GetName() string {
-	return a.Underlying.GetName()
-}
-
 func (a *Adapter) Delete() client.Result {
 	err := a.Underlying.Delete()
 	if err != nil {
 		logging.Error(err)
 		return client.Result{
-			Name:    a.Underlying.GetName(),
 			Success: false,
 			Error:   err.Error(),
 		}
 	}
 	return client.Result{
-		Name:    a.Underlying.GetName(),
 		Success: true,
 	}
 }
@@ -64,13 +57,11 @@ func (a *Adapter) Start(ctx context.Context, startConfig types.StartConfig) clie
 		logging.Error(err)
 		return client.StartResult{
 			Success: false,
-			Name:    a.Underlying.GetName(),
 			Error:   err.Error(),
 		}
 	}
 	return client.StartResult{
 		Success:        true,
-		Name:           a.Underlying.GetName(),
 		Status:         res.Status.String(),
 		ClusterConfig:  res.ClusterConfig,
 		KubeletStarted: res.KubeletStarted,
@@ -82,13 +73,11 @@ func (a *Adapter) Status() client.ClusterStatusResult {
 	if err != nil {
 		logging.Error(err)
 		return client.ClusterStatusResult{
-			Name:    a.Underlying.GetName(),
 			Error:   err.Error(),
 			Success: false,
 		}
 	}
 	return client.ClusterStatusResult{
-		Name:             a.Underlying.GetName(),
 		CrcStatus:        res.CrcStatus.String(),
 		OpenshiftStatus:  string(res.OpenshiftStatus),
 		OpenshiftVersion: res.OpenshiftVersion,
@@ -107,7 +96,6 @@ func (a *Adapter) Stop() client.Result {
 			if err != nil {
 				logging.Error(err)
 				return client.Result{
-					Name:    a.Underlying.GetName(),
 					Success: false,
 					Error:   err.Error(),
 				}
@@ -115,7 +103,6 @@ func (a *Adapter) Stop() client.Result {
 		}
 	}
 	return client.Result{
-		Name:    a.Underlying.GetName(),
 		Success: true,
 	}
 }

--- a/pkg/crc/api/adapter.go
+++ b/pkg/crc/api/adapter.go
@@ -63,11 +63,13 @@ func (a *Adapter) Start(ctx context.Context, startConfig types.StartConfig) clie
 	if err != nil {
 		logging.Error(err)
 		return client.StartResult{
-			Name:  a.Underlying.GetName(),
-			Error: err.Error(),
+			Success: false,
+			Name:    a.Underlying.GetName(),
+			Error:   err.Error(),
 		}
 	}
 	return client.StartResult{
+		Success:        true,
 		Name:           a.Underlying.GetName(),
 		Status:         res.Status.String(),
 		ClusterConfig:  res.ClusterConfig,

--- a/pkg/crc/api/api_http_test.go
+++ b/pkg/crc/api/api_http_test.go
@@ -59,6 +59,7 @@ func TestHTTPApi(t *testing.T) {
 			Status:         "",
 			Error:          "",
 			KubeletStarted: true,
+			Success:        true,
 			ClusterConfig: types.ClusterConfig{
 				ClusterCACert: "MIIDODCCAiCgAwIBAgIIRVfCKNUa1wIwDQYJ",
 				KubeConfig:    "/tmp/kubeconfig",
@@ -100,7 +101,8 @@ func TestHTTPApi(t *testing.T) {
 	assert.Equal(
 		t,
 		apiClient.GetConfigResult{
-			Error: "",
+			Success: true,
+			Error:   "",
 			Configs: map[string]interface{}{
 				"cpus": float64(4),
 			},
@@ -117,6 +119,7 @@ func TestHTTPApi(t *testing.T) {
 	assert.Equal(
 		t,
 		apiClient.SetOrUnsetConfigResult{
+			Success:    true,
 			Error:      "",
 			Properties: []string{"cpus"},
 		},

--- a/pkg/crc/api/api_http_test.go
+++ b/pkg/crc/api/api_http_test.go
@@ -38,7 +38,6 @@ func TestHTTPApi(t *testing.T) {
 	assert.Equal(
 		t,
 		apiClient.ClusterStatusResult{
-			Name:             "crc",
 			CrcStatus:        "Running",
 			OpenshiftStatus:  "Running",
 			OpenshiftVersion: "4.5.1",
@@ -55,7 +54,6 @@ func TestHTTPApi(t *testing.T) {
 	assert.Equal(
 		t,
 		apiClient.StartResult{
-			Name:           "crc",
 			Status:         "",
 			Error:          "",
 			KubeletStarted: true,
@@ -77,7 +75,6 @@ func TestHTTPApi(t *testing.T) {
 	assert.Equal(
 		t,
 		apiClient.Result{
-			Name:    "crc",
 			Success: true,
 			Error:   "",
 		},
@@ -89,7 +86,6 @@ func TestHTTPApi(t *testing.T) {
 	assert.Equal(
 		t,
 		apiClient.Result{
-			Name:    "crc",
 			Success: true,
 			Error:   "",
 		},

--- a/pkg/crc/api/api_test.go
+++ b/pkg/crc/api/api_test.go
@@ -87,6 +87,7 @@ func TestApi(t *testing.T) {
 				"Status":         "",
 				"Error":          "Incorrect arguments given: json: unknown field \"pull-secret\"",
 				"KubeletStarted": false,
+				"Success":        false,
 				"ClusterConfig": map[string]interface{}{
 					"KubeConfig":    "",
 					"KubeAdminPass": "",
@@ -105,6 +106,7 @@ func TestApi(t *testing.T) {
 				"Status":         "",
 				"Error":          "",
 				"KubeletStarted": true,
+				"Success":        true,
 				"ClusterConfig": map[string]interface{}{
 					"ClusterCACert": "MIIDODCCAiCgAwIBAgIIRVfCKNUa1wIwDQYJ",
 					"KubeConfig":    "/tmp/kubeconfig",
@@ -176,6 +178,7 @@ func TestSetconfigApi(t *testing.T) {
 	var setconfigRes apiClient.SetOrUnsetConfigResult
 	assert.NoError(t, json.Unmarshal(payload[:n], &setconfigRes))
 	assert.Equal(t, apiClient.SetOrUnsetConfigResult{
+		Success:    true,
 		Error:      "",
 		Properties: []string{"cpus"},
 	}, setconfigRes)
@@ -206,6 +209,7 @@ func TestGetconfigApi(t *testing.T) {
 	configs["cpus"] = 4.0
 
 	assert.Equal(t, apiClient.GetConfigResult{
+		Success: true,
 		Error:   "",
 		Configs: configs,
 	}, getconfigRes)

--- a/pkg/crc/api/api_test.go
+++ b/pkg/crc/api/api_test.go
@@ -54,7 +54,6 @@ func TestApi(t *testing.T) {
 		{
 			command: "status",
 			expected: map[string]interface{}{
-				"Name":             "crc",
 				"CrcStatus":        "Running",
 				"OpenshiftStatus":  "Running",
 				"OpenshiftVersion": "4.5.1",
@@ -68,7 +67,6 @@ func TestApi(t *testing.T) {
 			command:       "status",
 			clientFailing: true,
 			expected: map[string]interface{}{
-				"Name":             "crc",
 				"CrcStatus":        "",
 				"OpenshiftStatus":  "",
 				"OpenshiftVersion": "",
@@ -83,7 +81,6 @@ func TestApi(t *testing.T) {
 			clientFailing: true,
 			args:          json.RawMessage(`{"pull-secret":"/Users/fake/pull-secret"}`),
 			expected: map[string]interface{}{
-				"Name":           "crc",
 				"Status":         "",
 				"Error":          "Incorrect arguments given: json: unknown field \"pull-secret\"",
 				"KubeletStarted": false,
@@ -102,7 +99,6 @@ func TestApi(t *testing.T) {
 			command: "start",
 			args:    json.RawMessage(`{"pullSecretFile":"/Users/fake/pull-secret"}`),
 			expected: map[string]interface{}{
-				"Name":           "crc",
 				"Status":         "",
 				"Error":          "",
 				"KubeletStarted": true,
@@ -129,7 +125,6 @@ func TestApi(t *testing.T) {
 			args:    json.RawMessage(`{"action":"click start"}`),
 			expected: map[string]interface{}{
 				"Success": true,
-				"Name":    "",
 				"Error":   "",
 			},
 		},

--- a/pkg/crc/api/client/types.go
+++ b/pkg/crc/api/client/types.go
@@ -18,6 +18,7 @@ type Result struct {
 }
 
 type StartResult struct {
+	Success        bool
 	Name           string
 	Status         string
 	Error          string
@@ -45,12 +46,14 @@ type ConsoleResult struct {
 // setOrUnsetConfigResult struct is used to return the result of
 // setconfig/unsetconfig command
 type SetOrUnsetConfigResult struct {
+	Success    bool
 	Error      string
 	Properties []string
 }
 
 // getConfigResult struct is used to return the result of getconfig command
 type GetConfigResult struct {
+	Success bool
 	Error   string
 	Configs map[string]interface{}
 }

--- a/pkg/crc/api/client/types.go
+++ b/pkg/crc/api/client/types.go
@@ -12,14 +12,12 @@ type VersionResult struct {
 }
 
 type Result struct {
-	Name    string
 	Success bool
 	Error   string
 }
 
 type StartResult struct {
 	Success        bool
-	Name           string
 	Status         string
 	Error          string
 	ClusterConfig  types.ClusterConfig
@@ -27,7 +25,6 @@ type StartResult struct {
 }
 
 type ClusterStatusResult struct {
-	Name             string
 	CrcStatus        string
 	OpenshiftStatus  string
 	OpenshiftVersion string

--- a/pkg/crc/api/handlers.go
+++ b/pkg/crc/api/handlers.go
@@ -68,7 +68,6 @@ func (h *Handler) Start(args json.RawMessage) string {
 		if err != nil {
 			startErr := &client.StartResult{
 				Success: false,
-				Name:    h.MachineClient.GetName(),
 				Error:   fmt.Sprintf("Incorrect arguments given: %s", err.Error()),
 			}
 			return encodeStructToJSON(startErr)
@@ -77,7 +76,6 @@ func (h *Handler) Start(args json.RawMessage) string {
 	if err := preflight.StartPreflightChecks(h.Config); err != nil {
 		startErr := &client.StartResult{
 			Success: false,
-			Name:    h.MachineClient.GetName(),
 			Error:   err.Error(),
 		}
 		return encodeStructToJSON(startErr)

--- a/pkg/crc/api/handlers.go
+++ b/pkg/crc/api/handlers.go
@@ -67,16 +67,18 @@ func (h *Handler) Start(args json.RawMessage) string {
 		parsedArgs, err = parseStartArgs(args)
 		if err != nil {
 			startErr := &client.StartResult{
-				Name:  h.MachineClient.GetName(),
-				Error: fmt.Sprintf("Incorrect arguments given: %s", err.Error()),
+				Success: false,
+				Name:    h.MachineClient.GetName(),
+				Error:   fmt.Sprintf("Incorrect arguments given: %s", err.Error()),
 			}
 			return encodeStructToJSON(startErr)
 		}
 	}
 	if err := preflight.StartPreflightChecks(h.Config); err != nil {
 		startErr := &client.StartResult{
-			Name:  h.MachineClient.GetName(),
-			Error: err.Error(),
+			Success: false,
+			Name:    h.MachineClient.GetName(),
+			Error:   err.Error(),
 		}
 		return encodeStructToJSON(startErr)
 	}
@@ -127,8 +129,11 @@ func (h *Handler) GetWebconsoleInfo() string {
 }
 
 func (h *Handler) SetConfig(args json.RawMessage) string {
-	setConfigResult := client.SetOrUnsetConfigResult{}
+	setConfigResult := client.SetOrUnsetConfigResult{
+		Success: true,
+	}
 	if args == nil {
+		setConfigResult.Success = false
 		setConfigResult.Error = "No config keys provided"
 		return encodeStructToJSON(setConfigResult)
 	}
@@ -138,12 +143,14 @@ func (h *Handler) SetConfig(args json.RawMessage) string {
 
 	err := json.Unmarshal(args, &a)
 	if err != nil {
+		setConfigResult.Success = false
 		setConfigResult.Error = fmt.Sprintf("%v", err)
 		return encodeStructToJSON(setConfigResult)
 	}
 
 	configs, ok := a["properties"].(map[string]interface{})
 	if !ok {
+		setConfigResult.Success = false
 		setConfigResult.Error = "No config keys provided"
 		return encodeStructToJSON(setConfigResult)
 	}
@@ -161,6 +168,7 @@ func (h *Handler) SetConfig(args json.RawMessage) string {
 	}
 
 	if len(multiError.Errors) != 0 {
+		setConfigResult.Success = false
 		setConfigResult.Error = fmt.Sprintf("%v", multiError)
 	}
 
@@ -169,8 +177,11 @@ func (h *Handler) SetConfig(args json.RawMessage) string {
 }
 
 func (h *Handler) UnsetConfig(args json.RawMessage) string {
-	unsetConfigResult := client.SetOrUnsetConfigResult{}
+	unsetConfigResult := client.SetOrUnsetConfigResult{
+		Success: true,
+	}
 	if args == nil {
+		unsetConfigResult.Success = false
 		unsetConfigResult.Error = "No config keys provided"
 		return encodeStructToJSON(unsetConfigResult)
 	}
@@ -180,6 +191,7 @@ func (h *Handler) UnsetConfig(args json.RawMessage) string {
 
 	err := json.Unmarshal(args, &keys)
 	if err != nil {
+		unsetConfigResult.Success = false
 		unsetConfigResult.Error = fmt.Sprintf("%v", err)
 		return encodeStructToJSON(unsetConfigResult)
 	}
@@ -197,6 +209,7 @@ func (h *Handler) UnsetConfig(args json.RawMessage) string {
 		successProps = append(successProps, key)
 	}
 	if len(multiError.Errors) != 0 {
+		unsetConfigResult.Success = false
 		unsetConfigResult.Error = fmt.Sprintf("%v", multiError)
 	}
 	unsetConfigResult.Properties = successProps
@@ -204,7 +217,9 @@ func (h *Handler) UnsetConfig(args json.RawMessage) string {
 }
 
 func (h *Handler) GetConfig(args json.RawMessage) string {
-	configResult := client.GetConfigResult{}
+	configResult := client.GetConfigResult{
+		Success: true,
+	}
 	if args == nil {
 		allConfigs := h.Config.AllConfigs()
 		configResult.Error = ""
@@ -219,6 +234,7 @@ func (h *Handler) GetConfig(args json.RawMessage) string {
 
 	err := json.Unmarshal(args, &a)
 	if err != nil {
+		configResult.Success = false
 		configResult.Error = fmt.Sprintf("%v", err)
 		return encodeStructToJSON(configResult)
 	}
@@ -235,6 +251,7 @@ func (h *Handler) GetConfig(args json.RawMessage) string {
 		configs[key] = v.Value
 	}
 	if len(configs) == 0 {
+		configResult.Success = false
 		configResult.Error = "Unable to get configs"
 		configResult.Configs = nil
 	} else {


### PR DESCRIPTION
This PR cleans up the http a little bit. It forces consumers to not rely on success field but use the status code. 

When an error occurs, 
* returns a 500 error code (to be refine when the binary protocol will be gone)
* returns error text (instead of a full object)

All API objects contains success and eventually error. 


Before

``` 
$ curl  --unix-socket ~/.crc/crc-http.sock http:/unix/api/start -v | jq .
< HTTP/1.1 200 OK
{
  "Name": "crc",
  "Status": "",
  "Error": "Bundle 'crc_libvirt_4.7.8.crcbundle' was requested, but the existing VM is using 'crc_libvirt_4.7.7.crcbundle'",
  "ClusterConfig": {
    "ClusterCACert": "",
    "KubeConfig": "",
    "KubeAdminPass": "",
    "ClusterAPI": "",
    "WebConsoleURL": "",
    "ProxyConfig": null
  },
  "KubeletStarted": false
}
```

After

``` 
$ curl  --unix-socket ~/.crc/crc-http.sock http:/unix/api/start -v | jq .
< HTTP/1.1 500 Internal Server Error
Bundle 'crc_libvirt_4.7.8.crcbundle' was requested, but the existing VM is using 'crc_libvirt_4.7.7.crcbundle.
```
