### PR TITLE
Use Select-Object instead of parenthesis to get Hyper-V VM status

### DIFF
--- a/pkg/drivers/hyperv/hyperv_windows.go
+++ b/pkg/drivers/hyperv/hyperv_windows.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	log "github.com/code-ready/crc/pkg/crc/logging"
+	"github.com/code-ready/crc/pkg/os/windows/powershell"
 	"github.com/code-ready/machine/libmachine/drivers"
 	"github.com/code-ready/machine/libmachine/state"
 )
@@ -86,14 +87,14 @@ func (d *Driver) DriverName() string {
 }
 
 func (d *Driver) GetState() (state.State, error) {
-	stdout, err := cmdOut("(", "Hyper-V\\Get-VM", d.MachineName, ").state")
+	stdout, stderr, err := powershell.Execute("Hyper-V\\Get-VM", d.MachineName, "|", "Select-Object", "-ExpandProperty", "State")
 	if err != nil {
-		return state.Error, fmt.Errorf("Failed to find the VM status")
+		return state.Error, fmt.Errorf("Failed to find the VM status: %v - %s", err, stderr)
 	}
 
 	resp := parseLines(stdout)
 	if len(resp) < 1 {
-		return state.Error, fmt.Errorf("unexpected Hyper-V state %s", resp)
+		return state.Error, fmt.Errorf("unexpected Hyper-V state %s", stdout)
 	}
 
 	switch resp[0] {


### PR DESCRIPTION
Previous implementation doesn't fail if the VM doesn't exist. With
Select-Object, the Hyper-V Get-VM error is correctly reported.

Before:
$ crc status
Error getting the machine state: unexpected Hyper-V state []

After:
$ crc status
Cannot get machine state: Failed to find the VM status: exit status 1 - Hyper-V\Get-VM : Hyper-V was unable to find a virtual machine with name "crc"

---

This is a split of https://github.com/code-ready/crc/pull/2616
It will be easier to merge if there are less commits. This one was good to go.