### PR TITLE
Replace kubeconfig file for each fresh start of crc 

### DIFF
--- a/pkg/crc/cluster/clusteroperator.go
+++ b/pkg/crc/cluster/clusteroperator.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/code-ready/crc/pkg/crc/machine/bundle"
 	clientset "github.com/openshift/client-go/config/clientset/versioned"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -80,8 +79,8 @@ func (status *Status) IsReady() bool {
 	return status.Available && !status.Progressing && !status.Degraded && !status.Disabled
 }
 
-func GetClusterOperatorsStatus(ctx context.Context, ip string, bundle *bundle.CrcBundleInfo) (*Status, error) {
-	lister, err := kubernetesClient(ip, bundle)
+func GetClusterOperatorsStatus(ctx context.Context, ip string, kubeconfigFilePath string) (*Status, error) {
+	lister, err := kubernetesClient(ip, kubeconfigFilePath)
 	if err != nil {
 		return nil, err
 	}
@@ -157,16 +156,16 @@ type operatorLister interface {
 	List(ctx context.Context, opts metav1.ListOptions) (*openshiftapi.ClusterOperatorList, error)
 }
 
-func kubernetesClient(ip string, bundle *bundle.CrcBundleInfo) (*clientset.Clientset, error) {
-	config, err := kubernetesClientConfiguration(ip, bundle)
+func kubernetesClient(ip string, kubeconfigFilePath string) (*clientset.Clientset, error) {
+	config, err := kubernetesClientConfiguration(ip, kubeconfigFilePath)
 	if err != nil {
 		return nil, err
 	}
 	return clientset.NewForConfig(config)
 }
 
-func kubernetesClientConfiguration(ip string, bundle *bundle.CrcBundleInfo) (*restclient.Config, error) {
-	config, err := clientcmd.BuildConfigFromFlags("", bundle.GetKubeConfigPath())
+func kubernetesClientConfiguration(ip string, kubeconfigFilePath string) (*restclient.Config, error) {
+	config, err := clientcmd.BuildConfigFromFlags("", kubeconfigFilePath)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/crc/cluster/status.go
+++ b/pkg/crc/cluster/status.go
@@ -6,11 +6,10 @@ import (
 	"time"
 
 	"github.com/code-ready/crc/pkg/crc/logging"
-	"github.com/code-ready/crc/pkg/crc/machine/bundle"
 )
 
 // WaitForClusterStable checks that the cluster is running a number of consecutive times
-func WaitForClusterStable(ctx context.Context, ip string, bundle *bundle.CrcBundleInfo) error {
+func WaitForClusterStable(ctx context.Context, ip string, kubeconfigFilePath string) error {
 	if ctx.Err() != nil {
 		return ctx.Err()
 	}
@@ -24,7 +23,7 @@ func WaitForClusterStable(ctx context.Context, ip string, bundle *bundle.CrcBund
 	var count int // holds num of consecutive matches
 
 	for i := 0; i < retryCount; i++ {
-		status, err := GetClusterOperatorsStatus(ctx, ip, bundle)
+		status, err := GetClusterOperatorsStatus(ctx, ip, kubeconfigFilePath)
 		if err == nil {
 			// update counter for consecutive matches
 			if status.IsReady() {

--- a/pkg/crc/constants/constants.go
+++ b/pkg/crc/constants/constants.go
@@ -96,6 +96,7 @@ var (
 	MachineInstanceDir = filepath.Join(MachineBaseDir, "machines")
 	DefaultBundlePath  = defaultBundlePath()
 	DaemonSocketPath   = filepath.Join(CrcBaseDir, "crc.sock")
+	KubeconfigFilePath = filepath.Join(MachineInstanceDir, DefaultName, "kubeconfig")
 )
 
 func defaultBundlePath() string {

--- a/pkg/crc/machine/kubeconfig_test.go
+++ b/pkg/crc/machine/kubeconfig_test.go
@@ -52,3 +52,13 @@ func TestCleanKubeconfig(t *testing.T) {
 	assert.NoError(t, err)
 	assert.YAMLEq(t, string(expected), string(actual))
 }
+
+func TestUpdateUserCaAndKeyToKubeconfig(t *testing.T) {
+	f, err := ioutil.TempFile("", "kubeconfig")
+	assert.NoError(t, err, "")
+	err = updateClientCrtAndKeyToKubeconfig([]byte("dummykey"), []byte("dummycert"), filepath.Join("testdata", "kubeconfig.in"), f.Name())
+	assert.NoError(t, err)
+	userClientCA, err := adminClientCertificate(f.Name())
+	assert.NoError(t, err)
+	assert.Equal(t, "dummycert", userClientCA)
+}

--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -448,8 +448,7 @@ func (client *client) Start(ctx context.Context, startConfig types.StartConfig) 
 	}
 
 	logging.Info("Starting OpenShift cluster... [waiting for the cluster to stabilize]")
-
-	if err := cluster.WaitForClusterStable(ctx, instanceIP, crcBundleMetadata); err != nil {
+	if err := cluster.WaitForClusterStable(ctx, instanceIP, constants.KubeconfigFilePath); err != nil {
 		logging.Errorf("Cluster is not ready: %v", err)
 	}
 
@@ -616,16 +615,15 @@ func updateSSHKeyPair(sshRunner *crcssh.Runner) error {
 }
 
 func copyKubeconfig(name string, machineConfig config.MachineConfig) error {
-	kubeConfigFilePath := filepath.Join(constants.MachineInstanceDir, name, "kubeconfig")
-	if _, err := os.Stat(kubeConfigFilePath); err == nil {
+	if _, err := os.Stat(constants.KubeconfigFilePath); err == nil {
 		return nil
 	}
 
-	// Copy Kubeconfig file from bundle extract path to machine directory.
-	// In our case it would be ~/.crc/machines/crc/
+	// Copy Kubeconfig file content from bundle extract path to machine directory.
+	// In our case it would be `constants.KubeconfigFilePath`
 	logging.Info("Copying kubeconfig file to instance dir...")
 	err := crcos.CopyFileContents(machineConfig.KubeConfig,
-		kubeConfigFilePath,
+		constants.KubeconfigFilePath,
 		0644)
 	if err != nil {
 		return fmt.Errorf("Error copying kubeconfig file to instance dir: %v", err)

--- a/pkg/crc/machine/status.go
+++ b/pkg/crc/machine/status.go
@@ -55,7 +55,7 @@ func (client *client) Status() (*types.ClusterStatusResult, error) {
 	diskSize, diskUse := client.getDiskDetails(ip, crcBundleMetadata)
 	return &types.ClusterStatusResult{
 		CrcStatus:        state.Running,
-		OpenshiftStatus:  getOpenShiftStatus(context.Background(), ip, crcBundleMetadata),
+		OpenshiftStatus:  getOpenShiftStatus(context.Background(), ip),
 		OpenshiftVersion: crcBundleMetadata.GetOpenshiftVersion(),
 		DiskUse:          diskUse,
 		DiskSize:         diskSize,
@@ -82,8 +82,8 @@ func (client *client) getDiskDetails(ip string, bundle *bundle.CrcBundleInfo) (i
 	return disk.([]int64)[0], disk.([]int64)[1]
 }
 
-func getOpenShiftStatus(ctx context.Context, ip string, bundle *bundle.CrcBundleInfo) types.OpenshiftStatus {
-	status, err := cluster.GetClusterOperatorsStatus(ctx, ip, bundle)
+func getOpenShiftStatus(ctx context.Context, ip string) types.OpenshiftStatus {
+	status, err := cluster.GetClusterOperatorsStatus(ctx, ip, constants.KubeconfigFilePath)
 	if err != nil {
 		logging.Debugf("cannot get OpenShift status: %v", err)
 		return types.OpenshiftUnreachable

--- a/pkg/crc/machine/testdata/kubeconfig.in
+++ b/pkg/crc/machine/testdata/kubeconfig.in
@@ -61,3 +61,7 @@ users:
 - name: kubeadmin
   user:
     token: token4
+- name: admin
+  user:
+    client-certificate-data: ZW1wdHkK
+    client-key-data: ZW1wdHkK

--- a/pkg/crc/machine/testdata/kubeconfig.out
+++ b/pkg/crc/machine/testdata/kubeconfig.out
@@ -22,6 +22,10 @@ current-context: ""
 kind: Config
 preferences: {}
 users:
+- name: admin
+  user:
+    client-certificate-data: ZW1wdHkK
+    client-key-data: ZW1wdHkK
 - name: developer/192-168-42-71:8443
   user:
     token: token2

--- a/pkg/crc/tls/tls.go
+++ b/pkg/crc/tls/tls.go
@@ -1,0 +1,279 @@
+package tls
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"encoding/pem"
+	"math"
+	"math/big"
+	"net"
+	"time"
+
+	"github.com/code-ready/crc/pkg/crc/logging"
+	"github.com/pkg/errors"
+)
+
+// This file is taken from openshift/installer repo and adds more function
+// https://github.com/openshift/installer/blob/master/pkg/asset/tls/tls.go
+// Importing installer just for this file adds lots of different dependencies
+// and also increase the binary size.
+const (
+	keySize = 2048
+
+	// ValidityOneDay sets the validity of a cert to 24 hours.
+	ValidityOneDay = time.Hour * 24
+
+	// ValidityOneYear sets the validity of a cert to 1 year.
+	ValidityOneYear = ValidityOneDay * 365
+
+	// ValidityTenYears sets the validity of a cert to 10 years.
+	ValidityTenYears = ValidityOneYear * 10
+)
+
+// CertCfg contains all needed fields to configure a new certificate
+type CertCfg struct {
+	DNSNames     []string
+	ExtKeyUsages []x509.ExtKeyUsage
+	IPAddresses  []net.IP
+	KeyUsages    x509.KeyUsage
+	Subject      pkix.Name
+	Validity     time.Duration
+	IsCA         bool
+}
+
+// rsaPublicKey reflects the ASN.1 structure of a PKCS#1 public key.
+type rsaPublicKey struct {
+	N *big.Int
+	E int
+}
+
+// PrivateKey generates an RSA Private key and returns the value
+func PrivateKey() (*rsa.PrivateKey, error) {
+	rsaKey, err := rsa.GenerateKey(rand.Reader, keySize)
+	if err != nil {
+		return nil, errors.Wrap(err, "error generating RSA private key")
+	}
+
+	return rsaKey, nil
+}
+
+// SelfSignedCertificate creates a self signed certificate
+func SelfSignedCertificate(cfg *CertCfg, key *rsa.PrivateKey) (*x509.Certificate, error) {
+	serial, err := rand.Int(rand.Reader, new(big.Int).SetInt64(math.MaxInt64))
+	if err != nil {
+		return nil, err
+	}
+	cert := x509.Certificate{
+		BasicConstraintsValid: true,
+		IsCA:                  cfg.IsCA,
+		KeyUsage:              cfg.KeyUsages,
+		NotAfter:              time.Now().Add(cfg.Validity),
+		NotBefore:             time.Now(),
+		SerialNumber:          serial,
+		Subject:               cfg.Subject,
+	}
+	// verifies that the CN and/or OU for the cert is set
+	if len(cfg.Subject.CommonName) == 0 || len(cfg.Subject.OrganizationalUnit) == 0 {
+		return nil, errors.Errorf("certification's subject is not set, or invalid")
+	}
+	pub := key.Public()
+	cert.SubjectKeyId, err = generateSubjectKeyID(pub)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to set subject key identifier")
+	}
+	certBytes, err := x509.CreateCertificate(rand.Reader, &cert, &cert, key.Public(), key)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create certificate")
+	}
+	return x509.ParseCertificate(certBytes)
+}
+
+// SignedCertificate creates a new X.509 certificate based on a template.
+func SignedCertificate(
+	cfg *CertCfg,
+	csr *x509.CertificateRequest,
+	key *rsa.PrivateKey,
+	caCert *x509.Certificate,
+	caKey *rsa.PrivateKey,
+) (*x509.Certificate, error) {
+	serial, err := rand.Int(rand.Reader, new(big.Int).SetInt64(math.MaxInt64))
+	if err != nil {
+		return nil, err
+	}
+
+	certTmpl := x509.Certificate{
+		DNSNames:              csr.DNSNames,
+		ExtKeyUsage:           cfg.ExtKeyUsages,
+		IPAddresses:           csr.IPAddresses,
+		KeyUsage:              cfg.KeyUsages,
+		NotAfter:              time.Now().Add(cfg.Validity),
+		NotBefore:             caCert.NotBefore,
+		SerialNumber:          serial,
+		Subject:               csr.Subject,
+		IsCA:                  cfg.IsCA,
+		Version:               3,
+		BasicConstraintsValid: true,
+	}
+	pub := key.Public()
+	certTmpl.SubjectKeyId, err = generateSubjectKeyID(pub)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to set subject key identifier")
+	}
+	certBytes, err := x509.CreateCertificate(rand.Reader, &certTmpl, caCert, key.Public(), caKey)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create x509 certificate")
+	}
+	return x509.ParseCertificate(certBytes)
+}
+
+// generateSubjectKeyID generates a SHA-1 hash of the subject public key.
+func generateSubjectKeyID(pub crypto.PublicKey) ([]byte, error) {
+	var publicKeyBytes []byte
+	var err error
+
+	switch pub := pub.(type) {
+	case *rsa.PublicKey:
+		publicKeyBytes, err = asn1.Marshal(rsaPublicKey{N: pub.N, E: pub.E})
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to Marshal ans1 public key")
+		}
+	case *ecdsa.PublicKey:
+		publicKeyBytes = elliptic.Marshal(pub.Curve, pub.X, pub.Y)
+	default:
+		return nil, errors.New("only RSA and ECDSA public keys supported")
+	}
+
+	hash := sha256.Sum256(publicKeyBytes)
+	return hash[:], nil
+}
+
+// GenerateSignedCertificate generate a key and cert defined by CertCfg and signed by CA.
+func GenerateSignedCertificate(caKey *rsa.PrivateKey, caCert *x509.Certificate,
+	cfg *CertCfg) (*rsa.PrivateKey, *x509.Certificate, error) {
+
+	// create a private key
+	key, err := PrivateKey()
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "failed to generate private key")
+	}
+
+	// create a CSR
+	csrTmpl := x509.CertificateRequest{Subject: cfg.Subject, DNSNames: cfg.DNSNames, IPAddresses: cfg.IPAddresses}
+	csrBytes, err := x509.CreateCertificateRequest(rand.Reader, &csrTmpl, key)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "failed to create certificate request")
+	}
+
+	csr, err := x509.ParseCertificateRequest(csrBytes)
+	if err != nil {
+		logging.Debugf("Failed to parse x509 certificate request: %s", err)
+		return nil, nil, errors.Wrap(err, "error parsing x509 certificate request")
+	}
+
+	// create a cert
+	cert, err := SignedCertificate(cfg, csr, key, caCert, caKey)
+	if err != nil {
+		logging.Debugf("Failed to create a signed certificate: %s", err)
+		return nil, nil, errors.Wrap(err, "failed to create a signed certificate")
+	}
+	return key, cert, nil
+}
+
+// GenerateSelfSignedCertificate generates a key/cert pair defined by CertCfg.
+func GenerateSelfSignedCertificate(cfg *CertCfg) (*rsa.PrivateKey, *x509.Certificate, error) {
+	key, err := PrivateKey()
+	if err != nil {
+		logging.Debugf("Failed to generate a private key: %s", err)
+		return nil, nil, errors.Wrap(err, "failed to generate private key")
+	}
+
+	crt, err := SelfSignedCertificate(cfg, key)
+	if err != nil {
+		logging.Debugf("Failed to create self-signed certificate: %s", err)
+		return nil, nil, errors.Wrap(err, "failed to create self-signed certificate")
+	}
+	return key, crt, nil
+}
+
+func GetSelfSignedCA() (*rsa.PrivateKey, *x509.Certificate, error) {
+	rootCAConf := &CertCfg{
+		Subject:   pkix.Name{CommonName: "admin-kubeconfig-signer-custom", OrganizationalUnit: []string{"openshift"}},
+		KeyUsages: x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		Validity:  ValidityTenYears,
+		IsCA:      true,
+	}
+	return GenerateSelfSignedCertificate(rootCAConf)
+}
+
+func GenerateClientCertificate(rootCAKey *rsa.PrivateKey, rootCACert *x509.Certificate) ([]byte, []byte, error) {
+	adminUserConf := &CertCfg{
+		Subject:      pkix.Name{CommonName: "system:admin", OrganizationalUnit: []string{"system:masters"}},
+		KeyUsages:    x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+		Validity:     ValidityTenYears,
+	}
+	clientKey, clientCrt, err := GenerateSignedCertificate(rootCAKey, rootCACert, adminUserConf)
+	if err != nil {
+		return nil, nil, err
+	}
+	return PrivateKeyToPem(clientKey), CertToPem(clientCrt), nil
+}
+
+// PrivateKeyToPem converts an rsa.PrivateKey object to pem string
+func PrivateKeyToPem(key *rsa.PrivateKey) []byte {
+	keyInBytes := x509.MarshalPKCS1PrivateKey(key)
+	keyinPem := pem.EncodeToMemory(
+		&pem.Block{
+			Type:  "RSA PRIVATE KEY",
+			Bytes: keyInBytes,
+		},
+	)
+	return keyinPem
+}
+
+// CertToPem converts an x509.Certificate object to a pem string
+func CertToPem(cert *x509.Certificate) []byte {
+	certInPem := pem.EncodeToMemory(
+		&pem.Block{
+			Type:  "CERTIFICATE",
+			Bytes: cert.Raw,
+		},
+	)
+	return certInPem
+}
+
+// VerifyCertificateAgainstRootCA  takes caPEM and certificatePEM as string
+// to validate if given certificate is signed by given ca.
+func VerifyCertificateAgainstRootCA(ca, certificate string) (bool, error) {
+	roots := x509.NewCertPool()
+	ok := roots.AppendCertsFromPEM([]byte(ca))
+	if !ok {
+		return false, errors.New("failed to parse root certificate")
+	}
+
+	block, _ := pem.Decode([]byte(certificate))
+	if block == nil {
+		return false, errors.New("failed to decode client PEM")
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return false, errors.Wrapf(err, "failed to parse client PEM")
+	}
+
+	opts := x509.VerifyOptions{
+		Roots:     roots,
+		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+
+	if _, err := cert.Verify(opts); err != nil {
+		return false, nil
+	}
+	return true, nil
+}


### PR DESCRIPTION
**Fixes:** Issue #2432

## Solution/Idea
This patch tries to implement a KCS article about replacing the
kubeconfig file which generated during installation time.

- https://access.redhat.com/solutions/6054981

## Proposed changes
No changes from ux side.

## Testing
This patch make sure once the cluster is provisioned then old kubeconfig file which is part of bundle metadata should be outdated.
```
$ crc start 
$ oc --kubeconfig=$HOME/.crc/cache/<bundle_location>/kubeconfig whoami
error: You must be logged in to the server (Unauthorized)
```
