### PR TITLE
Enclose path with quotes in powershell command for fetching tray version

### DIFF
--- a/pkg/crc/preflight/preflight_checks_tray_windows.go
+++ b/pkg/crc/preflight/preflight_checks_tray_windows.go
@@ -95,7 +95,7 @@ func fixTrayExecutableExists() error {
 }
 
 func checkTrayVersion() bool {
-	cmd := fmt.Sprintf(`(Get-Item %s).VersionInfo.FileVersion`, constants.TrayExecutablePath)
+	cmd := fmt.Sprintf(`(Get-Item "%s").VersionInfo.FileVersion`, constants.TrayExecutablePath)
 	stdOut, _, err := powershell.Execute(cmd)
 	if err != nil {
 		logging.Debugf("Failed to get the version of tray: %v", err)


### PR DESCRIPTION
This fixes the following error during `crc setup`:
```
DEBU stderr: Get-Item : A positional parameter cannot be found that accepts argument 'Files\CodeReady'.
At line:1 char:44
+ ... Continue'; (Get-Item C:\Program Files\CodeReady Containers\crc-tray.e ...
+                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidArgument: (:) [Get-Item], ParameterBindingException
    + FullyQualifiedErrorId : PositionalParameterNotFound,Microsoft.PowerShell.Commands.GetItemCommand

DEBU Failed to get the version of tray: exit status 1
```
