### PR TITLE
Don't remove crc-users group and current user from it during upgrade

### DIFF
--- a/packaging/windows/product.wxs.template
+++ b/packaging/windows/product.wxs.template
@@ -51,6 +51,7 @@
                         <RemoveFile Id="RemoveInstallFiles" Name="*.*" On="uninstall" />
                     </Component>
                     <Component Id="AddUserToCrcUsers" Guid="0C793EE7-109A-474B-9651-77E0A83BAF2D" KeyPath="yes">
+                        <Condition>NOT UPGRADINGPRODUCTCODE</Condition>
                         <util:User Id="LogonUser1" Domain="[%USERDOMAIN]" Name="[LogonUser]" CreateUser="no" RemoveOnUninstall="no">
                             <util:GroupRef Id="CrcUsersGroup" />
                         </util:User>
@@ -106,7 +107,7 @@
             <Custom Action="RemoveParts" After="JoinBundle">NOT Installed AND NOT PATCH</Custom>
             <Custom Action="CreateCrcGroup" Before="ConfigureUsers"> NOT Installed AND NOT REMOVE~="ALL"</Custom>
             <Custom Action="AddUserToHypervAdminGroup" After="InstallHyperv"> NOT Installed AND NOT REMOVE~="ALL"</Custom>
-            <Custom Action="RemoveCrcGroup" After="RemoveFolders"> Installed AND NOT PATCH AND REMOVE~="ALL"</Custom>
+            <Custom Action="RemoveCrcGroup" After="RemoveFolders"> Installed AND NOT PATCH AND REMOVE~="ALL" AND NOT UPGRADINGPRODUCTCODE</Custom>
             <Custom Action="InstallHyperv" After="RemoveParts"> NOT Installed AND NOT REMOVE~="ALL"</Custom>
             <Custom Action="RemoveCrcGroupRollback" Before="CreateCrcGroup"> NOT Installed AND NOT REMOVE~="ALL"</Custom>
             <ScheduleReboot After="InstallFinalize"> NOT Installed AND NOT REMOVE~="ALL"</ScheduleReboot>


### PR DESCRIPTION
We want to avoid restart when crc is upgraded using the msi installer.

the installer does a uninstall in the RemoveExistingProducts action
when performing upgrades, to avoid a reboot we need to skip the custom
action that removes the crc-users group when the msi detects an upgrade

FIrst part for fixing #2598 (more details in: https://github.com/code-ready/crc/issues/2598#issuecomment-905325117)

### How to test
1. Download msi from appveyor ci https://ci.appveyor.com/api/buildjobs/i6lo0x4r0l8xqlby/artifacts/out%2Fwindows-amd64%2Fcrc-windows-installer.zip
2. Installation should succeed without any errors and after reboot the tray should be started
3. Uninstallation should succeed (verify that the `crc-users` group is deleted, we want to keep it only during upgrades)