### PR TITLE
[WIP] Integration config tests

### DIFF
--- a/test/integration/config_test.go
+++ b/test/integration/config_test.go
@@ -3,6 +3,7 @@ package test_test
 import (
 	"runtime"
 	"time"
+	"strings"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -24,7 +25,6 @@ var _ = Describe("config", func() {
 				stdout, _, err := RunOnHostWithPrivilege("2s", "systemctl", "status", "libvirtd")
 				Expect(err).To(HaveOccurred()) // exitcode 3, inactive
 				Expect(stdout).To(ContainSubstring("inactive"))
-				Expect(stdout).To(ContainSubstring("Stopped Virtualization daemon"))
 			})
 
 			It("set config to skip check that libvirt service is running", func() {
@@ -32,9 +32,8 @@ var _ = Describe("config", func() {
 			})
 
 			It("check if setup needs to be run", func() {
-				out, err := RunCRCExpectFail("setup", "--check-only")
+				_, err := RunCRCExpectFail("setup", "--check-only")
 				Expect(err).NotTo(HaveOccurred())
-				Expect(out).To(ContainSubstring("Failed to run 'virsh capabilities'"))
 			})
 
 			It("run setup", func() {
@@ -78,7 +77,8 @@ var _ = Describe("config", func() {
 				Expect(RunCRCExpectSuccess("start", "-b", bundlePath, "-p", pullSecretPath, "--memory", "11200")).To(ContainSubstring("Started the OpenShift cluster"))
 			}
 			// memory amount should respect the flag
-			out, err := SendCommandToVM("cat /proc/meminfo", "192.168.130.11", "22")
+			ip := strings.TrimSpace(RunCRCExpectSuccess("ip"))
+			out, err := SendCommandToVM("cat /proc/meminfo", ip, "22")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(out).Should(MatchRegexp(`MemTotal:[\s]*11\d{6}`))
 		})
@@ -94,7 +94,8 @@ var _ = Describe("config", func() {
 				Expect(RunCRCExpectSuccess("start", "-b", bundlePath, "-p", pullSecretPath)).To(ContainSubstring("Started the OpenShift cluster"))
 			}
 			// memory amount should respect the flag
-			out, err := SendCommandToVM("cat /proc/meminfo", "192.168.130.11", "22")
+			ip := strings.TrimSpace(RunCRCExpectSuccess("ip"))
+			out, err := SendCommandToVM("cat /proc/meminfo", ip, "22")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(out).Should(MatchRegexp(`MemTotal:[\s]*10\d{6}`))
 		})
@@ -114,7 +115,8 @@ var _ = Describe("config", func() {
 				Expect(RunCRCExpectSuccess("start", "-b", bundlePath, "-p", pullSecretPath)).To(ContainSubstring("Started the OpenShift cluster"))
 			}
 			// memory amount should respect the flag
-			out, err := SendCommandToVM("cat /proc/meminfo", "192.168.130.11", "22")
+			ip := strings.TrimSpace(RunCRCExpectSuccess("ip"))
+			out, err := SendCommandToVM("cat /proc/meminfo", ip, "22")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(out).Should(MatchRegexp(`MemTotal:[\s]*9\d{6}`))
 		})
@@ -155,7 +157,8 @@ var _ = Describe("config", func() {
 
 				Expect(RunCRCExpectSuccess("start", "-p", pullSecretPath)).To(ContainSubstring("Started the OpenShift cluster"))
 
-				out, err := SendCommandToVM("curl host.crc.testing:1234", "127.0.0.1", "2222")
+				ip := strings.TrimSpace(RunCRCExpectSuccess("ip"))
+				out, err := SendCommandToVM("curl host.crc.testing:1234", ip, "2222")
 				Expect(err).NotTo(HaveOccurred())
 				Expect(out).To(ContainSubstring("hello"))
 

--- a/test/integration/config_test.go
+++ b/test/integration/config_test.go
@@ -166,11 +166,7 @@ var _ = Describe("Test config command", func() {
 				go RunCRCDaemon(dChan)
 				time.Sleep(10 * time.Second) // wait till daemon is running
 
-				// use test/testdata/host-network-access/Dockerfile
-				// podman build -t http-server:latest path/to/Dockerfile
-				// podman run -p 1234:8080 http-server:latest
-				// then ssh to VM and run from there: `curl host.crc.testing:1234` -> should give 'hello' string only.
-				// ideally, we could do this with podman-remote
+				// ideally, we could do this with podman-remote, but not yet
 
 				_, _, err := RunOnHost("120s", "podman", "build", "-t", "http-server:latest", "/home/jsliacan/github/code-ready/crc/test/testdata/host-network-access")
 				Expect(err).NotTo(HaveOccurred())
@@ -179,8 +175,7 @@ var _ = Describe("Test config command", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(RunCRCExpectSuccess("start", "-p", pullSecretPath)).To(ContainSubstring("Started the OpenShift cluster"))
-
-				out, _, err := RunOnHost("120s", "ssh", "-i", "~/.crc/machines/crc/id_ecdsa", "core@127.0.0.1", "-p", "2222", "curl host.crc.testing:1234")
+				out, err := SendCommandToVM("curl host.crc.testing:1234", "127.0.0.1", "2222")
 				Expect(err).NotTo(HaveOccurred())
 				Expect(out).To(ContainSubstring("hello"))
 

--- a/test/integration/config_test.go
+++ b/test/integration/config_test.go
@@ -8,130 +8,128 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("Test config command", func() {
-	/*
-		// 0 starts
-		Describe("skipping a check during setup", func() {
+var _ = Describe("config", func() {
 
-			if runtime.GOOS == "linux" {
-
-				It("stop libvirt service", func() {
-					_, _, err := RunOnHostWithPrivilege("2s", "systemctl", "stop", "libvirtd")
-					Expect(err).NotTo(HaveOccurred())
-				})
-
-				It("check libvirt service not running", func() {
-					stdout, _, err := RunOnHostWithPrivilege("2s", "systemctl", "status", "libvirtd")
-					Expect(err).To(HaveOccurred()) // exitcode 3, inactive
-					Expect(stdout).To(ContainSubstring("inactive"))
-					Expect(stdout).To(ContainSubstring("Stopped Virtualization daemon"))
-				})
-
-				It("set config to skip check that libvirt service is running", func() {
-					Expect(RunCRCExpectSuccess("config", "set", "skip-check-libvirt-running", "true")).To(ContainSubstring("Successfully configured skip-check-libvirt-running to true"))
-				})
-
-				It("check if setup needs to be run", func() {
-					out, err := RunCRCExpectFail("setup", "--check-only")
-					Expect(err).NotTo(HaveOccurred())
-					Expect(out).To(ContainSubstring("Failed to run 'virsh capabilities'"))
-				})
-
-				It("run setup", func() {
-					stderr, err := RunCRCExpectFail("setup")
-					Expect(err).NotTo(HaveOccurred())
-					Expect(stderr).To(ContainSubstring("failed to connect to the hypervisor"))
-				})
-
-				It("set config to not skip the check that libvirt service is running", func() {
-					Expect(RunCRCExpectSuccess("config", "unset", "skip-check-libvirt-running")).To(ContainSubstring("Successfully unset configuration property 'skip-check-libvirt-running'"))
-				})
-
-				It("run setup", func() {
-					Expect(RunCRCExpectSuccess("setup")).To(ContainSubstring("Your system is correctly setup for using CodeReady Containers"))
-				})
-
-				It("check libvirt service running", func() {
-					stdout, _, err := RunOnHostWithPrivilege("2s", "systemctl", "status", "libvirtd")
-					Expect(err).NotTo(HaveOccurred())
-					Expect(stdout).To(ContainSubstring("active"))
-				})
-
-			}
-		})
-
-		// 3 starts
-		Describe("Priority: flags >> config >> default", func() {
-
-			It("setup CRC", func() {
-				Expect(RunCRCExpectSuccess("setup")).To(ContainSubstring("Your system is correctly setup for using CodeReady Containers"))
-			})
-
-			It("set memory", func() {
-				Expect(RunCRCExpectSuccess("config", "set", "memory", "10200")).To(ContainSubstring("Changes to configuration property 'memory' are only applied when the CRC instance is started."))
-			})
-
-			It("start CRC with memory flag", func() {
-				if bundlePath == "embedded" {
-					Expect(RunCRCExpectSuccess("start", "-p", pullSecretPath, "--memory", "11200")).To(ContainSubstring("Started the OpenShift cluster"))
-				} else {
-					Expect(RunCRCExpectSuccess("start", "-b", bundlePath, "-p", pullSecretPath, "--memory", "11200")).To(ContainSubstring("Started the OpenShift cluster"))
-				}
-				// memory amount should respect the flag
-				out, err := SendCommandToVM("cat /proc/meminfo")
-				Expect(err).NotTo(HaveOccurred())
-				Expect(out).Should(MatchRegexp(`MemTotal:[\s]*11\d{6}`))
-			})
-
-			It("stop CRC", func() {
-				Expect(RunCRCExpectSuccess("stop", "-f")).To(ContainSubstring("Stopped the OpenShift cluster"))
-			})
-
-			It("start CRC and fall back on config settings", func() {
-				if bundlePath == "embedded" {
-					Expect(RunCRCExpectSuccess("start", "-p", pullSecretPath)).To(ContainSubstring("Started the OpenShift cluster"))
-				} else {
-					Expect(RunCRCExpectSuccess("start", "-b", bundlePath, "-p", pullSecretPath)).To(ContainSubstring("Started the OpenShift cluster"))
-				}
-				// memory amount should respect the flag
-				out, err := SendCommandToVM("cat /proc/meminfo")
-				Expect(err).NotTo(HaveOccurred())
-				Expect(out).Should(MatchRegexp(`MemTotal:[\s]*10\d{6}`))
-			})
-
-			It("stop CRC", func() {
-				Expect(RunCRCExpectSuccess("stop", "-f")).To(ContainSubstring("Stopped the OpenShift cluster"))
-			})
-
-			It("unset memory", func() {
-				Expect(RunCRCExpectSuccess("config", "unset", "memory")).To(ContainSubstring("Successfully unset configuration property 'memory'"))
-			})
-
-			It("start CRC and fall back on default settings", func() {
-				if bundlePath == "embedded" {
-					Expect(RunCRCExpectSuccess("start", "-p", pullSecretPath)).To(ContainSubstring("Started the OpenShift cluster"))
-				} else {
-					Expect(RunCRCExpectSuccess("start", "-b", bundlePath, "-p", pullSecretPath)).To(ContainSubstring("Started the OpenShift cluster"))
-				}
-				// memory amount should respect the flag
-				out, err := SendCommandToVM("cat /proc/meminfo")
-				Expect(err).NotTo(HaveOccurred())
-				Expect(out).Should(MatchRegexp(`MemTotal:[\s]*9\d{6}`))
-			})
-
-			It("cleanup and setup", func() {
-				Expect(RunCRCExpectSuccess("cleanup")).To(ContainSubstring("finished successfully"))
-				Expect(RunCRCExpectSuccess("setup")).To(ContainSubstring("Your system is correctly setup for using CodeReady Containers"))
-			})
-
-		})
-	*/
-	// 2 starts
-	Describe("Check host-network-access works", func() {
+	// 0 starts
+	Describe("skipping a check during setup", func() {
 
 		if runtime.GOOS == "linux" {
 
-			dChan := make(chan string, 1) // keeps track of when deamon is needed
+			It("stop libvirt service", func() {
+				_, _, err := RunOnHostWithPrivilege("2s", "systemctl", "stop", "libvirtd")
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("check libvirt service not running", func() {
+				stdout, _, err := RunOnHostWithPrivilege("2s", "systemctl", "status", "libvirtd")
+				Expect(err).To(HaveOccurred()) // exitcode 3, inactive
+				Expect(stdout).To(ContainSubstring("inactive"))
+				Expect(stdout).To(ContainSubstring("Stopped Virtualization daemon"))
+			})
+
+			It("set config to skip check that libvirt service is running", func() {
+				Expect(RunCRCExpectSuccess("config", "set", "skip-check-libvirt-running", "true")).To(ContainSubstring("Successfully configured skip-check-libvirt-running to true"))
+			})
+
+			It("check if setup needs to be run", func() {
+				out, err := RunCRCExpectFail("setup", "--check-only")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(out).To(ContainSubstring("Failed to run 'virsh capabilities'"))
+			})
+
+			It("run setup", func() {
+				stderr, err := RunCRCExpectFail("setup")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(stderr).To(ContainSubstring("failed to connect to the hypervisor"))
+			})
+
+			It("set config to not skip the check that libvirt service is running", func() {
+				Expect(RunCRCExpectSuccess("config", "unset", "skip-check-libvirt-running")).To(ContainSubstring("Successfully unset configuration property 'skip-check-libvirt-running'"))
+			})
+
+			It("run setup", func() {
+				Expect(RunCRCExpectSuccess("setup")).To(ContainSubstring("Your system is correctly setup for using CodeReady Containers"))
+			})
+
+			It("check libvirt service running", func() {
+				stdout, _, err := RunOnHostWithPrivilege("2s", "systemctl", "status", "libvirtd")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(stdout).To(ContainSubstring("active"))
+			})
+
+		}
+	})
+
+	// 3 starts
+	Describe("Priority: flags >> config >> default", func() {
+
+		It("setup CRC", func() {
+			Expect(RunCRCExpectSuccess("setup")).To(ContainSubstring("Your system is correctly setup for using CodeReady Containers"))
+		})
+
+		It("set memory", func() {
+			Expect(RunCRCExpectSuccess("config", "set", "memory", "10200")).To(ContainSubstring("Changes to configuration property 'memory' are only applied when the CRC instance is started."))
+		})
+
+		It("start CRC with memory flag", func() {
+			if bundlePath == "embedded" {
+				Expect(RunCRCExpectSuccess("start", "-p", pullSecretPath, "--memory", "11200")).To(ContainSubstring("Started the OpenShift cluster"))
+			} else {
+				Expect(RunCRCExpectSuccess("start", "-b", bundlePath, "-p", pullSecretPath, "--memory", "11200")).To(ContainSubstring("Started the OpenShift cluster"))
+			}
+			// memory amount should respect the flag
+			out, err := SendCommandToVM("cat /proc/meminfo", "192.168.130.11", "22")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(out).Should(MatchRegexp(`MemTotal:[\s]*11\d{6}`))
+		})
+
+		It("stop CRC", func() {
+			Expect(RunCRCExpectSuccess("stop", "-f")).To(ContainSubstring("stopped the OpenShift cluster"))
+		})
+
+		It("start CRC and fall back on config settings", func() {
+			if bundlePath == "embedded" {
+				Expect(RunCRCExpectSuccess("start", "-p", pullSecretPath)).To(ContainSubstring("Started the OpenShift cluster"))
+			} else {
+				Expect(RunCRCExpectSuccess("start", "-b", bundlePath, "-p", pullSecretPath)).To(ContainSubstring("Started the OpenShift cluster"))
+			}
+			// memory amount should respect the flag
+			out, err := SendCommandToVM("cat /proc/meminfo", "192.168.130.11", "22")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(out).Should(MatchRegexp(`MemTotal:[\s]*10\d{6}`))
+		})
+
+		It("stop CRC", func() {
+			Expect(RunCRCExpectSuccess("stop", "-f")).To(ContainSubstring("stopped the OpenShift cluster"))
+		})
+
+		It("unset memory", func() {
+			Expect(RunCRCExpectSuccess("config", "unset", "memory")).To(ContainSubstring("Successfully unset configuration property 'memory'"))
+		})
+
+		It("start CRC and fall back on default settings", func() {
+			if bundlePath == "embedded" {
+				Expect(RunCRCExpectSuccess("start", "-p", pullSecretPath)).To(ContainSubstring("Started the OpenShift cluster"))
+			} else {
+				Expect(RunCRCExpectSuccess("start", "-b", bundlePath, "-p", pullSecretPath)).To(ContainSubstring("Started the OpenShift cluster"))
+			}
+			// memory amount should respect the flag
+			out, err := SendCommandToVM("cat /proc/meminfo", "192.168.130.11", "22")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(out).Should(MatchRegexp(`MemTotal:[\s]*9\d{6}`))
+		})
+
+		It("cleanup and setup", func() {
+			Expect(RunCRCExpectSuccess("cleanup")).To(ContainSubstring("Cleanup finished"))
+			Expect(RunCRCExpectSuccess("setup")).To(ContainSubstring("Your system is correctly setup for using CodeReady Containers"))
+		})
+
+	})
+
+	// 2 starts
+	Describe("host-network-access", func() {
+
+		if runtime.GOOS == "linux" {
 
 			It("set network-mode to vsock", func() {
 				Expect(RunCRCExpectSuccess("config", "set", "network-mode", "vsock")).To(ContainSubstring("Please run `crc cleanup` and `crc setup`"))
@@ -142,54 +140,40 @@ var _ = Describe("Test config command", func() {
 				Expect(RunCRCExpectSuccess("setup")).To(ContainSubstring("Your system is correctly setup for using CodeReady Containers"))
 			})
 
-			/*
-				It("start CRC", func() {
-					Expect(RunCRCExpectSuccess("start", "-p", pullSecretPath)).To(ContainSubstring("Started the OpenShift cluster"))
-				})
-
-				It("fail to reach the server from VM", func() {
-					_, err := SendCommandToVM("curl host.crc.testing:8000")
-					Expect(err).To(HaveOccurred())
-				})
-
-				It("stop CRC", func() {
-					Expect(RunCRCExpectSuccess("stop", "-f")).To(ContainSubstring("Stopped the OpenShift cluster"))
-				})
-			*/
-
 			It("set host-network-access to true", func() {
 				Expect(RunCRCExpectSuccess("config", "set", "host-network-access", "true")).To(ContainSubstring("Successfully configured host-network-access to true"))
 			})
 
 			It("access host's network", func() {
 
+				dChan := make(chan string, 1)
 				go RunCRCDaemon(dChan)
 				time.Sleep(10 * time.Second) // wait till daemon is running
 
-				// ideally, we could do this with podman-remote, but not yet
-
-				_, _, err := RunOnHost("120s", "podman", "build", "-t", "http-server:latest", "/home/jsliacan/github/code-ready/crc/test/testdata/host-network-access")
-				Expect(err).NotTo(HaveOccurred())
-
-				_, _, err = RunOnHost("10s", "podman", "run", "--name", "crc-http-server", "-d", "-p", "1234:8080", "http-server:latest") // send to background
-				Expect(err).NotTo(HaveOccurred())
+				_ = RunPodmanExpectSuccess("build", "-t", "http-server:latest", "../testdata/host-network-access")
+				_ = RunPodmanExpectSuccess("run", "--name", "crc-http-server", "-d", "-p", "1234:8080", "http-server:latest") // send to background to get exit code
 
 				Expect(RunCRCExpectSuccess("start", "-p", pullSecretPath)).To(ContainSubstring("Started the OpenShift cluster"))
+
 				out, err := SendCommandToVM("curl host.crc.testing:1234", "127.0.0.1", "2222")
 				Expect(err).NotTo(HaveOccurred())
 				Expect(out).To(ContainSubstring("hello"))
 
-				_, _, err = RunOnHost("10s", "podman", "kill", "crc-http-server") // kill the container
+				_ = RunPodmanExpectSuccess("kill", "crc-http-server") // kill the container
 				Expect(err).NotTo(HaveOccurred())
 
-				_, _, err = RunOnHost("10s", "podman", "image", "rm", "http-server", "-f") // remove image
-				Expect(err).NotTo(HaveOccurred())
+				_ = RunPodmanExpectSuccess("image", "rm", "http-server", "-f") // remove image
 
-				dChan <- "done"
+				dChan <- "done" // stop the daemon
 			})
 
 			It("cleanup", func() {
 				Expect(RunCRCExpectSuccess("cleanup")).To(ContainSubstring("Cleanup finished"))
+			})
+
+			It("unset network config", func() {
+				Expect(RunCRCExpectSuccess("config", "unset", "host-network-access")).To(ContainSubstring("Successfully unset configuration property 'host-network-access'"))
+				Expect(RunCRCExpectSuccess("config", "unset", "network-mode")).To(ContainSubstring("Successfully unset configuration property 'network-mode'"))
 			})
 
 		}

--- a/test/integration/config_test.go
+++ b/test/integration/config_test.go
@@ -1,0 +1,202 @@
+package test_test
+
+import (
+	"runtime"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Test config command", func() {
+	/*
+		// 0 starts
+		Describe("skipping a check during setup", func() {
+
+			if runtime.GOOS == "linux" {
+
+				It("stop libvirt service", func() {
+					_, _, err := RunOnHostWithPrivilege("2s", "systemctl", "stop", "libvirtd")
+					Expect(err).NotTo(HaveOccurred())
+				})
+
+				It("check libvirt service not running", func() {
+					stdout, _, err := RunOnHostWithPrivilege("2s", "systemctl", "status", "libvirtd")
+					Expect(err).To(HaveOccurred()) // exitcode 3, inactive
+					Expect(stdout).To(ContainSubstring("inactive"))
+					Expect(stdout).To(ContainSubstring("Stopped Virtualization daemon"))
+				})
+
+				It("set config to skip check that libvirt service is running", func() {
+					Expect(RunCRCExpectSuccess("config", "set", "skip-check-libvirt-running", "true")).To(ContainSubstring("Successfully configured skip-check-libvirt-running to true"))
+				})
+
+				It("check if setup needs to be run", func() {
+					out, err := RunCRCExpectFail("setup", "--check-only")
+					Expect(err).NotTo(HaveOccurred())
+					Expect(out).To(ContainSubstring("Failed to run 'virsh capabilities'"))
+				})
+
+				It("run setup", func() {
+					stderr, err := RunCRCExpectFail("setup")
+					Expect(err).NotTo(HaveOccurred())
+					Expect(stderr).To(ContainSubstring("failed to connect to the hypervisor"))
+				})
+
+				It("set config to not skip the check that libvirt service is running", func() {
+					Expect(RunCRCExpectSuccess("config", "unset", "skip-check-libvirt-running")).To(ContainSubstring("Successfully unset configuration property 'skip-check-libvirt-running'"))
+				})
+
+				It("run setup", func() {
+					Expect(RunCRCExpectSuccess("setup")).To(ContainSubstring("Your system is correctly setup for using CodeReady Containers"))
+				})
+
+				It("check libvirt service running", func() {
+					stdout, _, err := RunOnHostWithPrivilege("2s", "systemctl", "status", "libvirtd")
+					Expect(err).NotTo(HaveOccurred())
+					Expect(stdout).To(ContainSubstring("active"))
+				})
+
+			}
+		})
+
+		// 3 starts
+		Describe("Priority: flags >> config >> default", func() {
+
+			It("setup CRC", func() {
+				Expect(RunCRCExpectSuccess("setup")).To(ContainSubstring("Your system is correctly setup for using CodeReady Containers"))
+			})
+
+			It("set memory", func() {
+				Expect(RunCRCExpectSuccess("config", "set", "memory", "10200")).To(ContainSubstring("Changes to configuration property 'memory' are only applied when the CRC instance is started."))
+			})
+
+			It("start CRC with memory flag", func() {
+				if bundlePath == "embedded" {
+					Expect(RunCRCExpectSuccess("start", "-p", pullSecretPath, "--memory", "11200")).To(ContainSubstring("Started the OpenShift cluster"))
+				} else {
+					Expect(RunCRCExpectSuccess("start", "-b", bundlePath, "-p", pullSecretPath, "--memory", "11200")).To(ContainSubstring("Started the OpenShift cluster"))
+				}
+				// memory amount should respect the flag
+				out, err := SendCommandToVM("cat /proc/meminfo")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(out).Should(MatchRegexp(`MemTotal:[\s]*11\d{6}`))
+			})
+
+			It("stop CRC", func() {
+				Expect(RunCRCExpectSuccess("stop", "-f")).To(ContainSubstring("Stopped the OpenShift cluster"))
+			})
+
+			It("start CRC and fall back on config settings", func() {
+				if bundlePath == "embedded" {
+					Expect(RunCRCExpectSuccess("start", "-p", pullSecretPath)).To(ContainSubstring("Started the OpenShift cluster"))
+				} else {
+					Expect(RunCRCExpectSuccess("start", "-b", bundlePath, "-p", pullSecretPath)).To(ContainSubstring("Started the OpenShift cluster"))
+				}
+				// memory amount should respect the flag
+				out, err := SendCommandToVM("cat /proc/meminfo")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(out).Should(MatchRegexp(`MemTotal:[\s]*10\d{6}`))
+			})
+
+			It("stop CRC", func() {
+				Expect(RunCRCExpectSuccess("stop", "-f")).To(ContainSubstring("Stopped the OpenShift cluster"))
+			})
+
+			It("unset memory", func() {
+				Expect(RunCRCExpectSuccess("config", "unset", "memory")).To(ContainSubstring("Successfully unset configuration property 'memory'"))
+			})
+
+			It("start CRC and fall back on default settings", func() {
+				if bundlePath == "embedded" {
+					Expect(RunCRCExpectSuccess("start", "-p", pullSecretPath)).To(ContainSubstring("Started the OpenShift cluster"))
+				} else {
+					Expect(RunCRCExpectSuccess("start", "-b", bundlePath, "-p", pullSecretPath)).To(ContainSubstring("Started the OpenShift cluster"))
+				}
+				// memory amount should respect the flag
+				out, err := SendCommandToVM("cat /proc/meminfo")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(out).Should(MatchRegexp(`MemTotal:[\s]*9\d{6}`))
+			})
+
+			It("cleanup and setup", func() {
+				Expect(RunCRCExpectSuccess("cleanup")).To(ContainSubstring("finished successfully"))
+				Expect(RunCRCExpectSuccess("setup")).To(ContainSubstring("Your system is correctly setup for using CodeReady Containers"))
+			})
+
+		})
+	*/
+	// 2 starts
+	Describe("Check host-network-access works", func() {
+
+		if runtime.GOOS == "linux" {
+
+			dChan := make(chan string, 1) // keeps track of when deamon is needed
+
+			It("set network-mode to vsock", func() {
+				Expect(RunCRCExpectSuccess("config", "set", "network-mode", "vsock")).To(ContainSubstring("Please run `crc cleanup` and `crc setup`"))
+			})
+
+			It("cleanup and setup, as instructed", func() {
+				Expect(RunCRCExpectSuccess("cleanup")).To(ContainSubstring("Cleanup finished"))
+				Expect(RunCRCExpectSuccess("setup")).To(ContainSubstring("Your system is correctly setup for using CodeReady Containers"))
+			})
+
+			/*
+				It("start CRC", func() {
+					Expect(RunCRCExpectSuccess("start", "-p", pullSecretPath)).To(ContainSubstring("Started the OpenShift cluster"))
+				})
+
+				It("fail to reach the server from VM", func() {
+					_, err := SendCommandToVM("curl host.crc.testing:8000")
+					Expect(err).To(HaveOccurred())
+				})
+
+				It("stop CRC", func() {
+					Expect(RunCRCExpectSuccess("stop", "-f")).To(ContainSubstring("Stopped the OpenShift cluster"))
+				})
+			*/
+
+			It("set host-network-access to true", func() {
+				Expect(RunCRCExpectSuccess("config", "set", "host-network-access", "true")).To(ContainSubstring("Successfully configured host-network-access to true"))
+			})
+
+			It("access host's network", func() {
+
+				go RunCRCDaemon(dChan)
+				time.Sleep(10 * time.Second) // wait till daemon is running
+
+				// use test/testdata/host-network-access/Dockerfile
+				// podman build -t http-server:latest path/to/Dockerfile
+				// podman run -p 1234:8080 http-server:latest
+				// then ssh to VM and run from there: `curl host.crc.testing:1234` -> should give 'hello' string only.
+				// ideally, we could do this with podman-remote
+
+				_, _, err := RunOnHost("120s", "podman", "build", "-t", "http-server:latest", "/home/jsliacan/github/code-ready/crc/test/testdata/host-network-access")
+				Expect(err).NotTo(HaveOccurred())
+
+				_, _, err = RunOnHost("10s", "podman", "run", "--name", "crc-http-server", "-d", "-p", "1234:8080", "http-server:latest") // send to background
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(RunCRCExpectSuccess("start", "-p", pullSecretPath)).To(ContainSubstring("Started the OpenShift cluster"))
+
+				out, _, err := RunOnHost("120s", "ssh", "-i", "~/.crc/machines/crc/id_ecdsa", "core@127.0.0.1", "-p", "2222", "curl host.crc.testing:1234")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(out).To(ContainSubstring("hello"))
+
+				_, _, err = RunOnHost("10s", "podman", "kill", "crc-http-server") // kill the container
+				Expect(err).NotTo(HaveOccurred())
+
+				_, _, err = RunOnHost("10s", "podman", "image", "rm", "http-server", "-f") // remove image
+				Expect(err).NotTo(HaveOccurred())
+
+				dChan <- "done"
+			})
+
+			It("cleanup", func() {
+				Expect(RunCRCExpectSuccess("cleanup")).To(ContainSubstring("Cleanup finished"))
+			})
+
+		}
+	})
+})

--- a/test/integration/config_test.go
+++ b/test/integration/config_test.go
@@ -84,7 +84,7 @@ var _ = Describe("config", func() {
 		})
 
 		It("stop CRC", func() {
-			Expect(RunCRCExpectSuccess("stop", "-f")).To(ContainSubstring("stopped the OpenShift cluster"))
+			Expect(RunCRCExpectSuccess("stop", "-f")).To(MatchRegexp(`[Ss]topped the OpenShift cluster`))
 		})
 
 		It("start CRC and fall back on config settings", func() {
@@ -100,7 +100,7 @@ var _ = Describe("config", func() {
 		})
 
 		It("stop CRC", func() {
-			Expect(RunCRCExpectSuccess("stop", "-f")).To(ContainSubstring("stopped the OpenShift cluster"))
+			Expect(RunCRCExpectSuccess("stop", "-f")).To(MatchRegexp(`[Ss]topped the OpenShift cluster`))
 		})
 
 		It("unset memory", func() {

--- a/test/integration/resize_test.go
+++ b/test/integration/resize_test.go
@@ -2,6 +2,7 @@ package test_test
 
 import (
 	"runtime"
+	"strings"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -25,20 +26,23 @@ var _ = Describe("vary VM parameters: memory cpus, disk", func() {
 		})
 
 		It("check VM's memory size", func() {
-			out, err := SendCommandToVM("cat /proc/meminfo", "192.168.130.11", "22")
+			ip := strings.TrimSpace(RunCRCExpectSuccess("ip"))
+			out, err := SendCommandToVM("cat /proc/meminfo", ip, "22")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(out).Should(MatchRegexp(`MemTotal:[\s]*9\d{6}`))
 		})
 
 		It("check VM's number of cpus", func() {
-			out, err := SendCommandToVM("cat /proc/cpuinfo", "192.168.130.11", "22")
+			ip := strings.TrimSpace(RunCRCExpectSuccess("ip"))
+			out, err := SendCommandToVM("cat /proc/cpuinfo", ip, "22")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(out).Should(MatchRegexp(`processor[\s]*\:[\s]*3`))
 			Expect(out).ShouldNot(MatchRegexp(`processor[\s]*\:[\s]*4`))
 		})
 
 		It("check VM's disk size", func() {
-			out, err := SendCommandToVM("df -h | grep sysroot", "192.168.130.11", "22")
+			ip := strings.TrimSpace(RunCRCExpectSuccess("ip"))
+			out, err := SendCommandToVM("df -h | grep sysroot", ip, "22")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(out).Should(MatchRegexp(`.*31G[\s].*[\s]/sysroot`))
 		})
@@ -61,20 +65,23 @@ var _ = Describe("vary VM parameters: memory cpus, disk", func() {
 		})
 
 		It("check VM's memory size", func() {
-			out, err := SendCommandToVM("cat /proc/meminfo", "192.168.130.11", "22")
+			ip := strings.TrimSpace(RunCRCExpectSuccess("ip"))
+			out, err := SendCommandToVM("cat /proc/meminfo", ip, "22")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(out).Should(MatchRegexp(`MemTotal:[\s]*11\d{6}`))
 		})
 
 		It("check VM's number of cpus", func() {
-			out, err := SendCommandToVM("cat /proc/cpuinfo", "192.168.130.11", "22")
+			ip := strings.TrimSpace(RunCRCExpectSuccess("ip"))
+			out, err := SendCommandToVM("cat /proc/cpuinfo", ip, "22")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(out).Should(MatchRegexp(`processor[\s]*\:[\s]*5`))
 			Expect(out).ShouldNot(MatchRegexp(`processor[\s]*\:[\s]*6`))
 		})
 
 		It("check VM's disk size", func() {
-			out, err := SendCommandToVM("df -h | grep sysroot", "192.168.130.11", "22")
+			ip := strings.TrimSpace(RunCRCExpectSuccess("ip"))
+			out, err := SendCommandToVM("df -h | grep sysroot", ip, "22")
 			Expect(err).NotTo(HaveOccurred())
 			if runtime.GOOS == "darwin" { // darwin does not support resize
 				Expect(out).Should(MatchRegexp(`.*31G[\s].*[\s]/sysroot`))
@@ -118,13 +125,15 @@ var _ = Describe("vary VM parameters: memory cpus, disk", func() {
 		})
 
 		It("check VM's memory size", func() {
-			out, err := SendCommandToVM("cat /proc/meminfo", "192.168.130.11", "22")
+			ip := strings.TrimSpace(RunCRCExpectSuccess("ip"))
+			out, err := SendCommandToVM("cat /proc/meminfo", ip, "22")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(out).Should(MatchRegexp(`MemTotal:[\s]*9\d{6}`)) // there should be a check if cluster needs >9216MiB; it isn't there and mem gets scaled down regardless
 		})
 
 		It("check VM's number of cpus", func() {
-			out, err := SendCommandToVM("cat /proc/cpuinfo", "192.168.130.11", "22")
+			ip := strings.TrimSpace(RunCRCExpectSuccess("ip"))
+			out, err := SendCommandToVM("cat /proc/cpuinfo", ip, "22")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(out).Should(MatchRegexp(`processor[\s]*\:[\s]*3`))
 			Expect(out).ShouldNot(MatchRegexp(`processor[\s]*\:[\s]*4`))
@@ -132,7 +141,8 @@ var _ = Describe("vary VM parameters: memory cpus, disk", func() {
 
 		if runtime.GOOS != "darwin" {
 			It("check VM's disk size", func() {
-				out, err := SendCommandToVM("df -h | grep sysroot", "192.168.130.11", "22")
+				ip := strings.TrimSpace(RunCRCExpectSuccess("ip"))
+				out, err := SendCommandToVM("df -h | grep sysroot", ip, "22")
 				Expect(err).NotTo(HaveOccurred())
 				Expect(out).Should(MatchRegexp(`.*40G[\s].*[\s]/sysroot`))
 			})

--- a/test/integration/resize_test.go
+++ b/test/integration/resize_test.go
@@ -1,147 +1,148 @@
 package test_test
 
 import (
+	"runtime"
+
 	. "github.com/onsi/ginkgo"
-	//. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("vary VM parameters: memory cpus, disk", func() {
-	/*
-		Describe("use default values", func() {
 
-			It("setup CRC", func() {
-				Expect(RunCRCExpectSuccess("setup")).To(ContainSubstring("Your system is correctly setup for using CodeReady Containers"))
-			})
+	Describe("use default values", func() {
 
-			It("start CRC", func() {
-				// default values: "--memory", "9216", "--cpus", "4", "disk-size", "31"
-				if bundlePath == "embedded" {
-					Expect(RunCRCExpectSuccess("start", "-p", pullSecretPath)).To(ContainSubstring("Started the OpenShift cluster"))
-				} else {
-					Expect(RunCRCExpectSuccess("start", "-b", bundlePath, "-p", pullSecretPath)).To(ContainSubstring("Started the OpenShift cluster"))
-				}
-			})
-
-			It("check VM's memory size", func() {
-				out, err := SendCommandToVM("cat /proc/meminfo")
-				Expect(err).NotTo(HaveOccurred())
-				Expect(out).Should(MatchRegexp(`MemTotal:[\s]*9\d{6}`))
-			})
-
-			It("check VM's number of cpus", func() {
-				out, err := SendCommandToVM("cat /proc/cpuinfo")
-				Expect(err).NotTo(HaveOccurred())
-				Expect(out).Should(MatchRegexp(`processor[\s]*\:[\s]*3`))
-				Expect(out).ShouldNot(MatchRegexp(`processor[\s]*\:[\s]*4`))
-			})
-
-			It("check VM's disk size", func() {
-				out, err := SendCommandToVM("df -h | grep sysroot")
-				Expect(err).NotTo(HaveOccurred())
-				Expect(out).Should(MatchRegexp(`.*31G[\s].*[\s]/sysroot`))
-			})
-
-			It("stop CRC", func() {
-				Expect(RunCRCExpectSuccess("stop", "-f")).To(ContainSubstring("Stopped the OpenShift cluster"))
-			})
-
+		It("setup CRC", func() {
+			Expect(RunCRCExpectSuccess("setup")).To(ContainSubstring("Your system is correctly setup for using CodeReady Containers"))
 		})
 
-		Describe("use custom values", func() {
-
-			It("start CRC", func() {
-				if runtime.GOOS == "darwin" {
-					Expect(RunCRCExpectFail("start", "--memory", "12000", "--cpus", "6", "--disk-size", "40")).To(ContainSubstring("Disk resizing is not supported on macOS"))
-					Expect(RunCRCExpectSuccess("start", "--memory", "12000", "--cpus", "6")).To(ContainSubstring("Started the OpenShift cluster"))
-				} else {
-					Expect(RunCRCExpectSuccess("start", "--memory", "12000", "--cpus", "6", "--disk-size", "40")).To(ContainSubstring("Started the OpenShift cluster"))
-				}
-			})
-
-			It("check VM's memory size", func() {
-				out, err := SendCommandToVM("cat /proc/meminfo")
-				Expect(err).NotTo(HaveOccurred())
-				Expect(out).Should(MatchRegexp(`MemTotal:[\s]*11\d{6}`))
-			})
-
-			It("check VM's number of cpus", func() {
-				out, err := SendCommandToVM("cat /proc/cpuinfo")
-				Expect(err).NotTo(HaveOccurred())
-				Expect(out).Should(MatchRegexp(`processor[\s]*\:[\s]*5`))
-				Expect(out).ShouldNot(MatchRegexp(`processor[\s]*\:[\s]*6`))
-			})
-
-			It("check VM's disk size", func() {
-				out, err := SendCommandToVM("df -h | grep sysroot")
-				Expect(err).NotTo(HaveOccurred())
-				if runtime.GOOS == "darwin" { // darwin does not support resize
-					Expect(out).Should(MatchRegexp(`.*31G[\s].*[\s]/sysroot`))
-				} else {
-					Expect(out).Should(MatchRegexp(`.*40G[\s].*[\s]/sysroot`))
-				}
-			})
-
-			It("stop CRC", func() {
-				Expect(RunCRCExpectSuccess("stop", "-f")).To(ContainSubstring("Stopped the OpenShift cluster"))
-			})
-		})
-
-		Describe("use flawed values", func() {
-
-			It("start CRC with sub-minimum memory", func() { // less than min = 9216
-				Expect(RunCRCExpectFail("start", "--memory", "9000")).To(ContainSubstring("requires memory in MiB >= 9216"))
-			})
-			It("start CRC with sub-minimum cpus", func() { // fewer than min
-				Expect(RunCRCExpectFail("start", "--cpus", "3")).To(ContainSubstring("requires CPUs >= 4"))
-			})
-			It("start CRC with smaller disk", func() { // bigger than default && smaller than current
-				switch runtime.GOOS {
-				case "darwin":
-					Expect(RunCRCExpectFail("start", "--disk-size", "35")).To(ContainSubstring("Disk resizing is not supported on macOS"))
-				case "linux":
-					Expect(RunCRCExpectFail("start", "--disk-size", "35")).To(ContainSubstring("current disk image capacity is bigger than the requested size"))
-				case "windows":
-					Expect(RunCRCExpectFail("start", "--disk-size", "35")).To(ContainSubstring("Failed to set disk size to"))
-				}
-			})
-			It("start CRC with sub-minimum disk", func() { // smaller than min = default = 31GiB
-				Expect(RunCRCExpectFail("start", "--disk-size", "30")).To(ContainSubstring("requires disk size in GiB >= 31")) // TODO: message should be different on macOS!
-			})
-		})
-
-		Describe("use default values again", func() {
-
-			It("start CRC", func() {
-				Expect(RunCRCExpectSuccess("start")).To(ContainSubstring("Started the OpenShift cluster")) // default values: "--memory", "9216", "--cpus", "4", "disk-size", "31"
-			})
-
-			It("check VM's memory size", func() {
-				out, err := SendCommandToVM("cat /proc/meminfo")
-				Expect(err).NotTo(HaveOccurred())
-				Expect(out).Should(MatchRegexp(`MemTotal:[\s]*9\d{6}`)) // there should be a check if cluster needs >9216MiB; it isn't there and mem gets scaled down regardless
-			})
-
-			It("check VM's number of cpus", func() {
-				out, err := SendCommandToVM("cat /proc/cpuinfo")
-				Expect(err).NotTo(HaveOccurred())
-				Expect(out).Should(MatchRegexp(`processor[\s]*\:[\s]*3`))
-				Expect(out).ShouldNot(MatchRegexp(`processor[\s]*\:[\s]*4`))
-			})
-
-			if runtime.GOOS != "darwin" {
-				It("check VM's disk size", func() {
-					out, err := SendCommandToVM("df -h | grep sysroot")
-					Expect(err).NotTo(HaveOccurred())
-					Expect(out).Should(MatchRegexp(`.*40G[\s].*[\s]/sysroot`))
-				})
+		It("start CRC", func() {
+			// default values: "--memory", "9216", "--cpus", "4", "disk-size", "31"
+			if bundlePath == "embedded" {
+				Expect(RunCRCExpectSuccess("start", "-p", pullSecretPath)).To(ContainSubstring("Started the OpenShift cluster"))
+			} else {
+				Expect(RunCRCExpectSuccess("start", "-b", bundlePath, "-p", pullSecretPath)).To(ContainSubstring("Started the OpenShift cluster"))
 			}
-
-			It("clean up", func() {
-				RunCRCExpectSuccess("stop", "-f")
-				RunCRCExpectSuccess("delete", "-f")
-				RunCRCExpectSuccess("cleanup")
-
-			})
 		})
-	*/
+
+		It("check VM's memory size", func() {
+			out, err := SendCommandToVM("cat /proc/meminfo", "192.168.130.11", "22")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(out).Should(MatchRegexp(`MemTotal:[\s]*9\d{6}`))
+		})
+
+		It("check VM's number of cpus", func() {
+			out, err := SendCommandToVM("cat /proc/cpuinfo", "192.168.130.11", "22")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(out).Should(MatchRegexp(`processor[\s]*\:[\s]*3`))
+			Expect(out).ShouldNot(MatchRegexp(`processor[\s]*\:[\s]*4`))
+		})
+
+		It("check VM's disk size", func() {
+			out, err := SendCommandToVM("df -h | grep sysroot", "192.168.130.11", "22")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(out).Should(MatchRegexp(`.*31G[\s].*[\s]/sysroot`))
+		})
+
+		It("stop CRC", func() {
+			Expect(RunCRCExpectSuccess("stop", "-f")).To(ContainSubstring("Stopped the OpenShift cluster"))
+		})
+
+	})
+
+	Describe("use custom values", func() {
+
+		It("start CRC", func() {
+			if runtime.GOOS == "darwin" {
+				Expect(RunCRCExpectFail("start", "--memory", "12000", "--cpus", "6", "--disk-size", "40")).To(ContainSubstring("Disk resizing is not supported on macOS"))
+				Expect(RunCRCExpectSuccess("start", "--memory", "12000", "--cpus", "6")).To(ContainSubstring("Started the OpenShift cluster"))
+			} else {
+				Expect(RunCRCExpectSuccess("start", "--memory", "12000", "--cpus", "6", "--disk-size", "40")).To(ContainSubstring("Started the OpenShift cluster"))
+			}
+		})
+
+		It("check VM's memory size", func() {
+			out, err := SendCommandToVM("cat /proc/meminfo", "192.168.130.11", "22")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(out).Should(MatchRegexp(`MemTotal:[\s]*11\d{6}`))
+		})
+
+		It("check VM's number of cpus", func() {
+			out, err := SendCommandToVM("cat /proc/cpuinfo", "192.168.130.11", "22")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(out).Should(MatchRegexp(`processor[\s]*\:[\s]*5`))
+			Expect(out).ShouldNot(MatchRegexp(`processor[\s]*\:[\s]*6`))
+		})
+
+		It("check VM's disk size", func() {
+			out, err := SendCommandToVM("df -h | grep sysroot", "192.168.130.11", "22")
+			Expect(err).NotTo(HaveOccurred())
+			if runtime.GOOS == "darwin" { // darwin does not support resize
+				Expect(out).Should(MatchRegexp(`.*31G[\s].*[\s]/sysroot`))
+			} else {
+				Expect(out).Should(MatchRegexp(`.*40G[\s].*[\s]/sysroot`))
+			}
+		})
+
+		It("stop CRC", func() {
+			Expect(RunCRCExpectSuccess("stop", "-f")).To(ContainSubstring("Stopped the OpenShift cluster"))
+		})
+	})
+
+	Describe("use flawed values", func() {
+
+		It("start CRC with sub-minimum memory", func() { // less than min = 9216
+			Expect(RunCRCExpectFail("start", "--memory", "9000")).To(ContainSubstring("requires memory in MiB >= 9216"))
+		})
+		It("start CRC with sub-minimum cpus", func() { // fewer than min
+			Expect(RunCRCExpectFail("start", "--cpus", "3")).To(ContainSubstring("requires CPUs >= 4"))
+		})
+		It("start CRC with smaller disk", func() { // bigger than default && smaller than current
+			switch runtime.GOOS {
+			case "darwin":
+				Expect(RunCRCExpectFail("start", "--disk-size", "35")).To(ContainSubstring("Disk resizing is not supported on macOS"))
+			case "linux":
+				Expect(RunCRCExpectFail("start", "--disk-size", "35")).To(ContainSubstring("current disk image capacity is bigger than the requested size"))
+			case "windows":
+				Expect(RunCRCExpectFail("start", "--disk-size", "35")).To(ContainSubstring("Failed to set disk size to"))
+			}
+		})
+		It("start CRC with sub-minimum disk", func() { // smaller than min = default = 31GiB
+			Expect(RunCRCExpectFail("start", "--disk-size", "30")).To(ContainSubstring("requires disk size in GiB >= 31")) // TODO: message should be different on macOS!
+		})
+	})
+
+	Describe("use default values again", func() {
+
+		It("start CRC", func() {
+			Expect(RunCRCExpectSuccess("start")).To(ContainSubstring("Started the OpenShift cluster")) // default values: "--memory", "9216", "--cpus", "4", "disk-size", "31"
+		})
+
+		It("check VM's memory size", func() {
+			out, err := SendCommandToVM("cat /proc/meminfo", "192.168.130.11", "22")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(out).Should(MatchRegexp(`MemTotal:[\s]*9\d{6}`)) // there should be a check if cluster needs >9216MiB; it isn't there and mem gets scaled down regardless
+		})
+
+		It("check VM's number of cpus", func() {
+			out, err := SendCommandToVM("cat /proc/cpuinfo", "192.168.130.11", "22")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(out).Should(MatchRegexp(`processor[\s]*\:[\s]*3`))
+			Expect(out).ShouldNot(MatchRegexp(`processor[\s]*\:[\s]*4`))
+		})
+
+		if runtime.GOOS != "darwin" {
+			It("check VM's disk size", func() {
+				out, err := SendCommandToVM("df -h | grep sysroot", "192.168.130.11", "22")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(out).Should(MatchRegexp(`.*40G[\s].*[\s]/sysroot`))
+			})
+		}
+
+		It("clean up", func() {
+			RunCRCExpectSuccess("stop", "-f")
+			RunCRCExpectSuccess("delete", "-f")
+			RunCRCExpectSuccess("cleanup")
+
+		})
+	})
 })

--- a/test/integration/resize_test.go
+++ b/test/integration/resize_test.go
@@ -1,148 +1,147 @@
 package test_test
 
 import (
-	"runtime"
-
 	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
+	//. "github.com/onsi/gomega"
 )
 
 var _ = Describe("vary VM parameters: memory cpus, disk", func() {
+	/*
+		Describe("use default values", func() {
 
-	Describe("use default values", func() {
+			It("setup CRC", func() {
+				Expect(RunCRCExpectSuccess("setup")).To(ContainSubstring("Your system is correctly setup for using CodeReady Containers"))
+			})
 
-		It("setup CRC", func() {
-			Expect(RunCRCExpectSuccess("setup")).To(ContainSubstring("Your system is correctly setup for using CodeReady Containers"))
-		})
+			It("start CRC", func() {
+				// default values: "--memory", "9216", "--cpus", "4", "disk-size", "31"
+				if bundlePath == "embedded" {
+					Expect(RunCRCExpectSuccess("start", "-p", pullSecretPath)).To(ContainSubstring("Started the OpenShift cluster"))
+				} else {
+					Expect(RunCRCExpectSuccess("start", "-b", bundlePath, "-p", pullSecretPath)).To(ContainSubstring("Started the OpenShift cluster"))
+				}
+			})
 
-		It("start CRC", func() {
-			// default values: "--memory", "9216", "--cpus", "4", "disk-size", "31"
-			if bundlePath == "embedded" {
-				Expect(RunCRCExpectSuccess("start", "-p", pullSecretPath)).To(ContainSubstring("Started the OpenShift cluster"))
-			} else {
-				Expect(RunCRCExpectSuccess("start", "-b", bundlePath, "-p", pullSecretPath)).To(ContainSubstring("Started the OpenShift cluster"))
-			}
-		})
+			It("check VM's memory size", func() {
+				out, err := SendCommandToVM("cat /proc/meminfo")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(out).Should(MatchRegexp(`MemTotal:[\s]*9\d{6}`))
+			})
 
-		It("check VM's memory size", func() {
-			out, err := SendCommandToVM("cat /proc/meminfo")
-			Expect(err).NotTo(HaveOccurred())
-			Expect(out).Should(MatchRegexp(`MemTotal:[\s]*9\d{6}`))
-		})
+			It("check VM's number of cpus", func() {
+				out, err := SendCommandToVM("cat /proc/cpuinfo")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(out).Should(MatchRegexp(`processor[\s]*\:[\s]*3`))
+				Expect(out).ShouldNot(MatchRegexp(`processor[\s]*\:[\s]*4`))
+			})
 
-		It("check VM's number of cpus", func() {
-			out, err := SendCommandToVM("cat /proc/cpuinfo")
-			Expect(err).NotTo(HaveOccurred())
-			Expect(out).Should(MatchRegexp(`processor[\s]*\:[\s]*3`))
-			Expect(out).ShouldNot(MatchRegexp(`processor[\s]*\:[\s]*4`))
-		})
-
-		It("check VM's disk size", func() {
-			out, err := SendCommandToVM("df -h | grep sysroot")
-			Expect(err).NotTo(HaveOccurred())
-			Expect(out).Should(MatchRegexp(`.*31G[\s].*[\s]/sysroot`))
-		})
-
-		It("stop CRC", func() {
-			Expect(RunCRCExpectSuccess("stop", "-f")).To(ContainSubstring("Stopped the OpenShift cluster"))
-		})
-
-	})
-
-	Describe("use custom values", func() {
-
-		It("start CRC", func() {
-			if runtime.GOOS == "darwin" {
-				Expect(RunCRCExpectFail("start", "--memory", "12000", "--cpus", "6", "--disk-size", "40")).To(ContainSubstring("Disk resizing is not supported on macOS"))
-				Expect(RunCRCExpectSuccess("start", "--memory", "12000", "--cpus", "6")).To(ContainSubstring("Started the OpenShift cluster"))
-			} else {
-				Expect(RunCRCExpectSuccess("start", "--memory", "12000", "--cpus", "6", "--disk-size", "40")).To(ContainSubstring("Started the OpenShift cluster"))
-			}
-		})
-
-		It("check VM's memory size", func() {
-			out, err := SendCommandToVM("cat /proc/meminfo")
-			Expect(err).NotTo(HaveOccurred())
-			Expect(out).Should(MatchRegexp(`MemTotal:[\s]*11\d{6}`))
-		})
-
-		It("check VM's number of cpus", func() {
-			out, err := SendCommandToVM("cat /proc/cpuinfo")
-			Expect(err).NotTo(HaveOccurred())
-			Expect(out).Should(MatchRegexp(`processor[\s]*\:[\s]*5`))
-			Expect(out).ShouldNot(MatchRegexp(`processor[\s]*\:[\s]*6`))
-		})
-
-		It("check VM's disk size", func() {
-			out, err := SendCommandToVM("df -h | grep sysroot")
-			Expect(err).NotTo(HaveOccurred())
-			if runtime.GOOS == "darwin" { // darwin does not support resize
-				Expect(out).Should(MatchRegexp(`.*31G[\s].*[\s]/sysroot`))
-			} else {
-				Expect(out).Should(MatchRegexp(`.*40G[\s].*[\s]/sysroot`))
-			}
-		})
-
-		It("stop CRC", func() {
-			Expect(RunCRCExpectSuccess("stop", "-f")).To(ContainSubstring("Stopped the OpenShift cluster"))
-		})
-	})
-
-	Describe("use flawed values", func() {
-
-		It("start CRC with sub-minimum memory", func() { // less than min = 9216
-			Expect(RunCRCExpectFail("start", "--memory", "9000")).To(ContainSubstring("requires memory in MiB >= 9216"))
-		})
-		It("start CRC with sub-minimum cpus", func() { // fewer than min
-			Expect(RunCRCExpectFail("start", "--cpus", "3")).To(ContainSubstring("requires CPUs >= 4"))
-		})
-		It("start CRC with smaller disk", func() { // bigger than default && smaller than current
-			switch runtime.GOOS {
-			case "darwin":
-				Expect(RunCRCExpectFail("start", "--disk-size", "35")).To(ContainSubstring("Disk resizing is not supported on macOS"))
-			case "linux":
-				Expect(RunCRCExpectFail("start", "--disk-size", "35")).To(ContainSubstring("current disk image capacity is bigger than the requested size"))
-			case "windows":
-				Expect(RunCRCExpectFail("start", "--disk-size", "35")).To(ContainSubstring("Failed to set disk size to"))
-			}
-		})
-		It("start CRC with sub-minimum disk", func() { // smaller than min = default = 31GiB
-			Expect(RunCRCExpectFail("start", "--disk-size", "30")).To(ContainSubstring("requires disk size in GiB >= 31")) // TODO: message should be different on macOS!
-		})
-	})
-
-	Describe("use default values again", func() {
-
-		It("start CRC", func() {
-			Expect(RunCRCExpectSuccess("start")).To(ContainSubstring("Started the OpenShift cluster")) // default values: "--memory", "9216", "--cpus", "4", "disk-size", "31"
-		})
-
-		It("check VM's memory size", func() {
-			out, err := SendCommandToVM("cat /proc/meminfo")
-			Expect(err).NotTo(HaveOccurred())
-			Expect(out).Should(MatchRegexp(`MemTotal:[\s]*9\d{6}`)) // there should be a check if cluster needs >9216MiB; it isn't there and mem gets scaled down regardless
-		})
-
-		It("check VM's number of cpus", func() {
-			out, err := SendCommandToVM("cat /proc/cpuinfo")
-			Expect(err).NotTo(HaveOccurred())
-			Expect(out).Should(MatchRegexp(`processor[\s]*\:[\s]*3`))
-			Expect(out).ShouldNot(MatchRegexp(`processor[\s]*\:[\s]*4`))
-		})
-
-		if runtime.GOOS != "darwin" {
 			It("check VM's disk size", func() {
 				out, err := SendCommandToVM("df -h | grep sysroot")
 				Expect(err).NotTo(HaveOccurred())
-				Expect(out).Should(MatchRegexp(`.*40G[\s].*[\s]/sysroot`))
+				Expect(out).Should(MatchRegexp(`.*31G[\s].*[\s]/sysroot`))
 			})
-		}
 
-		It("clean up", func() {
-			RunCRCExpectSuccess("stop", "-f")
-			RunCRCExpectSuccess("delete", "-f")
-			RunCRCExpectSuccess("cleanup")
+			It("stop CRC", func() {
+				Expect(RunCRCExpectSuccess("stop", "-f")).To(ContainSubstring("Stopped the OpenShift cluster"))
+			})
 
 		})
-	})
+
+		Describe("use custom values", func() {
+
+			It("start CRC", func() {
+				if runtime.GOOS == "darwin" {
+					Expect(RunCRCExpectFail("start", "--memory", "12000", "--cpus", "6", "--disk-size", "40")).To(ContainSubstring("Disk resizing is not supported on macOS"))
+					Expect(RunCRCExpectSuccess("start", "--memory", "12000", "--cpus", "6")).To(ContainSubstring("Started the OpenShift cluster"))
+				} else {
+					Expect(RunCRCExpectSuccess("start", "--memory", "12000", "--cpus", "6", "--disk-size", "40")).To(ContainSubstring("Started the OpenShift cluster"))
+				}
+			})
+
+			It("check VM's memory size", func() {
+				out, err := SendCommandToVM("cat /proc/meminfo")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(out).Should(MatchRegexp(`MemTotal:[\s]*11\d{6}`))
+			})
+
+			It("check VM's number of cpus", func() {
+				out, err := SendCommandToVM("cat /proc/cpuinfo")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(out).Should(MatchRegexp(`processor[\s]*\:[\s]*5`))
+				Expect(out).ShouldNot(MatchRegexp(`processor[\s]*\:[\s]*6`))
+			})
+
+			It("check VM's disk size", func() {
+				out, err := SendCommandToVM("df -h | grep sysroot")
+				Expect(err).NotTo(HaveOccurred())
+				if runtime.GOOS == "darwin" { // darwin does not support resize
+					Expect(out).Should(MatchRegexp(`.*31G[\s].*[\s]/sysroot`))
+				} else {
+					Expect(out).Should(MatchRegexp(`.*40G[\s].*[\s]/sysroot`))
+				}
+			})
+
+			It("stop CRC", func() {
+				Expect(RunCRCExpectSuccess("stop", "-f")).To(ContainSubstring("Stopped the OpenShift cluster"))
+			})
+		})
+
+		Describe("use flawed values", func() {
+
+			It("start CRC with sub-minimum memory", func() { // less than min = 9216
+				Expect(RunCRCExpectFail("start", "--memory", "9000")).To(ContainSubstring("requires memory in MiB >= 9216"))
+			})
+			It("start CRC with sub-minimum cpus", func() { // fewer than min
+				Expect(RunCRCExpectFail("start", "--cpus", "3")).To(ContainSubstring("requires CPUs >= 4"))
+			})
+			It("start CRC with smaller disk", func() { // bigger than default && smaller than current
+				switch runtime.GOOS {
+				case "darwin":
+					Expect(RunCRCExpectFail("start", "--disk-size", "35")).To(ContainSubstring("Disk resizing is not supported on macOS"))
+				case "linux":
+					Expect(RunCRCExpectFail("start", "--disk-size", "35")).To(ContainSubstring("current disk image capacity is bigger than the requested size"))
+				case "windows":
+					Expect(RunCRCExpectFail("start", "--disk-size", "35")).To(ContainSubstring("Failed to set disk size to"))
+				}
+			})
+			It("start CRC with sub-minimum disk", func() { // smaller than min = default = 31GiB
+				Expect(RunCRCExpectFail("start", "--disk-size", "30")).To(ContainSubstring("requires disk size in GiB >= 31")) // TODO: message should be different on macOS!
+			})
+		})
+
+		Describe("use default values again", func() {
+
+			It("start CRC", func() {
+				Expect(RunCRCExpectSuccess("start")).To(ContainSubstring("Started the OpenShift cluster")) // default values: "--memory", "9216", "--cpus", "4", "disk-size", "31"
+			})
+
+			It("check VM's memory size", func() {
+				out, err := SendCommandToVM("cat /proc/meminfo")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(out).Should(MatchRegexp(`MemTotal:[\s]*9\d{6}`)) // there should be a check if cluster needs >9216MiB; it isn't there and mem gets scaled down regardless
+			})
+
+			It("check VM's number of cpus", func() {
+				out, err := SendCommandToVM("cat /proc/cpuinfo")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(out).Should(MatchRegexp(`processor[\s]*\:[\s]*3`))
+				Expect(out).ShouldNot(MatchRegexp(`processor[\s]*\:[\s]*4`))
+			})
+
+			if runtime.GOOS != "darwin" {
+				It("check VM's disk size", func() {
+					out, err := SendCommandToVM("df -h | grep sysroot")
+					Expect(err).NotTo(HaveOccurred())
+					Expect(out).Should(MatchRegexp(`.*40G[\s].*[\s]/sysroot`))
+				})
+			}
+
+			It("clean up", func() {
+				RunCRCExpectSuccess("stop", "-f")
+				RunCRCExpectSuccess("delete", "-f")
+				RunCRCExpectSuccess("cleanup")
+
+			})
+		})
+	*/
 })

--- a/test/testdata/host-network-access/Dockerfile
+++ b/test/testdata/host-network-access/Dockerfile
@@ -1,0 +1,10 @@
+FROM registry.access.redhat.com/ubi8/ubi-minimal
+
+WORKDIR /tmp
+
+RUN echo "hello" > index.html
+RUN microdnf install python3
+
+ENTRYPOINT ["python3", "-m", "http.server"]
+
+CMD ["8080"]


### PR DESCRIPTION
Introduces 3 tests of the config command:

1. Test the priority of the flags, config file, and default values. 
2. Test skip-check and consequent fail during start.
3. Test host-network-access with vsock mode (and eventually, not yet, podman-remote).


## Testing

Should get triggered automatically as part of `make integration` and run without failures. 

### NOTE

- Do more testing/polish on Windows and MacOS
- Squash some/all commits before merging

- We can eliminate 1 crc start in the host-network-access check after vsock becomes deafult
- Should test 1 more functionality when podman-remote becomes usable
