### PR TITLE
Several bug fixes

### DIFF
--- a/cmd/crc/cmd/version_test.go
+++ b/cmd/crc/cmd/version_test.go
@@ -10,10 +10,11 @@ import (
 func TestPlainVersion(t *testing.T) {
 	out := new(bytes.Buffer)
 	assert.NoError(t, runPrintVersion(out, &version{
-		Version:          "1.13",
-		Commit:           "aabbcc",
-		OpenshiftVersion: "4.5.4",
-		Embedded:         false,
+		Version:             "1.13",
+		Commit:              "aabbcc",
+		OpenshiftVersion:    "4.5.4",
+		Embedded:            false,
+		InstalledBundlePath: "",
 	}, ""))
 	assert.Equal(t, `CodeReady Containers version: 1.13+aabbcc
 OpenShift version: 4.5.4 (not embedded in executable)
@@ -23,10 +24,11 @@ OpenShift version: 4.5.4 (not embedded in executable)
 func TestJsonVersion(t *testing.T) {
 	out := new(bytes.Buffer)
 	assert.NoError(t, runPrintVersion(out, &version{
-		Version:          "1.13",
-		Commit:           "aabbcc",
-		OpenshiftVersion: "4.5.4",
-		Embedded:         false,
+		Version:             "1.13",
+		Commit:              "aabbcc",
+		OpenshiftVersion:    "4.5.4",
+		Embedded:            false,
+		InstalledBundlePath: "",
 	}, "json"))
 
 	expected := `{"version": "1.13", "commit": "aabbcc", "openshiftVersion": "4.5.4", "embedded": false}`

--- a/pkg/crc/machine/delete.go
+++ b/pkg/crc/machine/delete.go
@@ -1,6 +1,8 @@
 package machine
 
 import (
+	"os"
+
 	"github.com/code-ready/crc/pkg/crc/logging"
 	"github.com/pkg/errors"
 )
@@ -23,7 +25,9 @@ func (client *client) Delete() error {
 	}
 
 	if err := cleanKubeconfig(getGlobalKubeConfigPath(), getGlobalKubeConfigPath()); err != nil {
-		logging.Warn(err)
+		if !errors.Is(err, os.ErrNotExist) {
+			logging.Warnf("Failed to remove crc contexts from kubeconfig: %v", err)
+		}
 	}
 	return nil
 }

--- a/pkg/crc/preflight/preflight_checks_linux.go
+++ b/pkg/crc/preflight/preflight_checks_linux.go
@@ -421,6 +421,12 @@ func removeDaemonSystemdService() error {
 	return nil
 }
 
+func warnNoDaemonAutostart() error {
+	// only purpose of this check is to trigger a warning for RHEL7/CentOS7 users
+	logging.Warnf("systemd --user is not available, crc daemon won't be autostarted and must be run manually before using CodeReady Containers")
+	return nil
+}
+
 func checkLibvirtServiceRunning() error {
 	logging.Debug("Checking if libvirtd service is running")
 	sd := systemd.NewHostSystemdCommander()

--- a/pkg/crc/preflight/preflight_linux.go
+++ b/pkg/crc/preflight/preflight_linux.go
@@ -130,6 +130,12 @@ func libvirtPreflightChecks(distro *linux.OsRelease) []Check {
 
 			labels: labels{Os: Linux, SystemdUser: Supported},
 		},
+		{
+			checkDescription: "Checking if crc daemon will be autostarted",
+			check:            warnNoDaemonAutostart,
+
+			labels: labels{Os: Linux, NetworkMode: User, SystemdUser: Unsupported},
+		},
 	}
 	return checks
 }


### PR DESCRIPTION
This PR fixes 4 unrelated issues, I can file 4 different PRs if that's preferred.

The first 2 commits fix socket activation on el7 by disabling the checks, and warning the user they need to run the daemon manually. 
The CSR commits are more of a code cleanup than a bug fix, but I suspect they fix a potential issue in a corner case.
The 'version' commit improves `crc version` output regarding the bundle when using an installer, see the commit log for details.
The 'delete' commit fixes a warning on `crc delete` when `KUBECONFIG` is set to `~/.crc/machines/crc/kubeconfig.




**Fixes:** Issues #2653, #1824, #2676