### PR TITLE
Issue #2481 use current crc location to determine the msi installation path

### DIFF
--- a/cmd/crc-embedder/cmd/root.go
+++ b/cmd/crc-embedder/cmd/root.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/code-ready/crc/pkg/crc/logging"
@@ -26,6 +27,11 @@ when building the crc executable for release`,
 }
 
 func init() {
+	err := constants.EnsureBaseDirectoriesExist()
+	if err != nil {
+		fmt.Println("CRC base directories are missing: ", err)
+		os.Exit(1)
+	}
 	rootCmd.PersistentFlags().StringVar(&logging.LogLevel, "log-level", constants.DefaultLogLevel, "log level (e.g. \"debug | info | warn | error\")")
 }
 

--- a/pkg/crc/constants/constants.go
+++ b/pkg/crc/constants/constants.go
@@ -7,6 +7,7 @@ import (
 	"runtime"
 
 	"github.com/YourFin/binappend"
+	"github.com/code-ready/crc/pkg/crc/logging"
 	"github.com/code-ready/crc/pkg/crc/version"
 )
 
@@ -200,5 +201,11 @@ func GetCRCWindowsTrayDownloadURL() string {
 }
 
 func GetMsiInstallPath() string {
-	return filepath.Join(os.Getenv("PROGRAMFILES"), "CodeReady Containers")
+	// In case of error path will be empty string and upperr layer will handle
+	currentExecutablePath, err := os.Executable()
+	if err != nil {
+		logging.Errorf("Failed to find the MSI installation path: %v", err)
+		return ""
+	}
+	return filepath.Dir(currentExecutablePath)
 }

--- a/pkg/crc/logging/logging.go
+++ b/pkg/crc/logging/logging.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/sirupsen/logrus"
 	terminal "golang.org/x/term"
 )
@@ -18,10 +17,6 @@ var (
 )
 
 func OpenLogFile(path string) (*os.File, error) {
-	err := constants.EnsureBaseDirectoriesExist()
-	if err != nil {
-		return nil, err
-	}
 	logFile, err := os.OpenFile(path, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0600)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Since both are copied to the same location by the msi it is expected to find
crc-tray in the same directory


Fixes: #2481

Relates to: PR https://github.com/code-ready/tray-windows/pull/89

## Testing

Install crc using the msi in location other then `C:\Program Files\CodeReady Containers` and then running `crc setup` should not fail.

(Note: the tray will be started but will immediately fail with an error saying unable to find crc.exe this is fixed by https://github.com/code-ready/tray-windows/pull/89)