### PR TITLE
Delete outdated rendered master/worker machineconfigs and just keep the latest one

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL := /bin/bash
 
-BUNDLE_VERSION ?= 4.7.18
+BUNDLE_VERSION ?= 4.8.0
 BUNDLE_EXTENSION = crcbundle
 CRC_VERSION = 1.29.1
 COMMIT_SHA=$(shell git rev-parse --short HEAD)

--- a/centos_ci.sh
+++ b/centos_ci.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # bundle location
-BUNDLE_VERSION=4.7.18
+BUNDLE_VERSION=4.8.0
 BUNDLE=crc_libvirt_$BUNDLE_VERSION.crcbundle
 GO_VERSION=1.15.13
 

--- a/pkg/crc/machine/generate_bundle.go
+++ b/pkg/crc/machine/generate_bundle.go
@@ -1,7 +1,6 @@
 package machine
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -33,8 +32,7 @@ func (client *client) GenerateBundle(forceStop bool) error {
 	}
 
 	// Stop the cluster
-	currentState, err := client.Stop()
-	if err != nil {
+	if _, err := client.Stop(); err != nil {
 		if forceStop {
 			if err := client.PowerOff(); err != nil {
 				return err
@@ -42,8 +40,12 @@ func (client *client) GenerateBundle(forceStop bool) error {
 		}
 		return err
 	}
-	if currentState != state.Stopped {
-		return fmt.Errorf("VM is not stopped, current state is %s", currentState.String())
+	running, err := client.IsRunning()
+	if err != nil {
+		return err
+	}
+	if running {
+		return errors.New("VM is still running")
 	}
 
 	tmpBaseDir, err := ioutil.TempDir(constants.MachineCacheDir, "crc_custom_bundle")

--- a/pkg/crc/machine/generate_bundle.go
+++ b/pkg/crc/machine/generate_bundle.go
@@ -37,8 +37,9 @@ func (client *client) GenerateBundle(forceStop bool) error {
 			if err := client.PowerOff(); err != nil {
 				return err
 			}
+		} else {
+			return err
 		}
-		return err
 	}
 	running, err := client.IsRunning()
 	if err != nil {

--- a/pkg/crc/machine/generate_bundle.go
+++ b/pkg/crc/machine/generate_bundle.go
@@ -28,6 +28,10 @@ func (client *client) GenerateBundle(forceStop bool) error {
 		return errors.Wrap(err, "Error removing pull secret from cluster")
 	}
 
+	if err := cluster.RemoveOldRenderedMachineConfig(ocConfig); err != nil {
+		return errors.Wrap(err, "Error removing old rendered machine configs")
+	}
+
 	// Stop the cluster
 	currentState, err := client.Stop()
 	if err != nil {

--- a/pkg/crc/machine/generate_bundle.go
+++ b/pkg/crc/machine/generate_bundle.go
@@ -25,7 +25,7 @@ func (client *client) GenerateBundle(forceStop bool) error {
 
 	ocConfig := oc.UseOCWithSSH(sshRunner)
 	if err := cluster.RemovePullSecretFromCluster(ocConfig, sshRunner); err != nil {
-		return errors.Wrap(err, "Error loading bundle metadata")
+		return errors.Wrap(err, "Error removing pull secret from cluster")
 	}
 
 	// Stop the cluster

--- a/test/e2e/features/basic.feature
+++ b/test/e2e/features/basic.feature
@@ -148,7 +148,7 @@ Feature: Basic test
         # This will remove the pull secret from the instance and from the cluster
         # You need to provide pull secret file again if you want to start this cluster
         # from a stopped state.
-        Given executing "crc bundle generate" succeeds
+        Given executing "crc bundle generate -f" succeeds
 
     @darwin @windows
     Scenario: CRC forcible stop


### PR DESCRIPTION
Those old rendered machine config contain the initial pull spec for
the cluster so better to remove those before bundle generation.

```
$ oc get mc --sort-by=.metadata.creationTimestamp --no-headers
99-master-ssh                                                                                 3.2.0   43h
chronyd-mask                                                                                  3.1.0   43h
99-worker-ssh                                                                                 3.2.0   43h
99-openshift-machineconfig-master-dummy-networks                                              3.2.0   43h
00-master                                          b20ecdcd81dc3aa1269757ddfe97603918194b3b   3.2.0   43h
00-worker                                          b20ecdcd81dc3aa1269757ddfe97603918194b3b   3.2.0   43h
01-master-kubelet                                  b20ecdcd81dc3aa1269757ddfe97603918194b3b   3.2.0   43h
01-master-container-runtime                        b20ecdcd81dc3aa1269757ddfe97603918194b3b   3.2.0   43h
01-worker-container-runtime                        b20ecdcd81dc3aa1269757ddfe97603918194b3b   3.2.0   43h
01-worker-kubelet                                  b20ecdcd81dc3aa1269757ddfe97603918194b3b   3.2.0   43h
rendered-master-6a52c924beeab10c4d917eb7786d8d9c   b20ecdcd81dc3aa1269757ddfe97603918194b3b   3.2.0   43h
rendered-worker-c0d4ccd0599554ca84cdac121c99b8c0   b20ecdcd81dc3aa1269757ddfe97603918194b3b   3.2.0   43h
99-worker-generated-registries                     b20ecdcd81dc3aa1269757ddfe97603918194b3b   3.2.0   43h
99-master-generated-registries                     b20ecdcd81dc3aa1269757ddfe97603918194b3b   3.2.0   43h
rendered-worker-73ad21005c178f63a66398638aaa05ae   b20ecdcd81dc3aa1269757ddfe97603918194b3b   3.2.0   18h
rendered-master-35111bcd08dccd57f47acaa57cb1d296   b20ecdcd81dc3aa1269757ddfe97603918194b3b   3.2.0   18h
rendered-master-f5f05aad7d6a34e21fca04e799e54a44   b20ecdcd81dc3aa1269757ddfe97603918194b3b   3.2.0   3h21m
rendered-worker-24d71aa1fbe25a89567669d89d53065d   b20ecdcd81dc3aa1269757ddfe97603918194b3b   3.2.0   3h21m
rendered-master-de3a028583cb2ac28121fc8d527637a2   b20ecdcd81dc3aa1269757ddfe97603918194b3b   3.2.0   142m
rendered-worker-68ca5066a7c81354e3693a0abf8ff3df   b20ecdcd81dc3aa1269757ddfe97603918194b3b   3.2.0   142m

// All the rendered master except lastet one
$ oc get mc --sort-by=.metadata.creationTimestamp --no-headers -oname | grep rendered-master | head -n -1
machineconfig.machineconfiguration.openshift.io/rendered-master-6a52c924beeab10c4d917eb7786d8d9c
machineconfig.machineconfiguration.openshift.io/rendered-master-35111bcd08dccd57f47acaa57cb1d296
machineconfig.machineconfiguration.openshift.io/rendered-master-f5f05aad7d6a34e21fca04e799e54a44
```


**Fixes:** Issue #N

**Relates to:** Issue #N, PR #N, ...

## Solution/Idea

Describe in plain English what you solved and how. For instance, _Added `start` command to CRC so the user can create a VM and set-up a single-node OpenShift cluster on it with one command. It requires blablabla..._

## Proposed changes

List main as well as consequential changes you introduced or had to introduce.

1. Add `start` command.
2. Add `setup` as prerequisite to `start`.
3. ...

## Testing

What is the _bottom-line_ functionality that needs testing? Describe in pseudo-code or in English. Use verifiable statements that tie your changes to existing functionality.

1. `start` succeeds first time after `setup` succeeded
2. stdout contains ... if `start` succeeded
3. stderr contains ... after `start` failed
4. `status` returns ... if `start` succeeded
5. `status` returns ... if `start` failed
6. `start` fails after `start` succeeded or after `status` says CRC is `Running`
7. ...
