### PR TITLE
Handle error from os.UserHomeDir function

### DIFF
--- a/pkg/crc/constants/constants.go
+++ b/pkg/crc/constants/constants.go
@@ -128,8 +128,10 @@ func BinDir() string {
 
 // GetHomeDir returns the home directory for the current user
 func GetHomeDir() string {
-	homeDir, _ := os.UserHomeDir()
-
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		panic("Failed to get homeDir: " + err.Error())
+	}
 	return homeDir
 }
 


### PR DESCRIPTION
We should panic in case there is an error since base dir is depend
on it.

fixes #2582

