### PR TITLE
Update issue template to include triage label

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,9 +1,9 @@
 ---
-name: Bug report
-about: Create a report to help us improve
+name: "Bug report"
+about: "Create a report to help us improve"
 title: "[BUG]"
-labels: 'kind/bug'
-assignees: ''
+labels: "kind/bug, status/need triage"
+assignees: ""
 
 ---
 


### PR DESCRIPTION
This change adds a `status/need triage` label to newly created issues
