### PR TITLE
Issue #2492 return errors as JSON success=false

### DIFF
--- a/pkg/crc/api/api_http.go
+++ b/pkg/crc/api/api_http.go
@@ -179,8 +179,10 @@ func sendResponse(w http.ResponseWriter, response string) {
 			logging.Error("Failed to send response: ", err)
 		}
 	} else {
+		// Success = false, so only return the basic Result
+		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusInternalServerError)
-		if _, err := io.WriteString(w, result.Error); err != nil {
+		if _, err := io.WriteString(w, encodeStructToJSON(result)); err != nil {
 			logging.Error("Failed to send response: ", err)
 		}
 	}


### PR DESCRIPTION
**Fixes:** Issue #2492

With this change the returned JSON is:


```json
{
   "Error":"Machine doesn't exist",
   "Success":false
}
```

### Steps to verify:

  * `crc delete`
  * verify message
    * socket mangling on macOS for `/api/status`
    * breakpoint at `DaemonCommander.cs`'s `getResultsForBasicCommand` to inspect the output on Windows
 
---
Re-added this comment:

Note: filing this to start a discussion