### PR TITLE
api: return state.Stopped when the machine doesnt exist

### DIFF
--- a/pkg/crc/machine/status.go
+++ b/pkg/crc/machine/status.go
@@ -23,7 +23,10 @@ func (client *client) Status() (*types.ClusterStatusResult, error) {
 		return nil, errors.Wrap(err, "Cannot check if machine exists")
 	}
 	if !exists {
-		return nil, errors.New("Machine doesn't exist")
+		return &types.ClusterStatusResult{
+			CrcStatus:       state.Stopped,
+			OpenshiftStatus: types.OpenshiftStopped,
+		}, nil
 	}
 
 	host, err := libMachineAPIClient.Load(client.name)


### PR DESCRIPTION
With this change, machine.Status() will always return a status.

crc cli still answers 'Machine does not exist. Use 'crc start' to create
 it'.
Only the http api will return Stopped status and not fail. This is
useful for showing a nice status in the tray.