### PR TITLE
Remove windows tray from experimental and enable it by default when using the msi to install

### DIFF
--- a/pkg/crc/config/settings.go
+++ b/pkg/crc/config/settings.go
@@ -33,8 +33,8 @@ const (
 
 func RegisterSettings(cfg *Config) {
 	validateTrayAutostart := func(value interface{}) (bool, string) {
-		if runtime.GOOS != "darwin" {
-			return false, "Tray autostart is only supported on macOS"
+		if runtime.GOOS == "linux" {
+			return false, "Tray autostart is only supported on macOS and windows"
 		}
 		return ValidateBool(value)
 	}

--- a/pkg/crc/preflight/preflight_windows.go
+++ b/pkg/crc/preflight/preflight_windows.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/code-ready/crc/pkg/crc/network"
+	"github.com/code-ready/crc/pkg/crc/version"
 	"github.com/code-ready/crc/pkg/os/windows/powershell"
 )
 
@@ -141,7 +142,7 @@ func getAllPreflightChecks() []Check {
 	return getPreflightChecks(true, true, network.UserNetworkingMode)
 }
 
-func getPreflightChecks(experimentalFeatures bool, _ bool, networkMode network.Mode) []Check {
+func getPreflightChecks(_ bool, trayAutostart bool, networkMode network.Mode) []Check {
 	checks := []Check{}
 	checks = append(checks, genericPreflightChecks[:]...)
 	checks = append(checks, hypervPreflightChecks[:]...)
@@ -150,8 +151,7 @@ func getPreflightChecks(experimentalFeatures bool, _ bool, networkMode network.M
 		checks = append(checks, vsockChecks[:]...)
 	}
 
-	// Experimental feature
-	if experimentalFeatures {
+	if version.IsMsiBuild() && trayAutostart {
 		checks = append(checks, traySetupChecks[:]...)
 	}
 

--- a/pkg/crc/preflight/preflight_windows_test.go
+++ b/pkg/crc/preflight/preflight_windows_test.go
@@ -16,8 +16,8 @@ func TestCountConfigurationOptions(t *testing.T) {
 
 func TestCountPreflights(t *testing.T) {
 	assert.Len(t, getPreflightChecks(false, false, network.SystemNetworkingMode), 17)
-	assert.Len(t, getPreflightChecks(true, true, network.SystemNetworkingMode), 20)
+	assert.Len(t, getPreflightChecks(true, true, network.SystemNetworkingMode), 17)
 
 	assert.Len(t, getPreflightChecks(false, false, network.UserNetworkingMode), 18)
-	assert.Len(t, getPreflightChecks(true, true, network.UserNetworkingMode), 21)
+	assert.Len(t, getPreflightChecks(true, true, network.UserNetworkingMode), 18)
 }


### PR DESCRIPTION
### Proposed changes

1. User installs crc using the msi
2. runs `crc setup`
3. tray should be enabled and auto-started after reboot

The tray cannot be enabled now using the embedded `crc` binary

msi to test can be found at: https://ci.appveyor.com/api/buildjobs/t2q5ot2ep91nempt/artifacts/out%2Fwindows-amd64%2Fcrc-windows-installer.zip
