### PR TITLE
Msi and tray preflight checks improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -324,7 +324,7 @@ endif
 
 $(BUILD_DIR)/windows-amd64/crc-windows-amd64.msi: msidir
 	candle.exe -arch x64 -ext WixUtilExtension -o $(PACKAGE_DIR)/msi/ $(PACKAGE_DIR)/msi/*.wxs
-	cd $(PACKAGE_DIR)/msi && light.exe -ext WixUIExtension -ext WixUtilExtension -sacl -spdb -sice:ICE61 -out ../../../$@ *.wixobj
+	cd $(PACKAGE_DIR)/msi && light.exe -ext WixUIExtension -ext WixUtilExtension -sacl -spdb -sice:ICE61 -sice:ICE69 -out ../../../$@ *.wixobj
 
 CABS_MSI = "cab1.cab,cab2.cab,cab3.cab,crc-windows-amd64.msi"
 $(BUILD_DIR)/windows-amd64/crc-windows-installer.zip: $(BUILD_DIR)/windows-amd64/crc-windows-amd64.msi

--- a/packaging/windows/product.wxs.in
+++ b/packaging/windows/product.wxs.in
@@ -59,6 +59,17 @@
                     </Component>
                 </Directory>
             </Directory>
+            <Directory Id="StartupFolder">
+                <Component Id="TrayStartup" Guid="*">
+                    <Shortcut Id="TrayStartupShortcut" 
+                     Name="CodeReady Containers"
+                     Target="[#CrcTray]"
+                     Icon="crcicon.ico"
+                     WorkingDirectory="AppDataFolder"/>
+                    <RemoveFile Id="RemoveTrayShortCut" Name="CodeReady Containers" On="uninstall"/>
+                    <RegistryValue Root="HKCU" Key="Software\Red Hat\CodeReady Containers" Name="installed" Type="integer" Value="1" KeyPath="yes"/>
+                </Component>
+            </Directory>
         </Directory>
         <SetProperty Action="CAJoinBundle"  Id="JoinBundle"  Value='"[WindowsFolder]\System32\cmd.exe" /c cd "[INSTALLDIR]" &amp;&amp; copy /b $(var.crcBundlePart0)+$(var.crcBundlePart1)+$(var.crcBundlePart2) $(var.crcBundleName)' Before="JoinBundle" Sequence="execute"/>
         <CustomAction Id="JoinBundle" BinaryKey="WixCA" DllEntry="WixQuietExec" Execute="deferred" Impersonate="no" />
@@ -81,6 +92,7 @@
             <ComponentRef Id="CrcTray" />
             <ComponentRef Id="AdminHelper" />
             <ComponentRef Id="AddToPath"/>
+            <ComponentRef Id="TrayStartup"/>
         </Feature>
         <UI>
             <UIRef Id="WixUI_ErrorProgressText"/>

--- a/packaging/windows/product.wxs.in
+++ b/packaging/windows/product.wxs.in
@@ -70,6 +70,17 @@
                     <RegistryValue Root="HKCU" Key="Software\Red Hat\CodeReady Containers" Name="installed" Type="integer" Value="1" KeyPath="yes"/>
                 </Component>
             </Directory>
+            <Directory Id="ProgramMenuFolder">
+                <Component Id="StartMenuEntry" Guid="*">
+                    <Shortcut Id="TrayStartMenuEntry" 
+                        Name="CodeReady Containers"
+                        Target="[#CrcTray]"
+                        Icon="crcicon.ico"
+                        WorkingDirectory="AppDataFolder"/>
+                    <RemoveFile Id="RemoveStartMenuEntry" Name="CodeReady Containers" On="uninstall"/>
+                    <RegistryValue Root="HKCU" Key="Software\Red Hat\CodeReady Containers" Name="startmenu" Type="integer" Value="1" KeyPath="yes"/>
+                </Component>
+            </Directory>
         </Directory>
         <SetProperty Action="CAJoinBundle"  Id="JoinBundle"  Value='"[WindowsFolder]\System32\cmd.exe" /c cd "[INSTALLDIR]" &amp;&amp; copy /b $(var.crcBundlePart0)+$(var.crcBundlePart1)+$(var.crcBundlePart2) $(var.crcBundleName)' Before="JoinBundle" Sequence="execute"/>
         <CustomAction Id="JoinBundle" BinaryKey="WixCA" DllEntry="WixQuietExec" Execute="deferred" Impersonate="no" />
@@ -93,6 +104,7 @@
             <ComponentRef Id="AdminHelper" />
             <ComponentRef Id="AddToPath"/>
             <ComponentRef Id="TrayStartup"/>
+            <ComponentRef Id="StartMenuEntry" />
         </Feature>
         <UI>
             <UIRef Id="WixUI_ErrorProgressText"/>

--- a/pkg/crc/preflight/preflight_checks_tray_windows.go
+++ b/pkg/crc/preflight/preflight_checks_tray_windows.go
@@ -102,3 +102,25 @@ func checkTrayVersion() bool {
 	logging.Debugf("Got tray version: %s", strings.TrimSpace(stdOut))
 	return strings.TrimSpace(stdOut) == version.GetCRCWindowsTrayVersion()
 }
+
+func checkIfTrayRunning() error {
+	cmd := fmt.Sprintf("Get-Process -Name %s",
+		strings.TrimSuffix(constants.TrayExecutableName, filepath.Ext(constants.TrayExecutableName)))
+
+	_, stdErr, err := powershell.Execute(cmd)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(stdErr) != "" {
+		return fmt.Errorf("Tray not running: %s", stdErr)
+	}
+	return nil
+}
+
+func startTray() error {
+	cmd := fmt.Sprintf(`Start-Process -FilePath "%s"`, constants.TrayExecutablePath)
+	if _, _, err := powershell.Execute(cmd); err != nil {
+		return fmt.Errorf("Failed to start tray process: %w", err)
+	}
+	return nil
+}

--- a/pkg/crc/preflight/preflight_checks_tray_windows.go
+++ b/pkg/crc/preflight/preflight_checks_tray_windows.go
@@ -16,13 +16,6 @@ import (
 
 var daemonBatchFileShortcutPath = filepath.Join(constants.StartupFolder, constants.DaemonBatchFileShortcutName)
 
-func checkIfTrayInstalled() error {
-	if os.FileExists(filepath.Join(constants.StartupFolder, constants.TrayShortcutName)) && checkTrayVersion() {
-		return nil
-	}
-	return fmt.Errorf("CodeReady Containers tray is not Installed")
-}
-
 func checkIfDaemonInstalled() error {
 	if os.FileExists(constants.DaemonBatchFilePath) || os.FileExists(constants.DaemonPSScriptPath) {
 		return fmt.Errorf("Daemon should not be installed")
@@ -31,38 +24,6 @@ func checkIfDaemonInstalled() error {
 		return fmt.Errorf("Daemon should not be installed")
 	}
 	return nil
-}
-
-func fixTrayInstalled() error {
-	/* Start the tray process and copy the executable to start-up folder
-	 * "$USERPROFILE\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Startup"
-	 */
-	_ = stopTray()
-
-	cmd := fmt.Sprintf(`New-Item -ItemType SymbolicLink -Path "%s" -Name "%s" -Value "%s"`,
-		constants.StartupFolder,
-		constants.TrayShortcutName,
-		constants.TrayExecutablePath,
-	)
-	if _, _, err := powershell.ExecuteAsAdmin("Create symlink to tray in start-up folder", cmd); err != nil {
-		return fmt.Errorf("Error trying to create symlink to tray in start-up folder: %w", err)
-	}
-	cmd = fmt.Sprintf(`Start-Process -FilePath "%s"`, constants.TrayExecutablePath)
-	if _, _, err := powershell.Execute(cmd); err != nil {
-		return fmt.Errorf("Failed to start tray process: %w", err)
-	}
-	return nil
-}
-
-func removeTray() error {
-	trayShortcutPath := filepath.Join(constants.StartupFolder, constants.TrayShortcutName)
-	_ = stopTray()
-	/* we changed the name of the tray executable to crc-tray.exe from tray-windows.exe
-	 * this tries to remove the old tray shortcut, can be removed after a  few releases
-	 */
-	_ = os.RemoveFileIfExists(filepath.Join(constants.StartupFolder, "tray-windows.lnk"))
-
-	return os.RemoveFileIfExists(trayShortcutPath)
 }
 
 func stopTray() error {

--- a/pkg/crc/preflight/preflight_windows.go
+++ b/pkg/crc/preflight/preflight_windows.go
@@ -111,17 +111,6 @@ var traySetupChecks = []Check{
 
 		labels: labels{Os: Windows, Tray: Enabled},
 	},
-	{
-		checkDescription:   "Checking if tray is installed",
-		check:              checkIfTrayInstalled,
-		fixDescription:     "Installing CodeReady Containers tray",
-		fix:                fixTrayInstalled,
-		cleanupDescription: "Uninstalling tray if installed",
-		cleanup:            removeTray,
-		flags:              SetupOnly,
-
-		labels: labels{Os: Windows, Tray: Enabled},
-	},
 }
 
 var vsockChecks = []Check{

--- a/pkg/crc/preflight/preflight_windows.go
+++ b/pkg/crc/preflight/preflight_windows.go
@@ -120,6 +120,13 @@ var traySetupChecks = []Check{
 
 		labels: labels{Os: Windows, Tray: Enabled},
 	},
+	{
+		cleanupDescription: "Stopping tray if running",
+		cleanup:            stopTray,
+		flags:              CleanUpOnly,
+
+		labels: labels{Os: Windows, Tray: Enabled},
+	},
 }
 
 var vsockChecks = []Check{

--- a/pkg/crc/preflight/preflight_windows.go
+++ b/pkg/crc/preflight/preflight_windows.go
@@ -111,6 +111,15 @@ var traySetupChecks = []Check{
 
 		labels: labels{Os: Windows, Tray: Enabled},
 	},
+	{
+		checkDescription: "Checking if tray is running",
+		check:            checkIfTrayRunning,
+		fixDescription:   "Starting CodeReady Containers tray",
+		fix:              startTray,
+		flags:            SetupOnly,
+
+		labels: labels{Os: Windows, Tray: Enabled},
+	},
 }
 
 var vsockChecks = []Check{


### PR DESCRIPTION
Fixes #2378 

**Relates to:** Issue #2372 

1. Create tray shortcut in start-up folder from the msi
2. Add CodeReady Containers entry in the start menu
3. Start an already installed tray during `crc setup`

## Testing

What is the _bottom-line_ functionality that needs testing? Describe in pseudo-code or in English. Use verifiable statements that tie your changes to existing functionality.

1. After installing the msi there should be a "CodeReady Containers" program in the start menu
2. A shortcut to the crc-tray should be created in `C:\Program Data\Microsoft\Windows\Start Menu\Programs\Start-Up` folder
3. Cleanup should stop a running tray but not remove it, that'll be done by the msi.
4. When msi uninstalled it should remove the start menu entry of crc and remove it from the Start-Up folder.

MSI available from appveyor CI: https://ci.appveyor.com/api/buildjobs/wjo735l7s6vcc8kv/artifacts/out%2Fwindows-amd64%2Fcrc-windows-installer.zip