### PR TITLE
Introduce a new type for crc status. Distinguish it from machine status.

### DIFF
--- a/cmd/crc/cmd/console.go
+++ b/cmd/crc/cmd/console.go
@@ -8,8 +8,8 @@ import (
 
 	crcErrors "github.com/code-ready/crc/pkg/crc/errors"
 	"github.com/code-ready/crc/pkg/crc/machine"
+	"github.com/code-ready/crc/pkg/crc/machine/state"
 	"github.com/code-ready/crc/pkg/crc/machine/types"
-	"github.com/code-ready/machine/libmachine/state"
 	"github.com/pkg/browser"
 	"github.com/spf13/cobra"
 )

--- a/cmd/crc/cmd/status.go
+++ b/cmd/crc/cmd/status.go
@@ -68,7 +68,7 @@ func getStatus(client machine.Client, cacheDir string) *status {
 
 	return &status{
 		Success:          true,
-		CrcStatus:        clusterStatus.CrcStatus.String(),
+		CrcStatus:        string(clusterStatus.CrcStatus),
 		OpenShiftStatus:  clusterStatus.OpenshiftStatus,
 		OpenShiftVersion: clusterStatus.OpenshiftVersion,
 		DiskUsage:        clusterStatus.DiskUse,

--- a/cmd/crc/cmd/stop.go
+++ b/cmd/crc/cmd/stop.go
@@ -8,7 +8,7 @@ import (
 	crcErrors "github.com/code-ready/crc/pkg/crc/errors"
 	"github.com/code-ready/crc/pkg/crc/input"
 	"github.com/code-ready/crc/pkg/crc/machine"
-	"github.com/code-ready/machine/libmachine/state"
+	"github.com/code-ready/crc/pkg/crc/machine/state"
 	"github.com/spf13/cobra"
 )
 

--- a/pkg/crc/api/adapter.go
+++ b/pkg/crc/api/adapter.go
@@ -62,7 +62,7 @@ func (a *Adapter) Start(ctx context.Context, startConfig types.StartConfig) clie
 	}
 	return client.StartResult{
 		Success:        true,
-		Status:         res.Status.String(),
+		Status:         string(res.Status),
 		ClusterConfig:  res.ClusterConfig,
 		KubeletStarted: res.KubeletStarted,
 	}
@@ -78,7 +78,7 @@ func (a *Adapter) Status() client.ClusterStatusResult {
 		}
 	}
 	return client.ClusterStatusResult{
-		CrcStatus:        res.CrcStatus.String(),
+		CrcStatus:        string(res.CrcStatus),
 		OpenshiftStatus:  string(res.OpenshiftStatus),
 		OpenshiftVersion: res.OpenshiftVersion,
 		DiskUse:          res.DiskUse,

--- a/pkg/crc/machine/client.go
+++ b/pkg/crc/machine/client.go
@@ -5,9 +5,9 @@ import (
 	"time"
 
 	crcConfig "github.com/code-ready/crc/pkg/crc/config"
+	"github.com/code-ready/crc/pkg/crc/machine/state"
 	"github.com/code-ready/crc/pkg/crc/machine/types"
 	"github.com/code-ready/crc/pkg/crc/network"
-	"github.com/code-ready/machine/libmachine/state"
 	"github.com/kofalt/go-memoize"
 )
 

--- a/pkg/crc/machine/console.go
+++ b/pkg/crc/machine/console.go
@@ -1,6 +1,7 @@
 package machine
 
 import (
+	"github.com/code-ready/crc/pkg/crc/machine/state"
 	"github.com/code-ready/crc/pkg/crc/machine/types"
 	"github.com/pkg/errors"
 )
@@ -34,6 +35,6 @@ func (client *client) GetConsoleURL() (*types.ConsoleResult, error) {
 
 	return &types.ConsoleResult{
 		ClusterConfig: *clusterConfig,
-		State:         vmState,
+		State:         state.FromMachine(vmState),
 	}, nil
 }

--- a/pkg/crc/machine/fakemachine/client.go
+++ b/pkg/crc/machine/fakemachine/client.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"errors"
 
+	"github.com/code-ready/crc/pkg/crc/machine/state"
 	"github.com/code-ready/crc/pkg/crc/machine/types"
 	"github.com/code-ready/crc/pkg/crc/network"
-	"github.com/code-ready/machine/libmachine/state"
 )
 
 func NewClient() *Client {

--- a/pkg/crc/machine/state/state.go
+++ b/pkg/crc/machine/state/state.go
@@ -1,0 +1,24 @@
+package state
+
+import libmachinestate "github.com/code-ready/machine/libmachine/state"
+
+// State represents the state of crc (both VM and components)
+type State string
+
+const (
+	Running  State = "Running"
+	Stopped  State = "Stopped"
+	Stopping State = "Stopping"
+	Starting State = "Starting"
+	Error    State = "Error"
+)
+
+func FromMachine(input libmachinestate.State) State {
+	switch input {
+	case libmachinestate.Running:
+		return Running
+	case libmachinestate.Stopped:
+		return Stopped
+	}
+	return Error
+}

--- a/pkg/crc/machine/status.go
+++ b/pkg/crc/machine/status.go
@@ -7,9 +7,10 @@ import (
 	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/code-ready/crc/pkg/crc/logging"
 	"github.com/code-ready/crc/pkg/crc/machine/bundle"
+	"github.com/code-ready/crc/pkg/crc/machine/state"
 	"github.com/code-ready/crc/pkg/crc/machine/types"
 	crcssh "github.com/code-ready/crc/pkg/crc/ssh"
-	"github.com/code-ready/machine/libmachine/state"
+	libmachinestate "github.com/code-ready/machine/libmachine/state"
 	"github.com/pkg/errors"
 )
 
@@ -39,9 +40,9 @@ func (client *client) Status() (*types.ClusterStatusResult, error) {
 		return nil, errors.Wrap(err, "Error loading bundle metadata")
 	}
 
-	if vmStatus != state.Running {
+	if vmStatus != libmachinestate.Running {
 		return &types.ClusterStatusResult{
-			CrcStatus:        vmStatus,
+			CrcStatus:        state.FromMachine(vmStatus),
 			OpenshiftStatus:  types.OpenshiftStopped,
 			OpenshiftVersion: crcBundleMetadata.GetOpenshiftVersion(),
 		}, nil

--- a/pkg/crc/machine/stop.go
+++ b/pkg/crc/machine/stop.go
@@ -3,10 +3,10 @@ package machine
 import (
 	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/code-ready/crc/pkg/crc/logging"
+	"github.com/code-ready/crc/pkg/crc/machine/state"
 	"github.com/code-ready/crc/pkg/crc/oc"
 	crcssh "github.com/code-ready/crc/pkg/crc/ssh"
 	"github.com/code-ready/crc/pkg/libmachine/host"
-	"github.com/code-ready/machine/libmachine/state"
 	"github.com/pkg/errors"
 )
 
@@ -27,9 +27,13 @@ func (client *client) Stop() (state.State, error) {
 		if stateErr != nil {
 			logging.Debugf("Cannot get VM status after stopping it: %v", stateErr)
 		}
-		return status, errors.Wrap(err, "Cannot stop machine")
+		return state.FromMachine(status), errors.Wrap(err, "Cannot stop machine")
 	}
-	return host.Driver.GetState()
+	status, err := host.Driver.GetState()
+	if err != nil {
+		return state.Error, errors.Wrap(err, "Cannot get VM status")
+	}
+	return state.FromMachine(status), nil
 }
 
 // This should be removed after https://bugzilla.redhat.com/show_bug.cgi?id=1965992

--- a/pkg/crc/machine/sync.go
+++ b/pkg/crc/machine/sync.go
@@ -7,8 +7,8 @@ import (
 	"time"
 
 	"github.com/code-ready/crc/pkg/crc/logging"
+	"github.com/code-ready/crc/pkg/crc/machine/state"
 	"github.com/code-ready/crc/pkg/crc/machine/types"
-	"github.com/code-ready/machine/libmachine/state"
 )
 
 const startCancelTimeout = 15 * time.Second

--- a/pkg/crc/machine/sync_test.go
+++ b/pkg/crc/machine/sync_test.go
@@ -6,8 +6,8 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/code-ready/crc/pkg/crc/machine/state"
 	"github.com/code-ready/crc/pkg/crc/machine/types"
-	"github.com/code-ready/machine/libmachine/state"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/crc/machine/types/types.go
+++ b/pkg/crc/machine/types/types.go
@@ -2,8 +2,8 @@ package types
 
 import (
 	"github.com/code-ready/crc/pkg/crc/cluster"
+	"github.com/code-ready/crc/pkg/crc/machine/state"
 	"github.com/code-ready/crc/pkg/crc/network"
-	"github.com/code-ready/machine/libmachine/state"
 )
 
 type StartConfig struct {


### PR DESCRIPTION
crc pkgs should not leak libmachine state enums. This commit converts it
to the crc status type when needed.

Starting/Stopping are proper to crc. It is not used in drivers/machine.
libmachine None, Paused and Saved states are not used anymore and will
be deleted.

---

It will help refactor statuses while not touching too much libmachine.