### PR TITLE
mco: delete the leader lease right after start.

### DIFF
--- a/pkg/crc/cluster/cluster.go
+++ b/pkg/crc/cluster/cluster.go
@@ -524,3 +524,11 @@ func CheckProxySettingsForOperator(ocConfig oc.Config, proxy *network.ProxyConfi
 	}
 	return false, nil
 }
+
+func DeleteMCOLeaderLease(ocConfig oc.Config) error {
+	if err := WaitForOpenshiftResource(ocConfig, "cm"); err != nil {
+		return err
+	}
+	_, _, err := ocConfig.RunOcCommand("delete", "-n", "openshift-machine-config-operator", "cm", "machine-config-controller")
+	return err
+}

--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -394,6 +394,10 @@ func (client *client) Start(ctx context.Context, startConfig types.StartConfig) 
 		return nil, errors.Wrap(err, "Error waiting for apiserver")
 	}
 
+	if err := cluster.DeleteMCOLeaderLease(ocConfig); err != nil {
+		return nil, err
+	}
+
 	if err := cluster.EnsurePullSecretPresentInTheCluster(ocConfig, startConfig.PullSecret); err != nil {
 		return nil, errors.Wrap(err, "Failed to update cluster pull secret")
 	}


### PR DESCRIPTION
It allows the machine-config-controller to start fast and not wait 2min
before acquiring the lease and change the pull secret.

---

It takes 20s to change the pull secret on the disk compared to 2min+.