### PR TITLE
Create VM auth files right after driver.Create()

### DIFF
--- a/pkg/crc/cluster/kubeadmin_password_test.go
+++ b/pkg/crc/cluster/kubeadmin_password_test.go
@@ -7,35 +7,52 @@ import (
 )
 
 func TestCompareHtpasswdWithOneUsername(t *testing.T) {
-	htpasswd, err := getHtpasswd(map[string]string{"username": "password1"})
+	htpasswd, err := getHtpasswd(map[string]string{"username": "password1"}, []string{})
 	assert.NoError(t, err)
 
-	ok, err := compareHtpasswd(htpasswd, map[string]string{"username": "password1"})
+	ok, _, err := compareHtpasswd(htpasswd, map[string]string{"username": "password1"})
 	assert.NoError(t, err)
 	assert.True(t, ok)
 
-	ok, err = compareHtpasswd(htpasswd, map[string]string{"username": "password2"})
+	ok, _, err = compareHtpasswd(htpasswd, map[string]string{"username": "password2"})
 	assert.NoError(t, err)
 	assert.False(t, ok)
 
-	ok, err = compareHtpasswd(htpasswd, map[string]string{"other": "password1"})
+	ok, _, err = compareHtpasswd(htpasswd, map[string]string{"other": "password1"})
 	assert.NoError(t, err)
 	assert.False(t, ok)
 
-	ok, err = compareHtpasswd(htpasswd, map[string]string{"username1": "password1", "username2": "password2"})
+	ok, _, err = compareHtpasswd(htpasswd, map[string]string{"username1": "password1", "username2": "password2"})
 	assert.NoError(t, err)
 	assert.False(t, ok)
 }
 
 func TestCompareHtpasswdWithTwoUsernames(t *testing.T) {
-	htpasswd, err := getHtpasswd(map[string]string{"username1": "password1", "username2": "password2"})
+	htpasswd, err := getHtpasswd(map[string]string{"username1": "password1", "username2": "password2"}, []string{})
 	assert.NoError(t, err)
 
-	ok, err := compareHtpasswd(htpasswd, map[string]string{"username1": "password1", "username2": "password2"})
+	ok, _, err := compareHtpasswd(htpasswd, map[string]string{"username1": "password1", "username2": "password2"})
 	assert.NoError(t, err)
 	assert.True(t, ok)
 
-	ok, err = compareHtpasswd(htpasswd, map[string]string{"username1": "password1", "username2": "password3"})
+	ok, _, err = compareHtpasswd(htpasswd, map[string]string{"username1": "password1", "username2": "password3"})
 	assert.NoError(t, err)
 	assert.False(t, ok)
+}
+
+func TestCompareFalseWithCustomEntries(t *testing.T) {
+	wanted := map[string]string{"username": "password"}
+
+	htpasswd, err := getHtpasswd(map[string]string{"username": "wrong", "external1": "external1", "external2": "external2"}, []string{})
+	assert.NoError(t, err)
+
+	ok, externals, err := compareHtpasswd(htpasswd, wanted)
+	assert.NoError(t, err)
+	assert.False(t, ok)
+
+	htpasswd, err = getHtpasswd(wanted, externals)
+	assert.NoError(t, err)
+	ok, _, err = compareHtpasswd(htpasswd, map[string]string{"username": "password", "external1": "external1", "external2": "external2"})
+	assert.NoError(t, err)
+	assert.True(t, ok)
 }

