### PR TITLE
[e2e] e2e container image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,6 +160,16 @@ build_e2e: $(SOURCES)
 	GOOS=windows go test ./test/e2e/ -c -o $(BUILD_DIR)/windows-amd64/e2e.test.exe
 	GOOS=darwin  go test ./test/e2e/ -c -o $(BUILD_DIR)/macos-amd64/e2e.test
 
+#  Build the container image
+.PHONY: containerized_e2e
+containerized_e2e:
+ifndef CRC_E2E_IMG_VERSION
+CRC_E2E_IMG_VERSION=v$(CRC_VERSION)-$(COMMIT_SHA)
+endif
+IMG = quay.io/crcont/crc-e2e:$(CRC_E2E_IMG_VERSION)
+containerized_e2e: clean
+	$(CONTAINER_RUNTIME) build -t $(IMG) -f images/build-e2e/Dockerfile .
+
 .PHONY: integration ## Run integration tests in Ginkgo
 integration:
 ifndef PULL_SECRET_PATH

--- a/images/build-e2e/Dockerfile
+++ b/images/build-e2e/Dockerfile
@@ -1,0 +1,29 @@
+
+FROM registry.access.redhat.com/ubi8/go-toolset:1.15.13 as builder
+
+USER root
+WORKDIR /workspace
+COPY . .
+RUN make build_e2e
+
+FROM registry.access.redhat.com/ubi8/ubi-minimal 
+
+LABEL MAINTAINER "CodeReady Containers <devtools-cdk@redhat.com>"
+
+COPY --from=builder /workspace/images/build-e2e/entrypoint.sh /usr/local/bin/
+COPY --from=builder /workspace/out /opt/crc/bin
+# Review this when go 1.16 with embed support
+COPY --from=builder /workspace/test/e2e/features /opt/crc/features
+COPY --from=builder /workspace/test/testdata /opt/crc/testdata
+COPY --from=builder /workspace/test/extended/crc/ux/installer/applescripts /opt/crc/ux/installer/applescripts
+COPY --from=builder /workspace/test/extended/crc/ux/notification/applescripts /opt/crc/ux/notification/applescripts
+COPY --from=builder /workspace/test/extended/crc/ux/tray/applescripts /opt/crc/ux/tray/applescripts
+
+
+ENV EPEL https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+
+RUN rpm -ivh ${EPEL} \ 
+    && microdnf --enablerepo=epel install -y openssh-clients sshpass \
+    && microdnf clean all
+
+ENTRYPOINT ["entrypoint.sh"]

--- a/images/build-e2e/README.md
+++ b/images/build-e2e/README.md
@@ -1,0 +1,46 @@
+# Overview
+
+The container includes the e2e binary for all 3 platforms plus the required resources to run it.  
+
+The container connects through ssh to the target host and copy the right binary for the platform, run e2e tests and pick the results and logs back.
+
+## Envs
+
+* PLATFORM              define target platform (windows, macos, linux).  
+* TARGET_HOST           dns or ip for the target host.  
+* TARGET_HOST_USERNAME  username for target host.  
+* TARGET_HOST_KEY_PATH  private key for user. (Mandatory if not TARGET_HOST_PASSWORD).  
+* TARGET_HOST_PASSWORD  password for user. (Mandatory if not TARGET_HOST_KEY_PATH).  
+* PULL_SECRET_FILE_PATH pull secret file path (local to container).  
+* BUNDLE_VERSION        testing agaisnt crc released version bundle version for crc released version. (Mandatory if not BUNDLE_LOCATION).  
+* BUNDLE_LOCATION       when testing crc with custom bundle set the bundle location on target server. (Mandatory if not BUNDLE_VERSION).  
+* RESULTS_PATH          Optional. Path inside container to pick results and logs from e2e execution.  
+
+# Samples
+
+```bash
+# Run e2e on macos platform with ssh key and custom bundle
+podman run --rm -it --name crc-e2e \
+		    -e PLATFORM=macos \
+            -e TARGET_HOST=$IP \
+		    -e TARGET_HOST_USERNAME=$USER \
+            -e TARGET_HOST_KEY_PATH=/opt/crc/id_rsa \
+		    -e PULL_SECRET_FILE_PATH=/opt/crc/pull-secret \
+            -e BUNDLE_LOCATION=/bundles/crc_hyperv_4.8.0-rc.3.crcbundle \
+            -v $PWD/pull-secret:/opt/crc/pull-secret:Z \
+            -v $PWD/id_rsa:/opt/crc/id_rsa:Z \
+            -v $PWD/output:/output:Z \
+		    quay.io/crcont/crc-e2e:v1.29.0-465452f4
+
+# Run e2e on windows platform with ssh password and crc released version
+podman run --rm -it --name crc-e2e \
+		    -e PLATFORM=windows \
+            -e TARGET_HOST=$IP \
+		    -e TARGET_HOST_USERNAME=$USER \
+            -e TARGET_HOST_PASSWORD=$PASSWORD \
+		    -e PULL_SECRET_FILE_PATH=/opt/crc/pull-secret \
+            -e BUNDLE_VERSION=4.7.18 \
+            -v $PWD/pull-secret:/opt/crc/pull-secret:Z \
+            -v $PWD/output:/output:Z \
+		    quay.io/crcont/crc-e2e:v1.29.0-465452f4
+```

