### PR TITLE
[integration] Add container to run integration test within a target host

### DIFF
--- a/images/build-integration/Dockerfile
+++ b/images/build-integration/Dockerfile
@@ -1,0 +1,22 @@
+
+FROM registry.access.redhat.com/ubi8/go-toolset:1.15.13 as builder
+
+USER root
+WORKDIR /workspace
+COPY . .
+RUN make build_integration
+
+FROM registry.access.redhat.com/ubi8/ubi-minimal 
+
+LABEL MAINTAINER "CodeReady Containers <devtools-cdk@redhat.com>"
+
+COPY --from=builder /workspace/images/build-integration/entrypoint.sh /usr/local/bin/
+COPY --from=builder /workspace/out /opt/crc/bin
+
+ENV EPEL https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+
+RUN rpm -ivh ${EPEL} \ 
+    && microdnf --enablerepo=epel install -y openssh-clients sshpass \
+    && microdnf clean all
+
+ENTRYPOINT ["entrypoint.sh"]

--- a/images/build-integration/README.md
+++ b/images/build-integration/README.md
@@ -1,0 +1,44 @@
+# Overview
+
+The container includes the integration binary for all 3 platforms plus the required resources to run it.  
+
+The container connects through ssh to the target host and copy the right binary for the platform, run integration tests and pick the results and logs back.
+
+## Envs
+
+**PLATFORM**:*define target platform (windows, macos, linux).*
+**TARGET_HOST**:*dns or ip for the target host.*  
+**TARGET_HOST_USERNAME**:*username for target host.*  
+**TARGET_HOST_KEY_PATH**:*private key for user. (Mandatory if not TARGET_HOST_PASSWORD).*  
+**TARGET_HOST_PASSWORD**:*password for user. (Mandatory if not TARGET_HOST_KEY_PATH).*  
+**PULL_SECRET_FILE_PATH** pull secret file path (local to container).*  
+**BUNDLE_LOCATION**:*(Optional). When testing crc with custom bundle set the bundle location on target server.*  
+**RESULTS_PATH**:*(Optional). Path inside container to pick results and logs from integration execution.*
+
+## Samples
+
+```bash
+# Run integration on macos platform with ssh key and custom bundle
+podman run --rm -it --name crc-integration \
+    -e PLATFORM=macos \
+    -e TARGET_HOST=$IP \
+    -e TARGET_HOST_USERNAME=$USER \
+    -e TARGET_HOST_KEY_PATH=/opt/crc/id_rsa \
+    -e PULL_SECRET_FILE_PATH=/opt/crc/pull-secret \
+    -e BUNDLE_LOCATION=/bundles/crc_hyperv_4.8.0-rc.3.crcbundle \
+    -v $PWD/pull-secret:/opt/crc/pull-secret:Z \
+    -v $PWD/id_rsa:/opt/crc/id_rsa:Z \
+    -v $PWD/output:/output:Z \
+    quay.io/crcont/crc-integration:v1.29.0
+
+# Run integration on windows platform with ssh password and crc released version
+podman run --rm -it --name crc-integration \
+    -e PLATFORM=windows \
+    -e TARGET_HOST=$IP \
+    -e TARGET_HOST_USERNAME=$USER \
+    -e TARGET_HOST_PASSWORD=$PASSWORD \
+    -e PULL_SECRET_FILE_PATH=/opt/crc/pull-secret \
+    -v $PWD/pull-secret:/opt/crc/pull-secret:Z \
+    -v $PWD/output:/output:Z \
+    quay.io/crcont/crc-integration:v1.29.0
+```

