### PR TITLE
docs: Fix small errors, adhere to Red Hat style

### DIFF
--- a/docs/source/meta/product-attributes.adoc
+++ b/docs/source/meta/product-attributes.adoc
@@ -28,7 +28,7 @@
 :crc-gsg: {rh-prod} Getting Started Guide
 
 // URLs
-:crc-download-url: https://cloud.redhat.com/openshift/create/local
+:crc-download-url: https://console.redhat.com/openshift/create/local
 :crc-gsg-url: https://code-ready.github.io/crc/
 
 :oc-download-url: https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/

--- a/docs/source/topics/assembly_accessing-the-openshift-cluster.adoc
+++ b/docs/source/topics/assembly_accessing-the-openshift-cluster.adoc
@@ -1,7 +1,7 @@
 [id="accessing-the-openshift-cluster_{context}"]
 = Accessing the OpenShift cluster
 
-Access the OpenShift cluster running in the {prod} virtual machine through the OpenShift web console or client executable ([command]`oc`).
+Access the OpenShift cluster running in the {prod} virtual machine by using the OpenShift web console or OpenShift CLI ([command]`oc`).
 
 include::proc_accessing-the-openshift-web-console.adoc[leveloffset=+1]
 

--- a/docs/source/topics/con_about-codeready-containers.adoc
+++ b/docs/source/topics/con_about-codeready-containers.adoc
@@ -6,6 +6,6 @@ This cluster provides a minimal environment for development and testing purposes
 {prod} is mainly targeted at running on developers' desktops.
 For other use cases, such as headless or multi-developer setups, use the link:https://cloud.redhat.com/openshift/install/[full OpenShift installer].
 
-Refer to the link:https://docs.openshift.com/container-platform/latest/welcome/index.html#developer-activities[OpenShift documentation] for a full introduction to OpenShift.
+See the link:https://docs.openshift.com/container-platform/latest/welcome/index.html#developer-activities[OpenShift documentation] for a full introduction to OpenShift.
 
 {prod} includes the [command]`{bin}` command-line interface (CLI) to interact with the {prod} virtual machine running the OpenShift cluster.

--- a/docs/source/topics/con_differences-from-production-openshift-install.adoc
+++ b/docs/source/topics/con_differences-from-production-openshift-install.adoc
@@ -4,10 +4,10 @@
 {rh-prod} is a regular OpenShift installation with the following notable differences:
 
 * **The {prod} OpenShift cluster is ephemeral and is not intended for production use.**
-* **There is no supported upgrade path to newer OpenShift versions.**
+* **{prod} does not have a supported upgrade path to newer OpenShift versions.**
 Upgrading the OpenShift version may cause issues that are difficult to reproduce.
 * It uses a single node which behaves as both a master and worker node.
-* It disables the `monitoring` Operator by default.
+* It disables the Cluster Monitoring Operator by default.
 This disabled Operator causes the corresponding part of the web console to be non-functional.
 * The OpenShift instance runs in a virtual machine.
 This may cause other differences, particularly with external networking.

--- a/docs/source/topics/proc_accessing-the-internal-openshift-registry.adoc
+++ b/docs/source/topics/proc_accessing-the-internal-openshift-registry.adoc
@@ -9,8 +9,8 @@ To access the internal OpenShift registry, follow these steps.
 
 * A running {prod} virtual machine.
 For more information, see link:{crc-gsg-url}#starting-the-virtual-machine_gsg[Starting the virtual machine].
-* A working [command]`oc` command.
-For more information, see link:{crc-gsg-url}#accessing-the-openshift-cluster-with-oc_gsg[Accessing the OpenShift cluster with `oc`].
+* A working OpenShift CLI ([command]`oc`) command.
+For more information, see link:{crc-gsg-url}#accessing-the-openshift-cluster-with-oc_gsg[Accessing the OpenShift cluster with the OpenShift CLI].
 * An installation of [command]`podman` or [command]`docker`.
 ** For Docker, add `default-route-openshift-image-registry.apps-crc.testing` as an insecure registry.
 For more information, see link:https://docs.docker.com/registry/insecure/[the Docker documentation].

--- a/docs/source/topics/proc_accessing-the-openshift-cluster-with-oc.adoc
+++ b/docs/source/topics/proc_accessing-the-openshift-cluster-with-oc.adoc
@@ -1,5 +1,7 @@
 [id="accessing-the-openshift-cluster-with-oc_{context}"]
