### PR TITLE
Use regex instead string match for stop command

### DIFF
--- a/test/integration/resize_test.go
+++ b/test/integration/resize_test.go
@@ -44,7 +44,7 @@ var _ = Describe("vary VM parameters: memory cpus, disk", func() {
 		})
 
 		It("stop CRC", func() {
-			Expect(RunCRCExpectSuccess("stop", "-f")).To(ContainSubstring("Stopped the OpenShift cluster"))
+			Expect(RunCRCExpectSuccess("stop", "-f")).To(MatchRegexp("[Ss]topped the OpenShift cluster"))
 		})
 
 	})
@@ -84,7 +84,7 @@ var _ = Describe("vary VM parameters: memory cpus, disk", func() {
 		})
 
 		It("stop CRC", func() {
-			Expect(RunCRCExpectSuccess("stop", "-f")).To(ContainSubstring("Stopped the OpenShift cluster"))
+			Expect(RunCRCExpectSuccess("stop", "-f")).To(MatchRegexp("[Ss]topped the OpenShift cluster"))
 		})
 	})
 


### PR DESCRIPTION
`crc stop -f` can have different output if vm is shutdown
gracefully or vm is shutdown forcefully. To capture both kind
of output we need to use regex match instead string match.


