### PR TITLE
Skip setup steps that would trigger a reboot during upgrade

### DIFF
--- a/packaging/windows/WixUI_HK.wxs
+++ b/packaging/windows/WixUI_HK.wxs
@@ -11,8 +11,7 @@
          <Property Id="WixUI_Mode" Value="InstallDir" />
          <Property Id="ARPNOMODIFY" Value="1" />
          <Property Id="ARPNOREPAIR" Value="1" />
-         <Property Id="WIXUI_EXITDIALOGOPTIONALTEXT" Value="To finish installation of CodeReady Containers please restart you computer. After restart Open PowerShell or Command Prompt and run the command 'crc.exe setup' to setup your environment." />
-
+        
          <DialogRef Id="BrowseDlg" />
          <DialogRef Id="DiskCostDlg" />
          <DialogRef Id="ErrorDlg" />
@@ -74,5 +73,12 @@
       </UI>
 
       <UIRef Id="WixUI_Common" />
+
+      <CustomAction Id="CA_Set_WIXUI_EXITDIALOGOPTIONALTEXT" Property="WIXUI_EXITDIALOGOPTIONALTEXT" Value="To finish installation of  [ProductName] please restart your computer. After restart Open PowerShell or Command Prompt and run the command 'crc.exe setup' to setup your environment."/>
+      <CustomAction Id="CA_Set_WIXUI_EXITDIALOGOPTIONALTEXT_NOREBOOT" Property="WIXUI_EXITDIALOGOPTIONALTEXT" Value="Suceesfully installed [ProductName]. You can now start [ProductName] from the Start menu."/>
+      <InstallUISequence>
+         <Custom Action="CA_Set_WIXUI_EXITDIALOGOPTIONALTEXT" After="FindRelatedProducts"><![CDATA[NOT WIX_UPGRADE_DETECTED]]></Custom>
+         <Custom Action="CA_Set_WIXUI_EXITDIALOGOPTIONALTEXT_NOREBOOT" After="FindRelatedProducts"><![CDATA[WIX_UPGRADE_DETECTED]]></Custom>
+      </InstallUISequence>
    </Fragment>
 </Wix>

--- a/packaging/windows/WixUI_HK.wxs
+++ b/packaging/windows/WixUI_HK.wxs
@@ -28,13 +28,28 @@
                especially if they are not included explicitly in the publish chain below -->
          <DialogRef Id="LicenseAgreementDlg_HK"/>
 
+         <!-- Custom dialog to ask for removal of old version if an upgrade is detected -->
+         <Dialog Id="OldVersionDlg" Width="240" Height="95" Title="[ProductName] Setup" NoMinimize="yes">
+            <Control Id="Text" Type="Text" X="28" Y="15" Width="194" Height="50">
+               <Text>A previous version of CodeReady Containers is currently installed. By continuing the installation this version will be uninstalled. Do you want to continue?</Text>
+            </Control>
+            <Control Id="Exit" Type="PushButton" X="123" Y="67" Width="62" Height="17" Default="yes" Cancel="yes" Text="No, Exit">
+               <Publish Event="EndDialog" Value="Exit">1</Publish>
+            </Control>
+            <Control Id="Next" Type="PushButton" X="55" Y="67" Width="62" Height="17" Text="Yes, Uninstall">
+               <Publish Event="EndDialog" Value="Return">1</Publish>
+            </Control>
+         </Dialog>
+
          <Publish Dialog="BrowseDlg" Control="OK" Event="DoAction" Value="WixUIValidatePath" Order="3">1</Publish>
          <Publish Dialog="BrowseDlg" Control="OK" Event="SpawnDialog" Value="InvalidDirDlg" Order="4"><![CDATA[WIXUI_INSTALLDIR_VALID<>"1"]]></Publish>
 
          <Publish Dialog="ExitDialog" Control="Finish" Event="EndDialog" Value="Return" Order="999">1</Publish>
 
-         <Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Value="LicenseAgreementDlg_HK">NOT Installed</Publish>
-         <Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg">Installed AND PATCH</Publish>
+         <Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Value="OldVersionDlg"><![CDATA[CRCINSTALLED << "#1"]]></Publish>
+         <Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Value="LicenseAgreementDlg_HK"><![CDATA[NOT (CRCINSTALLED << "#1")]]></Publish>
+
+         <Publish Dialog="OldVersionDlg" Control="Next" Event="NewDialog" Value="LicenseAgreementDlg_HK">1</Publish>
 
          <Publish Dialog="LicenseAgreementDlg_HK" Control="Back" Event="NewDialog" Value="WelcomeDlg">1</Publish>
          <Publish Dialog="LicenseAgreementDlg_HK" Control="Next" Event="NewDialog" Value="InstallDirDlg">LicenseAccepted = "1"</Publish>

--- a/packaging/windows/product.wxs.template
+++ b/packaging/windows/product.wxs.template
@@ -29,6 +29,10 @@
             <![CDATA[Installed OR (WINDOWSEDITION <> "Core")]]>
         </Condition>
 
