### PR TITLE
Enable and start vsock and http crc sockets 

### DIFF
--- a/pkg/crc/preflight/preflight_checks_linux.go
+++ b/pkg/crc/preflight/preflight_checks_linux.go
@@ -379,6 +379,9 @@ func fixSystemdUnit(unitName string, unitContent string, shouldBeRunning bool) e
 	running := systemdUnitRunning(sd, unitName)
 	if !running && shouldBeRunning {
 		logging.Debugf("Starting %s", unitName)
+		if err := sd.Enable(unitName); err != nil {
+			return err
+		}
 		return sd.Start(unitName)
 	} else if running && !shouldBeRunning {
 		logging.Debugf("Stopping %s", unitName)

--- a/pkg/crc/preflight/preflight_checks_linux.go
+++ b/pkg/crc/preflight/preflight_checks_linux.go
@@ -290,6 +290,9 @@ Description=CodeReady Containers vsock socket
 [Socket]
 ListenStream=vsock::1024
 Service=crc-daemon.service
+
+[Install]
+WantedBy=default.target
 `
 
 	httpUnitName = "crc-http.socket"
@@ -299,6 +302,9 @@ Description=CodeReady Containers HTTP socket
 [Socket]
 ListenStream=%h/.crc/crc-http.sock
 Service=crc-daemon.service
+
+[Install]
+WantedBy=default.target
 `
 
 	daemonUnitName     = "crc-daemon.service"


### PR DESCRIPTION
**Fixes:** Issue #2739 

## Solution/Idea
This patch enable the http/vsock crc sockets from systemd side.

## Testing
Without this patch (on linux)
- `crc setup`
- Reboot the host
- `crc start` => gives the error 
```
INFO Checking crc daemon systemd socket units
WARN Preflight checks failed during `crc start`, please try to run `crc setup` first in case you haven't done so yet
```

With this patch after rebooting the host, user doesn't need to do `setup` again for an already configured crc.
