### PR TITLE
`crc setup` hangs when trying to enable hyperv

### DIFF
--- a/pkg/crc/preflight/preflight_checks_windows.go
+++ b/pkg/crc/preflight/preflight_checks_windows.go
@@ -87,7 +87,7 @@ func checkHyperVInstalled() error {
 
 //
 func fixHyperVInstalled() error {
-	enableHyperVCommand := `Enable-WindowsOptionalFeature -Online -FeatureName Microsoft-Hyper-V -All`
+	enableHyperVCommand := `Enable-WindowsOptionalFeature -Online -FeatureName Microsoft-Hyper-V -All -NoRestart`
 	_, _, err := powershell.ExecuteAsAdmin("enable Hyper-V", enableHyperVCommand)
 
 	if err != nil {

--- a/pkg/crc/preflight/preflight_windows.go
+++ b/pkg/crc/preflight/preflight_windows.go
@@ -105,7 +105,7 @@ var hypervPreflightChecks = []Check{
 	},
 	{
 		configKeySuffix:  "check-hyperv-switch",
-		checkDescription: "Checking if the Hyper-V virtual switch exist",
+		checkDescription: "Checking if the Hyper-V virtual switch exists",
 		check:            checkIfHyperVVirtualSwitchExists,
 		fixDescription:   "Unable to perform Hyper-V administrative commands. Please reboot your system and run 'crc setup' to complete the setup process",
 		flags:            NoFix,


### PR DESCRIPTION
On my Windows 10 21h1 install, when I run
'Enable-WindowsOptionalFeature -Online -FeatureName Microsoft-Hyper-V -All'
the command asks whether I want to reboot the system now or not, and
does not complete until it gets an answer.
This causes `crc setup` to hang when it calls it to setup hyper-v.
This commit uses the -NoRestart argument to make sure there is no
interactive prompt, `crc setup` will tell the user to reboot when
appropriate.

This is a pre-existing issue which was made visible by 0f044b17a6 since
we now wait until the end of execution of powershell scripts that we
spawn.