### PR TITLE
ci: Always run 'crc' with '--log-level debug'

### DIFF
--- a/test/e2e/crcsuite/crcsuite.go
+++ b/test/e2e/crcsuite/crcsuite.go
@@ -63,9 +63,9 @@ func FeatureContext(s *godog.Suite) {
 		CheckCRCStatus)
 	s.Step(`^(stdout|stderr) (?:should contain|contains) "(.*)" if bundle (is|is not) embedded$`,
 		CommandReturnShouldContainIfBundleEmbeddedOrNot)
-	s.Step(`^execute crc (.*) command$`,
+	s.Step(`^execut(?:e|ing) crc (.*) command$`,
 		ExecuteCommand)
-	s.Step(`^execute crc (.*) command (.*)$`,
+	s.Step(`^execut(?:e|ing) crc (.*) command (.*)$`,
 		ExecuteCommandWithExpectedExitStatus)
 
 	// CRC file operations

--- a/test/e2e/features/basic.feature
+++ b/test/e2e/features/basic.feature
@@ -6,12 +6,12 @@ Feature: Basic test
 
     @darwin @linux @windows
     Scenario: CRC version
-        When execute crc version command
+        When executing crc version command
         Then stdout should contain "version:"
 
     @darwin @linux @windows
     Scenario: CRC help
-        When execute crc help command succeeds
+        When executing crc help command succeeds
         Then stdout should contain "Usage:"
         And stdout should contain "Available Commands:"
         And stdout should contain "help"
@@ -29,7 +29,7 @@ Feature: Basic test
 
     @darwin @linux @windows
     Scenario: CRC status
-        When execute crc status command fails
+        When executing crc status command fails
         Then stderr should contain
             """
             Machine does not exist. Use 'crc start' to create it
@@ -38,8 +38,8 @@ Feature: Basic test
     @linux
     Scenario: CRC setup on Linux
         When executing "crc setup --check-only" fails
-        Then execute crc start command fails
-        And execute crc setup command succeeds
+        Then executing crc start command fails
+        And executing crc setup command succeeds
         And stderr should contain "Checking if CRC bundle is extracted in '$HOME/.crc'"
         And stderr should contain "Checking if running as non-root"
         And stderr should contain "Checking if Virtualization is enabled"
@@ -68,7 +68,7 @@ Feature: Basic test
     @darwin
     Scenario: CRC setup on Mac
         When executing "crc setup --check-only" fails
-        And execute crc setup command succeeds
+        And executing crc setup command succeeds
         And stderr should contain "Checking if running as non-root"
         And stderr should contain "Checking if HyperKit is installed"
         And stderr should contain "Checking if crc-driver-hyperkit is installed"
@@ -79,7 +79,7 @@ Feature: Basic test
 
     @windows
     Scenario: CRC setup on Windows
-        When execute crc setup command succeeds
+        When executing crc setup command succeeds
         Then stderr should contain "Extracting bundle from the CRC executable" if bundle is embedded
         Then stderr should contain "Checking Windows 10 release"
         Then stderr should contain "Checking if Hyper-V is installed"
@@ -109,7 +109,7 @@ Feature: Basic test
 
     @darwin @linux @windows
     Scenario: CRC IP check
-        When execute crc ip command succeeds
+        When executing crc ip command succeeds
         Then stdout should match "\d+\.\d+\.\d+\.\d+"
 
     @darwin @linux @windows
@@ -163,7 +163,7 @@ Feature: Basic test
 
     @darwin @linux @windows
     Scenario: CRC console check
-        When execute crc console command
+        When executing crc console command
         Then stderr should contain "The OpenShift cluster is not running, cannot open the OpenShift Web Console"
 
     @darwin @linux @windows
@@ -178,7 +178,7 @@ Feature: Basic test
 
     @darwin
     Scenario Outline: CRC clean-up
-        When execute crc cleanup command succeeds
+        When executing crc cleanup command succeeds
         Then stderr should contain "Removing /etc/resolver/testing file"
         And stderr should contain "Unload CodeReady Containers daemon"
         And stderr should contain "Removing pull secret from the keyring"
@@ -187,7 +187,7 @@ Feature: Basic test
 
     @linux
     Scenario Outline: CRC clean-up
-        When execute crc cleanup command succeeds
+        When executing crc cleanup command succeeds
         Then stderr should contain "Removing the crc VM if exists"
         And stderr should contain "Removing 'crc' network from libvirt"
         And stderr should contain "Using root access: Executing systemctl daemon-reload command"
@@ -199,7 +199,7 @@ Feature: Basic test
 
     @windows
     Scenario Outline: CRC clean-up
-        When execute crc cleanup command succeeds
+        When executing crc cleanup command succeeds
         Then stderr should contain "Uninstalling tray if installed"
         Then stderr should contain "Uninstalling daemon if installed"
         And stderr should contain "Removing the crc VM if exists"

--- a/test/e2e/features/cert_rotation.feature
+++ b/test/e2e/features/cert_rotation.feature
@@ -29,4 +29,4 @@ Feature: Certificate rotation test
     Scenario: CRC delete and cleanup
         When executing "crc delete -f" succeeds
         Then stdout should contain "Deleted the OpenShift cluster"
-        When execute crc cleanup command succeeds
+        When executing crc cleanup command succeeds

--- a/test/e2e/features/config.feature
+++ b/test/e2e/features/config.feature
@@ -41,7 +41,7 @@ Feature: Test configuration settings
 
     @linux @darwin @windows
     Scenario: CRC config checks (bundle version)
-        Given execute crc setup command succeeds
+        Given executing crc setup command succeeds
         When setting config property "bundle" to value "current bundle" succeeds
         And "JSON" config file "crc.json" in CRC home folder contains key "bundle" with value matching "current bundle"
         And setting config property "bundle" to value "/path/to/nonexistent/bundle/crc_hypervisor_version.tar.xz" fails
@@ -112,7 +112,7 @@ Feature: Test configuration settings
     @linux
     Scenario: Check network setup and destroy it, then check again
         When removing file "crc.json" from CRC home folder succeeds
-        And execute crc setup command succeeds
+        And executing crc setup command succeeds
         And executing "sudo virsh net-list --name" succeeds
         Then stdout contains "crc"
         When executing "sudo virsh net-undefine crc && sudo virsh net-destroy crc" succeeds
@@ -123,7 +123,7 @@ Feature: Test configuration settings
     Scenario: Running `crc setup` with checks enabled restores destroyed network
         When executing "crc config set skip-check-crc-network false" succeeds
         And executing "crc config set skip-check-crc-network-active false" succeeds
-        Then execute crc setup command succeeds
+        Then executing crc setup command succeeds
         And executing "sudo virsh net-list --name" succeeds
         And stdout contains "crc"
 
@@ -144,6 +144,6 @@ Feature: Test configuration settings
     Scenario: Clean-up
         # Remove the config file
         When removing file "crc.json" from CRC home folder succeeds
-        And execute crc setup command succeeds
+        And executing crc setup command succeeds
         Then stderr should not contain "Skipping above check"
-       
+

--- a/test/e2e/features/proxy.feature
+++ b/test/e2e/features/proxy.feature
@@ -8,7 +8,7 @@ Feature: Behind proxy test
         Given executing "podman run --name squid -d -p 3128:3128 quay.io/crcont/squid" succeeds
 
     Scenario: Start CRC
-        Given execute crc setup command succeeds
+        Given executing crc setup command succeeds
         And  executing "crc config set http-proxy http://192.168.130.1:3128" succeeds
         Then executing "crc config set https-proxy http://192.168.130.1:3128" succeeds
         When starting CRC with default bundle succeeds
@@ -27,6 +27,6 @@ Feature: Behind proxy test
         Then stdout should contain "Deleted the OpenShift cluster"
         And  executing "crc config unset http-proxy" succeeds
         And executing "crc config unset https-proxy" succeeds
-        And execute crc cleanup command succeeds
+        And executing crc cleanup command succeeds
         
 

--- a/test/e2e/features/story_marketplace.feature
+++ b/test/e2e/features/story_marketplace.feature
@@ -52,10 +52,10 @@ Feature: Operator from marketplace
         Then stdout should match "^pod(.*)deleted$"
         # after a while 1 pods should be up & running again
         And with up to "10" retries with wait period of "30s" command "oc get pods" output matches "redis-standalone-[a-z0-9]* .*Running.*"
-        
+
     @darwin @linux @windows
     Scenario: Clean up
         When executing "crc delete -f" succeeds
         Then stdout should contain "Deleted the OpenShift cluster"
-        When execute crc cleanup command succeeds
+        When executing crc cleanup command succeeds
         Then stdout should contain "Cleanup finished"

--- a/test/e2e/features/story_registry.feature
+++ b/test/e2e/features/story_registry.feature
@@ -41,5 +41,5 @@ Feature: Local image to image-registry
         And executing "oc delete project testproj-img" succeeds
         And executing "crc delete -f" succeeds
         Then stdout should contain "Deleted the OpenShift cluster"
-        When execute crc cleanup command succeeds
+        When executing crc cleanup command succeeds
         Then stdout should contain "Cleanup finished"

--- a/test/extended/crc/cmd/cmd.go
+++ b/test/extended/crc/cmd/cmd.go
@@ -93,8 +93,12 @@ func envVariable(key, value string) string {
 }
 
 func (c Command) validate() error {
-	if _, ok := commands[c.command]; !ok {
-		return fmt.Errorf("%s is not a supported command", c.command)
+	cmdline := strings.Fields(c.command)
+	if len(cmdline) < 1 {
+		return fmt.Errorf("empty command? %s", c.command)
+	}
+	if _, ok := commands[cmdline[0]]; !ok {
+		return fmt.Errorf("%s is not a supported command", cmdline[0])
 	}
 	return nil
 }


### PR DESCRIPTION
Rather than manually adding '--log-level debug' here and there in feature
files, this PR adds it unconditionally for all crc command runs