### PR TITLE
docs: Expand installation procedure, cover binary and installer

### DIFF
--- a/docs/source/topics/proc_installing-codeready-containers.adoc
+++ b/docs/source/topics/proc_installing-codeready-containers.adoc
@@ -1,6 +1,9 @@
 [id="installing-codeready-containers_{context}"]
 = Installing {prod}
 
+{prod} is available as a portable executable for {rhel} and {msw}.
+On {mac}, {prod} is available using a guided installer.
+
 .Prerequisites
 
 * Your host machine must meet the minimum system requirements.
@@ -8,4 +11,47 @@ For more information, see link:{crc-gsg-url}#minimum-system-requirements_gsg[Min
 
 .Procedure
 
-. Download the link:{crc-download-url}[latest release of {prod}] for your platform and extract the contents of the archive to a location in your `_PATH_`.
+. Download the link:{crc-download-url}[latest release of {prod}] for your platform.
+
+. On {mac}, run the guided installer and follow the instructions.
+On {rhel} or {msw}, assuming the archive is in the [filename]*_~/Downloads_* directory, follow the procedure for your platform.
++
+** For {rhel}:
++
+... Extract the contents of the archive:
++
+[subs="attributes"]
+----
+$ cd ~/Downloads
+$ tar xvf crc-linux-amd64.tar.xz
+----
++
+... Create the [filename]*_~/bin_* directory if it does not exist and copy the [command]`{bin}` executable to it:
++
+[subs="attributes"]
+----
+$ mkdir -p ~/bin
+$ cp ~/Downloads/crc-linux-*-amd64/{bin} ~/bin
+----
++
+... Add the [filename]*_~/bin_* directory to your `_PATH_`:
++
+[subs="attributes"]
+----
+$ export PATH=$PATH:$HOME/bin
+$ echo 'export PATH=$PATH:$HOME/bin' >> ~/.bashrc
+----
++
+** For {msw}:
++
+... Extract the contents of the archive.
+... Create the desired directory path for {prod} and copy the extracted [command]`{bin}.exe` executable to it.
+... Add the directory path to your `_PATH_` environment variable.
++
+[NOTE]
+====
+On {msw}, you must execute the {prod} executable from your local [filename]*_C:\_* drive.
+You cannot run {prod} from a network drive.
+
+If you cannot install the executable in your `_PATH_`, run {prod} from the current directory as `./{bin}.exe`.
+====


### PR DESCRIPTION
## Solution/Idea

Describe the installation procedure in more detail, particularly for installing the portable binary on RHEL. This PR also briefly documents that CRC is available on macOS using a guided installer. In the future, we will likely replace the Windows instructions in this PR once the installer for Windows is the default installation method for that platform (but will retain the notice regarding installing to the `C:\` drive).

**Note:** Regarding the wording of the installation procedure, I wasn't sure if we should advocate for _copying_ the executable or _moving_ it from the extracted location. I opted for copying due to that action being non-destructive.