### PR TITLE
Issue #2666 Fix win edition check in the preflight and msi

### DIFF
--- a/packaging/windows/product.wxs.template
+++ b/packaging/windows/product.wxs.template
@@ -26,7 +26,7 @@
             <RegistrySearch Id="WindowsEditionReg" Root="HKLM" Key="SOFTWARE\Microsoft\Windows NT\CurrentVersion" Name="EditionID" Type="raw" />
         </Property>
         <Condition Message="CodeReady Containers cannot run on Windows Home edition">
-            <![CDATA[Installed OR (WINDOWSEDITION <> "Home")]]>
+            <![CDATA[Installed OR (WINDOWSEDITION <> "Core")]]>
         </Condition>
 
         <util:Group Id="CrcUsersGroup" Name="crc-users" />

--- a/pkg/crc/preflight/preflight_checks_windows.go
+++ b/pkg/crc/preflight/preflight_checks_windows.go
@@ -52,7 +52,7 @@ func checkWindowsEdition() error {
 	windowsEdition := strings.TrimSpace(stdOut)
 	logging.Debugf("Running on Windows %s edition", windowsEdition)
 
-	if strings.HasPrefix(windowsEdition, "Home") {
+	if strings.ToLower(windowsEdition) == "core" {
 		return fmt.Errorf("Windows Home edition is not supported")
 	}
 


### PR DESCRIPTION
The name of the edition for windows 10 Home edition is "Core"
and not "Home"

```
PS > (Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion").EditionID
Core
```

Fixes #2666 
