### PR TITLE
Add support for https_proxy=https://...

### DIFF
--- a/cmd/crc/cmd/root.go
+++ b/cmd/crc/cmd/root.go
@@ -142,12 +142,7 @@ func setProxyDefaults() error {
 	}
 
 	if proxyConfig.IsEnabled() {
-		var caFileForDisplay string
-		if proxyCAFile != "" {
-			caFileForDisplay = fmt.Sprintf(", proxyCAFile: %s", proxyCAFile)
-		}
-		logging.Debugf("HTTP-PROXY: %s, HTTPS-PROXY: %s, NO-PROXY: %s%s", proxyConfig.HTTPProxyForDisplay(),
-			proxyConfig.HTTPSProxyForDisplay(), proxyConfig.GetNoProxyString(), caFileForDisplay)
+		logging.Debugf(proxyConfig.String())
 		proxyConfig.ApplyToEnvironment()
 	}
 	return nil

--- a/cmd/crc/cmd/root.go
+++ b/cmd/crc/cmd/root.go
@@ -147,8 +147,12 @@ func setProxyDefaults() error {
 	}
 
 	if proxyConfig.IsEnabled() {
-		logging.Debugf("HTTP-PROXY: %s, HTTPS-PROXY: %s, NO-PROXY: %s, proxyCAFile: %s", proxyConfig.HTTPProxyForDisplay(),
-			proxyConfig.HTTPSProxyForDisplay(), proxyConfig.GetNoProxyString(), proxyCAFile)
+		var caFileForDisplay string
+		if proxyCAFile != "" {
+			caFileForDisplay = fmt.Sprintf(", proxyCAFile: %s", proxyCAFile)
+		}
+		logging.Debugf("HTTP-PROXY: %s, HTTPS-PROXY: %s, NO-PROXY: %s%s", proxyConfig.HTTPProxyForDisplay(),
+			proxyConfig.HTTPSProxyForDisplay(), proxyConfig.GetNoProxyString(), caFileForDisplay)
 		proxyConfig.ApplyToEnvironment()
 	}
 	return nil

