### PR TITLE
preset: add configuration key

### DIFF
--- a/pkg/crc/config/callbacks.go
+++ b/pkg/crc/config/callbacks.go
@@ -12,6 +12,12 @@ func RequiresRestartMsg(key string, _ interface{}) string {
 		"stop the CRC instance with 'crc stop' and restart it with 'crc start'.", key)
 }
 
+func RequiresDeleteMsg(key string, _ interface{}) string {
+	return fmt.Sprintf("Changes to configuration property '%s' are only applied when the CRC instance is created.\n"+
+		"If you already have a running CRC instance, then for this configuration change to take effect, "+
+		"delete the CRC instance with 'crc delete' and start it with 'crc start'.", key)
+}
+
 func SuccessfullyApplied(key string, value interface{}) string {
 	return fmt.Sprintf("Successfully configured %s to %s", key, cast.ToString(value))
 }

--- a/pkg/crc/config/settings.go
+++ b/pkg/crc/config/settings.go
@@ -11,6 +11,14 @@ import (
 	"github.com/spf13/cast"
 )
 
+type Preset string
+
+const (
+	Podman  Preset = "podman"
+	Minimal Preset = "minimal"
+	Full    Preset = "full"
+)
+
 const (
 	Bundle                  = "bundle"
 	CPUs                    = "cpus"
@@ -30,6 +38,7 @@ const (
 	EnableClusterMonitoring = "enable-cluster-monitoring"
 	AutostartTray           = "autostart-tray"
 	KubeAdminPassword       = "kubeadmin-password"
+	PresetConfigurationKey  = "preset"
 )
 
 func RegisterSettings(cfg *Config) {
@@ -109,6 +118,9 @@ func RegisterSettings(cfg *Config) {
 
 	cfg.AddSetting(KubeAdminPassword, "", ValidateString, SuccessfullyApplied,
 		"User defined kubeadmin password")
+
+	cfg.AddSetting(PresetConfigurationKey, string(Minimal), validatePreset, RequiresDeleteMsg,
+		fmt.Sprintf("Virtal machine preset (alpha feature - valid values are: %s, %s or %s)", Podman, Minimal, Full))
 }
 
 func defaultNetworkMode() network.Mode {
@@ -126,4 +138,13 @@ func GetNetworkMode(config Storage) network.Mode {
 		return network.UserNetworkingMode
 	}
 	return network.ParseMode(config.Get(NetworkMode).AsString())
+}
+
+func validatePreset(i interface{}) (bool, string) {
+	switch Preset(cast.ToString(i)) {
+	case Podman, Minimal, Full:
+		return true, ""
+	default:
+		return false, fmt.Sprintf("Unknown preset. Only %s, %s and %s are valid.", Podman, Minimal, Full)
+	}
 }


### PR DESCRIPTION
Valid values are podman, minimal and full. The value is not used for the
moment.


**Fixes:** Issue #2525
