### PR TITLE
Issue 2468 Add forceStop flag for bundle generate command

### DIFF
--- a/cmd/crc/cmd/bundle/generate.go
+++ b/cmd/crc/cmd/bundle/generate.go
@@ -9,20 +9,23 @@ import (
 )
 
 func getGenerateCmd(config *config.Config) *cobra.Command {
-	return &cobra.Command{
+	var forceStop bool
+	generateCmd := &cobra.Command{
 		Use:   "generate",
 		Short: "Generate a custom bundle from the running OpenShift cluster",
 		Long:  "Generate a custom bundle from the running OpenShift cluster",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runGenerate(config)
+			return runGenerate(config, forceStop)
 		},
 	}
+	generateCmd.PersistentFlags().BoolVarP(&forceStop, "forceStop", "f", false, "Forcefully stop the instance")
+	return generateCmd
 }
 
-func runGenerate(config *config.Config) error {
+func runGenerate(config *config.Config, forceStop bool) error {
 	client := machine.NewClient(constants.DefaultName, isDebugLog(), config)
 
-	return client.GenerateBundle()
+	return client.GenerateBundle(forceStop)
 }
 
 func isDebugLog() bool {

--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,7 @@ require (
 	github.com/pelletier/go-toml v1.9.1 // indirect
 	github.com/pkg/browser v0.0.0-20210115035449-ce105d075bb4
 	github.com/pkg/errors v0.9.1
-	github.com/segmentio/analytics-go v3.2.0+incompatible
+	github.com/segmentio/analytics-go v1.2.1-0.20201110202747-0566e489c7b9
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/afero v1.5.1 // indirect
 	github.com/spf13/cast v1.3.1

--- a/go.sum
+++ b/go.sum
@@ -813,8 +813,8 @@ github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sclevine/spec v1.2.0/go.mod h1:W4J29eT/Kzv7/b9IWLB055Z+qvVC9vt0Arko24q7p+U=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
-github.com/segmentio/analytics-go v3.2.0+incompatible h1:OgwqVXxWzan4yR/3vZHBajaHB/W1rpHqF1IYe2YAGk8=
-github.com/segmentio/analytics-go v3.2.0+incompatible/go.mod h1:hce3YxWWeelowcvE47nVz5ECMFf/ADjtbFzGi0zsgug=
+github.com/segmentio/analytics-go v1.2.1-0.20201110202747-0566e489c7b9 h1:UjvQddFFXEVncfsF8qzBmCyPDHKlGDw3UW1SnlSJXkQ=
+github.com/segmentio/analytics-go v1.2.1-0.20201110202747-0566e489c7b9/go.mod h1:hce3YxWWeelowcvE47nVz5ECMFf/ADjtbFzGi0zsgug=
 github.com/segmentio/backo-go v0.0.0-20200129164019-23eae7c10bd3 h1:ZuhckGJ10ulaKkdvJtiAqsLTiPrLaXSdnVgXJKJkTxE=
 github.com/segmentio/backo-go v0.0.0-20200129164019-23eae7c10bd3/go.mod h1:9/Rh6yILuLysoQnZ2oNooD2g7aBnvM7r/fNVxRNWfBc=
 github.com/segmentio/conf v1.2.0/go.mod h1:Y3B9O/PqqWqjyxyWWseyj/quPEtMu1zDp/kVbSWWaB0=

--- a/pkg/crc/machine/client.go
+++ b/pkg/crc/machine/client.go
@@ -23,7 +23,7 @@ type Client interface {
 	Status() (*types.ClusterStatusResult, error)
 	Stop() (state.State, error)
 	IsRunning() (bool, error)
-	GenerateBundle() error
+	GenerateBundle(forceStop bool) error
 }
 
 type client struct {

--- a/pkg/crc/machine/fakemachine/client.go
+++ b/pkg/crc/machine/fakemachine/client.go
@@ -68,7 +68,7 @@ func (c *Client) PowerOff() error {
 	return nil
 }
 
-func (c *Client) GenerateBundle() error {
+func (c *Client) GenerateBundle(forceStop bool) error {
 	return nil
 }
 

--- a/pkg/crc/machine/generate_bundle.go
+++ b/pkg/crc/machine/generate_bundle.go
@@ -16,7 +16,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func (client *client) GenerateBundle() error {
+func (client *client) GenerateBundle(forceStop bool) error {
 	bundleMetadata, sshRunner, err := loadVM(client)
 	if err != nil {
 		return err
@@ -31,6 +31,11 @@ func (client *client) GenerateBundle() error {
 	// Stop the cluster
 	currentState, err := client.Stop()
 	if err != nil {
+		if forceStop {
+			if err := client.PowerOff(); err != nil {
+				return err
+			}
+		}
 		return err
 	}
 	if currentState != state.Stopped {

--- a/pkg/crc/machine/sync.go
+++ b/pkg/crc/machine/sync.go
@@ -183,6 +183,6 @@ func (s *Synchronized) IsRunning() (bool, error) {
 	return s.underlying.IsRunning()
 }
 
-func (s *Synchronized) GenerateBundle() error {
-	return s.underlying.GenerateBundle()
+func (s *Synchronized) GenerateBundle(forceStop bool) error {
+	return s.underlying.GenerateBundle(forceStop)
 }

--- a/pkg/crc/machine/sync_test.go
+++ b/pkg/crc/machine/sync_test.go
@@ -166,6 +166,6 @@ func (m *waitingMachine) Stop() (state.State, error) {
 	return state.Stopped, nil
 }
 
-func (m *waitingMachine) GenerateBundle() error {
+func (m *waitingMachine) GenerateBundle(forceStop bool) error {
 	return errors.New("not implemented")
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -298,7 +298,7 @@ github.com/pkg/errors
 github.com/pmezard/go-difflib/difflib
 # github.com/rivo/uniseg v0.2.0
 github.com/rivo/uniseg
-# github.com/segmentio/analytics-go v3.2.0+incompatible
+# github.com/segmentio/analytics-go v1.2.1-0.20201110202747-0566e489c7b9
 ## explicit
 github.com/segmentio/analytics-go
 # github.com/segmentio/backo-go v0.0.0-20200129164019-23eae7c10bd3


### PR DESCRIPTION
Recently with 4.8 testing one of the blocking issue we found is vm taking longer time to shutdown gracefully
(~7-8 mins) and a bug is filled against it https://bugzilla.redhat.com/show_bug.cgi?id=1965992.
As part of bundle creation we first stop the cluster and that run client.Stop functionality
which waits for 2 min before error out and currently if there is any error we just error out
from the bundle generate command. This patch adds a `forceStop` flag for `bundle generate` command
to make sure if user uses it then force stop the VM otherwise error out.