### PR TITLE
Delete csr for kubernetes.io/kube-apiserver-client signer 

### DIFF
--- a/pkg/crc/cluster/cert-renewal.go
+++ b/pkg/crc/cluster/cert-renewal.go
@@ -38,6 +38,14 @@ func ApproveCSRAndWaitForCertsRenewal(sshRunner *ssh.Runner, ocConfig oc.Config,
 			logging.Debugf("Error approving pending kube-apiserver-client-kubelet CSR: %v", err)
 			return err
 		}
+		// This deleteCSR block only needed for 4.8 version and should be removed when we start shipping 4.9 or
+		// if the patch backported to 4.8 z stream.
+		// https://github.com/openshift/library-go/pull/1190 and https://github.com/openshift/cluster-authentication-operator/pull/475
+		// https://bugzilla.redhat.com/show_bug.cgi?id=1997906
+		if err := deleteCSR(ocConfig, authClientSignerName); err != nil {
+			logging.Debugf("Error deleting openshift-authenticator csr: %v", err)
+			return err
+		}
 		if err := crcerrors.RetryAfter(5*time.Minute, waitForCertRenewal(sshRunner, KubeletClientCert), time.Second*5); err != nil {
 			logging.Debugf("Error approving pending kube-apiserver-client-kubelet CSR: %v", err)
 			return err

--- a/pkg/crc/cluster/cluster.go
+++ b/pkg/crc/cluster/cluster.go
@@ -31,6 +31,7 @@ const (
 	KubeletClientCert = "/var/lib/kubelet/pki/kubelet-client-current.pem"
 
 	kubeletClientSignerName = "kubernetes.io/kube-apiserver-client-kubelet"
+	authClientSignerName    = "kubernetes.io/kube-apiserver-client"
 
 	AggregatorClientCert = "/etc/kubernetes/static-pod-resources/kube-apiserver-certs/configmaps/aggregator-client-ca/ca-bundle.crt"
 )

--- a/test/e2e/features/cert_rotation.feature
+++ b/test/e2e/features/cert_rotation.feature
@@ -19,6 +19,8 @@ Feature: Certificate rotation test
         And executing "eval $(crc oc-env)" succeeds
         When checking that CRC is running
         Then login to the oc cluster succeeds
+        Then execute "oc whoami" succeeds
+        And stdout should contain "kubeadmin"
 
     Scenario: Set clock back to the original time
         When executing "sudo date -s '-3 month'" succeeds


### PR DESCRIPTION
This patch should fix the issue which users are facing after bundle cert
expire.
```
$ oc login -u kubeadmin -p AEJ7z-trsoy-EqQZS-ArzvC https://api.crc.testing:6443
Login failed (401 Unauthorized)
```

More details
- https://bugzilla.redhat.com/show_bug.cgi?id=1997906

We will not need it if the patch is cherry picked to 4.8.z branch but
even it is there, this shouldn't cause any issue because we are first
checking if respective signer is available.
- openshift/library-go#1190
- openshift/cluster-authentication-operator#475