### PR TITLE
Add proxy-ca-file to http transport

### DIFF
--- a/cmd/crc/cmd/start.go
+++ b/cmd/crc/cmd/start.go
@@ -211,7 +211,7 @@ func checkIfNewVersionAvailable(noUpdateCheck bool) error {
 }
 
 func newVersionAvailable() (bool, string, string, error) {
-	release, err := crcversion.GetCRCLatestVersionFromMirror()
+	release, err := crcversion.GetCRCLatestVersionFromMirror(httpTransport())
 	if err != nil {
 		return false, "", "", err
 	}

--- a/pkg/crc/segment/segment.go
+++ b/pkg/crc/segment/segment.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -30,19 +31,20 @@ type Client struct {
 	telemetryFilePath string
 }
 
-func NewClient(config *crcConfig.Config) (*Client, error) {
-	return newCustomClient(config,
+func NewClient(config *crcConfig.Config, transport http.RoundTripper) (*Client, error) {
+	return newCustomClient(config, transport,
 		filepath.Join(constants.GetHomeDir(), ".redhat", "anonymousId"),
 		analytics.DefaultEndpoint)
 }
 
-func newCustomClient(config *crcConfig.Config, telemetryFilePath, segmentEndpoint string) (*Client, error) {
+func newCustomClient(config *crcConfig.Config, transport http.RoundTripper, telemetryFilePath, segmentEndpoint string) (*Client, error) {
 	client, err := analytics.NewWithConfig(WriteKey, analytics.Config{
 		Endpoint: segmentEndpoint,
 		Logger:   &loggingAdapter{},
 		DefaultContext: &analytics.Context{
 			IP: net.IPv4(0, 0, 0, 0),
 		},
+		Transport: transport,
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/crc/segment/segment_test.go
+++ b/pkg/crc/segment/segment_test.go
@@ -88,7 +88,7 @@ func TestClientUploadWithConsentAndWithSerializableError(t *testing.T) {
 
 	uuidFile := filepath.Join(dir, "telemetry")
 
-	c, err := newCustomClient(config, uuidFile, server.URL)
+	c, err := newCustomClient(config, http.DefaultTransport, uuidFile, server.URL)
 	require.NoError(t, err)
 
 	require.NoError(t, c.UploadCmd(context.Background(), "start", time.Minute, crcErr.ToSerializableError(crcErr.VMNotExist)))
@@ -128,7 +128,7 @@ func TestClientUploadWithConsentAndWithoutSerializableError(t *testing.T) {
 	config, err := newTestConfig("yes")
 	require.NoError(t, err)
 
-	c, err := newCustomClient(config, filepath.Join(dir, "telemetry"), server.URL)
+	c, err := newCustomClient(config, http.DefaultTransport, filepath.Join(dir, "telemetry"), server.URL)
 	require.NoError(t, err)
 
 	require.NoError(t, c.UploadCmd(context.Background(), "start", time.Minute, errors.New("an error occurred")))
@@ -163,7 +163,7 @@ func TestClientUploadWithContext(t *testing.T) {
 	config, err := newTestConfig("yes")
 	require.NoError(t, err)
 
-	c, err := newCustomClient(config, filepath.Join(dir, "telemetry"), server.URL)
+	c, err := newCustomClient(config, http.DefaultTransport, filepath.Join(dir, "telemetry"), server.URL)
 	require.NoError(t, err)
 
 	ctx := telemetry.NewContext(context.Background())
@@ -193,7 +193,7 @@ func TestClientUploadWithOutConsent(t *testing.T) {
 	config, err := newTestConfig("no")
 	require.NoError(t, err)
 
-	c, err := newCustomClient(config, filepath.Join(dir, "telemetry"), server.URL)
+	c, err := newCustomClient(config, http.DefaultTransport, filepath.Join(dir, "telemetry"), server.URL)
 	require.NoError(t, err)
 
 	require.NoError(t, c.UploadCmd(context.Background(), "start", time.Second, errors.New("an error occurred")))

--- a/pkg/crc/version/version.go
+++ b/pkg/crc/version/version.go
@@ -83,9 +83,10 @@ func IsMsiBuild() bool {
 	return msiBuild != "false"
 }
 
-func GetCRCLatestVersionFromMirror() (*CrcReleaseInfo, error) {
+func GetCRCLatestVersionFromMirror(transport http.RoundTripper) (*CrcReleaseInfo, error) {
 	client := &http.Client{
-		Timeout: 5 * time.Second,
+		Timeout:   5 * time.Second,
+		Transport: transport,
 	}
 	req, err := http.NewRequest(http.MethodGet, releaseInfoLink, nil)
 	if err != nil {


### PR DESCRIPTION
Segment and version check may use the proxy via HTTP_PROXY env
variables. This doesn't include the proxy CA.
This change loads the cert from proxy-ca-file configuration key and use
 it when it is possible.

How to test:
* run mitmproxy
* crc config set proxy-ca-file $HOME/.mitmproxy/mitmproxy-ca-cert.cer
* run crc version with telemetry enabled.

