### PR TITLE
Check if running in WSL2 right after checking root

### DIFF
--- a/pkg/crc/preflight/preflight_linux.go
+++ b/pkg/crc/preflight/preflight_linux.go
@@ -228,16 +228,13 @@ func removeVsockCrcSettings() error {
 func getAllPreflightChecks() []Check {
 	usingSystemdResolved := checkSystemdResolvedIsRunning()
 	checks := getPreflightChecksForDistro(distro(), network.SystemNetworkingMode, usingSystemdResolved == nil)
-	checks = append(checks, wsl2PreflightChecks)
 	checks = append(checks, vsockPreflightChecks)
 	return checks
 }
 
 func getPreflightChecks(_ bool, _ bool, networkMode network.Mode) []Check {
 	usingSystemdResolved := checkSystemdResolvedIsRunning()
-	checks := getPreflightChecksForDistro(distro(), networkMode, usingSystemdResolved == nil)
-	checks = append(checks, wsl2PreflightChecks)
-	return checks
+	return getPreflightChecksForDistro(distro(), networkMode, usingSystemdResolved == nil)
 }
 
 func getNetworkChecks(networkMode network.Mode, systemdResolved bool) []Check {
@@ -260,6 +257,7 @@ func getNetworkChecks(networkMode network.Mode, systemdResolved bool) []Check {
 func getPreflightChecksForDistro(distro *linux.OsRelease, networkMode network.Mode, systemdResolved bool) []Check {
 	var checks []Check
 	checks = append(checks, nonWinPreflightChecks[:]...)
+	checks = append(checks, wsl2PreflightChecks)
 	checks = append(checks, genericPreflightChecks[:]...)
 	checks = append(checks, libvirtPreflightChecks(distro)...)
 	networkChecks := getNetworkChecks(networkMode, systemdResolved)

--- a/pkg/crc/preflight/preflight_linux_test.go
+++ b/pkg/crc/preflight/preflight_linux_test.go
@@ -63,6 +63,7 @@ var checkListForDistros = []checkListForDistro{
 		systemdResolved: true,
 		checks: []Check{
 			{check: checkIfRunningAsNormalUser},
+			{check: checkRunningInsideWSL2},
 			{check: checkAdminHelperExecutableCached},
 			{check: checkSupportedCPUArch},
 			{configKeySuffix: "check-ram"},
@@ -96,6 +97,7 @@ var checkListForDistros = []checkListForDistro{
 		systemdResolved: false,
 		checks: []Check{
 			{check: checkIfRunningAsNormalUser},
+			{check: checkRunningInsideWSL2},
 			{check: checkAdminHelperExecutableCached},
 			{check: checkSupportedCPUArch},
 			{configKeySuffix: "check-ram"},
@@ -128,6 +130,7 @@ var checkListForDistros = []checkListForDistro{
 		systemdResolved: false,
 		checks: []Check{
 			{check: checkIfRunningAsNormalUser},
+			{check: checkRunningInsideWSL2},
 			{check: checkAdminHelperExecutableCached},
 			{check: checkSupportedCPUArch},
 			{configKeySuffix: "check-ram"},
@@ -154,6 +157,7 @@ var checkListForDistros = []checkListForDistro{
 		systemdResolved: true,
 		checks: []Check{
 			{check: checkIfRunningAsNormalUser},
+			{check: checkRunningInsideWSL2},
 			{check: checkAdminHelperExecutableCached},
 			{check: checkSupportedCPUArch},
 			{configKeySuffix: "check-ram"},
@@ -187,6 +191,7 @@ var checkListForDistros = []checkListForDistro{
 		systemdResolved: false,
 		checks: []Check{
 			{check: checkIfRunningAsNormalUser},
+			{check: checkRunningInsideWSL2},
 			{check: checkAdminHelperExecutableCached},
 			{check: checkSupportedCPUArch},
 			{configKeySuffix: "check-ram"},
@@ -219,6 +224,7 @@ var checkListForDistros = []checkListForDistro{
 		systemdResolved: false,
 		checks: []Check{
 			{check: checkIfRunningAsNormalUser},
+			{check: checkRunningInsideWSL2},
 			{check: checkAdminHelperExecutableCached},
 			{check: checkSupportedCPUArch},
 			{configKeySuffix: "check-ram"},
@@ -245,6 +251,7 @@ var checkListForDistros = []checkListForDistro{
 		systemdResolved: true,
 		checks: []Check{
 			{check: checkIfRunningAsNormalUser},
+			{check: checkRunningInsideWSL2},
 			{check: checkAdminHelperExecutableCached},
 			{check: checkSupportedCPUArch},
 			{configKeySuffix: "check-ram"},
@@ -278,6 +285,7 @@ var checkListForDistros = []checkListForDistro{
 		systemdResolved: false,
 		checks: []Check{
 			{check: checkIfRunningAsNormalUser},
+			{check: checkRunningInsideWSL2},
 			{check: checkAdminHelperExecutableCached},
 			{check: checkSupportedCPUArch},
 			{configKeySuffix: "check-ram"},
@@ -310,6 +318,7 @@ var checkListForDistros = []checkListForDistro{
 		systemdResolved: false,
 		checks: []Check{
 			{check: checkIfRunningAsNormalUser},
+			{check: checkRunningInsideWSL2},
 			{check: checkAdminHelperExecutableCached},
 			{check: checkSupportedCPUArch},
 			{configKeySuffix: "check-ram"},
@@ -336,6 +345,7 @@ var checkListForDistros = []checkListForDistro{
 		systemdResolved: true,
 		checks: []Check{
 			{check: checkIfRunningAsNormalUser},
+			{check: checkRunningInsideWSL2},
 			{check: checkAdminHelperExecutableCached},
 			{check: checkSupportedCPUArch},
 			{configKeySuffix: "check-ram"},
@@ -370,6 +380,7 @@ var checkListForDistros = []checkListForDistro{
 		systemdResolved: false,
 		checks: []Check{
 			{check: checkIfRunningAsNormalUser},
+			{check: checkRunningInsideWSL2},
 			{check: checkAdminHelperExecutableCached},
 			{check: checkSupportedCPUArch},
 			{configKeySuffix: "check-ram"},
@@ -403,6 +414,7 @@ var checkListForDistros = []checkListForDistro{
 		systemdResolved: false,
 		checks: []Check{
 			{check: checkIfRunningAsNormalUser},
+			{check: checkRunningInsideWSL2},
 			{check: checkAdminHelperExecutableCached},
 			{check: checkSupportedCPUArch},
 			{configKeySuffix: "check-ram"},


### PR DESCRIPTION
There is no point trying to install KVM, etc before checking for WSL2
installation.

Before:

$ crc setup
INFO Checking if running as non-root
INFO Checking if libvirt is installed
INFO Checking if CRC bundle is extracted in '$HOME/.crc'
INFO Checking if running inside WSL2
Your system is correctly setup for using CodeReady Containers

After:

$ crc setup
INFO Checking if running as non-root
INFO Checking if running inside WSL2
INFO Checking if libvirt is installed
INFO Checking if CRC bundle is extracted in '$HOME/.crc'
Your system is correctly setup for using CodeReady Containers

