### PR TITLE
Improve usage hint of crc podman-env --root

### DIFF
--- a/cmd/crc/cmd/podman_env.go
+++ b/cmd/crc/cmd/podman_env.go
@@ -49,7 +49,11 @@ func runPodmanEnv() error {
 			connectionDetails.IP,
 			connectionDetails.SSHPort,
 			socket)))
-	fmt.Println(shell.GenerateUsageHintWithComment(userShell, "crc podman-env"))
+	cmdLine := "crc podman-env"
+	if root {
+		cmdLine += " --root"
+	}
+	fmt.Println(shell.GenerateUsageHintWithComment(userShell, cmdLine))
 	return nil
 }
 


### PR DESCRIPTION
## Solution/Idea
When `crc podman-env --root` is executed the "hint" should contain `--root` too:
```
...
# Run this command to configure your shell:
# eval $(crc podman-env --root)
```

## Testing
Running `crc podman-env --root` should print `# eval $(crc podman-env --root)` on the last line of the output.
