### PR TITLE
Add section on compiling CRC locally to developing.adoc

### DIFF
--- a/developing.adoc
+++ b/developing.adoc
@@ -46,6 +46,36 @@ For more information, see the following:
 . link:https://github.com/golang/go/wiki/Modules[Introduction to Go modules]
 . link:https://blog.golang.org/using-go-modules[Using Go modules]
 
+[[compiling-binaries]]
+== Compiling the CRC Binary
+
+In order to compile the crc executable for your local platform, run the following command:
+
+----
+$ make
+----
+
+By default, the above command will place the crc executable in the `$GOBIN` path.
+
+Run the following command to cross-compile the crc executable for many platforms:
+
+----
+$ make cross
+----
+
+*Note*: This command will output the cross-compiled crc executable(s) in the `out` directory by default:
+
+----
+$ tree out/
+out/
+├── linux-amd64
+│   └── crc
+├── macos-amd64
+│   └── crc
+└── windows-amd64
+    └── crc.exe
+----
+
 [[running-e2e-tests]]
 == Running e2e tests
 
@@ -71,7 +101,7 @@ To start e2e tests, run:
 $ make e2e
 ```
 
-===== How to run only a subset of all e2e tests
+==== How to run only a subset of all e2e tests
 
 Implicitly, all e2e tests for your operating system are executed. If you want to run only tests from one feature file, you have to override `GODOG_OPTS` environment variable. For example:
 


### PR DESCRIPTION
Update the developing.adoc developer documentation and add a section on
how to build the `crc` binary locally.


**Fixes:** Issue #N

**Relates to:** Issue #N, PR #N, ...

## Solution/Idea

Describe in plain English what you solved and how. For instance, _Added `start` command to CRC so the user can create a VM and set-up a single-node OpenShift cluster on it with one command. It requires blablabla..._

## Proposed changes

List main as well as consequential changes you introduced or had to introduce.

1. Add `start` command.
2. Add `setup` as prerequisite to `start`.
3. ...

## Testing

What is the _bottom-line_ functionality that needs testing? Describe in pseudo-code or in English. Use verifiable statements that tie your changes to existing functionality.

1. `start` succeeds first time after `setup` succeeded
2. stdout contains ... if `start` succeeded
3. stderr contains ... after `start` failed
4. `status` returns ... if `start` succeeded
5. `status` returns ... if `start` failed
6. `start` fails after `start` succeeded or after `status` says CRC is `Running`
7. ...
