### PR TITLE
[e2e] windows cmd with env fix missing semicolon

### DIFF
--- a/test/extended/crc/cmd/cmd.go
+++ b/test/extended/crc/cmd/cmd.go
@@ -87,7 +87,7 @@ func (c Command) env() []string {
 
 func envVariable(key, value string) string {
 	if runtime.GOOS == "windows" {
-		return fmt.Sprintf("$env:%s=%s", key, value)
+		return fmt.Sprintf("$env:%s=%s;", key, value)
 	}
 	return fmt.Sprintf("%s=%s", key, value)
 }


### PR DESCRIPTION
Follow up for #2532 during testing on specific windows platform the syntax was wrong as a semicolon is required after every env.

This fixes the syntax problem