### PR TITLE
bump windows tray to v0.6.0.0 and macOS tray to v1.0.9

### DIFF
--- a/pkg/crc/version/version.go
+++ b/pkg/crc/version/version.go
@@ -31,9 +31,9 @@ var (
 const (
 	releaseInfoLink = "https://mirror.openshift.com/pub/openshift-v4/clients/crc/latest/release-info.json"
 	// Tray version to be embedded in executable
-	crcMacTrayVersion = "1.0.8"
+	crcMacTrayVersion = "1.0.9"
 	// Windows forms application version type major.minor.buildnumber.revesion
-	crcWindowsTrayVersion = "0.5.0.0"
+	crcWindowsTrayVersion = "0.6.0.0"
 )
 
 type CrcReleaseInfo struct {


### PR DESCRIPTION
https://github.com/code-ready/tray-windows/releases/tag/v0.6.0.0
https://github.com/code-ready/tray-macos/releases/tag/v1.0.9
