### PR TITLE
Add config option to set kubeadmin password for cluster

### DIFF
--- a/cmd/crc/cmd/start.go
+++ b/cmd/crc/cmd/start.go
@@ -66,12 +66,13 @@ func runStart(ctx context.Context) (*types.StartResult, error) {
 	checkIfNewVersionAvailable(config.Get(crcConfig.DisableUpdateCheck).AsBool())
 
 	startConfig := types.StartConfig{
-		BundlePath: config.Get(crcConfig.Bundle).AsString(),
-		Memory:     config.Get(crcConfig.Memory).AsInt(),
-		DiskSize:   config.Get(crcConfig.DiskSize).AsInt(),
-		CPUs:       config.Get(crcConfig.CPUs).AsInt(),
-		NameServer: config.Get(crcConfig.NameServer).AsString(),
-		PullSecret: cluster.NewInteractivePullSecretLoader(config),
+		BundlePath:        config.Get(crcConfig.Bundle).AsString(),
+		Memory:            config.Get(crcConfig.Memory).AsInt(),
+		DiskSize:          config.Get(crcConfig.DiskSize).AsInt(),
+		CPUs:              config.Get(crcConfig.CPUs).AsInt(),
+		NameServer:        config.Get(crcConfig.NameServer).AsString(),
+		PullSecret:        cluster.NewInteractivePullSecretLoader(config),
+		KubeAdminPassword: config.Get(crcConfig.KubeAdminPassword).AsString(),
 	}
 
 	client := newMachine()

--- a/pkg/crc/api/handlers.go
+++ b/pkg/crc/api/handlers.go
@@ -89,11 +89,12 @@ func (h *Handler) Start(args json.RawMessage) string {
 
 func getStartConfig(cfg crcConfig.Storage, args client.StartConfig) types.StartConfig {
 	return types.StartConfig{
-		BundlePath: cfg.Get(crcConfig.Bundle).AsString(),
-		Memory:     cfg.Get(crcConfig.Memory).AsInt(),
-		CPUs:       cfg.Get(crcConfig.CPUs).AsInt(),
-		NameServer: cfg.Get(crcConfig.NameServer).AsString(),
-		PullSecret: cluster.NewNonInteractivePullSecretLoader(cfg, args.PullSecretFile),
+		BundlePath:        cfg.Get(crcConfig.Bundle).AsString(),
+		Memory:            cfg.Get(crcConfig.Memory).AsInt(),
+		CPUs:              cfg.Get(crcConfig.CPUs).AsInt(),
+		NameServer:        cfg.Get(crcConfig.NameServer).AsString(),
+		PullSecret:        cluster.NewNonInteractivePullSecretLoader(cfg, args.PullSecretFile),
+		KubeAdminPassword: cfg.Get(crcConfig.KubeAdminPassword).AsString(),
 	}
 }
 

--- a/pkg/crc/cluster/kubeadmin_password.go
+++ b/pkg/crc/cluster/kubeadmin_password.go
@@ -18,18 +18,20 @@ import (
 // UpdateKubeAdminUserPassword does following
 // - Create and put updated kubeadmin password to ~/.crc/machine/crc/kubeadmin-password
 // - Update the htpasswd secret
-func UpdateKubeAdminUserPassword(ocConfig oc.Config) error {
+func UpdateKubeAdminUserPassword(ocConfig oc.Config, kubeAdminPassword string) error {
+	var err error
 	kubeAdminPasswordFile := constants.GetKubeAdminPasswordPath()
 	if crcos.FileExists(kubeAdminPasswordFile) {
 		logging.Debugf("kubeadmin password has already been updated")
 		return nil
 	}
 
-	logging.Infof("Generating new password for the kubeadmin user")
-
-	kubeAdminPassword, err := GenerateRandomPasswordHash(23)
-	if err != nil {
-		return fmt.Errorf("Cannot generate the kubeadmin user password: %w", err)
+	if kubeAdminPassword == "" {
+		logging.Infof("Generating new password for the kubeadmin user")
+		kubeAdminPassword, err = GenerateRandomPasswordHash(23)
+		if err != nil {
+			return fmt.Errorf("Cannot generate the kubeadmin user password: %w", err)
+		}
 	}
 
 	hashDeveloperPasswd, err := hashBcrypt("developer")

--- a/pkg/crc/config/settings.go
+++ b/pkg/crc/config/settings.go
@@ -29,6 +29,7 @@ const (
 	ConsentTelemetry        = "consent-telemetry"
 	EnableClusterMonitoring = "enable-cluster-monitoring"
 	AutostartTray           = "autostart-tray"
+	KubeAdminPassword       = "kubeadmin-password"
 )
 
 func RegisterSettings(cfg *Config) {
@@ -101,6 +102,9 @@ func RegisterSettings(cfg *Config) {
 	// Telemeter Configuration
 	cfg.AddSetting(ConsentTelemetry, "", ValidateYesNo, SuccessfullyApplied,
 		"Consent to collection of anonymous usage data (yes/no)")
+
+	cfg.AddSetting(KubeAdminPassword, "", ValidateString, SuccessfullyApplied,
+		"User defined kubeadmin password")
 }
 
 func defaultNetworkMode() network.Mode {

--- a/pkg/crc/config/validations.go
+++ b/pkg/crc/config/validations.go
@@ -20,6 +20,13 @@ func ValidateBool(value interface{}) (bool, string) {
 	return true, ""
 }
 
+func ValidateString(value interface{}) (bool, string) {
+	if _, err := cast.ToStringE(value); err != nil {
+		return false, "must be a valid string"
+	}
+	return true, ""
+}
+
 // ValidateDiskSize checks if provided disk size is valid in the config
 func ValidateDiskSize(value interface{}) (bool, string) {
 	diskSize, err := cast.ToIntE(value)

--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -388,7 +388,7 @@ func (client *client) Start(ctx context.Context, startConfig types.StartConfig) 
 		return nil, errors.Wrap(err, "Failed to update cluster pull secret")
 	}
 
-	if err := cluster.UpdateKubeAdminUserPassword(ocConfig); err != nil {
+	if err := cluster.UpdateKubeAdminUserPassword(ocConfig, startConfig.KubeAdminPassword); err != nil {
 		return nil, errors.Wrap(err, "Failed to update kubeadmin user password")
 	}
 

--- a/pkg/crc/machine/types/types.go
+++ b/pkg/crc/machine/types/types.go
@@ -20,6 +20,9 @@ type StartConfig struct {
 
 	// User Pull secret
 	PullSecret cluster.PullSecretLoader
+
+	// User defined kubeadmin password
+	KubeAdminPassword string
 }
 
 type ClusterConfig struct {


### PR DESCRIPTION
This patch will provides an option to set kubeadmin password for
the user.
```
$ crc config set kubeadmin-password mypassword
$ crc start
[...]
INFO Adding crc-admin and crc-developer contexts to kubeconfig...
Started the OpenShift cluster.

The server is accessible via web console at:
  https://console-openshift-console.apps-crc.testing

Log in as administrator:
  Username: kubeadmin
  Password: mypassword
```

fixes: #2346
