### PR TITLE
Check if tray is running before trying to kill it during cleanup

### DIFF
--- a/pkg/crc/preflight/preflight_checks_tray_windows.go
+++ b/pkg/crc/preflight/preflight_checks_tray_windows.go
@@ -31,7 +31,9 @@ func stopTray() error {
 	 * this tries to stop the old tray process, can be removed after a  few releases
 	 */
 	_, _, _ = powershell.Execute(`Stop-Process -Name tray-windows`)
-
+	if err := checkIfTrayRunning(); err != nil {
+		return nil
+	}
 	trayProcessName := strings.TrimSuffix(constants.TrayExecutableName, ".exe")
 	cmd := fmt.Sprintf(`Stop-Process -Name "%s"`, trayProcessName)
 	if _, _, err := powershell.Execute(cmd); err != nil {

--- a/pkg/crc/preflight/preflight_windows.go
+++ b/pkg/crc/preflight/preflight_windows.go
@@ -64,6 +64,10 @@ var hypervPreflightChecks = []Check{
 			_, _, err := powershell.ExecuteAsAdmin("create crc-users group", "New-LocalGroup -Name crc-users")
 			return err
 		},
+		cleanup: func() error {
+			_, _, err := powershell.ExecuteAsAdmin("remove crc-users group", "Remove-LocalGroup -Name crc-users")
+			return err
+		},
 		labels: labels{Os: Windows},
 	},
 	{


### PR DESCRIPTION
Fixes #2433

- Check if the tray is running before attempting to kill the tray process, this prevents showing an error at the end of cleanup
- Removes the `crc-users` group during cleanup