### PR TITLE
Use context to eventually cancel waiting loops

### DIFF
--- a/pkg/crc/cluster/kubeadmin_password.go
+++ b/pkg/crc/cluster/kubeadmin_password.go
@@ -3,6 +3,7 @@ package cluster
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"crypto/rand"
 	"encoding/base64"
 	"fmt"
@@ -28,7 +29,7 @@ func GenerateKubeAdminUserPassword() error {
 }
 
 // UpdateKubeAdminUserPassword updates the htpasswd secret
-func UpdateKubeAdminUserPassword(ocConfig oc.Config, newPassword string) error {
+func UpdateKubeAdminUserPassword(ctx context.Context, ocConfig oc.Config, newPassword string) error {
 	if newPassword != "" {
 		logging.Infof("Overriding password for kubeadmin user")
 		if err := ioutil.WriteFile(constants.GetKubeAdminPasswordPath(), []byte(strings.TrimSpace(newPassword)), 0600); err != nil {
@@ -45,7 +46,7 @@ func UpdateKubeAdminUserPassword(ocConfig oc.Config, newPassword string) error {
 		"kubeadmin": kubeAdminPassword,
 	}
 
-	if err := WaitForOpenshiftResource(ocConfig, "secret"); err != nil {
+	if err := WaitForOpenshiftResource(ctx, ocConfig, "secret"); err != nil {
 		return err
 	}
 

--- a/pkg/crc/errors/multierror.go
+++ b/pkg/crc/errors/multierror.go
@@ -81,8 +81,8 @@ func (r *RetriableError) Error() string {
 	return "Temporary error: " + r.Err.Error()
 }
 
-// RetryAfterWithContext retries for a certain duration, after a delay
-func RetryAfterWithContext(ctx context.Context, limit time.Duration, callback func() error, d time.Duration) error {
+// Retry retries for a certain duration, after a delay
+func Retry(ctx context.Context, limit time.Duration, callback func() error, d time.Duration) error {
 	if ctx.Err() != nil {
 		return ctx.Err()
 	}
@@ -111,9 +111,4 @@ func RetryAfterWithContext(ctx context.Context, limit time.Duration, callback fu
 	}
 	logging.Debugf("RetryAfter timeout after %d tries", attempt)
 	return m
-}
-
-// RetryAfter retries for a certain duration, after a delay
-func RetryAfter(limit time.Duration, callback func() error, d time.Duration) error {
-	return RetryAfterWithContext(context.Background(), limit, callback, d)
 }

--- a/pkg/crc/errors/multierror_test.go
+++ b/pkg/crc/errors/multierror_test.go
@@ -1,6 +1,7 @@
 package errors
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"testing"
@@ -9,9 +10,9 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestRetryAfter(t *testing.T) {
+func TestRetryAfterWithContext(t *testing.T) {
 	calls := 0
-	ret := RetryAfter(time.Second, func() error {
+	ret := Retry(context.Background(), time.Second, func() error {
 		calls++
 		return nil
 	}, 0)
@@ -21,7 +22,7 @@ func TestRetryAfter(t *testing.T) {
 
 func TestRetryAfterFailure(t *testing.T) {
 	calls := 0
-	ret := RetryAfter(time.Second, func() error {
+	ret := Retry(context.Background(), time.Second, func() error {
 		calls++
 		return errors.New("failed")
 	}, 0)
@@ -31,7 +32,7 @@ func TestRetryAfterFailure(t *testing.T) {
 
 func TestRetryAfterSlowFailure(t *testing.T) {
 	calls := 0
-	ret := RetryAfter(time.Millisecond, func() error {
+	ret := Retry(context.Background(), time.Millisecond, func() error {
 		time.Sleep(50 * time.Millisecond)
 		calls++
 		if calls < 2 {
@@ -45,7 +46,7 @@ func TestRetryAfterSlowFailure(t *testing.T) {
 
 func TestRetryAfterMaxAttempts(t *testing.T) {
 	calls := 0
-	ret := RetryAfter(10*time.Millisecond, func() error {
+	ret := Retry(context.Background(), 10*time.Millisecond, func() error {
 		calls++
 		return &RetriableError{Err: errors.New("failed")}
 	}, 0)
@@ -55,7 +56,7 @@ func TestRetryAfterMaxAttempts(t *testing.T) {
 
 func TestRetryAfterSuccessAfterFailures(t *testing.T) {
 	calls := 0
-	ret := RetryAfter(time.Second, func() error {
+	ret := Retry(context.Background(), time.Second, func() error {
 		calls++
 		if calls < 3 {
 			return &RetriableError{Err: errors.New("failed")}

--- a/pkg/crc/machine/bundle/repository.go
+++ b/pkg/crc/machine/bundle/repository.go
@@ -1,6 +1,7 @@
 package bundle
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -153,7 +154,7 @@ func (repo *Repository) Extract(path string) error {
 	bundleBaseDir := GetBundleNameWithoutExtension(bundleName)
 	bundleDir := filepath.Join(repo.CacheDir, bundleBaseDir)
 	_ = os.RemoveAll(bundleDir)
-	return crcerrors.RetryAfter(time.Minute, func() error {
+	return crcerrors.Retry(context.Background(), time.Minute, func() error {
 		if err := os.Rename(filepath.Join(tmpDir, bundleBaseDir), bundleDir); err != nil {
 			return &crcerrors.RetriableError{Err: err}
 		}

--- a/pkg/crc/machine/generate_bundle.go
+++ b/pkg/crc/machine/generate_bundle.go
@@ -1,6 +1,7 @@
 package machine
 
 import (
+	"context"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -23,7 +24,7 @@ func (client *client) GenerateBundle(forceStop bool) error {
 	defer sshRunner.Close()
 
 	ocConfig := oc.UseOCWithSSH(sshRunner)
-	if err := cluster.RemovePullSecretFromCluster(ocConfig, sshRunner); err != nil {
+	if err := cluster.RemovePullSecretFromCluster(context.Background(), ocConfig, sshRunner); err != nil {
 		return errors.Wrap(err, "Error removing pull secret from cluster")
 	}
 

--- a/pkg/crc/services/dns/dns.go
+++ b/pkg/crc/services/dns/dns.go
@@ -1,6 +1,7 @@
 package dns
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -95,7 +96,7 @@ func dnsServers(serviceConfig services.ServicePostStartConfig) ([]network.NameSe
 	return append([]network.NameServer{{IPAddress: dnsContainerIP}}, orgResolvValues.NameServers...), nil
 }
 
-func CheckCRCLocalDNSReachable(serviceConfig services.ServicePostStartConfig) (string, error) {
+func CheckCRCLocalDNSReachable(ctx context.Context, serviceConfig services.ServicePostStartConfig) (string, error) {
 	appsURI := fmt.Sprintf("foo.%s", serviceConfig.BundleMetadata.ClusterInfo.AppsDomain)
 	// Try 30 times for 1 second interval, In nested environment most of time crc failed to get
 	// Internal dns query resolved for some time.
@@ -109,7 +110,7 @@ func CheckCRCLocalDNSReachable(serviceConfig services.ServicePostStartConfig) (s
 		return nil
 	}
 
-	if err := errors.RetryAfter(30*time.Second, checkLocalDNSReach, time.Second); err != nil {
+	if err := errors.Retry(ctx, 30*time.Second, checkLocalDNSReach, time.Second); err != nil {
 		return queryOutput, err
 	}
 	return queryOutput, err

--- a/pkg/crc/services/dns/dns_darwin.go
+++ b/pkg/crc/services/dns/dns_darwin.go
@@ -2,6 +2,7 @@ package dns
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -137,7 +138,7 @@ func waitForNetwork() error {
 		}
 		return nil
 	}
-	if err := crcerrors.RetryAfter(15*time.Second, retriableConnectivityCheck, time.Second); err != nil {
+	if err := crcerrors.Retry(context.Background(), 15*time.Second, retriableConnectivityCheck, time.Second); err != nil {
 		return fmt.Errorf("Host is not connected to internet")
 	}
 

--- a/pkg/crc/ssh/ssh.go
+++ b/pkg/crc/ssh/ssh.go
@@ -105,5 +105,5 @@ func (runner *Runner) WaitForConnectivity(ctx context.Context, timeout time.Dura
 		return nil
 	}
 
-	return errors.RetryAfterWithContext(ctx, timeout, checkSSHConnectivity, time.Second)
+	return errors.Retry(ctx, timeout, checkSSHConnectivity, time.Second)
 }

--- a/pkg/libmachine/host/host.go
+++ b/pkg/libmachine/host/host.go
@@ -1,6 +1,7 @@
 package host
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/rpc"
@@ -40,7 +41,7 @@ func (h *Host) runActionForState(action func() error, desiredState state.State) 
 		return err
 	}
 
-	return crcerrors.RetryAfter(3*time.Minute, MachineInState(h.Driver, desiredState), 3*time.Second)
+	return crcerrors.Retry(context.Background(), 3*time.Minute, MachineInState(h.Driver, desiredState), 3*time.Second)
 }
 
 func (h *Host) Stop() error {


### PR DESCRIPTION
When the user hit the stop or delete button while the VM is still starting, it 
allows a fast abort.
The daemon quicky stops the start sequence and can run stop or delete function.

---

I saw this when clicking on start in the tray with an old bundle. I couldnt stop or delete while kubelet was starting.