### PR TITLE
[e2e] Added options to control e2e container execution 

### DIFF
--- a/images/build-e2e/README.md
+++ b/images/build-e2e/README.md
@@ -15,6 +15,7 @@ The container connects through ssh to the target host and copy the right binary 
 **BUNDLE_VERSION**:*(Mandatory if not BUNDLE_LOCATION). Testing agaisnt crc released version bundle version for crc released version.*
 **BUNDLE_LOCATION**:*(Mandatory if not BUNDLE_VERSION). When testing crc with custom bundle set the bundle location on target server.*  
 **RESULTS_PATH**:*(Optional). Path inside container to pick results and logs from e2e execution.*  
+**CLEANUP_HOME**:*(Optional). Cleanup crc home folder or keep as it is to run test.*  
 
 ## Samples
 

--- a/images/build-e2e/README.md
+++ b/images/build-e2e/README.md
@@ -6,41 +6,41 @@ The container connects through ssh to the target host and copy the right binary 
 
 ## Envs
 
-* PLATFORM              define target platform (windows, macos, linux).  
-* TARGET_HOST           dns or ip for the target host.  
-* TARGET_HOST_USERNAME  username for target host.  
-* TARGET_HOST_KEY_PATH  private key for user. (Mandatory if not TARGET_HOST_PASSWORD).  
-* TARGET_HOST_PASSWORD  password for user. (Mandatory if not TARGET_HOST_KEY_PATH).  
-* PULL_SECRET_FILE_PATH pull secret file path (local to container).  
-* BUNDLE_VERSION        testing agaisnt crc released version bundle version for crc released version. (Mandatory if not BUNDLE_LOCATION).  
-* BUNDLE_LOCATION       when testing crc with custom bundle set the bundle location on target server. (Mandatory if not BUNDLE_VERSION).  
-* RESULTS_PATH          Optional. Path inside container to pick results and logs from e2e execution.  
+**PLATFORM**:*define target platform (windows, macos, linux).*
+**TARGET_HOST**:*dns or ip for the target host.*  
+**TARGET_HOST_USERNAME**:*username for target host.*  
+**TARGET_HOST_KEY_PATH**:*private key for user. (Mandatory if not TARGET_HOST_PASSWORD).*  
+**TARGET_HOST_PASSWORD**:*password for user. (Mandatory if not TARGET_HOST_KEY_PATH).*  
+**PULL_SECRET_FILE_PATH**: *pull secret file path (local to container).*  
+**BUNDLE_VERSION**:*(Mandatory if not BUNDLE_LOCATION). Testing agaisnt crc released version bundle version for crc released version.*
+**BUNDLE_LOCATION**:*(Mandatory if not BUNDLE_VERSION). When testing crc with custom bundle set the bundle location on target server.*  
+**RESULTS_PATH**:*(Optional). Path inside container to pick results and logs from e2e execution.*  
 
