### PR TITLE
start: Display help message when preflights fail

### DIFF
--- a/cmd/crc/cmd/start.go
+++ b/cmd/crc/cmd/start.go
@@ -21,10 +21,10 @@ import (
 	"github.com/code-ready/crc/pkg/crc/preflight"
 	"github.com/code-ready/crc/pkg/crc/validation"
 	crcversion "github.com/code-ready/crc/pkg/crc/version"
+	crcos "github.com/code-ready/crc/pkg/os"
 	"github.com/code-ready/crc/pkg/os/shell"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	"k8s.io/client-go/util/exec"
 )
 
 func init() {
@@ -83,7 +83,7 @@ func runStart(ctx context.Context) (*types.StartResult, error) {
 		}
 
 		if err := preflight.StartPreflightChecks(config); err != nil {
-			return nil, exec.CodeExitError{
+			return nil, crcos.CodeExitError{
 				Err:  err,
 				Code: preflightFailedExitCode,
 			}

--- a/pkg/os/execerror.go
+++ b/pkg/os/execerror.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package os
+
+// ExitError is an interface that presents an API similar to os.ProcessState, which is
+// what ExitError from os/exec is.  This is designed to make testing a bit easier and
+// probably loses some of the cross-platform properties of the underlying library.
+type ExitError interface {
+	String() string
+	Error() string
+	Exited() bool
+	ExitStatus() int
+	Unwrap() error
+}
+
+// CodeExitError is an implementation of ExitError consisting of an error object
+// and an exit code (the upper bits of os.exec.ExitStatus).
+type CodeExitError struct {
+	Err  error
+	Code int
+}
+
+var _ ExitError = CodeExitError{}
+
+func (e CodeExitError) Error() string {
+	return e.Err.Error()
+}
+
+func (e CodeExitError) String() string {
+	return e.Err.Error()
+}
+
+func (e CodeExitError) Exited() bool {
+	return true
+}
+
+func (e CodeExitError) ExitStatus() int {
+	return e.Code
+}
+
+func (e CodeExitError) Unwrap() error {
+	return e.Err
+}

--- a/test/e2e/features/basic.feature
+++ b/test/e2e/features/basic.feature
@@ -39,6 +39,7 @@ Feature: Basic test
     @linux
     Scenario: CRC setup on Linux
         When executing "crc setup --check-only" fails
+        Then executing "crc start" fails
         And executing "crc setup" succeeds
         And stderr should contain "Checking if CRC bundle is extracted in '$HOME/.crc'"
         And stderr should contain "Checking if running as non-root"
@@ -56,6 +57,14 @@ Feature: Basic test
         And stderr should contain "Using root access: Executing systemctl reload NetworkManager"
         And stdout should contain "Your system is correctly setup for using CodeReady Containers, you can now run 'crc start -b $bundlename' to start the OpenShift cluster" if bundle is not embedded
         And stdout should contain "Your system is correctly setup for using CodeReady Containers, you can now run 'crc start' to start the OpenShift cluster" if bundle is embedded
+
+    @linux
+    Scenario: Missing CRC setup
+	Given executing "rm ~/.crc/bin/crc-driver-libvirt" succeeds
+        Then executing "crc setup --check-only" fails
+        And starting CRC with default bundle fails
+	And stderr should contain "Preflight checks failed during `crc start`, please try to run `crc setup` first in case you haven't done so yet"
+	And executing "crc setup" succeeds
 
     @darwin
     Scenario: CRC setup on Mac


### PR DESCRIPTION
The message instructing to run `crc setup` when one of the preflight
check failed when running `crc start` is no longer shown after commit
c1d9b48. This happens because the type of the error for preflight
failures changed. This commit adjusts the check to use the right type.


## Testing

What is the _bottom-line_ functionality that needs testing? Describe in pseudo-code or in English. Use verifiable statements that tie your changes to existing functionality.

1. Check that when one of the preflight checks is failing, crc setup fails (I used `virsh -c qemu:///system net-destroy crc && crc start`)
2. stderr contains a message instructing to run crc setup, which is not the case before this PR