### PR TITLE
Make sure machine render happen successfully after pull secret removal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL := /bin/bash
 
-BUNDLE_VERSION ?= 4.8.1
+BUNDLE_VERSION ?= 4.8.2
 BUNDLE_EXTENSION = crcbundle
 CRC_VERSION = 1.29.1
 COMMIT_SHA=$(shell git rev-parse --short HEAD)

--- a/centos_ci.sh
+++ b/centos_ci.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # bundle location
-BUNDLE_VERSION=4.8.1
+BUNDLE_VERSION=4.8.2
 BUNDLE=crc_libvirt_$BUNDLE_VERSION.crcbundle
 GO_VERSION=1.15.13
 

--- a/pkg/crc/cluster/cluster.go
+++ b/pkg/crc/cluster/cluster.go
@@ -227,10 +227,10 @@ func RemoveOldRenderedMachineConfig(ocConfig oc.Config) error {
 		renderedWorker []string
 	)
 	for _, mc := range sortedMachineConfigsWithTime {
-		if strings.HasPrefix(mc, "rendered-master") {
+		if strings.Contains(mc, "rendered-master") {
 			renderedMaster = append(renderedMaster, mc)
 		}
-		if strings.HasPrefix(mc, "rendered-worker") {
+		if strings.Contains(mc, "rendered-worker") {
 			renderedWorker = append(renderedWorker, mc)
 		}
 	}


### PR DESCRIPTION
With this patch we make sure that after the removing the pull secret
machine config and machine config pool successfully rendered and not
in inconsistent state. This is causing issue on the CI where render
didn't happen correctly.