### PR TITLE
preflight: Fix rhel7 detection

### DIFF
--- a/pkg/crc/preflight/preflight_linux.go
+++ b/pkg/crc/preflight/preflight_linux.go
@@ -326,7 +326,7 @@ func (filter preflightFilter) SetDistro(distro *linux.OsRelease) {
 
 func (filter preflightFilter) SetSystemdUser(distro *linux.OsRelease) {
 	switch {
-	case distroIsLike(distro, linux.RHEL) && distro.VersionID == "7":
+	case distroIsLike(distro, linux.RHEL) && (distro.VersionID == "7" || strings.HasPrefix(distro.VersionID, "7.")):
 		filter[SystemdUser] = Unsupported
 	default:
 		filter[SystemdUser] = Supported


### PR DESCRIPTION
The check added in 'preflight: Don't try to setup daemon socket
activation on el7' works on centos7 but not on rhel7.
While centos7 uses "7" as VersionID for all its releases, rhel7 uses a
different VersionID for each minor release ("7.9" for the current one).

This commit checks for both and should fix https://github.com/code-ready/crc/issues/2653



**Fixes:** Issue #2653