### PR TITLE
Issue #2550 msi: check ram requirement before starting installation

### DIFF
--- a/packaging/windows/product.wxs.in
+++ b/packaging/windows/product.wxs.in
@@ -31,6 +31,9 @@
         <Condition Message="CodeReady Containers requires the Windows 10 Fall Creators Update (version 1709) or newer.">
             <![CDATA[Installed OR (CURRENTBUILD > MINIMUMBUILD)]]>
         </Condition>
+        <Condition Message="CodeReady Containers requires at least 9GB of RAM to run. Aborting installation.">
+            <![CDATA[Installed OR (PhysicalMemory >= 9126)]]>
+        </Condition>
         <util:Group Id="HypervAdminsGroup" Name="Hyper-V Administrators" />
         <util:Group Id="CrcUsersGroup" Name="crc-users" />
         <Directory Id="TARGETDIR" Name="SourceDir">


### PR DESCRIPTION
Fixes #2550 

## Testing
1. Running the msi on a system that doesn't have >=9GB of ram should abort the installation and show a message about the requirement.
![ram-check](https://user-images.githubusercontent.com/8885742/126435952-49261adf-0c0a-4a57-9587-5a7bdb1834d3.PNG)
