### PR TITLE
Hyper-V driver improvements

### DIFF
--- a/pkg/drivers/hyperv/hyperv_windows.go
+++ b/pkg/drivers/hyperv/hyperv_windows.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	log "github.com/code-ready/crc/pkg/crc/logging"
+	"github.com/code-ready/crc/pkg/os/windows/powershell"
 	"github.com/code-ready/machine/libmachine/drivers"
 	"github.com/code-ready/machine/libmachine/state"
 )
@@ -303,6 +304,10 @@ func (d *Driver) Stop() error {
 
 // Remove removes an host
 func (d *Driver) Remove() error {
+	if _, _, err := powershell.Execute(`Hyper-V\Get-VM`, d.MachineName, "-ErrorAction", "SilentlyContinue", "-ErrorVariable", "getVmErrors"); err != nil {
+		return nil
+	}
+
 	s, err := d.GetState()
 	if err != nil {
 		return err


### PR DESCRIPTION
After looking at telemetry, I saw couple of annoying failures:
- crc status returning `unexpected Hyper-V state []`
- crc delete dead-end when the VM is deleted in Hyper-V but not in ~/.crc/machines.

For delete error, I propose to change all drivers to return no error on Remove() when the VM doesn't exist. 
Hyperkit already does this (see https://github.com/code-ready/machine-driver-hyperkit/blob/master/pkg/hyperkit/driver.go#L143)