### PR TITLE
[wip] Check body is not empty before decoding request to api/config/get

### DIFF
--- a/pkg/crc/api/handlers.go
+++ b/pkg/crc/api/handlers.go
@@ -215,8 +215,10 @@ func (h *Handler) UnsetConfig(c *context) error {
 
 func (h *Handler) GetConfig(c *context) error {
 	var req client.GetOrUnsetConfigRequest
-	if err := c.Bind(&req); err != nil {
-		return err
+	if len(c.requestBody) > 0 {
+		if err := c.Bind(&req); err != nil {
+			return err
+		}
 	}
 
 	if len(req.Properties) == 0 {


### PR DESCRIPTION
This enables us to fetch all the configs, if an empty body and GET
is sent to /api/config

```
*   Trying /Users/anjan/.crc/crc-http.sock...
* Connected to unix (/Users/anjan/.crc/crc-http.sock) port 80 (#0)
> GET /api/config/get HTTP/1.1
> Host: unix
> User-Agent: curl/7.64.1
> Accept: */*
>
< HTTP/1.1 200 OK
< Date: Fri, 06 Aug 2021 07:33:04 GMT
< Content-Length: 855
< Content-Type: text/plain; charset=utf-8
<
* Connection #0 to host unix left intact
{"Success":true,"Error":"","Configs":{"autostart-tray":true,"bundle":"/Users/anjan/.crc/cache/crc_hyperkit_4.8.3.crcbundle","consent-telemetry":"no","cpus":4,"disable-update-check":false,"disk-size":66,"enable-cluster-monitoring":false,"enable-experimental-features":false,"host-network-access":false,"http-proxy":"","https-proxy":"","kubeadmin-password":"","memory":9216,"nameserver":"","network-mode":"user","no-proxy":"","proxy-ca-file":"","pull-secret-file":"","skip-check-admin-helper-cached":false,"skip-check-bundle-extracted":false,"skip-check-hyperkit-driver":false,"skip-check-hyperkit-installed":false,"skip-check-m1-cpu":false,"skip-check-obsolete-admin-helper":false,"skip-check-qcow-tool-installed":false,"skip-check-ram":false,"skip-check-resolver-file-permissions":false,"skip-check-root-user":false,"skip-check-supported-cpu-arch":false}}* Closing connection 0
```