### PR TITLE
Use HTTP verbs for config api instead of separarte urls

### DIFF
--- a/pkg/crc/api/api_http.go
+++ b/pkg/crc/api/api_http.go
@@ -29,12 +29,9 @@ func NewMux(config crcConfig.Storage, machine machine.Client, logger Logger, tel
 
 	server.GET("/webconsoleurl", handler.GetWebconsoleInfo)
 
-	server.GET("/config/set", handler.SetConfig)
-	server.GET("/config/get", handler.GetConfig)
-	server.GET("/config/unset", handler.UnsetConfig)
-	server.POST("/config/set", handler.SetConfig)
-	server.POST("/config/get", handler.GetConfig)
-	server.POST("/config/unset", handler.UnsetConfig)
+	server.GET("/config", handler.GetConfig)
+	server.POST("/config", handler.SetConfig)
+	server.DELETE("/config", handler.UnsetConfig)
 
 	server.GET("/logs", handler.Logs)
 

--- a/pkg/crc/api/handlers.go
+++ b/pkg/crc/api/handlers.go
@@ -214,9 +214,10 @@ func (h *Handler) UnsetConfig(c *context) error {
 }
 
 func (h *Handler) GetConfig(c *context) error {
+	queries := c.url.Query()
 	var req client.GetOrUnsetConfigRequest
-	if err := c.Bind(&req); err != nil {
-		return err
+	for key := range queries {
+		req.Properties = append(req.Properties, key)
 	}
 
 	if len(req.Properties) == 0 {

--- a/pkg/crc/api/helpers.go
+++ b/pkg/crc/api/helpers.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"sync"
 
 	"github.com/code-ready/crc/pkg/crc/logging"
@@ -12,6 +13,7 @@ import (
 type context struct {
 	method      string
 	requestBody []byte
+	url         *url.URL
 
 	code         int
 	headers      map[string]string
@@ -102,6 +104,7 @@ func (s *server) Handler() http.Handler {
 			method:      r.Method,
 			requestBody: requestBody,
 			headers:     make(map[string]string),
+			url:         r.URL,
 		}
 		if err := handler(c); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/pkg/crc/api/helpers_test.go
+++ b/pkg/crc/api/helpers_test.go
@@ -12,6 +12,8 @@ func setupNewInMemoryConfig() config.Storage {
 	cfg := config.New(&skipPreflights{
 		storage: storage,
 	})
+	cfg.AddSetting("a&a", "foo", nil, nil, "test special string")
+	cfg.AddSetting("b&&&b", "bar", nil, nil, "test special string")
 	config.RegisterSettings(cfg)
 	preflight.RegisterSettings(cfg)
 


### PR DESCRIPTION
Fixes #2570

```
// Get all the configs since empty property passed
$ curl -X GET --unix-socket ~/.crc/crc-http.sock http:/c/api/config

// Get cpus property
$ curl -X GET --unix-socket ~/.crc/crc-http.sock http:/c/api/config?cpus
{"Success":true,"Error":"","Configs":{"cpus":5}}

// Delete cpu property
$ curl -X DELETE -d '{"properties":["cpus"]}' --unix-socket ~/.crc/crc-http.sock http:/c/api/config
{"Success":true,"Error":"","Properties":["cpus"]}

$ curl -X GET --unix-socket ~/.crc/crc-http.sock http:/c/api/config?cpus
{"Success":true,"Error":"","Configs":{"cpus":4}}

// Update cpu propery
$ curl -X POST -d '{"properties":{"cpus":10}}' --unix-socket ~/.crc/crc-http.sock http:/c/api/config
{"Success":true,"Error":"","Properties":["cpus"]}

$ curl -X GET --unix-socket ~/.crc/crc-http.sock http:/c/api/config?cpus
{"Success":true,"Error":"","Configs":{"cpus":10}}
```