+        <Property Id="CRCINSTALLED" Secure="yes">
+            <RegistrySearch Id="CrcInstalledReg" Root="HKCU" Key="Software\Red Hat\CodeReady Containers" Name="installed" Type="raw" />
+        </Property>
+
         <util:Group Id="CrcUsersGroup" Name="crc-users" />
         <Directory Id="TARGETDIR" Name="SourceDir">
             <Directory Id="ProgramFiles64Folder">

--- a/packaging/windows/product.wxs.template
+++ b/packaging/windows/product.wxs.template
@@ -51,7 +51,7 @@
                         <RemoveFile Id="RemoveInstallFiles" Name="*.*" On="uninstall" />
                     </Component>
                     <Component Id="AddUserToCrcUsers" Guid="0C793EE7-109A-474B-9651-77E0A83BAF2D" KeyPath="yes">
-                        <Condition>NOT UPGRADINGPRODUCTCODE</Condition>
+                        <Condition>NOT UPGRADINGPRODUCTCODE AND NOT WIX_UPGRADE_DETECTED</Condition>
                         <util:User Id="LogonUser1" Domain="[%USERDOMAIN]" Name="[LogonUser]" CreateUser="no" RemoveOnUninstall="no">
                             <util:GroupRef Id="CrcUsersGroup" />
                         </util:User>
@@ -105,11 +105,11 @@
         <InstallExecuteSequence>
             <Custom Action="JoinBundle" After="InstallFiles">NOT Installed AND NOT PATCH</Custom>
             <Custom Action="RemoveParts" After="JoinBundle">NOT Installed AND NOT PATCH</Custom>
-            <Custom Action="CreateCrcGroup" Before="ConfigureUsers"> NOT Installed AND NOT REMOVE~="ALL"</Custom>
-            <Custom Action="AddUserToHypervAdminGroup" After="InstallHyperv"> NOT Installed AND NOT REMOVE~="ALL"</Custom>
+            <Custom Action="CreateCrcGroup" Before="ConfigureUsers"> NOT Installed AND NOT REMOVE~="ALL" AND NOT WIX_UPGRADE_DETECTED</Custom>
+            <Custom Action="AddUserToHypervAdminGroup" After="InstallHyperv"> NOT Installed AND NOT REMOVE~="ALL" AND NOT WIX_UPGRADE_DETECTED</Custom>
             <Custom Action="RemoveCrcGroup" After="RemoveFolders"> Installed AND NOT PATCH AND REMOVE~="ALL" AND NOT UPGRADINGPRODUCTCODE</Custom>
-            <Custom Action="InstallHyperv" After="RemoveParts"> NOT Installed AND NOT REMOVE~="ALL"</Custom>
-            <Custom Action="RemoveCrcGroupRollback" Before="CreateCrcGroup"> NOT Installed AND NOT REMOVE~="ALL"</Custom>
+            <Custom Action="InstallHyperv" After="RemoveParts"> NOT Installed AND NOT REMOVE~="ALL" AND NOT WIX_UPGRADE_DETECTED</Custom>
+            <Custom Action="RemoveCrcGroupRollback" Before="CreateCrcGroup"> NOT Installed AND NOT REMOVE~="ALL" AND NOT WIX_UPGRADE_DETECTED</Custom>
             <ScheduleReboot After="InstallFinalize"> NOT Installed AND NOT REMOVE~="ALL"</ScheduleReboot>
         </InstallExecuteSequence>
         <Feature Id="DefaultFeature" Level="1">

--- a/packaging/windows/product.wxs.template
+++ b/packaging/windows/product.wxs.template
@@ -114,7 +114,7 @@
             <Custom Action="RemoveCrcGroup" After="RemoveFolders"> Installed AND NOT PATCH AND REMOVE~="ALL" AND NOT UPGRADINGPRODUCTCODE</Custom>
             <Custom Action="InstallHyperv" After="RemoveParts"> NOT Installed AND NOT REMOVE~="ALL" AND NOT WIX_UPGRADE_DETECTED</Custom>
             <Custom Action="RemoveCrcGroupRollback" Before="CreateCrcGroup"> NOT Installed AND NOT REMOVE~="ALL" AND NOT WIX_UPGRADE_DETECTED</Custom>
-            <ScheduleReboot After="InstallFinalize"> NOT Installed AND NOT REMOVE~="ALL"</ScheduleReboot>
+            <ScheduleReboot After="InstallFinalize"> NOT Installed AND NOT REMOVE~="ALL" AND NOT WIX_UPGRADE_DETECTED</ScheduleReboot>
         </InstallExecuteSequence>
         <Feature Id="DefaultFeature" Level="1">
             {{range $index, $element := .Parts}}


### PR DESCRIPTION
Skip adding user to hyperv-admins and crc-users group, skip creation
of the crc-users group and enabling hyperv optional features,  these
are already setup in an upgrade scenario

Fixes #2598 

### How to test
For a clean install and uninstall this does not change the behavior.

To test the upgrade scenario:
1. Ensure you have crc 1.32.1 installed
2. Install the msi from PR (https://ci.appveyor.com/api/buildjobs/a1rufcoy9jkwncwb/artifacts/out%2Fwindows-amd64%2Fcrc-windows-installer.zip)
3. It should not ask for reboot
4. After upgrade start the tray app from start menu
5. Tray should start, and start/stop and all other options should work as expected