### PR TITLE
Always validate pull secret before storing it in keyring

### DIFF
--- a/pkg/crc/api/api_http.go
+++ b/pkg/crc/api/api_http.go
@@ -13,7 +13,6 @@ import (
 	crcConfig "github.com/code-ready/crc/pkg/crc/config"
 	"github.com/code-ready/crc/pkg/crc/logging"
 	"github.com/code-ready/crc/pkg/crc/machine"
-	"github.com/code-ready/crc/pkg/crc/validation"
 )
 
 func NewMux(config crcConfig.Storage, machine machine.Client, logger Logger, telemetry Telemetry) http.Handler {
@@ -98,10 +97,6 @@ func pullSecretHandler(config crcConfig.Storage) func(w http.ResponseWriter, r *
 		if r.Method == http.MethodPost {
 			bin, err := ioutil.ReadAll(r.Body)
 			if err != nil {
-				http.Error(w, err.Error(), http.StatusBadRequest)
-				return
-			}
-			if err := validation.ImagePullSecret(string(bin)); err != nil {
 				http.Error(w, err.Error(), http.StatusBadRequest)
 				return
 			}

--- a/pkg/crc/cluster/pullsecret.go
+++ b/pkg/crc/cluster/pullsecret.go
@@ -131,6 +131,11 @@ func loadFromKeyring() (string, error) {
 
 func StoreInKeyring(pullSecret string) error {
 	var b bytes.Buffer
+
+	if err := validation.ImagePullSecret(pullSecret); err != nil {
+		return err
+	}
+
 	compressor := gzip.NewWriter(&b)
 	if _, err := compressor.Write([]byte(pullSecret)); err != nil {
 		return err

--- a/pkg/crc/cluster/pullsecret_test.go
+++ b/pkg/crc/cluster/pullsecret_test.go
@@ -15,6 +15,7 @@ const (
 	secret1 = `{"auths":{"quay.io":{"auth":"secret1"}}}` // #nosec G101
 	secret2 = `{"auths":{"quay.io":{"auth":"secret2"}}}` // #nosec G101
 	secret3 = `{"auths":{"quay.io":{"auth":"secret3"}}}` // #nosec G101
+	secret4 = `{`
 )
 
 func TestLoadPullSecret(t *testing.T) {
@@ -54,4 +55,6 @@ func TestLoadPullSecret(t *testing.T) {
 	val, err = loader.Value()
 	assert.NoError(t, err)
 	assert.Equal(t, secret1, val)
+
+	assert.Error(t, StoreInKeyring(secret4))
 }


### PR DESCRIPTION
Better to do the validation once before saving the pull secret, rather
than expecting all callers of StoreInKeyring to do the validation
themselves.



## Proposed changes

This should not have any user visible change, except for a changed status code in the HTTP API when the pull secret is invalid.