-= Accessing the OpenShift cluster with `oc`
+= Accessing the OpenShift cluster with the OpenShift CLI
+
+Access the OpenShift cluster by using the OpenShift CLI ([command]`oc`).
 
 .Prerequisites
 
@@ -8,9 +10,7 @@ For more information, see link:{crc-gsg-url}#starting-the-virtual-machine_gsg[St
 
 .Procedure
 
-To access the OpenShift cluster through the [command]`oc` command, follow these steps:
-
-. Run the [command]`{bin} oc-env` command to print the command needed to add the cached [command]`oc` executable to your `_PATH_`:
+. Run the [command]`{bin} oc-env` command to print the command needed to add the cached [command]`oc` executable to your `$PATH`:
 +
 [subs="+quotes,attributes"]
 ----
@@ -33,8 +33,7 @@ You can also view it by running the [command]`{bin} console --credentials` comma
 ====
 
 . You can now use [command]`oc` to interact with your OpenShift cluster.
-For example, to verify that the OpenShift cluster Operators are available, you need to be logged in as `kubeadmin` user and
-run the following command:
+For example, to verify that the OpenShift cluster Operators are available, log in as the `kubeadmin` user and run the following command:
 +
 [subs="+quotes,attributes",options="nowrap"]
 ----
@@ -46,7 +45,7 @@ $ oc get co
 +
 [NOTE]
 ====
-* {prod} disables the `monitoring` Operator by default.
+{prod} disables the Cluster Monitoring Operator by default.
 ====
 
 See link:{crc-gsg-url}#troubleshooting-codeready-containers_gsg[Troubleshooting {prod}] if you cannot access the {prod} OpenShift cluster.

--- a/docs/source/topics/proc_accessing-the-openshift-web-console.adoc
+++ b/docs/source/topics/proc_accessing-the-openshift-web-console.adoc
@@ -1,6 +1,12 @@
 [id="accessing-the-openshift-web-console_{context}"]
 = Accessing the OpenShift web console
 
+Access the OpenShift web console by using your web browser.
+
+Access the cluster by using either the `kubeadmin` or `developer` user.
+Use the `developer` user for creating projects or OpenShift applications and for application deployment.
+Use the `kubeadmin` user only for administrative tasks such as creating new users or setting roles.
+
 .Prerequisites
 
 * A running {prod} virtual machine.
@@ -8,20 +14,20 @@ For more information, see link:{crc-gsg-url}#starting-the-virtual-machine_gsg[St
 
 .Procedure
 
-To access the OpenShift web console, follow these steps:
-
-. Run [command]`{bin} console`.
-This will open your web browser and direct it to the web console.
+. To access the OpenShift web console with your default web browser, run the following command:
++
+[subs="+quotes,attributes"]
+----
+$ {bin} console
+----
 
 . Log in as the `developer` user with the password printed in the output of the [command]`{bin} start` command.
+You can also view the password for the `developer` and `kubeadmin` users by running the following command:
 +
-[NOTE]
-====
-* You can also view the password for the `developer` and `kubeadmin` users by running [command]`{bin} console --credentials`.
-* You can initially access the cluster through either the `kubeadmin` or `developer` user.
-Use the `developer` user for creating projects or OpenShift applications and for application deployment.
-Only use the `kubeadmin` user for administrative tasks such as creating new users, setting roles, and so on.
-====
+[subs="+quotes,attributes"]
+----
+$ {bin} console --credentials
+----
 
 See link:{crc-gsg-url}#troubleshooting-codeready-containers_gsg[Troubleshooting {prod}] if you cannot access the {prod} OpenShift cluster.
 

--- a/docs/source/topics/proc_connecting-to-remote-instance.adoc
+++ b/docs/source/topics/proc_connecting-to-remote-instance.adoc
@@ -1,22 +1,22 @@
 [id="connecting-to-remote-instance_{context}"]
 = Connecting to a remote {prod} instance
 
-Follow this procedure to connect a client machine to a remote server running a {prod} OpenShift cluster.
+Use [application]`dnsmasq` to connect a client machine to a remote server running a {prod} OpenShift cluster.
 
-[NOTE]
+This procedure assumes the use of a {rhel}, {fed}, or {centos} client.
+Run every command in this procedure on the client.
+
+[IMPORTANT]
 ====
