### PR TITLE
Fix #2646: return empty responses to prevent JSON deserialization

### DIFF
--- a/pkg/crc/api/api_http.go
+++ b/pkg/crc/api/api_http.go
@@ -49,15 +49,15 @@ func setPullSecret() func(c *context) error {
 		if err := cluster.StoreInKeyring(string(c.requestBody)); err != nil {
 			return err
 		}
-		return c.String(http.StatusCreated, "pull secret added")
+		return c.String(http.StatusCreated, "")
 	}
 }
 
 func getPullSecret(config crcConfig.Storage) func(c *context) error {
 	return func(c *context) error {
 		if _, err := cluster.NewNonInteractivePullSecretLoader(config, "").Value(); err == nil {
-			return c.String(http.StatusOK, "pull secret exists")
+			return c.String(http.StatusOK, "")
 		}
-		return c.String(http.StatusNotFound, "pull secret not found")
+		return c.String(http.StatusNotFound, "")
 	}
 }


### PR DESCRIPTION
**Fixes:** Issue #2646 

On the Windows side we expect responses to be valid JSON messages
or empty. If empty, the status code determines if the call was successful
or not.

Due to a recent changes, the empty messages that were expected
were improved to return a message. While these messages aren't
user-facing this is unnecessary for now.
