### PR TITLE
bundle: Make sure perms of unpacked bundle are 0755

### DIFF
--- a/pkg/crc/machine/bundle/repository.go
+++ b/pkg/crc/machine/bundle/repository.go
@@ -154,12 +154,17 @@ func (repo *Repository) Extract(path string) error {
 	bundleBaseDir := GetBundleNameWithoutExtension(bundleName)
 	bundleDir := filepath.Join(repo.CacheDir, bundleBaseDir)
 	_ = os.RemoveAll(bundleDir)
-	return crcerrors.Retry(context.Background(), time.Minute, func() error {
+	err := crcerrors.Retry(context.Background(), time.Minute, func() error {
 		if err := os.Rename(filepath.Join(tmpDir, bundleBaseDir), bundleDir); err != nil {
 			return &crcerrors.RetriableError{Err: err}
 		}
 		return nil
 	}, 5*time.Second)
+	if err != nil {
+		return err
+	}
+
+	return os.Chmod(bundleDir, 0755)
 }
 
 func (repo *Repository) List() ([]CrcBundleInfo, error) {


### PR DESCRIPTION
The libvirt driver will access the bundle qcow2 image as qemu:qemu,
if the permissions are too restrictive, this will fail.
This is  an issue when umask is set to non default values on linux.
This should fix https://github.com/code-ready/crc/issues/2477



**Fixes:** Issue #2477

## Solution/Idea

This should fix `umask 077; rm -rf ~/.crc/cache; crc setup; crc start`
Before this PR, this scenario fails with some permissions issues.