### PR TITLE
Display a more precise download link when a new version is available

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 out/
 docs/build/
 release/
+/release-info.json

--- a/Makefile
+++ b/Makefile
@@ -204,9 +204,9 @@ cross-lint: $(GOPATH)/bin/golangci-lint
 
 .PHONY: gen_release_info
 gen_release_info:
-	@cat release-info.json.sample | sed s/@CRC_VERSION@/\"$(CRC_VERSION)\"/ > $(RELEASE_INFO)
-	@sed -i s/@GIT_COMMIT_SHA@/\"$(COMMIT_SHA)\"/ $(RELEASE_INFO)
-	@sed -i s/@OPENSHIFT_VERSION@/\"$(BUNDLE_VERSION)\"/ $(RELEASE_INFO)
+	@cat release-info.json.sample | sed s/@CRC_VERSION@/$(CRC_VERSION)/ > $(RELEASE_INFO)
+	@sed -i s/@GIT_COMMIT_SHA@/$(COMMIT_SHA)/ $(RELEASE_INFO)
+	@sed -i s/@OPENSHIFT_VERSION@/$(BUNDLE_VERSION)/ $(RELEASE_INFO)
 
 .PHONY: release
 release: LDFLAGS += $(RELEASE_VERSION_VARIABLES)

--- a/cmd/crc/cmd/version.go
+++ b/cmd/crc/cmd/version.go
@@ -7,6 +7,7 @@ import (
 
 	crcConfig "github.com/code-ready/crc/pkg/crc/config"
 	"github.com/code-ready/crc/pkg/crc/constants"
+	"github.com/code-ready/crc/pkg/crc/logging"
 	crcversion "github.com/code-ready/crc/pkg/crc/version"
 	"github.com/spf13/cobra"
 )
@@ -26,7 +27,9 @@ var versionCmd = &cobra.Command{
 }
 
 func runPrintVersion(writer io.Writer, version *version, outputFormat string) error {
-	checkIfNewVersionAvailable(config.Get(crcConfig.DisableUpdateCheck).AsBool())
+	if err := checkIfNewVersionAvailable(config.Get(crcConfig.DisableUpdateCheck).AsBool()); err != nil {
+		logging.Debugf("Unable to find out if a new version is available: %v", err)
+	}
 	return render(version, writer, outputFormat)
 }
 

--- a/pkg/crc/version/version.go
+++ b/pkg/crc/version/version.go
@@ -83,7 +83,7 @@ func IsMsiBuild() bool {
 	return msiBuild != "false"
 }
 
-func getCRCLatestVersionFromMirror() (*semver.Version, error) {
+func GetCRCLatestVersionFromMirror() (*CrcReleaseInfo, error) {
 	client := &http.Client{
 		Timeout: 5 * time.Second,
 	}
@@ -107,17 +107,5 @@ func getCRCLatestVersionFromMirror() (*semver.Version, error) {
 		return nil, fmt.Errorf("Error unmarshaling JSON metadata: %v", err)
 	}
 
-	return releaseInfo.Version.CrcVersion, nil
-}
-
-func NewVersionAvailable() (bool, string, error) {
-	latestVersion, err := getCRCLatestVersionFromMirror()
-	if err != nil {
-		return false, "", err
-	}
-	currentVersion, err := semver.NewVersion(GetCRCVersion())
-	if err != nil {
-		return false, "", err
-	}
-	return latestVersion.GreaterThan(currentVersion), latestVersion.String(), nil
+	return &releaseInfo, nil
 }

--- a/release-info.json.sample
+++ b/release-info.json.sample
@@ -1,7 +1,12 @@
 {
 	"version": {
-		"crcVersion": @CRC_VERSION@,
-		"gitSha": @GIT_COMMIT_SHA@,
-		"openshiftVersion": @OPENSHIFT_VERSION@
+		"crcVersion": "@CRC_VERSION@",
+		"gitSha": "@GIT_COMMIT_SHA@",
+		"openshiftVersion": "@OPENSHIFT_VERSION@"
+	},
+	"links": {
+	    "linux": "https://developers.redhat.com/content-gateway/file/pub/openshift-v4/clients/crc/@CRC_VERSION@/crc-linux-amd64.tar.xz",
+	    "darwin": "https://developers.redhat.com/content-gateway/file/pub/openshift-v4/clients/crc/@CRC_VERSION@/crc-macos-amd64.pkg",
+	    "windows": "https://developers.redhat.com/content-gateway/file/pub/openshift-v4/clients/crc/@CRC_VERSION@/crc-windows-amd64.zip"
 	}
 }


### PR DESCRIPTION
Before:

``` 
WARN A new version (1.27.0) has been published on https://cloud.redhat.com/openshift/create/local 
```

After:

```
WARN A new version (1.27.0) has been published on https://developers.redhat.com/content-gateway/file/pub/openshift-v4/clients/crc/1.27.0/crc-linux-amd64.tar.xz 
```

The goal is to allow people to upgrade easily. Right now they have to login to the portal, etc to get the tarball. 

It is also to better control the download link:
* if someone downloads from mirror.openshift.com, we advertise the new link developers.redhat.com,
* display the link to the tarball or the installer for instance.
