### PR TITLE
Add .testing to default no-proxy list

### DIFF
--- a/pkg/crc/network/proxy.go
+++ b/pkg/crc/network/proxy.go
@@ -10,7 +10,7 @@ import (
 
 var (
 	DefaultProxy     ProxyConfig
-	defaultNoProxies = []string{"127.0.0.1", "localhost"}
+	defaultNoProxies = []string{"127.0.0.1", "localhost", ".testing"}
 )
 
 // ProxyConfig keeps the proxy configuration for the current environment


### PR DESCRIPTION
This should fix the issue where auth operator is failing because of
apps-crc.testing goes through the proxy.

```
OAuthServerRouteEndpointAccessibleControllerDegraded: Get "https://oauth-openshift.apps-crc.testing/healthz": Service Unavailable
      ProxyConfigControllerDegraded: failed to reach endpoint("https://oauth-openshift.apps-crc.testing/healthz") missing in NO_PROXY(".cluster.local,.svc,10.217.0.0/22,10.217.4.0/23,127.0.0.1,192.168.126.0/24,api-int.crc.testing,localhost") with error: Get "https://oauth-openshift.apps-crc.testing/healthz": Service Unavailable
```

Note: We still need to stop and start to have everything working but
this patch is required even for this workaroud.