--- a/images/build-e2e/entrypoint.sh
+++ b/images/build-e2e/entrypoint.sh
@@ -1,0 +1,131 @@
+#!/bin/sh
+
+# Vars
+BINARY=e2e.test
+if [[ ${PLATFORM} == 'windows' ]]; then
+    BINARY=e2e.test.exe
+fi
+BINARY_PATH="/opt/crc/bin/${PLATFORM}-amd64/${BINARY}"
+# Review this when go 1.16 with embed support
+FEATURES_PATH=/opt/crc/features
+TESTDATA_PATH=/opt/crc/testdata
+UX_RESOURCES_PATH=/opt/crc/ux
+# Results
+RESULTS_PATH="${RESULTS_PATH:-/output}"
+
+if [ "${DEBUG:-}" = "true" ]; then
+    set -xuo 
+fi
+
+# Validate conf
+validate=true
+[[ -z "${TARGET_HOST+x}" ]] \
+    && echo "TARGET_HOST required" \
+    && validate=false
+
+[[ -z "${TARGET_HOST_USERNAME+x}" ]] \
+    && echo "TARGET_HOST_USERNAME required" \
+    && validate=false
+
+[[ -z "${TARGET_HOST_KEY_PATH+x}" && -z "${TARGET_HOST_PASSWORD+x}" ]] \
+    && echo "TARGET_HOST_KEY_PATH or TARGET_HOST_PASSWORD required" \
+    && validate=false
+
+[[ -z "${PULL_SECRET_FILE_PATH+x}" ]] \
+    && echo "PULL_SECRET_FILE_PATH required" \
+    && validate=false
+
+[[ -z "${BUNDLE_VERSION+x}" && -z "${BUNDLE_LOCATION+x}" ]] \
+    && echo "BUNDLE_VERSION or BUNDLE_LOCATION required" \
+    && validate=false
+
+[[ $validate == false ]] && exit 1
+
+# Define remote connection
+REMOTE="${TARGET_HOST_USERNAME}@${TARGET_HOST}"
+if [[ ! -z "${TARGET_HOST_DOMAIN+x}" ]]; then
+    REMOTE="${TARGET_HOST_USERNAME}@${TARGET_HOST_DOMAIN}@${TARGET_HOST}"
+fi
+
+# Set SCP / SSH command with pass or key
+NO_STRICT='-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
+if [[ ! -z "${TARGET_HOST_KEY_PATH+x}" ]]; then
+    SCP="scp -r ${NO_STRICT} -i ${TARGET_HOST_KEY_PATH}"
+    SSH="ssh ${NO_STRICT} -i ${TARGET_HOST_KEY_PATH}"
+else
+    SCP="sshpass -p ${TARGET_HOST_PASSWORD} scp -r ${NO_STRICT}" \
+    SSH="sshpass -p ${TARGET_HOST_PASSWORD} ssh ${NO_STRICT}"
+fi
+
+echo "Copy resources to target"
+# Create execution folder 
+EXECUTION_FOLDER="/Users/${TARGET_HOST_USERNAME}/crc-e2e"
+if [[ ${PLATFORM} == 'linux' ]]; then
+    EXECUTION_FOLDER="/home/${TARGET_HOST_USERNAME}/crc-e2e"
+fi
+DATA_FOLDER="${EXECUTION_FOLDER}/out"
+if [[ ${PLATFORM} == 'windows' ]]; then
+    # Todo change for powershell cmdlet
+    $SSH "${REMOTE}" "powershell.exe -c New-Item -ItemType directory -Path ${EXECUTION_FOLDER}/bin"
+else
+    $SSH "${REMOTE}" "mkdir -p ${EXECUTION_FOLDER}/bin"
+fi
+
+# Copy crc-e2e binary and pull-secret
+# Review this when ux feature cleanup environment 
+rm "${FEATURES_PATH}/ux.feature"
+# Review this when go 1.16 with embed support
+$SCP "${BINARY_PATH}" "${REMOTE}:${EXECUTION_FOLDER}/bin"
+$SCP "${PULL_SECRET_FILE_PATH}" "${REMOTE}:${EXECUTION_FOLDER}/pull-secret"
+$SCP "${FEATURES_PATH}" "${REMOTE}:${EXECUTION_FOLDER}/bin"
+# Applescripts
+REMOTE_RESOURCES_PATH=/workspace/test/extended/crc
+if [[ ${PLATFORM} == 'windows' ]]; then
+    # Todo change for powershell cmdlet
+    $SSH "${REMOTE}" "powershell.exe -c New-Item -ItemType directory -Path ${REMOTE_RESOURCES_PATH}"
+    $SCP "${UX_RESOURCES_PATH}" "${REMOTE}:${REMOTE_RESOURCES_PATH}"
+
+else
+    $SSH "${REMOTE}" "sudo mkdir -p ${REMOTE_RESOURCES_PATH}"
+    $SCP "${UX_RESOURCES_PATH}" "${REMOTE}:${EXECUTION_FOLDER}"
+    $SSH "${REMOTE}" "sudo mv ${EXECUTION_FOLDER}/ux ${REMOTE_RESOURCES_PATH}"
+fi
+# Testdata files
+$SCP "${TESTDATA_PATH}" "${REMOTE}:${EXECUTION_FOLDER}"
+
+echo "Running e2e tests"
+# Run e2e cmd
+if [[ ! -z "${BUNDLE_LOCATION+x}" ]]; then
+    OPTIONS="--bundle-location=${BUNDLE_LOCATION} "
+else
+    OPTIONS="--bundle-location='' --bundle-version=${BUNDLE_VERSION} "
+fi
+OPTIONS+="--pull-secret-file=${EXECUTION_FOLDER}/pull-secret "
+if [[ ${PLATFORM} == 'macos' ]]; then
+    PLATFORM="darwin"
+fi
+OPTIONS+="--godog.tags='@${PLATFORM}' --godog.format=junit"
+# Review when pwsh added as powershell supported
+if [[ ${PLATFORM} == 'windows' ]]; then
+    BINARY_EXEC="\$env:SHELL='powershell'; "
+fi
+BINARY_EXEC+="cd ${EXECUTION_FOLDER}/bin && ./${BINARY} ${OPTIONS} > e2e.results"
+# Execute command remote
+$SSH "${REMOTE}" "${BINARY_EXEC}"
+
+echo "Getting e2e tests results and logs"
+# Get results
+mkdir -p "${RESULTS_PATH}"
+$SCP "${REMOTE}:${EXECUTION_FOLDER}/bin/e2e.results" "${RESULTS_PATH}"
+$SCP "${REMOTE}:${EXECUTION_FOLDER}/bin/out/test-results" "${RESULTS_PATH}"
+
+echo "Cleanup target"
+# Clenaup
+# Review this when go 1.16 with embed support
+if [[ ${PLATFORM} == 'windows' ]]; then
+    # Todo change for powershell cmdlet
+    $SSH "${REMOTE}" "rm -r /workspace"
+else
+    $SSH "${REMOTE}" "sudo rm -rf /workspace"
+fi
+$SSH "${REMOTE}" "rm -r ${EXECUTION_FOLDER}"


### PR DESCRIPTION
Part of #2461

Current qe environments include go to run e2e tests, this approach impacts:

* Include a go dependency on guest machines for CRC when this is not a requisite, this should not affect but best approach would be use minimal environments as guests.
* Extra effort on maintenance, as every upgrade on go version would require to upgrade on every environment.
* In case of regression this is really problematic as it would be possible to have a situation where an upgraded (go) guest requires a re run tests from previous version (with previous go version).

The solution would be create a container holding the build bits for e2e, the container will handle the logic to run the tests on a guest machine and take back the results. 

At the moment there is a limitation on e2e due to non go files which requires the container to pick some extra content from the project this will be overworked when CRC will upgrade go to [version 1.16, then the embed package](https://blog.golang.org/go1.16) could be use to embed all non go files.