### PR TITLE
Use ExecuteAsAdmin to remove registry key for vsock

### DIFF
--- a/pkg/crc/preflight/preflight_windows.go
+++ b/pkg/crc/preflight/preflight_windows.go
@@ -283,7 +283,7 @@ func cleanVsock() error {
 	if err := checkVsock(); err != nil {
 		return nil
 	}
-	_, _, err := powershell.Execute(fmt.Sprintf(`Remove-Item -Path "%s\%s"`, registryDirectory, registryKey))
+	_, _, err := powershell.ExecuteAsAdmin("Removing vsock registry key", fmt.Sprintf(`Remove-Item -Path "%s\%s"`, registryDirectory, registryKey))
 	if err != nil {
 		return fmt.Errorf("Unable to remove vsock service from hyperv registry: %v", err)
 	}


### PR DESCRIPTION
The cleanup was failing with the following permission denied error:

```
INFO Removing vsock service from hyperv registry
DEBU Running 'Get-Item -Path "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Virtualization\GuestCommunicationServices\00000400-FACB-11E6-BD58-64006A7986D3"'
DEBU Running 'Remove-Item -Path "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Virtualization\GuestCommunicationServices\00000400-FACB-11E6-BD58-64006A7986D3"'
DEBU Command failed: exit status 1
DEBU stdout:
DEBU stderr: Remove-Item : Requested registry access is not allowed.
At line:1 char:43
+ ... yContinue'; Remove-Item -Path "HKLM:\SOFTWARE\Microsoft\Windows NT\Cu ...
+                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : PermissionDenied: (HKEY_LOCAL_MACH...icationServices:String) [Remove-Item], SecurityException
    + FullyQualifiedErrorId : System.Security.SecurityException,Microsoft.PowerShell.Commands.RemoveItemCommand

DEBU Unable to remove vsock service from hyperv registry: exit status 1
```