### PR TITLE
api: if an action is in progress, use this info. in the status

### DIFF
--- a/pkg/crc/machine/sync.go
+++ b/pkg/crc/machine/sync.go
@@ -163,7 +163,20 @@ func (s *Synchronized) PowerOff() error {
 }
 
 func (s *Synchronized) Status() (*types.ClusterStatusResult, error) {
-	return s.underlying.Status()
+	switch s.CurrentState() {
+	case Starting:
+		return &types.ClusterStatusResult{
+			CrcStatus:       state.Starting,
+			OpenshiftStatus: types.OpenshiftStarting,
+		}, nil
+	case Stopping, Deleting:
+		return &types.ClusterStatusResult{
+			CrcStatus:       state.Stopping,
+			OpenshiftStatus: types.OpenshiftStopping,
+		}, nil
+	default:
+		return s.underlying.Status()
+	}
 }
 
 func (s *Synchronized) IsRunning() (bool, error) {

--- a/pkg/crc/machine/types/types.go
+++ b/pkg/crc/machine/types/types.go
@@ -60,6 +60,7 @@ const (
 	OpenshiftRunning     OpenshiftStatus = "Running"
 	OpenshiftDegraded    OpenshiftStatus = "Degraded"
 	OpenshiftStopped     OpenshiftStatus = "Stopped"
+	OpenshiftStopping    OpenshiftStatus = "Stopping"
 )
 
 type ConsoleResult struct {


### PR DESCRIPTION
It improves the feedback of the tray: it says directly 'Starting' until
the machine.Start call ends.

