### PR TITLE
crc-embedder: Check number of args passed to 'download'

### DIFF
--- a/cmd/crc-embedder/cmd/download.go
+++ b/cmd/crc-embedder/cmd/download.go
@@ -11,6 +11,7 @@ func init() {
 }
 
 var downloadCmd = &cobra.Command{
+	Args:  cobra.ExactArgs(1),
 	Use:   "download",
 	Short: "Download data files embedded in the crc executable",
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/crc-embedder/cmd/download.go
+++ b/cmd/crc-embedder/cmd/download.go
@@ -12,8 +12,8 @@ func init() {
 
 var downloadCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
-	Use:   "download",
-	Short: "Download data files embedded in the crc executable",
+	Use:   "download [destination directory]",
+	Short: "Download data files to embed in the crc executable",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return runDownload(args)
 	},

--- a/cmd/crc-embedder/cmd/embed.go
+++ b/cmd/crc-embedder/cmd/embed.go
@@ -30,6 +30,7 @@ func init() {
 }
 
 var embedCmd = &cobra.Command{
+	Args:  cobra.ExactArgs(1),
 	Use:   "embed",
 	Short: "Embed data files in crc executable",
 	Long:  `Embed the OpenShift bundle and the binaries needed at runtime in the crc executable`,
@@ -39,9 +40,6 @@ var embedCmd = &cobra.Command{
 }
 
 func runEmbed(args []string) {
-	if len(args) != 1 {
-		logging.Fatal("embed takes exactly one argument")
-	}
 	executablePath := args[0]
 	destDir, err := ioutil.TempDir("", "crc-embedder")
 	if err != nil {

--- a/cmd/crc-embedder/cmd/embed.go
+++ b/cmd/crc-embedder/cmd/embed.go
@@ -31,7 +31,7 @@ func init() {
 
 var embedCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
-	Use:   "embed",
+	Use:   "embed [path to the (non-embedded) crc executable]",
 	Short: "Embed data files in crc executable",
 	Long:  `Embed the OpenShift bundle and the binaries needed at runtime in the crc executable`,
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/crc-embedder/cmd/extract.go
+++ b/cmd/crc-embedder/cmd/extract.go
@@ -14,7 +14,7 @@ func init() {
 
 var extractCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(3),
-	Use:   "extract",
+	Use:   "extract [crc executable] [key identifying the embedded data] [destination filename]",
 	Short: "Extract data file embedded in the crc executable",
 	Long:  `Extract a data file which is embedded in the crc executable`,
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/crc-embedder/cmd/extract.go
+++ b/cmd/crc-embedder/cmd/extract.go
@@ -13,6 +13,7 @@ func init() {
 }
 
 var extractCmd = &cobra.Command{
+	Args:  cobra.ExactArgs(3),
 	Use:   "extract",
 	Short: "Extract data file embedded in the crc executable",
 	Long:  `Extract a data file which is embedded in the crc executable`,
@@ -22,9 +23,6 @@ var extractCmd = &cobra.Command{
 }
 
 func runExtract(args []string) {
-	if len(args) != 3 {
-		logging.Fatalf("extract takes exactly three arguments")
-	}
 	executablePath := args[0]
 	embedName := args[1]
 	destFile := args[2]

--- a/cmd/crc-embedder/cmd/list.go
+++ b/cmd/crc-embedder/cmd/list.go
@@ -13,6 +13,7 @@ func init() {
 }
 
 var listCmd = &cobra.Command{
+	Args:  cobra.ExactArgs(1),
 	Use:   "list",
 	Short: "List data files embedded in the crc executable",
 	Long:  `List all the data files which were embedded in the crc executable`,
@@ -22,9 +23,6 @@ var listCmd = &cobra.Command{
 }
 
 func runList(args []string) {
-	if len(args) != 1 {
-		logging.Fatalf("list takes exactly one argument")
-	}
 	executablePath := args[0]
 	extractor, err := binappend.MakeExtractor(executablePath)
 	if err != nil {

--- a/cmd/crc-embedder/cmd/list.go
+++ b/cmd/crc-embedder/cmd/list.go
@@ -14,7 +14,7 @@ func init() {
 
 var listCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
-	Use:   "list",
+	Use:   "list [path to crc executable]",
 	Short: "List data files embedded in the crc executable",
 	Long:  `List all the data files which were embedded in the crc executable`,
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/crc-embedder/cmd/root.go
+++ b/cmd/crc-embedder/cmd/root.go
@@ -10,16 +10,12 @@ import (
 )
 
 var rootCmd = &cobra.Command{
-	Use:   "crc-embedder [list|embed|extract]",
+	Use:   "crc-embedder [command]",
 	Short: "Build helper for crc for binary embedding",
 	Long: `crc-embedder is a command line utility for listing or appending binary data
 when building the crc executable for release`,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		runPrerun()
-	},
-	Run: func(cmd *cobra.Command, args []string) {
-		runRoot()
-		_ = cmd.Help()
 	},
 	PersistentPostRun: func(cmd *cobra.Command, args []string) {
 		runPostrun()
@@ -44,11 +40,6 @@ func Execute() {
 func runPrerun() {
 	// Setting up logrus
 	logging.InitLogrus(logging.LogLevel, constants.LogFilePath)
-}
-
-func runRoot() {
-	fmt.Println("No command given")
-	fmt.Println("")
 }
 
 func runPostrun() {


### PR DESCRIPTION
It expects exactly one argument. Running `crc-embedder` with no args
currently prints a stacktrace:

$ ./out/linux-amd64/crc-embedder download
panic: runtime error: index out of range [0] with length 0

goroutine 1 [running]:
github.com/code-ready/crc/cmd/crc-embedder/cmd.runDownload(...)
        /home/teuf/redhat/crc/crc/cmd/crc-embedder/cmd/download.go:22
github.com/code-ready/crc/cmd/crc-embedder/cmd.glob..func1(0xb19b60, 0xb58e50, 0x0, 0x0, 0x0, 0x0)
        /home/teuf/redhat/crc/crc/cmd/crc-embedder/cmd/download.go:17 +0x7e
github.com/spf13/cobra.(*Command).execute(0xb19b60, 0xb58e50, 0x0, 0x0, 0xb19b60, 0xb58e50)
        /home/teuf/redhat/crc/crc/vendor/github.com/spf13/cobra/command.go:856 +0x472
github.com/spf13/cobra.(*Command).ExecuteC(0xb1a560, 0x407f05, 0xc000026118, 0x401230)
        /home/teuf/redhat/crc/crc/vendor/github.com/spf13/cobra/command.go:974 +0x375
github.com/spf13/cobra.(*Command).Execute(...)
        /home/teuf/redhat/crc/crc/vendor/github.com/spf13/cobra/command.go:902
github.com/code-ready/crc/cmd/crc-embedder/cmd.Execute()
        /home/teuf/redhat/crc/crc/cmd/crc-embedder/cmd/root.go:39 +0x31
main.main()
        /home/teuf/redhat/crc/crc/cmd/crc-embedder/crc-embedder.go:8 +0x25