### PR TITLE
Bump machine-driver-libvirt to 0.13.1

### DIFF
--- a/pkg/crc/machine/libvirt/constants.go
+++ b/pkg/crc/machine/libvirt/constants.go
@@ -16,7 +16,7 @@ const (
 
 const (
 	MachineDriverCommand = "crc-driver-libvirt"
-	MachineDriverVersion = "0.13.0"
+	MachineDriverVersion = "0.13.1"
 )
 
 var (


### PR DESCRIPTION
https://github.com/code-ready/machine-driver-libvirt/releases/tag/0.13.1