-* **It is strongly advised to connect to a server that is only exposed on your local network.**
-* All of the commands in this procedure must be run on the client.
-* This procedure assumes the use of a {rhel}, {fed}, or {centos} client.
+**Connect to a server that is only exposed on your local network.**
 ====
 
 .Prerequisites
 
 * A remote server is set up for the client to connect to.
 For more information, see link:{crc-gsg-url}#setting-up-remote-server_gsg[Setting up {prod} on a remote server].
-* NetworkManager is installed and running.
 * You know the external IP address of the server.
-* You have the link:{oc-download-url}[latest OpenShift client executable ([command]`oc`)] in your `$PATH` on the client.
+* You have the link:{oc-download-url}[latest OpenShift CLI ([command]`oc`)] in your `$PATH` on the client.
 
 .Procedure
 
@@ -47,7 +47,7 @@ EOF
 +
 [NOTE]
 ====
-Comment out any existing entries in `/etc/NetworkManager/dnsmasq.d/crc.conf`.
+Comment out any existing entries in [filename]*_/etc/NetworkManager/dnsmasq.d/crc.conf_*.
 These entries are created by running a local instance of {prod} and will conflict with the entries for the remote cluster.
 ====
 

--- a/docs/source/topics/proc_deploying-sample-application-with-odo.adoc
+++ b/docs/source/topics/proc_deploying-sample-application-with-odo.adoc
@@ -13,8 +13,6 @@ For more information, see link:{crc-gsg-url}#starting-the-virtual-machine_gsg[St
 
 .Procedure
 
-To deploy a sample application through [command]`odo`, follow these steps:
-
 . Log in to the running {prod} OpenShift cluster as the `developer` user:
 +
 [subs="+quotes,attributes"]

--- a/docs/source/topics/proc_getting-shell-access-to-the-openshift-cluster.adoc
+++ b/docs/source/topics/proc_getting-shell-access-to-the-openshift-cluster.adoc
@@ -1,17 +1,21 @@
 [id="getting-shell-access-to-the-openshift-cluster_{context}"]
 = Getting shell access to the OpenShift cluster
 
-Direct access to the OpenShift cluster is not needed for regular use and is strongly discouraged.
 To access the cluster for troubleshooting or debugging purposes, follow this procedure.
+
+[NOTE]
+====
+Direct access to the OpenShift cluster is not needed for regular use and is strongly discouraged.
+====
 
 .Prerequisites
 
-* Enable [command]`oc` access to the cluster and log in as the `kubeadmin` user.
-For detailed steps, see link:{crc-gsg-url}#accessing-the-openshift-cluster-with-oc_gsg[Accessing the OpenShift cluster with `oc`].
+* Enable OpenShift CLI ([command]`oc`) access to the cluster and log in as the `kubeadmin` user.
+For detailed steps, see link:{crc-gsg-url}#accessing-the-openshift-cluster-with-oc_gsg[Accessing the OpenShift cluster with the OpenShift CLI].
 
 .Procedure
 
-. Run [command]`oc get nodes`.
+. Run the [command]`oc get nodes` command to identify the desired node.
 The output will be similar to this:
 +
 [subs="+quotes,attributes",options="nowrap"]

--- a/docs/source/topics/proc_installing-codeready-containers.adoc
+++ b/docs/source/topics/proc_installing-codeready-containers.adoc
@@ -41,7 +41,7 @@ $ mkdir -p ~/bin
 $ cp ~/Downloads/crc-linux-*-amd64/{bin} ~/bin
 ----
 +
-.. Add the [filename]*_~/bin_* directory to your `_PATH_`:
+.. Add the [filename]*_~/bin_* directory to your `$PATH`:
 +
 [subs="attributes"]
 ----

--- a/docs/source/topics/proc_setting-up-codeready-containers.adoc
+++ b/docs/source/topics/proc_setting-up-codeready-containers.adoc
@@ -3,7 +3,12 @@
 
 The [command]`{bin} setup` command performs operations to set up the environment of your host machine for the {prod} virtual machine.
 
-This procedure will create the [filename]`~/.crc` directory if it does not already exist.
+This procedure creates the [filename]*_~/.crc_* directory if it does not already exist.
+
+[WARNING]
+====
+If you are setting up a new version, capture any changes made to the virtual machine before setting up a new {prod} release.
+====
 
 .Prerequisites
 
@@ -12,9 +17,8 @@ On {msw}, ensure that your user account can elevate to Administrator privileges.
 
 [NOTE]
 ====
