### PR TITLE
docs: Clarify `machine-config` Operator support status

### DIFF
--- a/docs/source/topics/con_differences-from-production-openshift-install.adoc
+++ b/docs/source/topics/con_differences-from-production-openshift-install.adoc
@@ -4,10 +4,11 @@
 {rh-prod} is a regular OpenShift installation with the following notable differences:
 
 * **The {prod} OpenShift cluster is ephemeral and is not intended for production use.**
+* **There is no supported upgrade path to newer OpenShift versions.**
+Upgrading the OpenShift version may cause issues that are difficult to reproduce.
 * It uses a single node which behaves as both a master and worker node.
-* It disables the `machine-config` and `monitoring` Operators by default.
-** These disabled Operators cause the corresponding parts of the web console to be non-functional.
-** For the same reason, there is no upgrade path to newer OpenShift versions.
+* It disables the `monitoring` Operator by default.
+This disabled Operator causes the corresponding part of the web console to be non-functional.
 * The OpenShift instance runs in a virtual machine.
 This may cause other differences, particularly with external networking.
 

--- a/docs/source/topics/proc_accessing-the-openshift-cluster-with-oc.adoc
+++ b/docs/source/topics/proc_accessing-the-openshift-cluster-with-oc.adoc
@@ -46,7 +46,7 @@ $ oc get co
 +
 [NOTE]
 ====
-* {prod} disables the `machine-config` and `monitoring` Operators by default.
+* {prod} disables the `monitoring` Operator by default.
 ====
 
 See link:{crc-gsg-url}#troubleshooting-codeready-containers_gsg[Troubleshooting {prod}] if you cannot access the {prod} OpenShift cluster.


### PR DESCRIPTION
**Relates to:** Issue #921 (specifically, [this comment about the `machine-config` Operator](https://github.com/code-ready/crc/issues/921#issuecomment-880150071))

## Solution/Idea

Remove existing references to the `machine-config` Operator being disabled, as this is no longer the case with the latest release. At the same time, clarify that in-place upgrades of the OpenShift cluster are not supported. We mention this rather vaguely, not mentioning the `machine-config` Operator directly.