### PR TITLE
Configure ssh connection to timeout after 30s. Use 5s timeout for crc status.

### DIFF
--- a/pkg/crc/machine/status.go
+++ b/pkg/crc/machine/status.go
@@ -2,6 +2,7 @@ package machine
 
 import (
 	"context"
+	"time"
 
 	"github.com/code-ready/crc/pkg/crc/cluster"
 	"github.com/code-ready/crc/pkg/crc/constants"
@@ -66,7 +67,8 @@ func (client *client) getDiskDetails(ip string, bundle *bundle.CrcBundleInfo) (i
 			return nil, errors.Wrap(err, "Error creating the ssh client")
 		}
 		defer sshRunner.Close()
-		diskSize, diskUse, err := cluster.GetRootPartitionUsage(sshRunner)
+		sshRunnerWithTimeout := sshRunner.WithTimeout(5 * time.Second)
+		diskSize, diskUse, err := cluster.GetRootPartitionUsage(sshRunnerWithTimeout)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/crc/ssh/client.go
+++ b/pkg/crc/ssh/client.go
@@ -24,7 +24,7 @@ type NativeClient struct {
 	Port     int
 	Keys     []string
 
-	conn *ssh.Client
+	sshClient *ssh.Client
 }
 
 func NewClient(user string, host string, port int, keys ...string) (Client, error) {
@@ -72,18 +72,18 @@ func clientConfig(user string, keys []string) (*ssh.ClientConfig, error) {
 }
 
 func (client *NativeClient) session() (*ssh.Session, error) {
-	if client.conn == nil {
+	if client.sshClient == nil {
 		var err error
 		config, err := clientConfig(client.User, client.Keys)
 		if err != nil {
 			return nil, fmt.Errorf("Error getting config for native Go SSH: %s", err)
 		}
-		client.conn, err = ssh.Dial("tcp", net.JoinHostPort(client.Hostname, strconv.Itoa(client.Port)), config)
+		client.sshClient, err = ssh.Dial("tcp", net.JoinHostPort(client.Hostname, strconv.Itoa(client.Port)), config)
 		if err != nil {
 			return nil, err
 		}
 	}
-	session, err := client.conn.NewSession()
+	session, err := client.sshClient.NewSession()
 	if err != nil {
 		return nil, err
 	}
@@ -110,10 +110,10 @@ func (client *NativeClient) Run(command string) ([]byte, []byte, error) {
 }
 
 func (client *NativeClient) Close() {
-	if client.conn == nil {
+	if client.sshClient == nil {
 		return
 	}
-	err := client.conn.Close()
+	err := client.sshClient.Close()
 	if err != nil {
 		log.Debugf("Error closing ssh client: %s", err)
 	}


### PR DESCRIPTION
I am not really a big fan of the solution but at least "it works". `crc status` should not hang anymore.

If `RunWithTimeout` times out, the next call will fail with "connection closed" error. I believe we should try to reconnect ?
Also, I realize the code with conn/sshClient is not really thread safe.. I am open to all suggestions :)

This loop below triggers the timeout (with zsh):
```
$ repeat 1000 time crc status                                                  
CRC VM:          Running
OpenShift:       Running (v4.7.11)
Disk Usage:      12.28GB of 32.74GB (Inside the CRC VM)
Cache Usage:     47.73GB
Cache Directory: /home/guillaumerose/.crc/cache
crc status  0.09s user 0.02s system 18% cpu 0.586 total
CRC VM:          Running
OpenShift:       Running (v4.7.11)
Disk Usage:      12.28GB of 32.74GB (Inside the CRC VM)
Cache Usage:     47.73GB
Cache Directory: /home/guillaumerose/.crc/cache
crc status  0.09s user 0.02s system 17% cpu 0.617 total
CRC VM:          Running
OpenShift:       Running (v4.7.11)
Disk Usage:      12.28GB of 32.74GB (Inside the CRC VM)
Cache Usage:     47.73GB
Cache Directory: /home/guillaumerose/.crc/cache
crc status  0.08s user 0.02s system 18% cpu 0.585 total
CRC VM:          Running
OpenShift:       Running (v4.7.11)
Disk Usage:      12.28GB of 32.74GB (Inside the CRC VM)
Cache Usage:     47.73GB
Cache Directory: /home/guillaumerose/.crc/cache
crc status  0.07s user 0.02s system 26% cpu 0.345 total
CRC VM:          Running
OpenShift:       Unreachable (v4.7.11)
Disk Usage:      0B of 0B (Inside the CRC VM)
Cache Usage:     47.73GB
Cache Directory: /home/guillaumerose/.crc/cache
crc status  0.08s user 0.02s system 1% cpu 5.122 total
CRC VM:          Running
OpenShift:       Unreachable (v4.7.11)
Disk Usage:      0B of 0B (Inside the CRC VM)
Cache Usage:     47.73GB
Cache Directory: /home/guillaumerose/.crc/cache
crc status  0.08s user 0.02s system 1% cpu 5.133 total

```