### PR TITLE
Issue #2458 Ignore return value from hyperv installation custom action

### DIFF
--- a/packaging/windows/product.wxs.in
+++ b/packaging/windows/product.wxs.in
@@ -116,7 +116,7 @@
         <CustomAction Id="RemoveCrcGroupRollback" BinaryKey="WixCA" DllEntry="WixQuietExec" Execute="rollback" Impersonate="no" Return="ignore" />
 
         <SetProperty Action="CAInstallHyperv" Id="InstallHyperv" Value='"[System64Folder]dism.exe" /online /enable-feature /featureName:microsoft-hyper-v-all /NoRestart /quiet' Before="InstallHyperv" Sequence="execute"/>
-        <CustomAction Id="InstallHyperv" BinaryKey="WixCA" DllEntry="WixQuietExec64" Execute="deferred" Impersonate="no" />
+        <CustomAction Id="InstallHyperv" BinaryKey="WixCA" DllEntry="WixQuietExec64" Execute="deferred" Impersonate="no" Return="ignore" />
 
         <util:CloseApplication Id = "TrayRunning" Description="Please exit CodeReady Containers from tray and run the installation again."
             Target="crc-tray.exe" RebootPrompt="no"


### PR DESCRIPTION
The `dism` command used to enable hyperv returns a non-zero exitcode (3)
if a reboot is needed, and the custom action is as a result marked as
failed and the msi installation fails. as a workaround we can ignore the
returned value

This was initially ignored but got removed in a later commit by mistake for testing purposes 613bcc66b1913b33a019fa525a1c30fb7f94c997

Artifact to test: https://ci.appveyor.com/project/code-ready/crc/builds/39910584/artifacts
Fixes #2548 
