### PR TITLE
Improve crc stop message for already stopped cluster

### DIFF
--- a/pkg/crc/machine/stop.go
+++ b/pkg/crc/machine/stop.go
@@ -11,6 +11,10 @@ import (
 )
 
 func (client *client) Stop() (state.State, error) {
+	if running, _ := client.IsRunning(); !running {
+		return state.Error, errors.New("Cluster is already stopped")
+	}
+
 	libMachineAPIClient, cleanup := createLibMachineClient()
 	defer cleanup()
 	host, err := libMachineAPIClient.Load(client.name)


### PR DESCRIPTION
It'll check if machine is already stopped before attempting
to perform the cluster stop related tasks

If a machine is already stopped it prints the following:

```
$ crc stop
Cluster is already stopped
```
Earlier this was:
```
$ crc stop
INFO Stopping kubelet and all containers...
Error getting the IP: Host is not running
```