-* Do not run the [command]`{bin}` executable as `root` (or Administrator).
+Do not run the [command]`{bin}` executable as the `root` user or an administrator.
 Always run the [command]`{bin}` executable with your user account.
-* If you are setting up a new version, capture any changes made to the virtual machine before setting up a new {prod} release.
 ====
 
 .Procedure

--- a/docs/source/topics/proc_setting-up-remote-server.adoc
+++ b/docs/source/topics/proc_setting-up-remote-server.adoc
@@ -1,14 +1,15 @@
 [id="setting-up-remote-server_{context}"]
 = Setting up {prod} on a remote server
 
-Follow this procedure to configure a remote server to run a {prod} OpenShift cluster.
+Configure a remote server to run a {prod} OpenShift cluster.
 
-[NOTE]
+This procedure assumes the use of a {rhel}, {fed}, or {centos} server.
+Run every command in this procedure on the remote server.
+
+[WARNING]
 ====
-* **It is strongly advised to perform this procedure on a local network.**
-Exposing an insecure server on the internet comes with many security implications.
-* All of the commands in this procedure must be run on the remote server.
-* This procedure assumes the use of a {rhel}, {fed}, or {centos} server.
+**Perform this procedure only on a local network.**
+Exposing an insecure server on the internet has many security implications.
 ====
 
 .Prerequisites
@@ -26,7 +27,7 @@ For more information, see link:{crc-gsg-url}#installing-codeready-containers_gsg
 $ {bin} start
 ----
 +
-Ensure that the cluster remains running throughout this procedure.
+Ensure that the cluster remains running during this procedure.
 
 . Install the [package]`haproxy` package and other utilities:
 +

--- a/docs/source/topics/proc_starting-codeready-containers-behind-proxy.adoc
+++ b/docs/source/topics/proc_starting-codeready-containers-behind-proxy.adoc
@@ -1,13 +1,18 @@
 [id="starting-codeready-containers-behind-proxy_{context}"]
 = Starting {prod} behind a proxy
 
+You can start {prod} behind a defined proxy using environment variables or configurable properties.
+
+[NOTE]
+====
+SOCKS proxies are not supported by OpenShift Container Platform.
+====
+
 .Prerequisites
 
-* To use an existing [command]`oc` executable on your host machine, export the `.testing` domain as part of the `no_proxy` environment variable.
-
-* The embedded [command]`oc` executable does not require manual settings.
-For more information about using the embedded [command]`oc` executable, see link:{crc-gsg-url}#accessing-the-openshift-cluster-with-oc_gsg[Accessing the OpenShift cluster with `oc`].
-
+* To use an existing OpenShift CLI ([command]`oc`) executable on your host machine, export the `.testing` domain as part of the `no_proxy` environment variable.
+The embedded [command]`oc` executable does not require manual settings.
+For more information about using the embedded [command]`oc` executable, see link:{crc-gsg-url}#accessing-the-openshift-cluster-with-oc_gsg[Accessing the OpenShift cluster with the OpenShift CLI].
 
 .Procedure
 
@@ -27,10 +32,7 @@ $ {bin} config set no-proxy __<comma-separated-no-proxy-entries>__
 $ {bin} config set proxy-ca-file __<path-to-custom-ca-file>__
 ----
 
-The [command]`{bin}` executable will be able to use the defined proxy once set through environment variables or {prod} configuration.
-
 [NOTE]
 ====
-* Proxy-related values set in the configuration for {prod} have priority over values set through environment variables.
-* SOCKS proxies are not supported by OpenShift Container Platform.
+Proxy-related values set in the configuration for {prod} have priority over values set with environment variables.
 ====

--- a/docs/source/topics/proc_starting-monitoring-alerting-telemetry.adoc
+++ b/docs/source/topics/proc_starting-monitoring-alerting-telemetry.adoc
@@ -1,14 +1,14 @@
 [id="starting-monitoring-alerting-telemetry_{context}"]
-= Starting Monitoring, Alerting, and Telemetry
+= Starting monitoring, alerting, and telemetry
 
-To make sure {prod} can run on a typical laptop, some resource-heavy services get disabled by default.
-One of these is Prometheus and the related monitoring, alerting, and telemetry functionality.
-Telemetry functionality is responsible for listing your cluster in the link:https://cloud.redhat.com/openshift[Red Hat OpenShift Cluster Manager].
+{prod} disables cluster monitoring by default to ensure that {prod} can run on a typical notebook.
+Telemetry is responsible for listing your cluster in the link:https://console.redhat.com/openshift[Red Hat Hybrid Cloud Console].
+Follow this procedure to enable monitoring for your cluster.
 
 .Prerequisites
 
 * You must assign additional memory to the {prod} virtual machine.
