### PR TITLE
Change `crc podman-env` to use the root Podman socket

### DIFF
--- a/cmd/crc/cmd/podman_env.go
+++ b/cmd/crc/cmd/podman_env.go
@@ -8,6 +8,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var (
+	rootless bool
+)
+
 var podmanEnvCmd = &cobra.Command{
 	Use:   "podman-env",
 	Short: "Setup podman environment",
@@ -33,18 +37,24 @@ func runPodmanEnv() error {
 		return err
 	}
 
+	socket := "/run/podman/podman.sock"
+	if rootless {
+		socket = "/run/user/1000/podman/podman.sock"
+	}
 	fmt.Println(shell.GetPathEnvString(userShell, constants.CrcOcBinDir))
 	fmt.Println(shell.GetEnvString(userShell, "CONTAINER_SSHKEY", connectionDetails.SSHKeys[0]))
 	fmt.Println(shell.GetEnvString(userShell, "CONTAINER_HOST",
-		fmt.Sprintf("ssh://%s@%s:%d/run/user/1000/podman/podman.sock",
+		fmt.Sprintf("ssh://%s@%s:%d%s",
 			connectionDetails.SSHUsername,
 			connectionDetails.IP,
-			connectionDetails.SSHPort)))
+			connectionDetails.SSHPort,
+			socket)))
 	fmt.Println(shell.GenerateUsageHintWithComment(userShell, "crc podman-env"))
 	return nil
 }
 
 func init() {
-	rootCmd.AddCommand(podmanEnvCmd)
+	podmanEnvCmd.Flags().BoolVar(&rootless, "rootless", false, "Use rootless podman in the virtual machine")
 	podmanEnvCmd.Flags().StringVar(&forceShell, "shell", "", "Set the environment for the specified shell: [fish, cmd, powershell, tcsh, bash, zsh]. Default is auto-detect.")
+	rootCmd.AddCommand(podmanEnvCmd)
 }

--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -304,6 +304,10 @@ func (client *client) Start(ctx context.Context, startConfig types.StartConfig) 
 		}
 	}
 
+	if _, _, err := sshRunner.RunPrivileged("make root Podman socket accessible", "chmod 777 /run/podman/ /run/podman/podman.sock"); err != nil {
+		return nil, errors.Wrap(err, "Failed to change permissions to root podman socket")
+	}
+
 	proxyConfig, err := getProxyConfig(crcBundleMetadata.ClusterInfo.BaseDomain)
 	if err != nil {
 		return nil, errors.Wrap(err, "Error getting proxy configuration")


### PR DESCRIPTION
Add a flag to choose rootless Podman.

Related to https://github.com/code-ready/crc/issues/1611