### PR TITLE
3 small changes

### DIFF
--- a/cmd/crc/cmd/daemon.go
+++ b/cmd/crc/cmd/daemon.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
-	"path/filepath"
 	"regexp"
 	"runtime"
 	"syscall"
@@ -59,7 +58,7 @@ var daemonCmd = &cobra.Command{
 
 		virtualNetworkConfig := types.Configuration{
 			Debug:             false, // never log packets
-			CaptureFile:       captureFile(),
+			CaptureFile:       os.Getenv("CRC_DAEMON_PCAP_FILE"),
 			MTU:               4000, // Large packets slightly improve the performance. Less small packets.
 			Subnet:            "192.168.127.0/24",
 			GatewayIP:         constants.VSockGateway,
@@ -112,13 +111,6 @@ var daemonCmd = &cobra.Command{
 		err := run(&virtualNetworkConfig)
 		return err
 	},
-}
-
-func captureFile() string {
-	if !isDebugLog() {
-		return ""
-	}
-	return filepath.Join(constants.CrcBaseDir, "capture.pcap")
 }
 
 func run(configuration *types.Configuration) error {

--- a/pkg/crc/constants/constants.go
+++ b/pkg/crc/constants/constants.go
@@ -128,20 +128,9 @@ func BinDir() string {
 
 // GetHomeDir returns the home directory for the current user
 func GetHomeDir() string {
-	if runtime.GOOS == "windows" {
-		if homeDrive, homePath := os.Getenv("HOMEDRIVE"), os.Getenv("HOMEPATH"); len(homeDrive) > 0 && len(homePath) > 0 {
-			homeDir := filepath.Join(homeDrive, homePath)
-			if _, err := os.Stat(homeDir); err == nil {
-				return homeDir
-			}
-		}
-		if userProfile := os.Getenv("USERPROFILE"); len(userProfile) > 0 {
-			if _, err := os.Stat(userProfile); err == nil {
-				return userProfile
-			}
-		}
-	}
-	return os.Getenv("HOME")
+	homeDir, _ := os.UserHomeDir()
+
+	return homeDir
 }
 
 // EnsureBaseDirectoryExists create the ~/.crc directory if it is not present


### PR DESCRIPTION
3 commits I don't want to keep locally for too long.

The only user-visible changes are:
- slightly different error message for some daemon startup failures
- `capture.pcap` is no longer always created when the daemon is started with `--log-level debug`, but only when `CRC_DAEMON_PCAP_FILE` is set in the environment