--- a/images/build-integration/entrypoint.sh
+++ b/images/build-integration/entrypoint.sh
@@ -1,0 +1,102 @@
+#!/bin/sh
+
+# Vars
+BINARY=integration.test
+if [[ ${PLATFORM} == 'windows' ]]; then
+    BINARY=integration.test.exe
+fi
+BINARY_PATH="/opt/crc/bin/${PLATFORM}-amd64/${BINARY}"
+
+# Results
+RESULTS_PATH="${RESULTS_PATH:-/output}"
+
+
+if [ "${DEBUG:-}" = "true" ]; then
+    set -xuo 
+fi
+
+# Validate conf
+validate=true
+[[ -z "${TARGET_HOST+x}" ]] \
+    && echo "TARGET_HOST required" \
+    && validate=false
+
+[[ -z "${TARGET_HOST_USERNAME+x}" ]] \
+    && echo "TARGET_HOST_USERNAME required" \
+    && validate=false
+
+[[ -z "${TARGET_HOST_KEY_PATH+x}" && -z "${TARGET_HOST_PASSWORD+x}" ]] \
+    && echo "TARGET_HOST_KEY_PATH or TARGET_HOST_PASSWORD required" \
+    && validate=false
+
+[[ -z "${PULL_SECRET_FILE_PATH+x}" ]] \
+    && echo "PULL_SECRET_FILE_PATH required" \
+    && validate=false
+
+[[ $validate == false ]] && exit 1
+
+# Define remote connection
+REMOTE="${TARGET_HOST_USERNAME}@${TARGET_HOST}"
+if [[ ! -z "${TARGET_HOST_DOMAIN+x}" ]]; then
+    REMOTE="${TARGET_HOST_USERNAME}@${TARGET_HOST_DOMAIN}@${TARGET_HOST}"
+fi
+
+# Set SCP / SSH command with pass or key
+NO_STRICT='-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
+if [[ ! -z "${TARGET_HOST_KEY_PATH+x}" ]]; then
+    SCP="scp -r ${NO_STRICT} -i ${TARGET_HOST_KEY_PATH}"
+    SSH="ssh ${NO_STRICT} -i ${TARGET_HOST_KEY_PATH}"
+else
+    SCP="sshpass -p ${TARGET_HOST_PASSWORD} scp -r ${NO_STRICT}" \
+    SSH="sshpass -p ${TARGET_HOST_PASSWORD} ssh ${NO_STRICT}"
+fi
+
+echo "Copy resources to target"
+# Create execution folder 
+EXECUTION_FOLDER="/Users/${TARGET_HOST_USERNAME}/crc-integration"
+if [[ ${PLATFORM} == 'linux' ]]; then
+    EXECUTION_FOLDER="/home/${TARGET_HOST_USERNAME}/crc-integration"
+fi
+DATA_FOLDER="${EXECUTION_FOLDER}/out"
+if [[ ${PLATFORM} == 'windows' ]]; then
+    # Todo change for powershell cmdlet
+    $SSH "${REMOTE}" "powershell.exe -c New-Item -ItemType directory -Path ${EXECUTION_FOLDER}/bin"
+else
+    $SSH "${REMOTE}" "mkdir -p ${EXECUTION_FOLDER}/bin"
+fi
+
+# Copy crc-integration binary and pull-secret
+$SCP "${BINARY_PATH}" "${REMOTE}:${EXECUTION_FOLDER}/bin"
+$SCP "${PULL_SECRET_FILE_PATH}" "${REMOTE}:${EXECUTION_FOLDER}/pull-secret"
+
+echo "Running integration tests"
+# Run integration cmd
+if [[ ! -z "${BUNDLE_LOCATION+x}" ]] && [[ -n "${BUNDLE_LOCATION}" ]]; then
+    BUNDLE_PATH="${BUNDLE_LOCATION}"
+else
+    BUNDLE_PATH="embedded"
+fi
+# Review when pwsh added as powershell supported
+if [[ ${PLATFORM} == 'windows' ]]; then
+    BINARY_EXEC="cd ${EXECUTION_FOLDER}/bin; "
+    BINARY_EXEC+="\$env:SHELL='powershell'; "
+    BINARY_EXEC+="\$env:PULL_SECRET_PATH='${EXECUTION_FOLDER}/pull-secret'; "
+    BINARY_EXEC+="\$env:BUNDLE_PATH='${BUNDLE_PATH}'; "
+else 
+    BINARY_EXEC="cd ${EXECUTION_FOLDER}/bin && "
+    BINARY_EXEC+="PULL_SECRET_PATH=${EXECUTION_FOLDER}/pull-secret "
+    BINARY_EXEC+="BUNDLE_PATH=${BUNDLE_PATH} "
+fi
+BINARY_EXEC+="./${BINARY} > integration.results"
+# Execute command remote
+$SSH "${REMOTE}" "${BINARY_EXEC}"
+
+echo "Getting integration results and logs"
+# Get results
+mkdir -p "${RESULTS_PATH}"
+$SCP "${REMOTE}:${EXECUTION_FOLDER}/bin/integration.results" "${RESULTS_PATH}"
+$SCP "${REMOTE}:${EXECUTION_FOLDER}/bin/out/integration.xml" "${RESULTS_PATH}"
+
+echo "Cleanup target"
+# Clenaup
+$SSH "${REMOTE}" "rm -r ${EXECUTION_FOLDER}"


### PR DESCRIPTION
This PR adds a makefile goal to generate a container image holding the integration tests binary. The container image will manage the installation and run of the integration tests and will pick the results back.

This PR will have a following one having only one crc-test container to hold both e2e and integration binaries, the container will be created per platform to reduce the sizing