### PR TITLE
cmd:bundle: Use --force-stop rather than --forceStop

### DIFF
--- a/cmd/crc/cmd/bundle/generate.go
+++ b/cmd/crc/cmd/bundle/generate.go
@@ -18,7 +18,7 @@ func getGenerateCmd(config *config.Config) *cobra.Command {
 			return runGenerate(config, forceStop)
 		},
 	}
-	generateCmd.PersistentFlags().BoolVarP(&forceStop, "forceStop", "f", false, "Forcefully stop the instance")
+	generateCmd.PersistentFlags().BoolVarP(&forceStop, "force-stop", "f", false, "Forcefully stop the instance")
 	return generateCmd
 }
 


### PR DESCRIPTION
--forceStop is not consistent with the way we capitalize our other
options (--pull-secret-file, --log-level, ...).
This commit changes this.
This is a user-visible breakage to our UI, but I expect the number of
users of `bundle generate` to be small, and the number of people using
this option, and using the long form of this option to be even smaller.