### PR TITLE
Remove .crcbundle from bundle name in driver config. Marshal/unmarshal the name in bundle json

### DIFF
--- a/pkg/crc/machine/bundle/copier.go
+++ b/pkg/crc/machine/bundle/copier.go
@@ -37,7 +37,7 @@ func NewCopier(srcBundle *CrcBundleInfo, basePath string, customBundleName strin
 		return nil, err
 	}
 
-	copier.copiedBundle.bundleName = customBundleName
+	copier.copiedBundle.Name = customBundleName
 	copier.copiedBundle.Type = "custom"
 	copier.srcBundle = srcBundle
 	copier.copiedBundle.cachedPath = bundlePath
@@ -114,7 +114,7 @@ func (copier *Copier) GenerateBundle(bundleName string) error {
 		return fmt.Errorf("error copying bundle metadata  %w", err)
 	}
 
-	logging.Infof("Compressing %s...", GetBundleNameWithoutExtension(copier.copiedBundle.bundleName))
+	logging.Infof("Compressing %s...", GetBundleNameWithoutExtension(copier.copiedBundle.Name))
 	return compress.Compress(copier.copiedBundle.cachedPath, fmt.Sprintf("%s%s", bundleName, bundleExtension))
 }
 

--- a/pkg/crc/machine/bundle/copier_test.go
+++ b/pkg/crc/machine/bundle/copier_test.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/code-ready/crc/pkg/crc/constants"
 	crcos "github.com/code-ready/crc/pkg/os"
 	"github.com/stretchr/testify/assert"
 )
@@ -16,12 +15,10 @@ import (
 func TestGenerateBundle(t *testing.T) {
 	var b CrcBundleInfo
 	assert.NoError(t, json.Unmarshal([]byte(jsonForBundle("crc_4.7.1")), &b))
-	b.bundleName = "crc_4.7.1"
-	b.Storage.Files[0].Name = constants.OcExecutableName
 
 	tmpBundleDir, err := ioutil.TempDir("", "bundle_data")
 	assert.NoError(t, err)
-	b.cachedPath = filepath.Join(tmpBundleDir, b.bundleName)
+	b.cachedPath = filepath.Join(tmpBundleDir, b.Name)
 	defer os.RemoveAll(tmpBundleDir)
 
 	createDummyBundleFiles(t, &b)

--- a/pkg/crc/machine/bundle/metadata.go
+++ b/pkg/crc/machine/bundle/metadata.go
@@ -17,13 +17,14 @@ import (
 type CrcBundleInfo struct {
 	Version     string      `json:"version"`
 	Type        string      `json:"type"`
+	Name        string      `json:"name"`
 	BuildInfo   BuildInfo   `json:"buildInfo"`
 	ClusterInfo ClusterInfo `json:"clusterInfo"`
 	Nodes       []Node      `json:"nodes"`
 	Storage     Storage     `json:"storage"`
 	DriverInfo  DriverInfo  `json:"driverInfo"`
-	cachedPath  string
-	bundleName  string
+
+	cachedPath string
 }
 
 type BuildInfo struct {
@@ -89,7 +90,7 @@ func (bundle *CrcBundleInfo) resolvePath(filename string) string {
 }
 
 func (bundle *CrcBundleInfo) GetBundleName() string {
-	return bundle.bundleName
+	return bundle.Name
 }
 
 func (bundle *CrcBundleInfo) GetAPIHostname() string {

--- a/pkg/crc/machine/bundle/metadata_test.go
+++ b/pkg/crc/machine/bundle/metadata_test.go
@@ -23,6 +23,7 @@ func jsonForBundleWithVersion(version, name string) string {
 	return fmt.Sprintf(`{
   "version": "%s",
   "type": "snc",
+  "name": "%s",
   "buildInfo": {
     "buildTime": "2020-10-26T04:48:26+00:00",
     "openshiftInstallerVersion": "./openshift-install v4.6.0\nbuilt from commit ebdbda57fc18d3b73e69f0f2cc499ddfca7e6593\nrelease image registry.svc.ci.openshift.org/origin/release:4.5",
@@ -68,7 +69,7 @@ func jsonForBundleWithVersion(version, name string) string {
   "driverInfo": {
     "name": "libvirt"
   }
-}`, version, openshiftVersion(name), constants.OcExecutableName)
+}`, version, name, openshiftVersion(name), constants.OcExecutableName)
 }
 
 func openshiftVersion(name string) string {
@@ -79,6 +80,7 @@ func openshiftVersion(name string) string {
 var parsedReference = CrcBundleInfo{
 	Version: "1.0",
 	Type:    "snc",
+	Name:    "crc_libvirt_4.6.1",
 	BuildInfo: BuildInfo{
 		BuildTime:                 "2020-10-26T04:48:26+00:00",
 		OpenshiftInstallerVersion: "./openshift-install v4.6.0\nbuilt from commit ebdbda57fc18d3b73e69f0f2cc499ddfca7e6593\nrelease image registry.svc.ci.openshift.org/origin/release:4.5",

--- a/pkg/crc/machine/bundle/repository.go
+++ b/pkg/crc/machine/bundle/repository.go
@@ -48,7 +48,6 @@ func (repo *Repository) Get(bundleName string) (*CrcBundleInfo, error) {
 		return nil, err
 	}
 	bundleInfo.cachedPath = path
-	bundleInfo.bundleName = bundleName
 
 	if err := bundleInfo.verify(); err != nil {
 		return nil, err


### PR DESCRIPTION
First commit is about using the bundle name without extension everywhere.
Second commit uses the name in the json instead of guessing it from the filename. This field is present since November so it is safe to say it will be always present.