### PR TITLE
Create crc-users group from the msi add logon user to that group and hyperv admins group

### DIFF
--- a/packaging/windows/WixUI_HK.wxs
+++ b/packaging/windows/WixUI_HK.wxs
@@ -11,7 +11,7 @@
          <Property Id="WixUI_Mode" Value="InstallDir" />
          <Property Id="ARPNOMODIFY" Value="1" />
          <Property Id="ARPNOREPAIR" Value="1" />
-         <Property Id="WIXUI_EXITDIALOGOPTIONALTEXT" Value="CodeReady Containers is installed in your computer. Run the command 'crc.exe setup' to setup your environment." />
+         <Property Id="WIXUI_EXITDIALOGOPTIONALTEXT" Value="To finish installation of CodeReady Containers please restart you computer. After restart Open PowerShell or Command Prompt and run the command 'crc.exe setup' to setup your environment." />
 
          <DialogRef Id="BrowseDlg" />
          <DialogRef Id="DiskCostDlg" />

--- a/packaging/windows/product.wxs.in
+++ b/packaging/windows/product.wxs.in
@@ -76,7 +76,7 @@
                     </Component>
                     <Component Id="AddToPath" Guid="09C1E713-44DE-44C3-BDAD-72BE10C10542">
                         <CreateFolder />
-                        <Environment Id="PATH" Name="PATH" Value="[INSTALLDIR]" Permanent="no" Part="last" Action="set" />
+                        <Environment Id="PATH" Name="PATH" Value="[INSTALLDIR]" Permanent="no" Part="last" Action="set" System="yes" />
                     </Component>
                 </Directory>
             </Directory>

--- a/packaging/windows/product.wxs.in
+++ b/packaging/windows/product.wxs.in
@@ -113,6 +113,9 @@
         <SetProperty Action="CARemoveCrcUsersGroup"  Id="RemoveCrcGroup"  Value='"[System64Folder]cmd.exe" /c net localgroup crc-users /del' Before="RemoveCrcGroup" Sequence="execute"/>
         <CustomAction Id="RemoveCrcGroup" BinaryKey="WixCA" DllEntry="WixQuietExec" Execute="deferred" Impersonate="no" Return="ignore" />
 
+        <SetProperty Action="CAInstallHyperv" Id="InstallHyperv" Value='"[System64Folder]dism.exe" /online /enable-feature /featureName:microsoft-hyper-v-all /NoRestart /quiet' Before="InstallHyperv" Sequence="execute"/>
+        <CustomAction Id="InstallHyperv" BinaryKey="WixCA" DllEntry="WixQuietExec64" Execute="deferred" Impersonate="no" Return="ignore" />
+
         <util:CloseApplication Id = "TrayRunning" Description="Please exit CodeReady Containers from tray and run the installation again."
             Target="crc-tray.exe" RebootPrompt="no"
             PromptToContinue="yes" />

--- a/packaging/windows/product.wxs.in
+++ b/packaging/windows/product.wxs.in
@@ -50,6 +50,15 @@
                     </Component>
                     <Component Id="AdminHelper" Guid="*">
                         <File Id="AdminHelper" Source="SourceDir\crc-admin-helper-windows.exe" KeyPath="yes" DiskId="3" />
+                        <ServiceInstall 
+                            Name="CodeReadyContainersAdminHelper"
+                            Description="Perform administrative tasks for the user"
+                            Arguments="daemon" 
+                            DisplayName="CodeReady Containers Admin Helper"
+                            ErrorControl="normal" Start="auto" Type="ownProcess" 
+                            />
+                        <ServiceControl Id="StartAdminHelperService" Name="CodeReadyContainersAdminHelper" Start='install' Stop='both' Remove='uninstall' />
+
                     </Component>
                     <Component Id="CrcTray" Guid="*">
                         <File Id="CrcTray" Source="SourceDir\crc-tray.exe" KeyPath="yes" DiskId="3" />