-At least 14 GiB of memory (a value of `14336`) is recommended for core functionality. 
+At least 14 GiB of memory, a value of `14336`, is recommended for core functionality.
 Increased workloads will require more memory.
 For more information, see link:{crc-gsg-url}#configuring-the-virtual-machine_gsg[Configuring the virtual machine].
 

--- a/docs/source/topics/proc_starting-the-virtual-machine.adoc
+++ b/docs/source/topics/proc_starting-the-virtual-machine.adoc
@@ -6,11 +6,11 @@ The [command]`{bin} start` command starts the {prod} virtual machine and OpenShi
 .Prerequisites
 
 * To avoid networking-related issues, ensure that you are not connected to a VPN and that your network connection is reliable.
-* You set up the host machine through the [command]`{bin} setup` command.
+* You set up the host machine using the [command]`{bin} setup` command.
 For more information, see link:{crc-gsg-url}#setting-up-codeready-containers_gsg[Setting up {prod}].
 * On {msw}, ensure that your user account can elevate to Administrator privileges.
 * You have a valid OpenShift user pull secret.
-Copy or download the pull secret from the Pull Secret section of the link:https://cloud.redhat.com/openshift/create/local[Install on Laptop: {rh-prod}] page on cloud.redhat.com.
+Copy or download the pull secret from the Pull Secret section of the link:https://console.redhat.com/openshift/create/local[{prod} page on the {rh} Hybrid Cloud Console].
 +
 [NOTE]
 ====
@@ -27,13 +27,13 @@ $ {bin} start
 ----
 
 . When prompted, supply your user pull secret.
-
++
 [NOTE]
 ====
-* The cluster takes a minimum of four minutes to start the necessary containers and Operators before serving a request.
-* If you see errors during [command]`{bin} start`, check the link:{crc-gsg-url}#troubleshooting-codeready-containers_gsg[Troubleshooting {prod}] section for potential solutions.
+The cluster takes a minimum of four minutes to start the necessary containers and Operators before serving a request.
 ====
 
 .Additional resources
 
 * To change the default resources allocated to the virtual machine, see link:{crc-gsg-url}#configuring-the-virtual-machine_gsg[Configuring the virtual machine].
+* If you see errors during [command]`{bin} start`, see the link:{crc-gsg-url}#troubleshooting-codeready-containers_gsg[Troubleshooting {prod}] section for potential solutions.

--- a/docs/source/topics/proc_troubleshooting-expired-certificates.adoc
+++ b/docs/source/topics/proc_troubleshooting-expired-certificates.adoc
@@ -6,7 +6,7 @@ This expiration is due to certificates embedded in the OpenShift cluster.
 The [command]`{bin} start` command triggers an automatic certificate renewal process when needed.
 Certificate renewal can add up to five minutes to the start time of the cluster.
 
-In order to avoid this additional startup time, or in case of failures in the certificate renewal process, use the following procedure:
+To avoid this additional startup time, or in case of failures in the certificate renewal process, use the following procedure:
 
 .Procedure
 

--- a/docs/source/topics/proc_troubleshooting-unknown-issues.adoc
+++ b/docs/source/topics/proc_troubleshooting-unknown-issues.adoc
@@ -6,9 +6,9 @@ This involves stopping the virtual machine, deleting it, reverting changes made 
 
 .Prerequisites
 
-* You set up the host machine through the [command]`{bin} setup` command.
+* You set up the host machine with the [command]`{bin} setup` command.
 For more information, see link:{crc-gsg-url}#setting-up-codeready-containers_gsg[Setting up {prod}].
-* You started {prod} through the [command]`{bin} start` command.
+* You started {prod} with the [command]`{bin} start` command.
 For more information, see link:{crc-gsg-url}#starting-the-virtual-machine_gsg[Starting the virtual machine].
 * You are using the latest {prod} release.
 Using a version earlier than {prod} 1.2.0 may result in errors related to expired x509 certificates.
@@ -64,5 +64,5 @@ The cluster takes a minimum of four minutes to start the necessary containers an
 If your issue is not resolved by this procedure, perform the following steps:
 
 . link:https://github.com/code-ready/crc/issues[Search open issues] for the issue that you are encountering.
