### PR TITLE
[e2e] Use executing instead execute for `oc whoami` step

### DIFF
--- a/test/e2e/features/cert_rotation.feature
+++ b/test/e2e/features/cert_rotation.feature
@@ -19,7 +19,7 @@ Feature: Certificate rotation test
         And executing "eval $(crc oc-env)" succeeds
         When checking that CRC is running
         Then login to the oc cluster succeeds
-        Then execute "oc whoami" succeeds
+        Then executing "oc whoami" succeeds
         And stdout should contain "kubeadmin"
 
     Scenario: Set clock back to the original time


### PR DESCRIPTION
Looks like in the CI run this step is not reconized and creating
diagonse log.
```
15:19:42     Then execute "oc whoami" succeeds
15:19:42     And stdout should contain "kubeadmin"                                                          # shell.go:286 -> github.com/code-ready/clicumber/testsuite.CommandReturnShouldContain
15:19:42 Writing diagnostics at ../test-results/diagnose-1638438582.zip
15:19:42 time="2021-12-02T09:49:42Z" level=error msg="error while collecting: open /home/crc_ci/.crc/crcd.log: no such file or directory"
15:19:48 time="2021-12-02T09:49:48Z" level=error msg="error while collecting: collecting journalctl.txt: exit status 1"
15:20:34 time="2021-12-02T09:50:34Z" level=info msg="diagnose took 51.932628948s"
```