--- a/packaging/windows/product.wxs.in
+++ b/packaging/windows/product.wxs.in
@@ -31,6 +31,8 @@
         <Condition Message="CodeReady Containers requires the Windows 10 Fall Creators Update (version 1709) or newer.">
             <![CDATA[Installed OR (CURRENTBUILD > MINIMUMBUILD)]]>
         </Condition>
+        <util:Group Id="HypervAdminsGroup" Name="Hyper-V Administrators" />
+        <util:Group Id="CrcUsersGroup" Name="crc-users" />
         <Directory Id="TARGETDIR" Name="SourceDir">
             <Directory Id="ProgramFiles64Folder">
                 <Directory Id="INSTALLDIR" Name="CodeReady Containers">
@@ -52,6 +54,16 @@
                     <Component Id="CrcTray" Guid="*">
                         <File Id="CrcTray" Source="SourceDir\crc-tray.exe" KeyPath="yes" DiskId="3" />
                         <RemoveFile Id="RemoveInstallFiles" Name="*.*" On="uninstall" />
+                    </Component>
+                    <Component Id="AddUserToHypervAdmins" Guid="B5FFE50B-A2AC-4F81-8656-2060BA3E54AD" KeyPath="yes">
+                        <util:User Id="LogonUser" Domain="[%USERDOMAIN]" Name="[LogonUser]" CreateUser="no" RemoveOnUninstall="no">
+                            <util:GroupRef Id="HypervAdminsGroup" />
+                        </util:User>
+                    </Component>
+                    <Component Id="AddUserToCrcUsers" Guid="0C793EE7-109A-474B-9651-77E0A83BAF2D" KeyPath="yes">
+                        <util:User Id="LogonUser1" Domain="[%USERDOMAIN]" Name="[LogonUser]" CreateUser="no" RemoveOnUninstall="no">
+                            <util:GroupRef Id="CrcUsersGroup" />
+                        </util:User>
                     </Component>
                     <Component Id="AddToPath" Guid="09C1E713-44DE-44C3-BDAD-72BE10C10542">
                         <CreateFolder />
@@ -86,6 +98,11 @@
         <CustomAction Id="JoinBundle" BinaryKey="WixCA" DllEntry="WixQuietExec" Execute="deferred" Impersonate="no" />
         <SetProperty Action="CARemoveParts"  Id="RemoveParts"  Value='"[WindowsFolder]\System32\cmd.exe" /c cd "[INSTALLDIR]" &amp;&amp; del /f /q $(var.crcBundlePart0) $(var.crcBundlePart1) $(var.crcBundlePart2)' Before="RemoveParts" Sequence="execute"/>
         <CustomAction Id="RemoveParts" BinaryKey="WixCA" DllEntry="WixQuietExec" Execute="deferred" Impersonate="no" />
+        
+        <SetProperty Action="CACreateCrcUsersGroup"  Id="CreateCrcGroup"  Value='"[WindowsFolder]\System32\cmd.exe" /c net localgroup crc-users /comment:"Group for CodeReady Containers users" /add' Before="CreateCrcGroup" Sequence="execute"/>
+        <CustomAction Id="CreateCrcGroup" BinaryKey="WixCA" DllEntry="WixQuietExec" Execute="deferred" Impersonate="no" Return="ignore" />
+        <SetProperty Action="CARemoveCrcUsersGroup"  Id="RemoveCrcGroup"  Value='"[WindowsFolder]\System32\cmd.exe" /c net localgroup crc-users /del' Before="RemoveCrcGroup" Sequence="execute"/>
+        <CustomAction Id="RemoveCrcGroup" BinaryKey="WixCA" DllEntry="WixQuietExec" Execute="deferred" Impersonate="no" Return="ignore" />
 
         <util:CloseApplication Id = "TrayRunning" Description="Please exit CodeReady Containers from tray and run the installation again."
             Target="crc-tray.exe" RebootPrompt="no"