--- a/pkg/crc/cluster/kubeadmin_password_test.go
+++ b/pkg/crc/cluster/kubeadmin_password_test.go
@@ -1,0 +1,41 @@
+package cluster
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCompareHtpasswdWithOneUsername(t *testing.T) {
+	htpasswd, err := getHtpasswd(map[string]string{"username": "password1"})
+	assert.NoError(t, err)
+
+	ok, err := compareHtpasswd(htpasswd, map[string]string{"username": "password1"})
+	assert.NoError(t, err)
+	assert.True(t, ok)
+
+	ok, err = compareHtpasswd(htpasswd, map[string]string{"username": "password2"})
+	assert.NoError(t, err)
+	assert.False(t, ok)
+
+	ok, err = compareHtpasswd(htpasswd, map[string]string{"other": "password1"})
+	assert.NoError(t, err)
+	assert.False(t, ok)
+
+	ok, err = compareHtpasswd(htpasswd, map[string]string{"username1": "password1", "username2": "password2"})
+	assert.NoError(t, err)
+	assert.False(t, ok)
+}
+
+func TestCompareHtpasswdWithTwoUsernames(t *testing.T) {
+	htpasswd, err := getHtpasswd(map[string]string{"username1": "password1", "username2": "password2"})
+	assert.NoError(t, err)
+
+	ok, err := compareHtpasswd(htpasswd, map[string]string{"username1": "password1", "username2": "password2"})
+	assert.NoError(t, err)
+	assert.True(t, ok)
+
+	ok, err = compareHtpasswd(htpasswd, map[string]string{"username1": "password1", "username2": "password3"})
+	assert.NoError(t, err)
+	assert.False(t, ok)
+}

--- a/pkg/crc/machine/config/config.go
+++ b/pkg/crc/machine/config/config.go
@@ -14,6 +14,7 @@ type MachineConfig struct {
 	ImageSourcePath string
 	ImageFormat     string
 	SSHKeyPath      string
+	KubeConfig      string
 
 	// HyperKit specific configuration
 	KernelCmdLine string

--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -524,6 +524,9 @@ func createHost(api libmachine.API, machineConfig config.MachineConfig) error {
 		return fmt.Errorf("Error in driver during machine creation: %s", err)
 	}
 
+	if err := cluster.GenerateKubeAdminUserPassword(); err != nil {
+		return errors.Wrap(err, "Error generating new kubeadmin password")
+	}
 	if err := copyKubeconfig(machineConfig.Name, machineConfig); err != nil {
 		return errors.Wrap(err, "Error copying kubeconfig file")
 	}

--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -524,6 +524,10 @@ func createHost(api libmachine.API, machineConfig config.MachineConfig) error {
 		return fmt.Errorf("Error in driver during machine creation: %s", err)
 	}
 
+	logging.Info("Generating new SSH Key pair...")
+	if err := crcssh.GenerateSSHKey(constants.GetPrivateKeyPath()); err != nil {
+		return fmt.Errorf("Error generating ssh key pair: %v", err)
+	}
 	if err := cluster.GenerateKubeAdminUserPassword(); err != nil {
 		return errors.Wrap(err, "Error generating new kubeadmin password")
 	}
@@ -573,18 +577,6 @@ func addNameServerToInstance(sshRunner *crcssh.Runner, ns string) error {
 }
 
 func updateSSHKeyPair(sshRunner *crcssh.Runner) error {
-	if _, err := os.Stat(constants.GetPrivateKeyPath()); err != nil {
-		if !os.IsNotExist(err) {
-			return err
-		}
-
-		// Generate ssh key pair
-		logging.Info("Generating new SSH Key pair...")
-		if err := crcssh.GenerateSSHKey(constants.GetPrivateKeyPath()); err != nil {
-			return fmt.Errorf("Error generating ssh key pair: %v", err)
-		}
-	}
-
 	// Read generated public key
 	publicKey, err := ioutil.ReadFile(constants.GetPublicKeyPath())
 	if err != nil {


### PR DESCRIPTION
crc console command is available if the VM exists. 
When running crc start, there is a time frame where the VM exists but the kubeadmin password doesn't exist in the instance directory.

Now, kubeadmin password, ssh key and kubeconfig files are written right after the VM is created (driver.Create())
Right after, there is a call to `api.SetExists()`, which unlock functions like crc console.

Also,
* Refactor kubeadmin password generation to be done at creation time only
* htpasswd is changed only if needed by comparing the htpasswd file in the cluster and the wanted passwords.
