### PR TITLE
circleci: Update xcode version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ version: 2
 jobs:
   build:
     macos:
-      xcode: "10.0.0"
+      xcode: "12.5.1"
     environment:
       GOVERSION: "1.15.13"
 


### PR DESCRIPTION
circleci started notifying that the image that we use will be dropped in
September 2021, better to upgrade now.
https://circleci.com/docs/2.0/xcode-policy/
https://circleci.com/docs/2.0/testing-ios/#supported-xcode-versions