@@ -94,6 +111,8 @@
         <InstallExecuteSequence>
             <Custom Action="JoinBundle"  After="InstallFiles" >NOT Installed AND NOT PATCH</Custom>
             <Custom Action="RemoveParts"  After="JoinBundle" >NOT Installed AND NOT PATCH</Custom>
+            <Custom Action="CreateCrcGroup" Before="ConfigureUsers" > NOT Installed AND NOT REMOVE~="ALL"</Custom>
+            <Custom Action="RemoveCrcGroup" After="RemoveFolders" > Installed AND NOT PATCH AND REMOVE~="ALL"</Custom>
         </InstallExecuteSequence>
         <Feature Id="DefaultFeature" Level="1">
             <ComponentRef Id="CrcBundlePart1"/>
@@ -105,6 +124,8 @@
             <ComponentRef Id="AddToPath"/>
             <ComponentRef Id="TrayStartup"/>
             <ComponentRef Id="StartMenuEntry" />
+            <ComponentRef Id="AddUserToHypervAdmins" />
+            <ComponentRef Id="AddUserToCrcUsers" />   
         </Feature>
         <UI>
             <UIRef Id="WixUI_ErrorProgressText"/>

--- a/packaging/windows/product.wxs.in
+++ b/packaging/windows/product.wxs.in
@@ -113,6 +113,9 @@
             <Custom Action="RemoveParts"  After="JoinBundle" >NOT Installed AND NOT PATCH</Custom>
             <Custom Action="CreateCrcGroup" Before="ConfigureUsers" > NOT Installed AND NOT REMOVE~="ALL"</Custom>
             <Custom Action="RemoveCrcGroup" After="RemoveFolders" > Installed AND NOT PATCH AND REMOVE~="ALL"</Custom>
+            <Custom Action="InstallHyperv" After="RemoveParts" > NOT Installed AND NOT REMOVE~="ALL"</Custom>
+            <Custom Action="RemoveCrcGroupRollback" Before="CreateCrcGroup" > NOT Installed AND NOT REMOVE~="ALL"</Custom>
+            <ScheduleReboot After="InstallFinalize"> NOT Installed AND NOT REMOVE~="ALL"</ScheduleReboot>
         </InstallExecuteSequence>
         <Feature Id="DefaultFeature" Level="1">
             <ComponentRef Id="CrcBundlePart1"/>

--- a/packaging/windows/product.wxs.in
+++ b/packaging/windows/product.wxs.in
@@ -103,14 +103,14 @@
                 </Component>
             </Directory>
         </Directory>
-        <SetProperty Action="CAJoinBundle"  Id="JoinBundle"  Value='"[WindowsFolder]\System32\cmd.exe" /c cd "[INSTALLDIR]" &amp;&amp; copy /b $(var.crcBundlePart0)+$(var.crcBundlePart1)+$(var.crcBundlePart2) $(var.crcBundleName)' Before="JoinBundle" Sequence="execute"/>
+        <SetProperty Action="CAJoinBundle"  Id="JoinBundle"  Value='"[System64Folder]cmd.exe" /c cd "[INSTALLDIR]" &amp;&amp; copy /b $(var.crcBundlePart0)+$(var.crcBundlePart1)+$(var.crcBundlePart2) $(var.crcBundleName)' Before="JoinBundle" Sequence="execute"/>
         <CustomAction Id="JoinBundle" BinaryKey="WixCA" DllEntry="WixQuietExec" Execute="deferred" Impersonate="no" />
