### PR TITLE
[qe] Adapt container e2e image for ux testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,9 +172,9 @@ containerized_e2e:
 ifndef CRC_E2E_IMG_VERSION
 CRC_E2E_IMG_VERSION=v$(CRC_VERSION)-$(COMMIT_SHA)
 endif
-IMG = quay.io/crcont/crc-e2e:$(CRC_E2E_IMG_VERSION)
+IMG_E2E = quay.io/crcont/crc-e2e:$(CRC_E2E_IMG_VERSION)
 containerized_e2e: clean
-	$(CONTAINER_RUNTIME) build -t $(IMG) -f images/build-e2e/Dockerfile .
+	$(CONTAINER_RUNTIME) build -t $(IMG_E2E) -f images/build-e2e/Dockerfile .
 
 #  Build the container image for integration
 .PHONY: containerized_integration
@@ -182,9 +182,9 @@ containerized_integration:
 ifndef CRC_INTEGRATION_IMG_VERSION
 CRC_INTEGRATION_IMG_VERSION=v$(CRC_VERSION)-$(COMMIT_SHA)
 endif
-IMG = quay.io/crcont/crc-integration:$(CRC_INTEGRATION_IMG_VERSION)
+IMG_INTEGRATION = quay.io/crcont/crc-integration:$(CRC_INTEGRATION_IMG_VERSION)
 containerized_integration: clean
-	$(CONTAINER_RUNTIME) build -t $(IMG) -f images/build-integration/Dockerfile .
+	$(CONTAINER_RUNTIME) build -t $(IMG_INTEGRATION) -f images/build-integration/Dockerfile .
 
 .PHONY: integration ## Run integration tests in Ginkgo
 integration:

--- a/images/build-e2e/README.md
+++ b/images/build-e2e/README.md
@@ -15,8 +15,11 @@ The container connects through ssh to the target host and copy the right binary 
 **BUNDLE_VERSION**:*(Mandatory if not BUNDLE_LOCATION). Testing agaisnt crc released version bundle version for crc released version.*
 **BUNDLE_LOCATION**:*(Mandatory if not BUNDLE_VERSION). When testing crc with custom bundle set the bundle location on target server.*  
 **RESULTS_PATH**:*(Optional). Path inside container to pick results and logs from e2e execution.*  
+**RESULTS_FILE**:*(Optional). File name for results xunit results. Default value: e2e.*  
 **CLEANUP_HOME**:*(Optional). Cleanup crc home folder or keep as it is to run test.*  
-**TESTING_MODE**:*(Optional). Define e2e testing mode (valid values are ux, non-ux. Default is non-ux)*  
+**E2E_TAG_EXPRESSION**:*(Optional). Define e2e tag expression to select tests. If empty all tests available for the platform will be executed.*  
+**INSTALLER_PATH**:*(Required when testing mode ux). Path on target host holding the installer*  
+**USER_PASSWORD**:*(Required when testing mode ux). Password for the user with privileges to run the installer*  
 
 ## Samples
 


### PR DESCRIPTION
This PR will adapt some of the previous existing envs passed to the e2e container to run ux testing. 

Also there was an issue with image name variable override for integration and e2e container images, now each has its own variable to set the name of the container image.