### PR TITLE
RFC: Refactor getAllPreflightChecks/getPreflightChecks

### DIFF
--- a/pkg/crc/preflight/labels.go
+++ b/pkg/crc/preflight/labels.go
@@ -1,0 +1,33 @@
+package preflight
+
+type LabelName uint32
+
+const (
+	Os LabelName = iota
+	NetworkMode
+
+	// Keep it last
+	lastLabelName // will be used in OS-specific go files to extend LabelName
+)
+
+type LabelValue uint32
+
+const (
+	// os
+	Darwin LabelValue = iota
+	Linux
+	Windows
+
+	// network mode
+	User
+	System
+
+	// Keep it last
+	lastLabelValue // will be used in OS-specific go files to extend LabelValue
+)
+
+var (
+	None = labels{}
+)
+
+type labels map[LabelName]LabelValue

--- a/pkg/crc/preflight/labels.go
+++ b/pkg/crc/preflight/labels.go
@@ -1,5 +1,11 @@
 package preflight
 
+import (
+	"runtime"
+
+	"github.com/code-ready/crc/pkg/crc/network"
+)
+
 type LabelName uint32
 
 const (
@@ -31,3 +37,57 @@ var (
 )
 
 type labels map[LabelName]LabelValue
+
+type preflightFilter map[LabelName]LabelValue
+
+func newFilter() preflightFilter {
+	switch runtime.GOOS {
+	case "darwin":
+		return preflightFilter{Os: Darwin}
+	case "linux":
+		return preflightFilter{Os: Linux}
+	case "windows":
+		return preflightFilter{Os: Windows}
+	}
+	// Should not happen
+	return preflightFilter{Os: Linux}
+}
+
+func (filter preflightFilter) SetNetworkMode(networkMode network.Mode) {
+	switch networkMode {
+	case network.SystemNetworkingMode:
+		filter[NetworkMode] = System
+	case network.UserNetworkingMode:
+		filter[NetworkMode] = User
+	}
+}
+
+/* This will iterate over 'checks' and only keep the checks which match the filter:
+ * - if a key is present in the filter and not in the check labels, the check is kept
+ * - if a key is present in the check labels, but not in the filter, the check is kept
+ * - if a key is present both in the filter and in the check labels, the check
+ *   is kept only if they have the same value, it is dropped if their values differ
+ */
+func (filter preflightFilter) Apply(checks []Check) []Check {
+	var filteredChecks []Check
+
+	for _, check := range checks {
+		if !skipCheck(check, filter) {
+			filteredChecks = append(filteredChecks, check)
+		}
+
+	}
+
+	return filteredChecks
+}
+
+func skipCheck(check Check, filter preflightFilter) bool {
+	for filterKey, filterValue := range filter {
+		checkValue, present := check.labels[filterKey]
+		if present && checkValue != filterValue {
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/crc/preflight/preflight.go
+++ b/pkg/crc/preflight/preflight.go
@@ -30,6 +30,8 @@ type Check struct {
 	flags              Flags
 	cleanupDescription string
 	cleanup            CleanUpFunc
+
+	labels labels
 }
 
 func (check *Check) getSkipConfigName() string {

--- a/pkg/crc/preflight/preflight_checks_common.go
+++ b/pkg/crc/preflight/preflight_checks_common.go
@@ -29,7 +29,7 @@ var bundleCheck = Check{
 	flags:            SetupOnly,
 }
 
-var genericPreflightChecks = [...]Check{
+var genericPreflightChecks = []Check{
 	{
 		configKeySuffix:  "check-admin-helper-cached",
 		checkDescription: "Checking if crc-admin-helper executable is cached",

--- a/pkg/crc/preflight/preflight_checks_common.go
+++ b/pkg/crc/preflight/preflight_checks_common.go
@@ -27,6 +27,8 @@ var bundleCheck = Check{
 	fixDescription:   "Extracting bundle from the CRC executable",
 	fix:              fixBundleExtracted,
 	flags:            SetupOnly,
+
+	labels: None,
 }
 
 var genericPreflightChecks = []Check{
@@ -36,6 +38,8 @@ var genericPreflightChecks = []Check{
 		check:            checkAdminHelperExecutableCached,
 		fixDescription:   "Caching crc-admin-helper executable",
 		fix:              fixAdminHelperExecutableCached,
+
+		labels: None,
 	},
 	{
 		configKeySuffix:  "check-obsolete-admin-helper",
@@ -51,6 +55,8 @@ var genericPreflightChecks = []Check{
 		check:            checkSupportedCPUArch,
 		fixDescription:   "CodeReady Containers is only supported on x86_64 hardware",
 		flags:            NoFix,
+
+		labels: None,
 	},
 	{
 		configKeySuffix:  "check-ram",
@@ -60,26 +66,36 @@ var genericPreflightChecks = []Check{
 		},
 		fixDescription: fmt.Sprintf("crc requires at least %s to run", units.HumanSize(float64(constants.DefaultMemory*1024*1024))),
 		flags:          NoFix,
+
+		labels: None,
 	},
 	{
 		cleanupDescription: "Removing CRC Machine Instance directory",
 		cleanup:            removeCRCMachinesDir,
 		flags:              CleanUpOnly,
+
+		labels: None,
 	},
 	{
 		cleanupDescription: "Removing hosts file records added by CRC",
 		cleanup:            removeHostsFileEntry,
 		flags:              CleanUpOnly,
+
+		labels: None,
 	},
 	{
 		cleanupDescription: "Removing older logs",
 		cleanup:            removeOldLogs,
 		flags:              CleanUpOnly,
+
+		labels: None,
 	},
 	{
 		cleanupDescription: "Removing pull secret from the keyring",
 		cleanup:            cluster.ForgetPullSecret,
 		flags:              CleanUpOnly,
+
+		labels: None,
 	},
 }
 

--- a/pkg/crc/preflight/preflight_checks_network_linux.go
+++ b/pkg/crc/preflight/preflight_checks_network_linux.go
@@ -21,6 +21,8 @@ var nmPreflightChecks = []Check{
 		check:            checkSystemdNetworkdIsNotRunning,
 		fixDescription:   "Network configuration with systemd-networkd is not supported. Perhaps you can try this new network mode: https://github.com/code-ready/crc/wiki/VPN-support--with-an--userland-network-stack",
 		flags:            NoFix,
+
+		labels: labels{Os: Linux, NetworkMode: System},
 	},
 	{
 		configKeySuffix:  "check-network-manager-installed",
@@ -28,6 +30,8 @@ var nmPreflightChecks = []Check{
 		check:            checkNetworkManagerInstalled,
 		fixDescription:   "NetworkManager is required and must be installed manually",
 		flags:            NoFix,
+
+		labels: labels{Os: Linux, NetworkMode: System},
 	},
 	{
 		configKeySuffix:  "check-network-manager-running",
@@ -35,6 +39,8 @@ var nmPreflightChecks = []Check{
 		check:            checkNetworkManagerIsRunning,
 		fixDescription:   "NetworkManager is required. Please make sure it is installed and running manually",
 		flags:            NoFix,
+
+		labels: labels{Os: Linux, NetworkMode: System},
 	},
 }
 
@@ -47,6 +53,8 @@ var dnsmasqPreflightChecks = []Check{
 		fix:                fixCrcNetworkManagerConfig,
 		cleanupDescription: "Removing /etc/NetworkManager/conf.d/crc-nm-dnsmasq.conf file",
 		cleanup:            removeCrcNetworkManagerConfig,
+
+		labels: labels{Os: Linux, NetworkMode: System, DNS: Dnsmasq},
 	},
 	{
 		configKeySuffix:    "check-crc-dnsmasq-file",
@@ -56,6 +64,8 @@ var dnsmasqPreflightChecks = []Check{
 		fix:                fixCrcDnsmasqConfigFile,
 		cleanupDescription: "Removing /etc/NetworkManager/dnsmasq.d/crc.conf file",
 		cleanup:            removeCrcDnsmasqConfigFile,
+
+		labels: labels{Os: Linux, NetworkMode: System, DNS: Dnsmasq},
 	},
 }
 
@@ -107,6 +117,8 @@ var systemdResolvedPreflightChecks = []Check{
 		check:            checkCrcDnsmasqAndNetworkManagerConfigFile,
 		fixDescription:   "Removing dnsmasq configuration file for NetworkManager",
 		fix:              fixCrcDnsmasqAndNetworkManagerConfigFile,
+
+		labels: labels{Os: Linux, NetworkMode: System, DNS: SystemdResolved},
 	},
 	{
 		configKeySuffix:  "check-systemd-resolved-running",
@@ -114,6 +126,8 @@ var systemdResolvedPreflightChecks = []Check{
 		check:            checkSystemdResolvedIsRunning,
 		fixDescription:   "systemd-resolved is required on this distribution. Please make sure it is installed and running manually",
 		flags:            NoFix,
+
+		labels: labels{Os: Linux, NetworkMode: System, DNS: SystemdResolved},
 	},
 	{
 		configKeySuffix:    "check-network-manager-dispatcher-file",
@@ -123,6 +137,8 @@ var systemdResolvedPreflightChecks = []Check{
 		fix:                fixCrcNetworkManagerDispatcherFile,
 		cleanupDescription: fmt.Sprintf("Removing %s file", crcNetworkManagerDispatcherPath),
 		cleanup:            removeCrcNetworkManagerDispatcherFile,
+
+		labels: labels{Os: Linux, NetworkMode: System, DNS: SystemdResolved},
 	},
 }
 

--- a/pkg/crc/preflight/preflight_checks_network_linux.go
+++ b/pkg/crc/preflight/preflight_checks_network_linux.go
@@ -14,7 +14,7 @@ import (
 	crcos "github.com/code-ready/crc/pkg/os"
 )
 
-var nmPreflightChecks = [...]Check{
+var nmPreflightChecks = []Check{
 	{
 		configKeySuffix:  "check-systemd-networkd-running",
 		checkDescription: "Checking if systemd-networkd is running",
@@ -38,7 +38,7 @@ var nmPreflightChecks = [...]Check{
 	},
 }
 
-var dnsmasqPreflightChecks = [...]Check{
+var dnsmasqPreflightChecks = []Check{
 	{
 		configKeySuffix:    "check-network-manager-config",
 		checkDescription:   "Checking if /etc/NetworkManager/conf.d/crc-nm-dnsmasq.conf exists",
@@ -100,7 +100,7 @@ exit 0
 `
 )
 
-var systemdResolvedPreflightChecks = [...]Check{
+var systemdResolvedPreflightChecks = []Check{
 	{
 		configKeySuffix:  "check-dnsmasq-network-manager-config",
 		checkDescription: "Checking if dnsmasq configurations file exist for NetworkManager",

--- a/pkg/crc/preflight/preflight_checks_nonwin.go
+++ b/pkg/crc/preflight/preflight_checks_nonwin.go
@@ -12,7 +12,7 @@ import (
 	crcos "github.com/code-ready/crc/pkg/os"
 )
 
-var nonWinPreflightChecks = [...]Check{
+var nonWinPreflightChecks = []Check{
 	{
 		configKeySuffix:  "check-root-user",
 		checkDescription: "Checking if running as non-root",

--- a/pkg/crc/preflight/preflight_checks_nonwin.go
+++ b/pkg/crc/preflight/preflight_checks_nonwin.go
@@ -19,6 +19,9 @@ var nonWinPreflightChecks = []Check{
 		check:            checkIfRunningAsNormalUser,
 		fixDescription:   "crc should not be run as root",
 		flags:            NoFix,
+
+		// no need for an "os" label as this is only built on relevant OSes through the use of golang build tags
+		labels: None,
 	},
 }
 

--- a/pkg/crc/preflight/preflight_darwin.go
+++ b/pkg/crc/preflight/preflight_darwin.go
@@ -84,6 +84,13 @@ var traySetupChecks = []Check{
 	},
 }
 
+// We want all preflight checks including
+// - experimental checks
+// - tray checks when using an installer, regardless of tray enabled or not
+// - both user and system networking checks
+//
+// Passing 'SystemNetworkingMode' to getPreflightChecks currently achieves this
+// as there are no user networking specific checks
 func getAllPreflightChecks() []Check {
 	return getPreflightChecks(true, true, network.SystemNetworkingMode)
 }

--- a/pkg/crc/preflight/preflight_darwin.go
+++ b/pkg/crc/preflight/preflight_darwin.go
@@ -16,6 +16,8 @@ func hyperkitPreflightChecks(networkMode network.Mode) []Check {
 			check:            checkM1CPU,
 			fixDescription:   "CodeReady Containers is unsupported on Apple M1 hardware",
 			flags:            NoFix,
+
+			labels: labels{Os: Darwin},
 		},
 		{
 			configKeySuffix:  "check-hyperkit-installed",
@@ -23,6 +25,8 @@ func hyperkitPreflightChecks(networkMode network.Mode) []Check {
 			check:            checkHyperKitInstalled(networkMode),
 			fixDescription:   "Setting up virtualization with HyperKit",
 			fix:              fixHyperKitInstallation(networkMode),
+
+			labels: labels{Os: Darwin},
 		},
 		{
 			configKeySuffix:  "check-hyperkit-driver",
@@ -30,11 +34,15 @@ func hyperkitPreflightChecks(networkMode network.Mode) []Check {
 			check:            checkMachineDriverHyperKitInstalled(networkMode),
 			fixDescription:   "Installing crc-machine-hyperkit",
 			fix:              fixMachineDriverHyperKitInstalled(networkMode),
+
+			labels: labels{Os: Darwin},
 		},
 		{
 			cleanupDescription: "Stopping CRC Hyperkit process",
 			cleanup:            stopCRCHyperkitProcess,
 			flags:              CleanUpOnly,
+
+			labels: labels{Os: Darwin},
 		},
 	}
 }
@@ -48,6 +56,8 @@ var resolverPreflightChecks = []Check{
 		fix:                fixResolverFilePermissions,
 		cleanupDescription: fmt.Sprintf("Removing %s file", resolverFile),
 		cleanup:            removeResolverFile,
+
+		labels: labels{Os: Darwin, NetworkMode: System},
 	},
 }
 
@@ -60,6 +70,8 @@ var daemonSetupChecks = []Check{
 		flags:              SetupOnly,
 		cleanupDescription: "Unload CodeReady Containers daemon",
 		cleanup:            unLoadDaemonAgent,
+
+		labels: labels{Os: Darwin},
 	},
 }
 
@@ -72,6 +84,8 @@ var traySetupChecks = []Check{
 		flags:              SetupOnly,
 		cleanupDescription: "Removing launchd configuration for tray",
 		cleanup:            removeTrayPlistFile,
+
+		labels: labels{Os: Darwin, Tray: Enabled},
 	},
 	{
 		checkDescription:   "Check if CodeReady Containers tray is running",
@@ -81,8 +95,20 @@ var traySetupChecks = []Check{
 		flags:              SetupOnly,
 		cleanupDescription: "Unload CodeReady Containers tray",
 		cleanup:            unLoadTrayAgent,
+
+		labels: labels{Os: Darwin, Tray: Enabled},
 	},
 }
+
+const (
+	Tray LabelName = iota + lastLabelName
+)
+
+const (
+	// tray
+	Enabled LabelValue = iota + lastLabelValue
+	Disabled
+)
 
 // We want all preflight checks including
 // - experimental checks

--- a/pkg/crc/preflight/preflight_darwin.go
+++ b/pkg/crc/preflight/preflight_darwin.go
@@ -129,22 +129,24 @@ func getAllPreflightChecks() []Check {
 	return getPreflightChecks(true, true, network.SystemNetworkingMode)
 }
 
-func getPreflightChecks(experimentalFeatures bool, trayAutostart bool, mode network.Mode) []Check {
+func getChecks(mode network.Mode) []Check {
 	checks := []Check{}
 
 	checks = append(checks, nonWinPreflightChecks...)
 	checks = append(checks, genericPreflightChecks...)
 	checks = append(checks, hyperkitPreflightChecks(mode)...)
 	checks = append(checks, daemonSetupChecks...)
-
-	if mode == network.SystemNetworkingMode {
-		checks = append(checks, resolverPreflightChecks...)
-	}
-
-	if version.IsMacosInstallPathSet() && trayAutostart {
-		checks = append(checks, traySetupChecks...)
-	}
-
+	checks = append(checks, resolverPreflightChecks...)
+	checks = append(checks, traySetupChecks...)
 	checks = append(checks, bundleCheck)
+
 	return checks
+}
+
+func getPreflightChecks(_ bool, trayAutostart bool, mode network.Mode) []Check {
+	filter := newFilter()
+	filter.SetNetworkMode(mode)
+	filter.SetTray(trayAutostart)
+
+	return filter.Apply(getChecks(mode))
 }

--- a/pkg/crc/preflight/preflight_darwin.go
+++ b/pkg/crc/preflight/preflight_darwin.go
@@ -110,6 +110,14 @@ const (
 	Disabled
 )
 
+func (filter preflightFilter) SetTray(enable bool) {
+	if version.IsMacosInstallPathSet() && enable {
+		filter[Tray] = Enabled
+	} else {
+		filter[Tray] = Disabled
+	}
+}
+
 // We want all preflight checks including
 // - experimental checks
 // - tray checks when using an installer, regardless of tray enabled or not

--- a/pkg/crc/preflight/preflight_darwin.go
+++ b/pkg/crc/preflight/preflight_darwin.go
@@ -39,7 +39,7 @@ func hyperkitPreflightChecks(networkMode network.Mode) []Check {
 	}
 }
 
-var resolverPreflightChecks = [...]Check{
+var resolverPreflightChecks = []Check{
 	{
 		configKeySuffix:    "check-resolver-file-permissions",
 		checkDescription:   fmt.Sprintf("Checking file permissions for %s", resolverFile),
@@ -51,7 +51,7 @@ var resolverPreflightChecks = [...]Check{
 	},
 }
 
-var daemonSetupChecks = [...]Check{
+var daemonSetupChecks = []Check{
 	{
 		checkDescription:   "Checking if CodeReady Containers daemon is running",
 		check:              checkIfDaemonAgentRunning,
@@ -63,7 +63,7 @@ var daemonSetupChecks = [...]Check{
 	},
 }
 
-var traySetupChecks = [...]Check{
+var traySetupChecks = []Check{
 	{
 		checkDescription:   "Checking if launchd configuration for tray exists",
 		check:              checkIfTrayPlistFileExists,
@@ -91,17 +91,17 @@ func getAllPreflightChecks() []Check {
 func getPreflightChecks(experimentalFeatures bool, trayAutostart bool, mode network.Mode) []Check {
 	checks := []Check{}
 
-	checks = append(checks, nonWinPreflightChecks[:]...)
-	checks = append(checks, genericPreflightChecks[:]...)
+	checks = append(checks, nonWinPreflightChecks...)
+	checks = append(checks, genericPreflightChecks...)
 	checks = append(checks, hyperkitPreflightChecks(mode)...)
-	checks = append(checks, daemonSetupChecks[:]...)
+	checks = append(checks, daemonSetupChecks...)
 
 	if mode == network.SystemNetworkingMode {
-		checks = append(checks, resolverPreflightChecks[:]...)
+		checks = append(checks, resolverPreflightChecks...)
 	}
 
 	if version.IsMacosInstallPathSet() && trayAutostart {
-		checks = append(checks, traySetupChecks[:]...)
+		checks = append(checks, traySetupChecks...)
 	}
 
 	checks = append(checks, bundleCheck)

--- a/pkg/crc/preflight/preflight_linux.go
+++ b/pkg/crc/preflight/preflight_linux.go
@@ -225,6 +225,10 @@ func removeVsockCrcSettings() error {
 	return mErr
 }
 
+// We want all preflight checks
+// - matching the current distro
+// - matching the networking daemon in use (NetworkManager or systemd-resolved) regardless of user/system networking
+// - and we also want the user networking checks
 func getAllPreflightChecks() []Check {
 	usingSystemdResolved := checkSystemdResolvedIsRunning()
 	checks := getPreflightChecksForDistro(distro(), network.SystemNetworkingMode, usingSystemdResolved == nil)

--- a/pkg/crc/preflight/preflight_linux.go
+++ b/pkg/crc/preflight/preflight_linux.go
@@ -266,6 +266,22 @@ const (
 	SystemdResolved
 )
 
+func (filter preflightFilter) SetSystemdResolved(usingSystemdResolved bool) {
+	if usingSystemdResolved {
+		filter[DNS] = SystemdResolved
+	} else {
+		filter[DNS] = Dnsmasq
+	}
+}
+
+func (filter preflightFilter) SetDistro(distro *linux.OsRelease) {
+	if distroIsLike(distro, linux.Ubuntu) {
+		filter[Distro] = UbuntuLike
+	} else {
+		filter[Distro] = Other
+	}
+}
+
 // We want all preflight checks
 // - matching the current distro
 // - matching the networking daemon in use (NetworkManager or systemd-resolved) regardless of user/system networking

--- a/pkg/crc/preflight/preflight_linux.go
+++ b/pkg/crc/preflight/preflight_linux.go
@@ -104,7 +104,7 @@ var libvirtNetworkPreflightChecks = []Check{
 	},
 }
 
-var vsockPreflightChecks = Check{
+var vsockPreflightCheck = Check{
 	configKeySuffix:    "check-vsock",
 	checkDescription:   "Checking if vsock is correctly configured",
 	check:              checkVsock,
@@ -114,7 +114,7 @@ var vsockPreflightChecks = Check{
 	cleanup:            removeVsockCrcSettings,
 }
 
-var wsl2PreflightChecks = Check{
+var wsl2PreflightCheck = Check{
 	configKeySuffix:  "check-wsl2",
 	checkDescription: "Checking if running inside WSL2",
 	check:            checkRunningInsideWSL2,
@@ -228,7 +228,7 @@ func removeVsockCrcSettings() error {
 func getAllPreflightChecks() []Check {
 	usingSystemdResolved := checkSystemdResolvedIsRunning()
 	checks := getPreflightChecksForDistro(distro(), network.SystemNetworkingMode, usingSystemdResolved == nil)
-	checks = append(checks, vsockPreflightChecks)
+	checks = append(checks, vsockPreflightCheck)
 	return checks
 }
 
@@ -241,7 +241,7 @@ func getNetworkChecks(networkMode network.Mode, systemdResolved bool) []Check {
 	var checks []Check
 
 	if networkMode == network.UserNetworkingMode {
-		return append(checks, vsockPreflightChecks)
+		return append(checks, vsockPreflightCheck)
 	}
 
 	checks = append(checks, nmPreflightChecks...)
@@ -257,7 +257,7 @@ func getNetworkChecks(networkMode network.Mode, systemdResolved bool) []Check {
 func getPreflightChecksForDistro(distro *linux.OsRelease, networkMode network.Mode, systemdResolved bool) []Check {
 	var checks []Check
 	checks = append(checks, nonWinPreflightChecks...)
-	checks = append(checks, wsl2PreflightChecks)
+	checks = append(checks, wsl2PreflightCheck)
 	checks = append(checks, genericPreflightChecks...)
 	checks = append(checks, libvirtPreflightChecks(distro)...)
 	networkChecks := getNetworkChecks(networkMode, systemdResolved)

--- a/pkg/crc/preflight/preflight_linux.go
+++ b/pkg/crc/preflight/preflight_linux.go
@@ -23,6 +23,8 @@ func libvirtPreflightChecks(distro *linux.OsRelease) []Check {
 			check:            checkVirtualizationEnabled,
 			fixDescription:   "Setting up virtualization",
 			fix:              fixVirtualizationEnabled,
+
+			labels: labels{Os: Linux},
 		},
 		{
 			configKeySuffix:  "check-kvm-enabled",
@@ -30,6 +32,8 @@ func libvirtPreflightChecks(distro *linux.OsRelease) []Check {
 			check:            checkKvmEnabled,
 			fixDescription:   "Setting up KVM",
 			fix:              fixKvmEnabled,
+
+			labels: labels{Os: Linux},
 		},
 		{
 			configKeySuffix:  "check-libvirt-installed",
@@ -37,6 +41,8 @@ func libvirtPreflightChecks(distro *linux.OsRelease) []Check {
 			check:            checkLibvirtInstalled,
 			fixDescription:   "Installing libvirt service and dependencies",
 			fix:              fixLibvirtInstalled(distro),
+
+			labels: labels{Os: Linux},
 		},
 		{
 			configKeySuffix:  "check-user-in-libvirt-group",
@@ -44,6 +50,8 @@ func libvirtPreflightChecks(distro *linux.OsRelease) []Check {
 			check:            checkUserPartOfLibvirtGroup,
 			fixDescription:   "Adding user to libvirt group",
 			fix:              fixUserPartOfLibvirtGroup,
+
+			labels: labels{Os: Linux},
 		},
 		{
 			configKeySuffix:  "check-libvirt-group-active",
@@ -51,6 +59,8 @@ func libvirtPreflightChecks(distro *linux.OsRelease) []Check {
 			check:            checkCurrentGroups(distro),
 			fixDescription:   "You need to logout, re-login, and run crc setup again before the user is effectively a member of the 'libvirt' group.",
 			flags:            NoFix,
+
+			labels: labels{Os: Linux},
 		},
 		{
 			configKeySuffix:  "check-libvirt-running",
@@ -58,6 +68,8 @@ func libvirtPreflightChecks(distro *linux.OsRelease) []Check {
 			check:            checkLibvirtServiceRunning,
 			fixDescription:   "Starting libvirt service",
 			fix:              fixLibvirtServiceRunning,
+
+			labels: labels{Os: Linux},
 		},
 		{
 			configKeySuffix:  "check-libvirt-version",
@@ -65,6 +77,8 @@ func libvirtPreflightChecks(distro *linux.OsRelease) []Check {
 			check:            checkLibvirtVersion,
 			fixDescription:   fmt.Sprintf("libvirt v%s or newer is required and must be updated manually", minSupportedLibvirtVersion),
 			flags:            NoFix,
+
+			labels: labels{Os: Linux},
 		},
 		{
 			configKeySuffix:  "check-libvirt-driver",
@@ -72,11 +86,15 @@ func libvirtPreflightChecks(distro *linux.OsRelease) []Check {
 			check:            checkMachineDriverLibvirtInstalled,
 			fixDescription:   "Installing crc-driver-libvirt",
 			fix:              fixMachineDriverLibvirtInstalled,
+
+			labels: labels{Os: Linux},
 		},
 		{
 			cleanupDescription: "Removing the crc VM if exists",
 			cleanup:            removeCrcVM,
 			flags:              CleanUpOnly,
+
+			labels: labels{Os: Linux},
 		},
 	}
 	if distroIsLike(distro, linux.Ubuntu) {
@@ -94,6 +112,8 @@ var libvirtNetworkPreflightChecks = []Check{
 		fix:                fixLibvirtCrcNetworkAvailable,
 		cleanupDescription: "Removing 'crc' network from libvirt",
 		cleanup:            removeLibvirtCrcNetwork,
+
+		labels: labels{Os: Linux, NetworkMode: System},
 	},
 	{
 		configKeySuffix:  "check-crc-network-active",
@@ -101,6 +121,8 @@ var libvirtNetworkPreflightChecks = []Check{
 		check:            checkLibvirtCrcNetworkActive,
 		fixDescription:   "Starting libvirt 'crc' network",
 		fix:              fixLibvirtCrcNetworkActive,
+
+		labels: labels{Os: Linux, NetworkMode: System},
 	},
 }
 
@@ -112,6 +134,8 @@ var vsockPreflightCheck = Check{
 	fix:                fixVsock,
 	cleanupDescription: "Removing vsock configuration",
 	cleanup:            removeVsockCrcSettings,
+
+	labels: labels{Os: Linux, NetworkMode: User},
 }
 
 var wsl2PreflightCheck = Check{
@@ -120,6 +144,8 @@ var wsl2PreflightCheck = Check{
 	check:            checkRunningInsideWSL2,
 	fixDescription:   "CodeReady Containers is unsupported using WSL2",
 	flags:            NoFix,
+
+	labels: labels{Os: Linux},
 }
 
 const (
@@ -224,6 +250,21 @@ func removeVsockCrcSettings() error {
 	}
 	return mErr
 }
+
+const (
+	Distro LabelName = iota + lastLabelName
+	DNS
+)
+
+const (
+	// distro
+	UbuntuLike LabelValue = iota + lastLabelValue
+	Other
+
+	// dns
+	Dnsmasq
+	SystemdResolved
+)
 
 // We want all preflight checks
 // - matching the current distro

--- a/pkg/crc/preflight/preflight_linux.go
+++ b/pkg/crc/preflight/preflight_linux.go
@@ -85,7 +85,7 @@ func libvirtPreflightChecks(distro *linux.OsRelease) []Check {
 	return checks
 }
 
-var libvirtNetworkPreflightChecks = [...]Check{
+var libvirtNetworkPreflightChecks = []Check{
 	{
 		configKeySuffix:    "check-crc-network",
 		checkDescription:   "Checking if libvirt 'crc' network is available",
@@ -244,11 +244,11 @@ func getNetworkChecks(networkMode network.Mode, systemdResolved bool) []Check {
 		return append(checks, vsockPreflightChecks)
 	}
 
-	checks = append(checks, nmPreflightChecks[:]...)
+	checks = append(checks, nmPreflightChecks...)
 	if systemdResolved {
-		checks = append(checks, systemdResolvedPreflightChecks[:]...)
+		checks = append(checks, systemdResolvedPreflightChecks...)
 	} else {
-		checks = append(checks, dnsmasqPreflightChecks[:]...)
+		checks = append(checks, dnsmasqPreflightChecks...)
 	}
 
 	return checks
@@ -256,14 +256,14 @@ func getNetworkChecks(networkMode network.Mode, systemdResolved bool) []Check {
 
 func getPreflightChecksForDistro(distro *linux.OsRelease, networkMode network.Mode, systemdResolved bool) []Check {
 	var checks []Check
-	checks = append(checks, nonWinPreflightChecks[:]...)
+	checks = append(checks, nonWinPreflightChecks...)
 	checks = append(checks, wsl2PreflightChecks)
-	checks = append(checks, genericPreflightChecks[:]...)
+	checks = append(checks, genericPreflightChecks...)
 	checks = append(checks, libvirtPreflightChecks(distro)...)
 	networkChecks := getNetworkChecks(networkMode, systemdResolved)
 	checks = append(checks, networkChecks...)
 	if networkMode == network.SystemNetworkingMode {
-		checks = append(checks, libvirtNetworkPreflightChecks[:]...)
+		checks = append(checks, libvirtNetworkPreflightChecks...)
 	}
 	checks = append(checks, bundleCheck)
 	return checks

--- a/pkg/crc/preflight/preflight_ubuntu_linux.go
+++ b/pkg/crc/preflight/preflight_ubuntu_linux.go
@@ -23,6 +23,8 @@ var ubuntuPreflightChecks = []Check{
 		fix:                addAppArmorExceptionForQcowDisks(ioutil.ReadFile, crcos.WriteToFileAsRoot),
 		cleanupDescription: "Cleaning up AppArmor configuration",
 		cleanup:            removeAppArmorExceptionForQcowDisks(ioutil.ReadFile, crcos.WriteToFileAsRoot),
+
+		labels: labels{Os: Linux, Distro: UbuntuLike},
 	},
 }
 

--- a/pkg/crc/preflight/preflight_windows.go
+++ b/pkg/crc/preflight/preflight_windows.go
@@ -10,7 +10,7 @@ import (
 	"github.com/code-ready/crc/pkg/os/windows/powershell"
 )
 
-var hypervPreflightChecks = [...]Check{
+var hypervPreflightChecks = []Check{
 	{
 		configKeySuffix:  "check-administrator-user",
 		checkDescription: "Checking if running in a shell with administrator rights",
@@ -72,7 +72,7 @@ var hypervPreflightChecks = [...]Check{
 	},
 }
 
-var traySetupChecks = [...]Check{
+var traySetupChecks = []Check{
 	{
 		checkDescription:   "Checking if CodeReady Containers daemon is installed",
 		check:              checkIfDaemonInstalled,
@@ -100,7 +100,7 @@ var traySetupChecks = [...]Check{
 	},
 }
 
-var vsockChecks = [...]Check{
+var vsockChecks = []Check{
 	{
 		configKeySuffix:  "check-vsock",
 		checkDescription: "Checking if vsock is correctly configured",
@@ -144,15 +144,15 @@ func getAllPreflightChecks() []Check {
 
 func getPreflightChecks(_ bool, trayAutostart bool, networkMode network.Mode) []Check {
 	checks := []Check{}
-	checks = append(checks, genericPreflightChecks[:]...)
-	checks = append(checks, hypervPreflightChecks[:]...)
+	checks = append(checks, genericPreflightChecks...)
+	checks = append(checks, hypervPreflightChecks...)
 
 	if networkMode == network.UserNetworkingMode {
-		checks = append(checks, vsockChecks[:]...)
+		checks = append(checks, vsockChecks...)
 	}
 
 	if version.IsMsiBuild() && trayAutostart {
-		checks = append(checks, traySetupChecks[:]...)
+		checks = append(checks, traySetupChecks...)
 	}
 
 	checks = append(checks, bundleCheck)

--- a/pkg/crc/preflight/preflight_windows.go
+++ b/pkg/crc/preflight/preflight_windows.go
@@ -138,6 +138,13 @@ func fixVsock() error {
 	return err
 }
 
+// We want all preflight checks including
+// - experimental checks
+// - tray checks when using an installer, regardless of tray enabled or not
+// - both user and system networking checks
+//
+// Passing 'UserNetworkingMode' to getPreflightChecks currently achieves this
+// as there are no system networking specific checks
 func getAllPreflightChecks() []Check {
 	return getPreflightChecks(true, true, network.UserNetworkingMode)
 }

--- a/pkg/crc/preflight/preflight_windows.go
+++ b/pkg/crc/preflight/preflight_windows.go
@@ -174,6 +174,14 @@ const (
 	Disabled
 )
 
+func (filter preflightFilter) SetTray(enable bool) {
+	if version.IsMsiBuild() && enable {
+		filter[Tray] = Enabled
+	} else {
+		filter[Tray] = Disabled
+	}
+}
+
 // We want all preflight checks including
 // - experimental checks
 // - tray checks when using an installer, regardless of tray enabled or not

--- a/pkg/crc/preflight/preflight_windows.go
+++ b/pkg/crc/preflight/preflight_windows.go
@@ -17,6 +17,8 @@ var hypervPreflightChecks = []Check{
 		check:            checkIfRunningAsNormalUser,
 		fixDescription:   "crc should be ran in a shell without administrator rights",
 		flags:            NoFix,
+
+		labels: labels{Os: Windows},
 	},
 	{
 		configKeySuffix:  "check-windows-version",
@@ -24,6 +26,8 @@ var hypervPreflightChecks = []Check{
 		check:            checkVersionOfWindowsUpdate,
 		fixDescription:   "Please manually update your Windows 10 installation",
 		flags:            NoFix,
+
+		labels: labels{Os: Windows},
 	},
 	{
 		configKeySuffix:  "check-windows-edition",
@@ -31,6 +35,8 @@ var hypervPreflightChecks = []Check{
 		check:            checkWindowsEdition,
 		fixDescription:   "Your Windows edition is not supported. Consider using Professional or Enterprise editions of Windows",
 		flags:            NoFix,
+
+		labels: labels{Os: Windows},
 	},
 	{
 		configKeySuffix:  "check-hyperv-installed",
@@ -38,6 +44,8 @@ var hypervPreflightChecks = []Check{
 		check:            checkHyperVInstalled,
 		fixDescription:   "Installing Hyper-V",
 		fix:              fixHyperVInstalled,
+
+		labels: labels{Os: Windows},
 	},
 	{
 		configKeySuffix:  "check-user-in-hyperv-group",
@@ -45,6 +53,8 @@ var hypervPreflightChecks = []Check{
 		check:            checkIfUserPartOfHyperVAdmins,
 		fixDescription:   "Adding user to the Hyper-V Administrators group",
 		fix:              fixUserPartOfHyperVAdmins,
+
+		labels: labels{Os: Windows},
 	},
 	{
 		configKeySuffix:  "check-hyperv-service-running",
@@ -52,6 +62,8 @@ var hypervPreflightChecks = []Check{
 		check:            checkHyperVServiceRunning,
 		fixDescription:   "Enabling Hyper-V service",
 		fix:              fixHyperVServiceRunning,
+
+		labels: labels{Os: Windows},
 	},
 	{
 		configKeySuffix:  "check-hyperv-switch",
@@ -59,16 +71,22 @@ var hypervPreflightChecks = []Check{
 		check:            checkIfHyperVVirtualSwitchExists,
 		fixDescription:   "Unable to perform Hyper-V administrative commands. Please reboot your system and run 'crc setup' to complete the setup process",
 		flags:            NoFix,
+
+		labels: labels{Os: Windows},
 	},
 	{
 		cleanupDescription: "Removing dns server from interface",
 		cleanup:            removeDNSServerAddress,
 		flags:              CleanUpOnly,
+
+		labels: labels{Os: Windows},
 	},
 	{
 		cleanupDescription: "Removing the crc VM if exists",
 		cleanup:            removeCrcVM,
 		flags:              CleanUpOnly,
+
+		labels: labels{Os: Windows},
 	},
 }
 
@@ -81,6 +99,8 @@ var traySetupChecks = []Check{
 		cleanupDescription: "Uninstalling daemon if installed",
 		cleanup:            removeDaemon,
 		flags:              SetupOnly,
+
+		labels: labels{Os: Windows, Tray: Enabled},
 	},
 	{
 		checkDescription: "Checking if tray executable is present",
@@ -88,6 +108,8 @@ var traySetupChecks = []Check{
 		fixDescription:   "Caching tray executable",
 		fix:              fixTrayExecutableExists,
 		flags:            SetupOnly,
+
+		labels: labels{Os: Windows, Tray: Enabled},
 	},
 	{
 		checkDescription:   "Checking if tray is installed",
@@ -97,6 +119,8 @@ var traySetupChecks = []Check{
 		cleanupDescription: "Uninstalling tray if installed",
 		cleanup:            removeTray,
 		flags:              SetupOnly,
+
+		labels: labels{Os: Windows, Tray: Enabled},
 	},
 }
 
@@ -107,6 +131,8 @@ var vsockChecks = []Check{
 		check:            checkVsock,
 		fixDescription:   "Checking if vsock is correctly configured",
 		fix:              fixVsock,
+
+		labels: labels{Os: Windows, NetworkMode: User},
 	},
 }
 
@@ -137,6 +163,16 @@ func fixVsock() error {
 	_, _, err := powershell.ExecuteAsAdmin("adding vsock registry key", strings.Join(cmds, ";"))
 	return err
 }
+
+const (
+	Tray LabelName = iota + lastLabelName
+)
+
+const (
+	// tray
+	Enabled LabelValue = iota + lastLabelValue
+	Disabled
+)
 
 // We want all preflight checks including
 // - experimental checks

--- a/pkg/crc/preflight/preflight_windows.go
+++ b/pkg/crc/preflight/preflight_windows.go
@@ -193,19 +193,21 @@ func getAllPreflightChecks() []Check {
 	return getPreflightChecks(true, true, network.UserNetworkingMode)
 }
 
-func getPreflightChecks(_ bool, trayAutostart bool, networkMode network.Mode) []Check {
+func getChecks() []Check {
 	checks := []Check{}
 	checks = append(checks, genericPreflightChecks...)
 	checks = append(checks, hypervPreflightChecks...)
-
-	if networkMode == network.UserNetworkingMode {
-		checks = append(checks, vsockChecks...)
-	}
-
-	if version.IsMsiBuild() && trayAutostart {
-		checks = append(checks, traySetupChecks...)
-	}
-
+	checks = append(checks, vsockChecks...)
+	checks = append(checks, traySetupChecks...)
 	checks = append(checks, bundleCheck)
+
 	return checks
+}
+
+func getPreflightChecks(_ bool, trayAutoStart bool, networkMode network.Mode) []Check {
+	filter := newFilter()
+	filter.SetNetworkMode(networkMode)
+	filter.SetTray(trayAutoStart)
+
+	return filter.Apply(getChecks())
 }


### PR DESCRIPTION
The implementation of these methods is currently a bit complicated, with the list of tests being manually generated by appending the 'right' tests depending on various parameters.
This PR tries to make this a bit easier, by adding labels to each `Check` instance in order to explicitly define when it should be used.

I tagged this as RFC to get feedback on this approach, maybe thet current way will be considered simpler, maybe this needs to be approached differently, ...

## Proposed changes

There should be no user-visible changes, exactly the same preflight as before should be run by crc setup/crc cleanup/crc start.