-. If no existing issue addresses the encountered issue, link:https://github.com/code-ready/crc/issues/new[create an issue] and link:https://help.github.com/en/articles/file-attachments-on-issues-and-pull-requests[attach the [filename]`~/.crc/crc.log` file] to the created issue.
-The [filename]`~/.crc/crc.log` file has detailed debugging and troubleshooting information which can help diagnose the problem that you are experiencing.
+. If no existing issue addresses the encountered issue, link:https://github.com/code-ready/crc/issues/new[create an issue] and link:https://help.github.com/en/articles/file-attachments-on-issues-and-pull-requests[attach the [filename]*_~/.crc/crc.log_* file] to the created issue.
+The [filename]*_~/.crc/crc.log_* file has detailed debugging and troubleshooting information which can help diagnose the problem that you are experiencing.

--- a/docs/source/topics/ref_dns-configuration.adoc
+++ b/docs/source/topics/ref_dns-configuration.adoc
@@ -8,10 +8,10 @@ The OpenShift cluster managed by {prod} uses 2 DNS domain names, `crc.testing` a
 The `crc.testing` domain is for core OpenShift services.
 The `apps-crc.testing` domain is for accessing OpenShift applications deployed on the cluster.
 
-For example, the OpenShift API server will be exposed as `api.crc.testing` while the OpenShift console is accessed through `console-openshift-console.apps-crc.testing`.
+For example, the OpenShift API server is exposed as `api.crc.testing` while the OpenShift console is accessed as `console-openshift-console.apps-crc.testing`.
 These DNS domains are served by a `dnsmasq` DNS container running inside the {prod} virtual machine.
 
-Running [command]`{bin} setup` will detect and adjust your system DNS configuration so that it can resolve these domains.
+The [command]`{bin} setup` command detects and adjusts your system DNS configuration so that it can resolve these domains.
 Additional checks are done to verify DNS is properly configured when running [command]`{bin} start`.
 
 [id="dns-configuration-linux_{context}"]
@@ -26,7 +26,7 @@ This configuration is used by default on Fedora 33 or newer, and on Ubuntu Deskt
 * {prod} expects NetworkManager to manage networking.
 * {prod} configures `systemd-resolved` to forward requests for the `testing` domain to the `192.168.130.11` DNS server.
 `192.168.130.11` is the IP of the {prod} virtual machine.
-* `systemd-resolved` configuration is done through a NetworkManager dispatcher script in `/etc/NetworkManager/dispatcher.d/99-crc.sh`:
+* `systemd-resolved` configuration is done with a NetworkManager dispatcher script in [filename]*_/etc/NetworkManager/dispatcher.d/99-crc.sh_*:
 +
 ----
 #!/bin/sh
@@ -49,8 +49,8 @@ After {rhel-resolved-docs}[configuring the host] to use `systemd-resolved`, stop
 This configuration is used by default on Fedora 32 or older, on {rhel}, and on {centos}.
 
 * {prod} expects NetworkManager to manage networking.
-* NetworkManager uses `dnsmasq` through the [filename]`/etc/NetworkManager/conf.d/crc-nm-dnsmasq.conf` configuration file.
-* The configuration file for this `dnsmasq` instance is [filename]`/etc/NetworkManager/dnsmasq.d/crc.conf`:
+* NetworkManager uses `dnsmasq` with the [filename]*_/etc/NetworkManager/conf.d/crc-nm-dnsmasq.conf_* configuration file.
+* The configuration file for this `dnsmasq` instance is [filename]*_/etc/NetworkManager/dnsmasq.d/crc.conf_*:
 +
 ----
 server=/crc.testing/192.168.130.11


### PR DESCRIPTION
This PR fixes the following issues:

- cloud.redhat.com is now console.redhat.com (Red Hat Hybrid Cloud Console)
- Amend references to OpenShift and Kubernetes terminology
- Amend common word usage which does not adhere to IBM or Red Hat style
- Admonitions should not contain lists. Each admonition must be self-contained.
- Remove leading sentences in "Prerequisites" and "Procedure" sections
- Fix formatting of file names and environment variables

This commit does not fix all style-related errors, but addresses the most common errors in formatting, word usage, and adherence to the modular documentation guidelines. Further commits will be necessary to fully comply with the Red Hat documentation style as needed.