--- a/cmd/crc/cmd/root.go
+++ b/cmd/crc/cmd/root.go
@@ -136,12 +136,7 @@ func setProxyDefaults() error {
 	noProxy := config.Get(crcConfig.NoProxy).AsString()
 	proxyCAFile := config.Get(crcConfig.ProxyCAFile).AsString()
 
-	proxyCAData, err := getProxyCAData(proxyCAFile)
-	if err != nil {
-		return fmt.Errorf("not able to read proxyCAFile %s: %v", proxyCAFile, err.Error())
-	}
-
-	proxyConfig, err := network.NewProxyDefaults(httpProxy, httpsProxy, noProxy, proxyCAData)
+	proxyConfig, err := network.NewProxyDefaults(httpProxy, httpsProxy, noProxy, proxyCAFile)
 	if err != nil {
 		return err
 	}
@@ -156,22 +151,6 @@ func setProxyDefaults() error {
 		proxyConfig.ApplyToEnvironment()
 	}
 	return nil
-}
-
-func getProxyCAData(proxyCAFile string) (string, error) {
-	if proxyCAFile == "" {
-		return "", nil
-	}
-	proxyCACert, err := ioutil.ReadFile(proxyCAFile)
-	if err != nil {
-		return "", err
-	}
-	// Before passing string back to caller function, remove the empty lines in the end
-	return trimTrailingEOL(string(proxyCACert)), nil
-}
-
-func trimTrailingEOL(s string) string {
-	return strings.TrimRight(s, "\n")
 }
 
 func newViperConfig() (*crcConfig.Config, *crcConfig.ViperStorage, error) {

--- a/cmd/crc/cmd/start.go
+++ b/cmd/crc/cmd/start.go
@@ -209,7 +209,7 @@ func checkIfNewVersionAvailable(noUpdateCheck bool) error {
 }
 
 func newVersionAvailable() (bool, string, string, error) {
-	release, err := crcversion.GetCRCLatestVersionFromMirror(httpTransport())
+	release, err := crcversion.GetCRCLatestVersionFromMirror(network.HTTPTransport())
 	if err != nil {
 		return false, "", "", err
 	}

--- a/pkg/crc/config/settings.go
+++ b/pkg/crc/config/settings.go
@@ -91,9 +91,9 @@ func RegisterSettings(cfg *Config) {
 	cfg.AddSetting(AutostartTray, true, validateTrayAutostart, disableEnableTrayAutostart,
 		"Automatically start the tray (true/false, default: true)")
 	// Proxy Configuration
-	cfg.AddSetting(HTTPProxy, "", ValidateURI, SuccessfullyApplied,
+	cfg.AddSetting(HTTPProxy, "", ValidateHTTPProxy, SuccessfullyApplied,
 		"HTTP proxy URL (string, like 'http://my-proxy.com:8443')")
-	cfg.AddSetting(HTTPSProxy, "", ValidateURI, SuccessfullyApplied,
+	cfg.AddSetting(HTTPSProxy, "", ValidateHTTPSProxy, SuccessfullyApplied,
 		"HTTPS proxy URL (string, like 'https://my-proxy.com:8443')")
 	cfg.AddSetting(NoProxy, "", ValidateNoProxy, SuccessfullyApplied,
 		"Hosts, ipv4 addresses or CIDR which do not use a proxy (string, comma-separated list such as '127.0.0.1,192.168.100.1/24')")

--- a/pkg/crc/config/validations.go
+++ b/pkg/crc/config/validations.go
@@ -88,9 +88,17 @@ func ValidatePath(value interface{}) (bool, string) {
 	return true, ""
 }
 
-// ValidateURI checks if given URI is valid
-func ValidateURI(value interface{}) (bool, string) {
-	if err := network.ValidateProxyURL(cast.ToString(value)); err != nil {
+// ValidateHTTPProxy checks if given URI is valid for a HTTP proxy
+func ValidateHTTPProxy(value interface{}) (bool, string) {
+	if err := network.ValidateProxyURL(cast.ToString(value), false); err != nil {
+		return false, err.Error()
+	}
+	return true, ""
+}
+
+// ValidateHTTPSProxy checks if given URI is valid for a HTTPS proxy
+func ValidateHTTPSProxy(value interface{}) (bool, string) {
+	if err := network.ValidateProxyURL(cast.ToString(value), true); err != nil {
 		return false, err.Error()
 	}
 	return true, ""

--- a/pkg/crc/network/proxy.go
+++ b/pkg/crc/network/proxy.go
@@ -202,8 +202,10 @@ func (p *ProxyConfig) tlsConfig() (*tls.Config, error) {
 	if p.ProxyCACert == "" {
 		return nil, nil
 	}
-
-	caCertPool := x509.NewCertPool()
+	caCertPool, err := x509.SystemCertPool()
+	if err != nil {
+		return nil, err
+	}
 	ok := caCertPool.AppendCertsFromPEM([]byte(p.ProxyCACert))
 	if !ok {
 		return nil, fmt.Errorf("Failed to append proxy CA to system CAs")

--- a/pkg/crc/network/proxy.go
+++ b/pkg/crc/network/proxy.go
@@ -28,13 +28,13 @@ type ProxyConfig struct {
 	HTTPSProxy  string
 	noProxy     []string
 	ProxyCACert string
-	proxyCAFile string
+	ProxyCAFile string
 }
 
 func (p *ProxyConfig) String() string {
 	var caCertForDisplay string
-	if p.proxyCAFile != "" {
-		caCertForDisplay = fmt.Sprintf(", proxyCAFile: %s", p.proxyCAFile)
+	if p.ProxyCAFile != "" {
+		caCertForDisplay = fmt.Sprintf(", proxyCAFile: %s", p.ProxyCAFile)
 	}
 	return fmt.Sprintf("HTTP-PROXY: %s, HTTPS-PROXY: %s, NO-PROXY: %s%s", p.HTTPProxyForDisplay(),
 		p.HTTPSProxyForDisplay(), p.GetNoProxyString(), caCertForDisplay)
@@ -65,7 +65,7 @@ func NewProxyDefaults(httpProxy, httpsProxy, noProxy, proxyCAFile string) (*Prox
 		HTTPProxy:   httpProxy,
 		HTTPSProxy:  httpsProxy,
 		ProxyCACert: proxyCAData,
-		proxyCAFile: proxyCAFile,
+		ProxyCAFile: proxyCAFile,
 	}
 	envProxy := httpproxy.FromEnvironment()
 
@@ -90,7 +90,7 @@ func NewProxyConfig() (*ProxyConfig, error) {
 		HTTPProxy:   DefaultProxy.HTTPProxy,
 		HTTPSProxy:  DefaultProxy.HTTPSProxy,
 		ProxyCACert: DefaultProxy.ProxyCACert,
-		proxyCAFile: DefaultProxy.proxyCAFile,
+		ProxyCAFile: DefaultProxy.ProxyCAFile,
 	}
 
 	config.noProxy = defaultNoProxies

--- a/pkg/crc/network/proxy.go
+++ b/pkg/crc/network/proxy.go
@@ -27,6 +27,15 @@ type ProxyConfig struct {
 	proxyCAFile string
 }
 
+func (p *ProxyConfig) String() string {
+	var caCertForDisplay string
+	if p.proxyCAFile != "" {
+		caCertForDisplay = fmt.Sprintf(", proxyCAFile: %s", p.proxyCAFile)
+	}
+	return fmt.Sprintf("HTTP-PROXY: %s, HTTPS-PROXY: %s, NO-PROXY: %s%s", p.HTTPProxyForDisplay(),
+		p.HTTPSProxyForDisplay(), p.GetNoProxyString(), caCertForDisplay)
+}
+
 func readProxyCAData(proxyCAFile string) (string, error) {
 	if proxyCAFile == "" {
 		return "", nil

--- a/pkg/crc/network/proxy_test.go
+++ b/pkg/crc/network/proxy_test.go
@@ -7,8 +7,11 @@ import (
 )
 
 func TestValidateProxyURL(t *testing.T) {
-	assert.NoError(t, ValidateProxyURL("http://company.com"))
+	assert.NoError(t, ValidateProxyURL("http://company.com", false))
+	assert.NoError(t, ValidateProxyURL("http://company.com", true))
+	assert.NoError(t, ValidateProxyURL("https://company.com", true))
 
-	assert.EqualError(t, ValidateProxyURL("company.com:8080"), "Proxy URL 'company.com:8080' is not valid: url should start with http://")
-	assert.EqualError(t, ValidateProxyURL("https://company.com"), "Proxy URL 'https://company.com' is not valid: https is not supported")
+	assert.EqualError(t, ValidateProxyURL("company.com:8080", false), "HTTP proxy URL 'company.com:8080' is not valid: url should start with http://")
+	assert.EqualError(t, ValidateProxyURL("company.com:8080", true), "HTTPS proxy URL 'company.com:8080' is not valid: url should start with http:// or https://")
+	assert.EqualError(t, ValidateProxyURL("https://company.com", false), "HTTP proxy URL 'https://company.com' is not valid: url should start with http://")
 }

--- a/pkg/download/download.go
+++ b/pkg/download/download.go
@@ -3,8 +3,10 @@ package download
 import (
 	"os"
 
-	"github.com/cavaliercoder/grab"
 	"github.com/code-ready/crc/pkg/crc/logging"
+	"github.com/code-ready/crc/pkg/crc/network"
+
+	"github.com/cavaliercoder/grab"
 	"github.com/pkg/errors"
 )
 
@@ -12,6 +14,7 @@ func Download(uri, destination string, mode os.FileMode) (string, error) {
 	logging.Debugf("Downloading %s to %s", uri, destination)
 
 	client := grab.NewClient()
+	client.HTTPClient.Transport = network.HTTPTransport()
 	req, err := grab.NewRequest(destination, uri)
 	if err != nil {
 		return "", errors.Wrapf(err, "unable to get response from %s", uri)


### PR DESCRIPTION
At the moment, crc rejects use of `https_proxy=https://...` because it was thought that OpenShift does not support it.
This is not correct, it's only `http_proxy=https://...` which is not supported by OpenShift.
This PR will fix usage of a proxy over https.

## Testing

Before this PR, using `crc config set https-proxy https://...` fails with an error, after this PR, this is allowed, and a cluster can be successfully started using such a proxy.