-# Samples
+## Samples
 
 ```bash
 # Run e2e on macos platform with ssh key and custom bundle
 podman run --rm -it --name crc-e2e \
-		    -e PLATFORM=macos \
-            -e TARGET_HOST=$IP \
-		    -e TARGET_HOST_USERNAME=$USER \
-            -e TARGET_HOST_KEY_PATH=/opt/crc/id_rsa \
-		    -e PULL_SECRET_FILE_PATH=/opt/crc/pull-secret \
-            -e BUNDLE_LOCATION=/bundles/crc_hyperv_4.8.0-rc.3.crcbundle \
-            -v $PWD/pull-secret:/opt/crc/pull-secret:Z \
-            -v $PWD/id_rsa:/opt/crc/id_rsa:Z \
-            -v $PWD/output:/output:Z \
-		    quay.io/crcont/crc-e2e:v1.29.0-465452f4
+    -e PLATFORM=macos \
+    -e TARGET_HOST=$IP \
+    -e TARGET_HOST_USERNAME=$USER \
+    -e TARGET_HOST_KEY_PATH=/opt/crc/id_rsa \
+    -e PULL_SECRET_FILE_PATH=/opt/crc/pull-secret \
+    -e BUNDLE_LOCATION=/bundles/crc_hyperv_4.8.0-rc.3.crcbundle \
+    -v $PWD/pull-secret:/opt/crc/pull-secret:Z \
+    -v $PWD/id_rsa:/opt/crc/id_rsa:Z \
+    -v $PWD/output:/output:Z \
+    quay.io/crcont/crc-e2e:v1.29.0-465452f4
 
 # Run e2e on windows platform with ssh password and crc released version
 podman run --rm -it --name crc-e2e \
-		    -e PLATFORM=windows \
-            -e TARGET_HOST=$IP \
-		    -e TARGET_HOST_USERNAME=$USER \
-            -e TARGET_HOST_PASSWORD=$PASSWORD \
-		    -e PULL_SECRET_FILE_PATH=/opt/crc/pull-secret \
-            -e BUNDLE_VERSION=4.7.18 \
-            -v $PWD/pull-secret:/opt/crc/pull-secret:Z \
-            -v $PWD/output:/output:Z \
-		    quay.io/crcont/crc-e2e:v1.29.0-465452f4
+    -e PLATFORM=windows \
+    -e TARGET_HOST=$IP \
+    -e TARGET_HOST_USERNAME=$USER \
+    -e TARGET_HOST_PASSWORD=$PASSWORD \
+    -e PULL_SECRET_FILE_PATH=/opt/crc/pull-secret \
+    -e BUNDLE_VERSION=4.7.18 \
+    -v $PWD/pull-secret:/opt/crc/pull-secret:Z \
+    -v $PWD/output:/output:Z \
+    quay.io/crcont/crc-e2e:v1.29.0-465452f4
 ```

--- a/images/build-e2e/README.md
+++ b/images/build-e2e/README.md
@@ -16,6 +16,7 @@ The container connects through ssh to the target host and copy the right binary 
 **BUNDLE_LOCATION**:*(Mandatory if not BUNDLE_VERSION). When testing crc with custom bundle set the bundle location on target server.*  
 **RESULTS_PATH**:*(Optional). Path inside container to pick results and logs from e2e execution.*  
 **CLEANUP_HOME**:*(Optional). Cleanup crc home folder or keep as it is to run test.*  
+**TESTING_MODE**:*(Optional). Define e2e testing mode (valid values are ux, non-ux. Default is non-ux)*  
 
 ## Samples
 

--- a/images/build-e2e/entrypoint.sh
+++ b/images/build-e2e/entrypoint.sh
@@ -6,12 +6,17 @@ if [[ ${PLATFORM} == 'windows' ]]; then
     BINARY=e2e.test.exe
 fi
 BINARY_PATH="/opt/crc/bin/${PLATFORM}-amd64/${BINARY}"
+
+# Running options
+CLEANUP_HOME="${CLEANUP_HOME:-"true"}"
 # Review this when go 1.16 with embed support
 FEATURES_PATH=/opt/crc/features
 TESTDATA_PATH=/opt/crc/testdata
 UX_RESOURCES_PATH=/opt/crc/ux
+
 # Results
 RESULTS_PATH="${RESULTS_PATH:-/output}"
+
 
 if [ "${DEBUG:-}" = "true" ]; then
     set -xuo 
@@ -104,7 +109,12 @@ OPTIONS+="--pull-secret-file=${EXECUTION_FOLDER}/pull-secret "
 if [[ ${PLATFORM} == 'macos' ]]; then
     PLATFORM="darwin"
 fi
-OPTIONS+="--godog.tags='@${PLATFORM}' --godog.format=junit"
+GODOG_TAGS="@${PLATFORM} "
+
+OPTIONS+="--godog.tags='${GODOG_TAGS}' --godog.format=junit "
+if [ "${CLEANUP_HOME}" = "false" ]; then
+    OPTIONS+="--cleanup-home=false "
+fi
 # Review when pwsh added as powershell supported
 if [[ ${PLATFORM} == 'windows' ]]; then
     BINARY_EXEC="\$env:SHELL='powershell'; "


### PR DESCRIPTION
This PR introduces two optional ENVS to control the execution of the e2e container:

* CLEANUP_HOME to control the deletion for crc home folder before running the test suite
* TESTING_MODE allowing to pick to modes: non-ux or ux