### PR TITLE
proxy: Add fallback to x509.NewCertPool() on Windows

### DIFF
--- a/pkg/crc/network/proxy.go
+++ b/pkg/crc/network/proxy.go
@@ -210,7 +210,8 @@ func (p *ProxyConfig) tlsConfig() (*tls.Config, error) {
 	}
 	caCertPool, err := x509.SystemCertPool()
 	if err != nil {
-		return nil, err
+		logging.Warnf("Could not load system CA pool: %v", err)
+		caCertPool = x509.NewCertPool()
 	}
 	ok := caCertPool.AppendCertsFromPEM([]byte(p.ProxyCACert))
 	if !ok {


### PR DESCRIPTION
On Windows, x509.SystemCertPool returns an error:
https://github.com/golang/go/issues/16736

This commit reverts to the behaviour before commit b50dc99 when catching
such an error. This means https_proxy=https://... will be broken for
non-mitm https proxies. Such proxies were not usable before the PR
adding b50dc99, so this should not have much impact for our existing
users.

These CAs are used:
- when accessing telemetry
- when checking for a new crc version
- when downloading binaries (only happens with git builds)



**Fixes:** https://github.com/code-ready/crc/issues/2770