### PR TITLE
Disable update check in the CI. Add User-Agent in http.Client{}

### DIFF
--- a/pkg/crc/version/version.go
+++ b/pkg/crc/version/version.go
@@ -87,7 +87,12 @@ func GetCRCLatestVersionFromMirror() (*CrcReleaseInfo, error) {
 	client := &http.Client{
 		Timeout: 5 * time.Second,
 	}
-	response, err := client.Get(releaseInfoLink)
+	req, err := http.NewRequest(http.MethodGet, releaseInfoLink, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", fmt.Sprintf("crc/%s", crcVersion))
+	response, err := client.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/test/e2e/crcsuite/crcsuite.go
+++ b/test/e2e/crcsuite/crcsuite.go
@@ -345,7 +345,7 @@ func StartCRCWithDefaultBundleSucceedsOrFails(expected string) error {
 	if !bundleEmbedded {
 		extraBundleArgs = fmt.Sprintf("-b %s", bundleLocation)
 	}
-	cmd = fmt.Sprintf("crc start -p '%s' %s --log-level debug", pullSecretFile, extraBundleArgs)
+	cmd = fmt.Sprintf("CRC_DISABLE_UPDATE_CHECK=true crc start -p '%s' %s --log-level debug", pullSecretFile, extraBundleArgs)
 	err := clicumber.ExecuteCommandSucceedsOrFails(cmd, expected)
 
 	return err
@@ -359,14 +359,14 @@ func StartCRCWithDefaultBundleWithStopNetworkTimeSynchronizationSucceedsOrFails(
 	if !bundleEmbedded {
 		extraBundleArgs = fmt.Sprintf("-b %s", bundleLocation)
 	}
-	cmd = fmt.Sprintf("CRC_DEBUG_ENABLE_STOP_NTP=true crc start -p '%s' %s --log-level debug", pullSecretFile, extraBundleArgs)
+	cmd = fmt.Sprintf("CRC_DISABLE_UPDATE_CHECK=true CRC_DEBUG_ENABLE_STOP_NTP=true crc start -p '%s' %s --log-level debug", pullSecretFile, extraBundleArgs)
 	err := clicumber.ExecuteCommandSucceedsOrFails(cmd, expected)
 
 	return err
 }
 
 func StartCRCWithCustomBundleSucceedsOrFails(expected string) error {
-	cmd := fmt.Sprintf("crc start -p '%s' -b *.crcbundle --log-level debug", pullSecretFile)
+	cmd := fmt.Sprintf("CRC_DISABLE_UPDATE_CHECK=true crc start -p '%s' -b *.crcbundle --log-level debug", pullSecretFile)
 	return clicumber.ExecuteCommandSucceedsOrFails(cmd, expected)
 }
 
@@ -377,7 +377,7 @@ func StartCRCWithDefaultBundleAndNameServerSucceedsOrFails(nameserver string, ex
 		extraBundleArgs = fmt.Sprintf("-b %s", bundleLocation)
 	}
 
-	cmd := fmt.Sprintf("crc start -n %s -p '%s' %s --log-level debug", nameserver, pullSecretFile, extraBundleArgs)
+	cmd := fmt.Sprintf("CRC_DISABLE_UPDATE_CHECK=true crc start -n %s -p '%s' %s --log-level debug", nameserver, pullSecretFile, extraBundleArgs)
 	return clicumber.ExecuteCommandSucceedsOrFails(cmd, expected)
 }
 

--- a/test/e2e/features/basic.feature
+++ b/test/e2e/features/basic.feature
@@ -6,7 +6,7 @@ Feature: Basic test
 
     @darwin @linux @windows
     Scenario: CRC version
-        When executing "crc version" succeeds
+        When executing "CRC_DISABLE_UPDATE_CHECK=true crc version" succeeds
         Then stderr should be empty
         And stdout should contain "version:"
 

--- a/test/integration/utilities_test.go
+++ b/test/integration/utilities_test.go
@@ -27,7 +27,7 @@ type CRCBuilder struct {
 // NewCRCCommand returns a CRCBuilder for running CRC.
 func NewCRCCommand(args ...string) *CRCBuilder {
 	cmd := exec.Command("crc", args...)
-	cmd.Env = os.Environ()
+	cmd.Env = append(os.Environ(), "CRC_DISABLE_UPDATE_CHECK=true")
 	return &CRCBuilder{
 		cmd: cmd,
 	}

--- a/test/integration/utilities_test.go
+++ b/test/integration/utilities_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
 	"strings"
 	"syscall"
@@ -26,15 +27,10 @@ type CRCBuilder struct {
 // NewCRCCommand returns a CRCBuilder for running CRC.
 func NewCRCCommand(args ...string) *CRCBuilder {
 	cmd := exec.Command("crc", args...)
+	cmd.Env = os.Environ()
 	return &CRCBuilder{
 		cmd: cmd,
 	}
-}
-
-// WithEnv sets the given environment and returns itself.
-func (b *CRCBuilder) WithEnv(env []string) *CRCBuilder {
-	b.cmd.Env = env
-	return b
 }
 
 // WithTimeout sets the given timeout and returns itself.


### PR DESCRIPTION
It will help counting the number of clusters started. 