### PR TITLE
Error in Stop() doesn't necessarily mean the VM needs PowerOff() 

### DIFF
--- a/pkg/crc/api/adapter.go
+++ b/pkg/crc/api/adapter.go
@@ -88,18 +88,12 @@ func (a *Adapter) Status() client.ClusterStatusResult {
 }
 
 func (a *Adapter) Stop() client.Result {
-	vmState, err := a.Underlying.Stop()
+	_, err := a.Underlying.Stop()
 	if err != nil {
 		logging.Error(err)
-		if vmState == state.Running {
-			err := a.Underlying.PowerOff()
-			if err != nil {
-				logging.Error(err)
-				return client.Result{
-					Success: false,
-					Error:   err.Error(),
-				}
-			}
+		return client.Result{
+			Success: false,
+			Error:   err.Error(),
 		}
 	}
 	return client.Result{

--- a/pkg/crc/api/adapter.go
+++ b/pkg/crc/api/adapter.go
@@ -7,7 +7,6 @@ import (
 	"github.com/code-ready/crc/pkg/crc/logging"
 	"github.com/code-ready/crc/pkg/crc/machine"
 	"github.com/code-ready/crc/pkg/crc/machine/types"
-	"github.com/code-ready/machine/libmachine/state"
 )
 
 type AdaptedClient interface {
@@ -16,6 +15,7 @@ type AdaptedClient interface {
 	Start(ctx context.Context, startConfig types.StartConfig) client.StartResult
 	Status() client.ClusterStatusResult
 	Stop() client.Result
+	PowerOff() client.Result
 }
 
 type Adapter struct {
@@ -90,6 +90,19 @@ func (a *Adapter) Status() client.ClusterStatusResult {
 func (a *Adapter) Stop() client.Result {
 	_, err := a.Underlying.Stop()
 	if err != nil {
+		logging.Error(err)
+		return client.Result{
+			Success: false,
+			Error:   err.Error(),
+		}
+	}
+	return client.Result{
+		Success: true,
+	}
+}
+
+func (a *Adapter) PowerOff() client.Result {
+	if err := a.Underlying.PowerOff(); err != nil {
 		logging.Error(err)
 		return client.Result{
 			Success: false,

--- a/pkg/crc/api/api.go
+++ b/pkg/crc/api/api.go
@@ -51,6 +51,8 @@ func (api Server) handleRequest(req commandRequest, conn net.Conn) {
 		result = api.handler.Start(req.Args)
 	case "stop":
 		result = api.handler.Stop()
+	case "poweroff":
+		result = api.handler.PowerOff()
 	case "status":
 		result = api.handler.Status()
 	case "delete":

--- a/pkg/crc/api/api_http.go
+++ b/pkg/crc/api/api_http.go
@@ -40,6 +40,14 @@ func NewMux(config crcConfig.Storage, machine machine.Client, logger Logger, tel
 		sendResponse(w, stopResult)
 	})
 
+	mux.HandleFunc("/poweroff", func(w http.ResponseWriter, r *http.Request) {
+		if wrongHTTPMethodUsed(r, w, http.MethodPost) {
+			return
+		}
+		stopResult := handler.PowerOff()
+		sendResponse(w, stopResult)
+	})
+
 	mux.HandleFunc("/status", func(w http.ResponseWriter, r *http.Request) {
 		if wrongHTTPMethodUsed(r, w, http.MethodGet) {
 			return

--- a/pkg/crc/api/handlers.go
+++ b/pkg/crc/api/handlers.go
@@ -60,6 +60,11 @@ func (h *Handler) Stop() string {
 	return encodeStructToJSON(commandResult)
 }
 
+func (h *Handler) PowerOff() string {
+	commandResult := h.MachineClient.PowerOff()
+	return encodeStructToJSON(commandResult)
+}
+
 func (h *Handler) Start(args json.RawMessage) string {
 	var parsedArgs startArgs
 	var err error


### PR DESCRIPTION
If the user clicks 2 times on [stop] in the tray, the second call is an
error because Stop is already in progress. The user didn't ask for a
poweroff.

Also add a /api/poweroff API.