### PR TITLE
macos: Add disk resizing support

### DIFF
--- a/cmd/crc-embedder/cmd/embed.go
+++ b/cmd/crc-embedder/cmd/embed.go
@@ -94,6 +94,7 @@ var (
 		"darwin": {
 			{hyperkit.MachineDriverDownloadURL, 0755},
 			{hyperkit.HyperKitDownloadURL, 0755},
+			{hyperkit.QcowToolDownloadURL, 0755},
 			{constants.GetCRCMacTrayDownloadURL(), 0644},
 			{constants.GetAdminHelperURLForOs("darwin"), 0755},
 		},

--- a/cmd/crc-embedder/cmd/embed.go
+++ b/cmd/crc-embedder/cmd/embed.go
@@ -84,21 +84,26 @@ func embedFiles(executablePath string, filenames []string) error {
 	return nil
 }
 
+type remoteFileInfo struct {
+	url         string
+	permissions os.FileMode
+}
+
 var (
-	dataFileUrls = map[string][]string{
+	dataFileUrls = map[string][]remoteFileInfo{
 		"darwin": {
-			hyperkit.MachineDriverDownloadURL,
-			hyperkit.HyperKitDownloadURL,
-			constants.GetCRCMacTrayDownloadURL(),
-			constants.GetAdminHelperURLForOs("darwin"),
+			{hyperkit.MachineDriverDownloadURL, 0755},
+			{hyperkit.HyperKitDownloadURL, 0755},
+			{constants.GetCRCMacTrayDownloadURL(), 0644},
+			{constants.GetAdminHelperURLForOs("darwin"), 0755},
 		},
 		"linux": {
-			libvirt.MachineDriverDownloadURL,
-			constants.GetAdminHelperURLForOs("linux"),
+			{libvirt.MachineDriverDownloadURL, 0755},
+			{constants.GetAdminHelperURLForOs("linux"), 0755},
 		},
 		"windows": {
-			constants.GetAdminHelperURLForOs("windows"),
-			constants.GetCRCWindowsTrayDownloadURL(),
+			{constants.GetAdminHelperURLForOs("windows"), 0755},
+			{constants.GetCRCWindowsTrayDownloadURL(), 0644},
 		},
 	}
 )
@@ -106,8 +111,8 @@ var (
 func downloadDataFiles(goos string, destDir string) ([]string, error) {
 	downloadedFiles := []string{}
 	downloads := dataFileUrls[goos]
-	for _, url := range downloads {
-		filename, err := download.Download(url, destDir, 0644)
+	for _, dl := range downloads {
+		filename, err := download.Download(dl.url, destDir, dl.permissions)
 		if err != nil {
 			return nil, err
 		}

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/code-ready/admin-helper v0.0.0-20210602075518-d22477037442
 	github.com/code-ready/clicumber v0.0.0-20210201104241-cecb794bdf9a
 	github.com/code-ready/gvisor-tap-vsock v0.0.0-20210308122700-d61f9aac135c
-	github.com/code-ready/machine v0.0.0-20210122113819-281ccfbb4566
+	github.com/code-ready/machine v0.0.0-20210616065635-eff475d32b9a
 	github.com/cucumber/godog v0.9.0
 	github.com/cucumber/messages-go/v10 v10.0.3
 	github.com/docker/go-units v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -149,8 +149,8 @@ github.com/code-ready/clicumber v0.0.0-20210201104241-cecb794bdf9a h1:VOQmCj9Y8p
 github.com/code-ready/clicumber v0.0.0-20210201104241-cecb794bdf9a/go.mod h1:ZPZUcYGpv/FQGnwakUuhiHP9x/IIcU2SKbn8xPe4ROc=
 github.com/code-ready/gvisor-tap-vsock v0.0.0-20210308122700-d61f9aac135c h1:UOg6w7Uv5hWvFVABjJpawCEmAK99vG96SozUaulqVCk=
 github.com/code-ready/gvisor-tap-vsock v0.0.0-20210308122700-d61f9aac135c/go.mod h1:DsNrkk0GUSTqt0E/4/GMvjqsP7ns++O/6YaJn/TDBVM=
-github.com/code-ready/machine v0.0.0-20210122113819-281ccfbb4566 h1:zBDinebc2kFq99UNTmLmTRfgxcxC6YieKQuXDRCljzw=
-github.com/code-ready/machine v0.0.0-20210122113819-281ccfbb4566/go.mod h1:4JgMqho7KuxFifYCIi7cKVmh4yA2l0QHOPftv9f5PNc=
+github.com/code-ready/machine v0.0.0-20210616065635-eff475d32b9a h1:LLL1mb5Nm1bghXXK9g0qJTkV8DqlttnyllEgCa92xdI=
+github.com/code-ready/machine v0.0.0-20210616065635-eff475d32b9a/go.mod h1:4JgMqho7KuxFifYCIi7cKVmh4yA2l0QHOPftv9f5PNc=
 github.com/containerd/cgroups v0.0.0-20190919134610-bf292b21730f/go.mod h1:OApqhQ4XNSNC13gXIwDjhOQxjWa/NxkwZXJ1EvqT0ko=
 github.com/containerd/cgroups v0.0.0-20201119153540-4cbc285b3327/go.mod h1:ZJeTFisyysqgcCdecO57Dj79RfL0LNeGiFUqLYQRYLE=
 github.com/containerd/console v0.0.0-20180822173158-c12b1e7919c1/go.mod h1:Tj/on1eG8kiEhd0+fhSDzsPAFESxzBBvdyEgyryXffw=

--- a/packaging/package.sh
+++ b/packaging/package.sh
@@ -30,6 +30,7 @@ sign "${binDir}/crc-driver-hyperkit"
 sign "${BASEDIR}/root/Applications/CodeReady Containers.app"
 
 codesign --verify --verbose "${binDir}/hyperkit"
+codesign --verify --verbose "${binDir}/qcow-tool"
 
 sudo chmod +sx "${binDir}/hyperkit" "${binDir}/crc-admin-helper-darwin" "${binDir}/crc-driver-hyperkit"
 

--- a/pkg/crc/cache/cache_darwin.go
+++ b/pkg/crc/cache/cache_darwin.go
@@ -15,12 +15,21 @@ func NewMachineDriverHyperKitCache() *Cache {
 	return New(hyperkit.MachineDriverCommand, hyperkit.MachineDriverDownloadURL, constants.CrcBinDir, hyperkit.MachineDriverVersion, getHyperKitMachineDriverVersion)
 }
 
+func NewQcowToolCache() *Cache {
+	return New(hyperkit.QcowToolCommand, hyperkit.QcowToolDownloadURL, constants.CrcBinDir, hyperkit.QcowToolVersion, getQcowToolVersion)
+}
+
 func NewHyperKitCache() *Cache {
 	return New(hyperkit.HyperKitCommand, hyperkit.HyperKitDownloadURL, constants.CrcBinDir, hyperkit.HyperKitVersion, getHyperKitVersion)
 }
 
 func getHyperKitMachineDriverVersion(executablePath string) (string, error) {
 	return getVersionGeneric(executablePath, "version")
+}
+
+func getQcowToolVersion(executablePath string) (string, error) {
+	stdout, _, err := crcos.RunWithDefaultLocale(executablePath, "--version")
+	return strings.TrimSpace(stdout), err
 }
 
 /* This is very similar to cache.getVersionGeneric, except that it's reading from stderr instead of

--- a/pkg/crc/machine/hyperkit/constants.go
+++ b/pkg/crc/machine/hyperkit/constants.go
@@ -9,6 +9,8 @@ const (
 	MachineDriverVersion = "0.13.0"
 	HyperKitCommand      = "hyperkit"
 	HyperKitVersion      = "v0.20200224-44-gb54460"
+	QcowToolCommand      = "qcow-tool"
+	QcowToolVersion      = "1.0.0"
 )
 
 var (
@@ -16,4 +18,5 @@ var (
 
 	HyperKitDownloadURL      = fmt.Sprintf("%s/%s", baseURL, HyperKitCommand)
 	MachineDriverDownloadURL = fmt.Sprintf("%s/%s", baseURL, MachineDriverCommand)
+	QcowToolDownloadURL      = fmt.Sprintf("%s/%s", baseURL, QcowToolCommand)
 )

--- a/pkg/crc/machine/hyperkit/constants.go
+++ b/pkg/crc/machine/hyperkit/constants.go
@@ -12,6 +12,8 @@ const (
 )
 
 var (
-	HyperKitDownloadURL      = fmt.Sprintf("https://github.com/code-ready/machine-driver-hyperkit/releases/download/v%s/hyperkit", MachineDriverVersion)
-	MachineDriverDownloadURL = fmt.Sprintf("https://github.com/code-ready/machine-driver-hyperkit/releases/download/v%s/crc-driver-hyperkit", MachineDriverVersion)
+	baseURL = fmt.Sprintf("https://github.com/code-ready/machine-driver-hyperkit/releases/download/v%s", MachineDriverVersion)
+
+	HyperKitDownloadURL      = fmt.Sprintf("%s/%s", baseURL, HyperKitCommand)
+	MachineDriverDownloadURL = fmt.Sprintf("%s/%s", baseURL, MachineDriverCommand)
 )

--- a/pkg/crc/machine/hyperkit/driver_darwin.go
+++ b/pkg/crc/machine/hyperkit/driver_darwin.go
@@ -19,6 +19,7 @@ func CreateHost(machineConfig config.MachineConfig) *hyperkit.Driver {
 	hyperkitDriver.VmlinuzPath = machineConfig.Kernel
 	hyperkitDriver.InitrdPath = machineConfig.Initramfs
 	hyperkitDriver.HyperKitPath = filepath.Join(constants.BinDir(), HyperKitCommand)
+	hyperkitDriver.QcowToolPath = filepath.Join(constants.BinDir(), QcowToolCommand)
 
 	hyperkitDriver.VMNet = machineConfig.NetworkMode == network.SystemNetworkingMode
 

--- a/pkg/crc/preflight/preflight_checks_darwin.go
+++ b/pkg/crc/preflight/preflight_checks_darwin.go
@@ -121,6 +121,36 @@ func fixMachineDriverHyperKitInstalled(networkMode network.Mode) func() error {
 	}
 }
 
+func checkQcowToolInstalled() error {
+	if version.IsMacosInstallPathSet() {
+		return nil
+	}
+
+	qcowTool := cache.NewQcowToolCache()
+
+	logging.Debugf("Checking if %s is installed", qcowTool.GetExecutableName())
+	if !qcowTool.IsCached() {
+		return fmt.Errorf("%s executable is not cached", qcowTool.GetExecutableName())
+	}
+
+	return qcowTool.CheckVersion()
+}
+
+func fixQcowToolInstalled() error {
+	if version.IsMacosInstallPathSet() {
+		return nil
+	}
+	qcowTool := cache.NewQcowToolCache()
+
+	logging.Debugf("Installing %s", qcowTool.GetExecutableName())
+
+	if err := qcowTool.EnsureIsCached(); err != nil {
+		return fmt.Errorf("Unable to download %s : %v", qcowTool.GetExecutableName(), err)
+	}
+
+	return nil
+}
+
 func checkResolverFilePermissions() error {
 	return isUserHaveFileWritePermission(resolverFile)
 }

--- a/pkg/crc/preflight/preflight_darwin.go
+++ b/pkg/crc/preflight/preflight_darwin.go
@@ -29,6 +29,15 @@ func hyperkitPreflightChecks(networkMode network.Mode) []Check {
 			labels: labels{Os: Darwin},
 		},
 		{
+			configKeySuffix:  "check-qcow-tool-installed",
+			checkDescription: "Checking if qcow-tool is installed",
+			check:            checkQcowToolInstalled,
+			fixDescription:   "Installing qcow-tool",
+			fix:              fixQcowToolInstalled,
+
+			labels: labels{Os: Darwin},
+		},
+		{
 			configKeySuffix:  "check-hyperkit-driver",
 			checkDescription: "Checking if crc-driver-hyperkit is installed",
 			check:            checkMachineDriverHyperKitInstalled(networkMode),

--- a/pkg/crc/preflight/preflight_darwin_test.go
+++ b/pkg/crc/preflight/preflight_darwin_test.go
@@ -12,13 +12,13 @@ import (
 func TestCountConfigurationOptions(t *testing.T) {
 	cfg := config.New(config.NewEmptyInMemoryStorage())
 	RegisterSettings(cfg)
-	assert.Len(t, cfg.AllConfigs(), 10)
+	assert.Len(t, cfg.AllConfigs(), 11)
 }
 
 func TestCountPreflights(t *testing.T) {
-	assert.Len(t, getPreflightChecks(true, false, network.SystemNetworkingMode), 16)
-	assert.Len(t, getPreflightChecks(true, true, network.SystemNetworkingMode), 16)
+	assert.Len(t, getPreflightChecks(true, false, network.SystemNetworkingMode), 17)
+	assert.Len(t, getPreflightChecks(true, true, network.SystemNetworkingMode), 17)
 
-	assert.Len(t, getPreflightChecks(true, false, network.UserNetworkingMode), 15)
-	assert.Len(t, getPreflightChecks(true, true, network.UserNetworkingMode), 15)
+	assert.Len(t, getPreflightChecks(true, false, network.UserNetworkingMode), 16)
+	assert.Len(t, getPreflightChecks(true, true, network.UserNetworkingMode), 16)
 }

--- a/pkg/crc/validation/validation.go
+++ b/pkg/crc/validation/validation.go
@@ -7,7 +7,6 @@ import (
 	"net"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 
 	"github.com/code-ready/crc/pkg/crc/constants"
@@ -36,10 +35,6 @@ func ValidateMemory(value int) error {
 func ValidateDiskSize(value int) error {
 	if value < constants.DefaultDiskSize {
 		return fmt.Errorf("requires disk size in GiB >= %d", constants.DefaultDiskSize)
-	}
-	// https://github.com/code-ready/machine-driver-hyperkit/issues/18
-	if runtime.GOOS == "darwin" && value > constants.DefaultDiskSize {
-		return fmt.Errorf("Disk resizing is not supported on macOS")
 	}
 
 	return nil

--- a/vendor/github.com/code-ready/machine/drivers/hyperkit/driver_darwin.go
+++ b/vendor/github.com/code-ready/machine/drivers/hyperkit/driver_darwin.go
@@ -14,11 +14,13 @@ type Driver struct {
 	Cmdline       string
 	UUID          string
 	VpnKitSock    string
+	VpnKitUUID    string
 	VSockPorts    []string
 	VmlinuzPath   string
 	InitrdPath    string
 	KernelCmdLine string
 	HyperKitPath  string
+	QcowToolPath  string
 	VMNet         bool
 }
 

--- a/vendor/github.com/code-ready/machine/libmachine/drivers/rpc/client_driver.go
+++ b/vendor/github.com/code-ready/machine/libmachine/drivers/rpc/client_driver.go
@@ -164,7 +164,7 @@ func (f *DefaultRPCClientDriverFactory) NewRPCClientDriver(driverName string, dr
 				return
 			case <-time.After(heartbeatInterval):
 				if err := c.Client.Call(HeartbeatMethod, struct{}{}, nil); err != nil {
-					log.Warnf("Wrapper Docker Machine process exiting due to closed plugin server (%s)", err)
+					log.Warnf("driver heartbeat failure: %v", err)
 					if err := c.close(); err != nil {
 						log.Warnf(err.Error())
 					}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -51,7 +51,7 @@ github.com/code-ready/gvisor-tap-vsock/pkg/tap
 github.com/code-ready/gvisor-tap-vsock/pkg/transport
 github.com/code-ready/gvisor-tap-vsock/pkg/types
 github.com/code-ready/gvisor-tap-vsock/pkg/virtualnetwork
-# github.com/code-ready/machine v0.0.0-20210122113819-281ccfbb4566
+# github.com/code-ready/machine v0.0.0-20210616065635-eff475d32b9a
 ## explicit
 github.com/code-ready/machine/drivers/hyperkit
 github.com/code-ready/machine/drivers/libvirt


### PR DESCRIPTION
This requires a new machine-driver-hyperkit release (+ the merge of the
corresponding PR) before it works.


**Fixes:** https://github.com/code-ready/crc/issues/1640 

## Testing

1. After this PR, and with a matching machine driver, crc start --disk-size xxx should work the same as on the other platforms