-        <SetProperty Action="CARemoveParts"  Id="RemoveParts"  Value='"[WindowsFolder]\System32\cmd.exe" /c cd "[INSTALLDIR]" &amp;&amp; del /f /q $(var.crcBundlePart0) $(var.crcBundlePart1) $(var.crcBundlePart2)' Before="RemoveParts" Sequence="execute"/>
+        <SetProperty Action="CARemoveParts"  Id="RemoveParts"  Value='"[System64Folder]cmd.exe" /c cd "[INSTALLDIR]" &amp;&amp; del /f /q $(var.crcBundlePart0) $(var.crcBundlePart1) $(var.crcBundlePart2)' Before="RemoveParts" Sequence="execute"/>
         <CustomAction Id="RemoveParts" BinaryKey="WixCA" DllEntry="WixQuietExec" Execute="deferred" Impersonate="no" />
         
-        <SetProperty Action="CACreateCrcUsersGroup"  Id="CreateCrcGroup"  Value='"[WindowsFolder]\System32\cmd.exe" /c net localgroup crc-users /comment:"Group for CodeReady Containers users" /add' Before="CreateCrcGroup" Sequence="execute"/>
+        <SetProperty Action="CACreateCrcUsersGroup"  Id="CreateCrcGroup"  Value='"[System64Folder]cmd.exe" /c net localgroup crc-users /comment:"Group for CodeReady Containers users" /add' Before="CreateCrcGroup" Sequence="execute"/>
         <CustomAction Id="CreateCrcGroup" BinaryKey="WixCA" DllEntry="WixQuietExec" Execute="deferred" Impersonate="no" Return="ignore" />
-        <SetProperty Action="CARemoveCrcUsersGroup"  Id="RemoveCrcGroup"  Value='"[WindowsFolder]\System32\cmd.exe" /c net localgroup crc-users /del' Before="RemoveCrcGroup" Sequence="execute"/>
+        <SetProperty Action="CARemoveCrcUsersGroup"  Id="RemoveCrcGroup"  Value='"[System64Folder]cmd.exe" /c net localgroup crc-users /del' Before="RemoveCrcGroup" Sequence="execute"/>
         <CustomAction Id="RemoveCrcGroup" BinaryKey="WixCA" DllEntry="WixQuietExec" Execute="deferred" Impersonate="no" Return="ignore" />
 
         <util:CloseApplication Id = "TrayRunning" Description="Please exit CodeReady Containers from tray and run the installation again."

--- a/packaging/windows/product.wxs.in
+++ b/packaging/windows/product.wxs.in
@@ -103,9 +103,9 @@
                 </Component>
             </Directory>
         </Directory>
-        <SetProperty Action="CAJoinBundle"  Id="JoinBundle"  Value='"[System64Folder]cmd.exe" /c cd "[INSTALLDIR]" &amp;&amp; copy /b $(var.crcBundlePart0)+$(var.crcBundlePart1)+$(var.crcBundlePart2) $(var.crcBundleName)' Before="JoinBundle" Sequence="execute"/>
+        <SetProperty Action="CAJoinBundle"  Id="JoinBundle"  Value='"[System64Folder]cmd.exe" /c cd /d "[INSTALLDIR]" &amp;&amp; copy /b $(var.crcBundlePart0)+$(var.crcBundlePart1)+$(var.crcBundlePart2) $(var.crcBundleName)' Before="JoinBundle" Sequence="execute"/>
         <CustomAction Id="JoinBundle" BinaryKey="WixCA" DllEntry="WixQuietExec" Execute="deferred" Impersonate="no" />
-        <SetProperty Action="CARemoveParts"  Id="RemoveParts"  Value='"[System64Folder]cmd.exe" /c cd "[INSTALLDIR]" &amp;&amp; del /f /q $(var.crcBundlePart0) $(var.crcBundlePart1) $(var.crcBundlePart2)' Before="RemoveParts" Sequence="execute"/>
+        <SetProperty Action="CARemoveParts"  Id="RemoveParts"  Value='"[System64Folder]cmd.exe" /c cd /d "[INSTALLDIR]" &amp;&amp; del /f /q $(var.crcBundlePart0) $(var.crcBundlePart1) $(var.crcBundlePart2)' Before="RemoveParts" Sequence="execute"/>
         <CustomAction Id="RemoveParts" BinaryKey="WixCA" DllEntry="WixQuietExec" Execute="deferred" Impersonate="no" />
         
         <SetProperty Action="CACreateCrcUsersGroup"  Id="CreateCrcGroup"  Value='"[System64Folder]cmd.exe" /c net localgroup crc-users /comment:"Group for CodeReady Containers users" /add' Before="CreateCrcGroup" Sequence="execute"/>

