### PR TITLE
Issue #2570 Use HTTP verbs for config api instead of separarte urls

### DIFF
--- a/pkg/crc/api/client/client.go
+++ b/pkg/crc/api/client/client.go
@@ -119,10 +119,23 @@ func (c *Client) GetConfig(configs []string) (GetConfigResult, error) {
 			return gcr, fmt.Errorf("Failed to encode data to JSON: %w", err)
 		}
 	}
-	body, err := c.sendPostRequest("/config/get", data)
+	req, err := http.NewRequest("GET", fmt.Sprintf("%s%s", c.base, "/config"), data)
 	if err != nil {
 		return gcr, err
 	}
+	req.Header.Set("Content-Type", "application/json")
+
+	res, err := c.client.Do(req)
+	if err != nil {
+		return gcr, err
+	}
+	defer res.Body.Close()
+
+	body, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return gcr, fmt.Errorf("Unknown error reading response: %w", err)
+	}
+
 	err = json.Unmarshal(body, &gcr)
 	if err != nil {
 		return gcr, err
@@ -142,7 +155,7 @@ func (c *Client) SetConfig(configs SetConfigRequest) (SetOrUnsetConfigResult, er
 		return scr, fmt.Errorf("Failed to encode data to JSON: %w", err)
 	}
 
-	body, err := c.sendPostRequest("/config/set", data)
+	body, err := c.sendPostRequest("/config", data)
 	if err != nil {
 		return scr, err
 	}
@@ -164,10 +177,23 @@ func (c *Client) UnsetConfig(configs []string) (SetOrUnsetConfigResult, error) {
 	if err := json.NewEncoder(data).Encode(cfg); err != nil {
 		return ucr, fmt.Errorf("Failed to encode data to JSON: %w", err)
 	}
-	body, err := c.sendPostRequest("/config/unset", data)
+	req, err := http.NewRequest("DELETE", fmt.Sprintf("%s%s", c.base, "/config"), data)
 	if err != nil {
 		return ucr, err
 	}
+	req.Header.Set("Content-Type", "application/json")
+
+	res, err := c.client.Do(req)
+	if err != nil {
+		return ucr, err
+	}
+	defer res.Body.Close()
+
+	body, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return ucr, fmt.Errorf("Unknown error reading response: %w", err)
+	}
+
 	err = json.Unmarshal(body, &ucr)
 	if err != nil {
 		return ucr, err


### PR DESCRIPTION
GET /config returns the configs, body can be empty in which case all the
configs are retunred or body can specify which config options to retrieve, e.g: {"properties":["cpus"]}

POST /config sets a config options, body contains the config options to
set, e.g:  {"properties":{"cpus":5}}, {"properties":{"cpus":5,"autostart-tray": true}}

DELETE /config unsets a config option, body contains the config options
to unset, e.g: {"properties":["cpus"]}

Fixes #2570 

This requires changes on the trays.