### PR TITLE
Add missing disk size when starting the VM from the API

### DIFF
--- a/pkg/crc/api/handlers.go
+++ b/pkg/crc/api/handlers.go
@@ -91,6 +91,7 @@ func getStartConfig(cfg crcConfig.Storage, args client.StartConfig) types.StartC
 	return types.StartConfig{
 		BundlePath:        cfg.Get(crcConfig.Bundle).AsString(),
 		Memory:            cfg.Get(crcConfig.Memory).AsInt(),
+		DiskSize:          cfg.Get(crcConfig.DiskSize).AsInt(),
 		CPUs:              cfg.Get(crcConfig.CPUs).AsInt(),
 		NameServer:        cfg.Get(crcConfig.NameServer).AsString(),
 		PullSecret:        cluster.NewNonInteractivePullSecretLoader(cfg, args.PullSecretFile),


### PR DESCRIPTION
When the VM was started from the tray, the disk was not resized
correctly.

Related to https://github.com/code-ready/crc/pull/2439