### PR TITLE
Bump golangci-lint to v1.41.1

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,4 +12,4 @@ linters:
     - gocritic
     - deadcode
     - misspell
-    - golint
+    - revive

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ CRC_VERSION = 1.28.0
 COMMIT_SHA=$(shell git rev-parse --short HEAD)
 MACOS_INSTALL_PATH = /Applications/CodeReady Containers.app/Contents/Resources/
 CONTAINER_RUNTIME ?= podman
-GOLANGCI_LINT_VERSION = v1.39.0
+GOLANGCI_LINT_VERSION = v1.41.1
 
 ifdef OKD_VERSION
     BUNDLE_VERSION = $(OKD_VERSION)

--- a/cmd/crc/cmd/start.go
+++ b/cmd/crc/cmd/start.go
@@ -52,10 +52,7 @@ var startCmd = &cobra.Command{
 		if err := viper.BindFlagSet(cmd.Flags()); err != nil {
 			return err
 		}
-		if err := renderStartResult(runStart(cmd.Context())); err != nil {
-			return err
-		}
-		return nil
+		return renderStartResult(runStart(cmd.Context()))
 	},
 }
 

--- a/pkg/crc/adminhelper/hosts.go
+++ b/pkg/crc/adminhelper/hosts.go
@@ -17,10 +17,7 @@ func UpdateHostsFile(instanceIP string, hostnames ...string) error {
 	if err := RemoveFromHostsFile(hostnames...); err != nil {
 		return err
 	}
-	if err := AddToHostsFile(instanceIP, hostnames...); err != nil {
-		return err
-	}
-	return nil
+	return AddToHostsFile(instanceIP, hostnames...)
 }
 
 func AddToHostsFile(instanceIP string, hostnames ...string) error {

--- a/pkg/crc/ssh/keys_windows.go
+++ b/pkg/crc/ssh/keys_windows.go
@@ -34,18 +34,10 @@ func (kp *KeyPair) WriteToFile(privateKeyPath string, publicKeyPath string) erro
 			return ErrUnableToWriteFile
 		}
 
-		if err := windowsChmod(v.File, 0600); err != nil {
+		if err := acl.Chmod(v.File, 0600); err != nil {
 			return err
 		}
 
-	}
-
-	return nil
-}
-
-func windowsChmod(filePath string, fileMode os.FileMode) error {
-	if err := acl.Chmod(filePath, fileMode); err != nil {
-		return err
 	}
 
 	return nil

--- a/pkg/drivers/hyperv/hyperv_windows.go
+++ b/pkg/drivers/hyperv/hyperv_windows.go
@@ -198,13 +198,9 @@ func (d *Driver) Create() error {
 		}
 	}
 
-	if err := cmd("Hyper-V\\Add-VMHardDiskDrive",
+	return cmd("Hyper-V\\Add-VMHardDiskDrive",
 		"-VMName", d.MachineName,
-		"-Path", quote(d.getDiskPath())); err != nil {
-		return err
-	}
-
-	return nil
+		"-Path", quote(d.getDiskPath()))
 }
 
 func (d *Driver) chooseVirtualSwitch() (string, error) {

--- a/pkg/os/launchd/launchd_darwin.go
+++ b/pkg/os/launchd/launchd_darwin.go
@@ -55,10 +55,7 @@ var (
 )
 
 func ensureLaunchAgentsDirExists() error {
-	if err := goos.MkdirAll(launchAgentsDir, 0700); err != nil {
-		return err
-	}
-	return nil
+	return goos.MkdirAll(launchAgentsDir, 0700)
 }
 
 func getPlistPath(label string) string {

--- a/test/extended/util/util.go
+++ b/test/extended/util/util.go
@@ -22,7 +22,8 @@ func CopyFilesToTestDir() error {
 	}
 
 	l := strings.Split(cwd, string(filepath.Separator))
-	dataDirPieces := append(l[:len(l)-3], "testdata")
+	dataDirPieces := l[:len(l)-3]
+	dataDirPieces = append(dataDirPieces, "testdata")
 	var volume string
 	if runtime.GOOS == "windows" {
 		volume = filepath.VolumeName(cwd)


### PR DESCRIPTION
This version is compatible with go1.15. golint linter is replaced by
revive.

