### PR TITLE
[e2e] add cleanup-home option to control remove crc home before suite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -184,7 +184,7 @@ ifndef CRC_BINARY
 	CRC_BINARY = --crc-binary=$(GOPATH)/bin
 endif
 e2e:
-	@go test --timeout=180m $(REPOPATH)/test/e2e -v $(PULL_SECRET_FILE) $(BUNDLE_LOCATION) $(CRC_BINARY) --bundle-version=$(BUNDLE_VERSION) $(GODOG_OPTS) $(INSTALLER_PATH) $(USER_PASSWORD) 
+	@go test --timeout=180m $(REPOPATH)/test/e2e -v $(PULL_SECRET_FILE) $(BUNDLE_LOCATION) $(CRC_BINARY) --bundle-version=$(BUNDLE_VERSION) $(GODOG_OPTS) $(CLEANUP_HOME) $(INSTALLER_PATH) $(USER_PASSWORD) 
 
 .PHONY: fmt
 fmt:

--- a/test/e2e/crcsuite/crcsuite.go
+++ b/test/e2e/crcsuite/crcsuite.go
@@ -30,6 +30,7 @@ var (
 	bundleLocation string
 	bundleVersion  string
 	pullSecretFile string
+	cleanupHome    bool
 )
 
 // FeatureContext defines godog.Suite steps for the test suite.
@@ -115,11 +116,13 @@ func FeatureContext(s *godog.Suite) {
 			os.Exit(1)
 		}
 
-		// remove $HOME/.crc
-		err = util.RemoveCRCHome(CRCHome)
-		if err != nil {
-			fmt.Println(err)
-			os.Exit(1)
+		if cleanupHome {
+			// remove $HOME/.crc
+			err = util.RemoveCRCHome(CRCHome)
+			if err != nil {
+				fmt.Println(err)
+				os.Exit(1)
+			}
 		}
 
 		if !bundleEmbedded {
@@ -178,6 +181,7 @@ func ParseFlags() {
 	flag.StringVar(&pullSecretFile, "pull-secret-file", "", "Path to the file containing pull secret")
 	flag.StringVar(&CRCExecutable, "crc-binary", "", "Path to the CRC executable to be tested")
 	flag.StringVar(&bundleVersion, "bundle-version", "", "Version of the bundle used in tests")
+	flag.BoolVar(&cleanupHome, "cleanup-home", true, "Try to remove crc home folder before starting the suite")
 
 	// Extend the context with tray when supported
 	ux.ParseFlags()


### PR DESCRIPTION
This PR adds a new option when running e2e tests to control if remove the crc home folder or not before executing the tests. The default behavior is like it was before it deletes the crc home folder (if no parameter passed)

If `--cleanup-home=false` is passed when running e2e tests it will keep the crc home folder, allowing to setup the environment for tests externally.