### PR TITLE
Report errors when Close() is called on a writable file

### DIFF
--- a/packaging/windows/split.go
+++ b/packaging/windows/split.go
@@ -43,5 +43,8 @@ func split(filePath string) error {
 			}
 			return err
 		}
+		if err = partFile.Close(); err != nil {
+			return err
+		}
 	}
 }

--- a/pkg/drivers/hyperv/copy.go
+++ b/pkg/drivers/hyperv/copy.go
@@ -29,5 +29,9 @@ func copyFile(src, dst string) error {
 		return err
 	}
 
-	return os.Chmod(dst, fi.Mode())
+	if err = os.Chmod(dst, fi.Mode()); err != nil {
+		return err
+	}
+
+	return out.Close()
 }

--- a/pkg/embed/embed.go
+++ b/pkg/embed/embed.go
@@ -65,5 +65,5 @@ func ExtractFromExecutable(executablePath, embedName, destFile string) error {
 	if err != nil {
 		return fmt.Errorf("Failed to copy embedded '%s' from %s to %s: %v", embedName, executablePath, destFile, err)
 	}
-	return nil
+	return writer.Close()
 }

--- a/pkg/extract/extract.go
+++ b/pkg/extract/extract.go
@@ -159,7 +159,10 @@ func uncompressFile(tarReader io.Reader, fileInfo os.FileInfo, path string, show
 	// copy over contents
 	// #nosec G110
 	_, err = io.Copy(file, reader)
-	return err
+	if err != nil {
+		return err
+	}
+	return file.Close()
 }
 
 func buildPath(baseDir, filename string) (string, error) {

--- a/pkg/os/util.go
+++ b/pkg/os/util.go
@@ -60,7 +60,7 @@ func CopyFileContents(src string, dst string, permission os.FileMode) error {
 		return fmt.Errorf("[%v] Cannot sync '%s' to '%s'", err, src, dst)
 	}
 
-	return nil
+	return destFile.Close()
 }
 
 func FileContentMatches(path string, expectedContent []byte) error {

--- a/test/extended/util/util.go
+++ b/test/extended/util/util.go
@@ -72,6 +72,11 @@ func CopyResourcesFromPath(resourcesPath string) error {
 			fmt.Printf("Error occurred syncing file: %s", err)
 			return err
 		}
+		err = dFile.Close()
+		if err != nil {
+			fmt.Printf("Error closing file: %s", err)
+			return err
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Close() can report errors which happened while writing file data to disk, so it's best not to ignore them.
See https://www.joeshaw.org/dont-defer-close-on-writable-files/ for more details.
This should not have any user visible impact expect in very rare cases (disk failures, kernel bugs, ..)