--- a/packaging/windows/product.wxs.in
+++ b/packaging/windows/product.wxs.in
@@ -112,9 +112,11 @@
         <CustomAction Id="CreateCrcGroup" BinaryKey="WixCA" DllEntry="WixQuietExec" Execute="deferred" Impersonate="no" Return="ignore" />
         <SetProperty Action="CARemoveCrcUsersGroup"  Id="RemoveCrcGroup"  Value='"[System64Folder]cmd.exe" /c net localgroup crc-users /del' Before="RemoveCrcGroup" Sequence="execute"/>
         <CustomAction Id="RemoveCrcGroup" BinaryKey="WixCA" DllEntry="WixQuietExec" Execute="deferred" Impersonate="no" Return="ignore" />
+        <SetProperty Action="CARemoveCrcUsersGroupRollback"  Id="RemoveCrcGroupRollback"  Value='"[System64Folder]cmd.exe" /c net localgroup crc-users /del' Before="RemoveCrcGroup" Sequence="execute"/>
+        <CustomAction Id="RemoveCrcGroupRollback" BinaryKey="WixCA" DllEntry="WixQuietExec" Execute="rollback" Impersonate="no" Return="ignore" />
 
         <SetProperty Action="CAInstallHyperv" Id="InstallHyperv" Value='"[System64Folder]dism.exe" /online /enable-feature /featureName:microsoft-hyper-v-all /NoRestart /quiet' Before="InstallHyperv" Sequence="execute"/>
-        <CustomAction Id="InstallHyperv" BinaryKey="WixCA" DllEntry="WixQuietExec64" Execute="deferred" Impersonate="no" Return="ignore" />
+        <CustomAction Id="InstallHyperv" BinaryKey="WixCA" DllEntry="WixQuietExec64" Execute="deferred" Impersonate="no" />
 
         <util:CloseApplication Id = "TrayRunning" Description="Please exit CodeReady Containers from tray and run the installation again."
             Target="crc-tray.exe" RebootPrompt="no"

--- a/packaging/windows/product.wxs.in
+++ b/packaging/windows/product.wxs.in
@@ -145,7 +145,12 @@
         <UI>
             <UIRef Id="WixUI_ErrorProgressText"/>
             <!-- Define the installer UI -->
-            <UIRef Id="WixUI_HK"/>
+            <UIRef Id="WixUI_HK"/> 
+            <ProgressText Action="JoinBundle">Combining bundle parts</ProgressText>
+            <ProgressText Action="RemoveParts">Removing bundle parts after combining</ProgressText>
+            <ProgressText Action="CreateCrcGroup">Creating crc-users group</ProgressText>
+            <ProgressText Action="RemoveCrcGroup">Removing crc-users group</ProgressText>
+            <ProgressText Action="InstallHyperv">Installing Hyper-V</ProgressText>
         </UI>
         <Property Id="WIXUI_INSTALLDIR" Value="INSTALLDIR" />
         <!-- this should help to propagate env var changes -->


### PR DESCRIPTION
### Steps to test:
After Installing the msi:
1. Check that `crc-users` group is created and has the current user as a member
2. the current user is also added to the `hyper-v administrators` group
3. after finishing installation user is prompted to reboot
4. When uninstalled `crc-users` group is removed

Msi to test can be downloaded from appveyor CI artifacts at: https://ci.appveyor.com/api/buildjobs/27np6xmfa3j9dg3v/artifacts/out%2Fwindows-amd64%2Fcrc-windows-installer.zip