### PR TITLE
Use the 'Preset' type more extensively, and rework the preset-related code in config and prefligts

### DIFF
--- a/cmd/crc/cmd/start.go
+++ b/cmd/crc/cmd/start.go
@@ -74,7 +74,7 @@ func runStart(ctx context.Context) (*types.StartResult, error) {
 		NameServer:        config.Get(crcConfig.NameServer).AsString(),
 		PullSecret:        cluster.NewInteractivePullSecretLoader(config),
 		KubeAdminPassword: config.Get(crcConfig.KubeAdminPassword).AsString(),
-		Preset:            config.Get(crcConfig.Preset).AsString(),
+		Preset:            crcConfig.GetPreset(config),
 	}
 
 	client := newMachine()

--- a/cmd/crc/cmd/start.go
+++ b/cmd/crc/cmd/start.go
@@ -74,7 +74,7 @@ func runStart(ctx context.Context) (*types.StartResult, error) {
 		NameServer:        config.Get(crcConfig.NameServer).AsString(),
 		PullSecret:        cluster.NewInteractivePullSecretLoader(config),
 		KubeAdminPassword: config.Get(crcConfig.KubeAdminPassword).AsString(),
-		Preset:            config.Get(crcConfig.PresetConfigurationKey).AsString(),
+		Preset:            config.Get(crcConfig.Preset).AsString(),
 	}
 
 	client := newMachine()

--- a/cmd/crc/cmd/start.go
+++ b/cmd/crc/cmd/start.go
@@ -36,8 +36,8 @@ func init() {
 	flagSet := pflag.NewFlagSet("start", pflag.ExitOnError)
 	flagSet.StringP(crcConfig.Bundle, "b", constants.DefaultBundlePath, "The system bundle used for deployment of the OpenShift cluster")
 	flagSet.StringP(crcConfig.PullSecretFile, "p", "", fmt.Sprintf("File path of image pull secret (download from %s)", constants.CrcLandingPageURL))
-	flagSet.IntP(crcConfig.CPUs, "c", crcConfig.DefaultCPUs(config), "Number of CPU cores to allocate to the OpenShift cluster")
-	flagSet.IntP(crcConfig.Memory, "m", crcConfig.DefaultMem(config), "MiB of memory to allocate to the OpenShift cluster")
+	flagSet.IntP(crcConfig.CPUs, "c", constants.GetDefaultCPUs(crcConfig.GetPreset(config)), "Number of CPU cores to allocate to the OpenShift cluster")
+	flagSet.IntP(crcConfig.Memory, "m", constants.GetDefaultMemory(crcConfig.GetPreset(config)), "MiB of memory to allocate to the OpenShift cluster")
 	flagSet.UintP(crcConfig.DiskSize, "d", constants.DefaultDiskSize, "Total size in GiB of the disk used by the OpenShift cluster")
 	flagSet.StringP(crcConfig.NameServer, "n", "", "IPv4 address of nameserver to use for the OpenShift cluster")
 	flagSet.Bool(crcConfig.DisableUpdateCheck, false, "Don't check for update")
@@ -169,10 +169,10 @@ func (s *startResult) prettyPrintTo(writer io.Writer) error {
 }
 
 func validateStartFlags() error {
-	if err := validation.ValidateMemory(config.Get(crcConfig.Memory).AsInt(), crcConfig.IsOpenShift(config)); err != nil {
+	if err := validation.ValidateMemory(config.Get(crcConfig.Memory).AsInt(), crcConfig.GetPreset(config)); err != nil {
 		return err
 	}
-	if err := validation.ValidateCPUs(config.Get(crcConfig.CPUs).AsInt(), crcConfig.IsOpenShift(config)); err != nil {
+	if err := validation.ValidateCPUs(config.Get(crcConfig.CPUs).AsInt(), crcConfig.GetPreset(config)); err != nil {
 		return err
 	}
 	if err := validation.ValidateDiskSize(config.Get(crcConfig.DiskSize).AsInt()); err != nil {

--- a/pkg/crc/api/handlers.go
+++ b/pkg/crc/api/handlers.go
@@ -115,7 +115,7 @@ func getStartConfig(cfg crcConfig.Storage, args client.StartConfig) types.StartC
 		NameServer:        cfg.Get(crcConfig.NameServer).AsString(),
 		PullSecret:        cluster.NewNonInteractivePullSecretLoader(cfg, args.PullSecretFile),
 		KubeAdminPassword: cfg.Get(crcConfig.KubeAdminPassword).AsString(),
-		Preset:            cfg.Get(crcConfig.Preset).AsString(),
+		Preset:            crcConfig.GetPreset(cfg),
 	}
 }
 

--- a/pkg/crc/api/handlers.go
+++ b/pkg/crc/api/handlers.go
@@ -115,7 +115,7 @@ func getStartConfig(cfg crcConfig.Storage, args client.StartConfig) types.StartC
 		NameServer:        cfg.Get(crcConfig.NameServer).AsString(),
 		PullSecret:        cluster.NewNonInteractivePullSecretLoader(cfg, args.PullSecretFile),
 		KubeAdminPassword: cfg.Get(crcConfig.KubeAdminPassword).AsString(),
-		Preset:            cfg.Get(crcConfig.PresetConfigurationKey).AsString(),
+		Preset:            cfg.Get(crcConfig.Preset).AsString(),
 	}
 }
 

--- a/pkg/crc/cluster/pullsecret.go
+++ b/pkg/crc/cluster/pullsecret.go
@@ -79,7 +79,7 @@ func NewNonInteractivePullSecretLoader(config crcConfig.Storage, path string) Pu
 func (loader *nonInteractivePullSecretLoader) Value() (string, error) {
 	// If crc is built from an OKD bundle or podman bundle is used, then use the fake pull secret in contants.
 	if crcversion.IsOkdBuild() ||
-		loader.config.Get(crcConfig.PresetConfigurationKey).AsString() == string(preset.Podman) {
+		loader.config.Get(crcConfig.Preset).AsString() == string(preset.Podman) {
 		return constants.OkdPullSecret, nil
 	}
 

--- a/pkg/crc/cluster/pullsecret.go
+++ b/pkg/crc/cluster/pullsecret.go
@@ -78,8 +78,7 @@ func NewNonInteractivePullSecretLoader(config crcConfig.Storage, path string) Pu
 
 func (loader *nonInteractivePullSecretLoader) Value() (string, error) {
 	// If crc is built from an OKD bundle or podman bundle is used, then use the fake pull secret in contants.
-	if crcversion.IsOkdBuild() ||
-		loader.config.Get(crcConfig.Preset).AsString() == string(preset.Podman) {
+	if crcversion.IsOkdBuild() || crcConfig.GetPreset(loader.config) == preset.Podman {
 		return constants.OkdPullSecret, nil
 	}
 

--- a/pkg/crc/config/settings.go
+++ b/pkg/crc/config/settings.go
@@ -31,7 +31,7 @@ const (
 	EnableClusterMonitoring = "enable-cluster-monitoring"
 	AutostartTray           = "autostart-tray"
 	KubeAdminPassword       = "kubeadmin-password"
-	PresetConfigurationKey  = "preset"
+	Preset                  = "preset"
 )
 
 func RegisterSettings(cfg *Config) {
@@ -73,7 +73,7 @@ func RegisterSettings(cfg *Config) {
 	}
 
 	// Preset setting should be on top because CPUs/Memory config depend on it.
-	cfg.AddSetting(PresetConfigurationKey, string(preset.OpenShift), validatePreset, RequiresDeleteMsg,
+	cfg.AddSetting(Preset, string(preset.OpenShift), validatePreset, RequiresDeleteMsg,
 		fmt.Sprintf("Virtal machine preset (alpha feature - valid values are: %s or %s)", preset.Podman, preset.OpenShift))
 	// Start command settings in config
 	cfg.AddSetting(Bundle, constants.DefaultBundlePath, ValidateBundlePath, SuccessfullyApplied,
@@ -133,7 +133,7 @@ func DefaultMem(cfg Storage) int {
 }
 
 func IsOpenShift(cfg Storage) bool {
-	return cfg.Get(PresetConfigurationKey).AsString() == string(preset.OpenShift)
+	return cfg.Get(Preset).AsString() == string(preset.OpenShift)
 }
 
 func defaultNetworkMode() network.Mode {

--- a/pkg/crc/config/settings.go
+++ b/pkg/crc/config/settings.go
@@ -65,11 +65,11 @@ func RegisterSettings(cfg *Config) {
 	}
 
 	validateCPUs := func(value interface{}) (bool, string) {
-		return ValidateCPUs(value, IsOpenShift(cfg))
+		return ValidateCPUs(value, GetPreset(cfg))
 	}
 
 	validateMemory := func(value interface{}) (bool, string) {
-		return ValidateMemory(value, IsOpenShift(cfg))
+		return ValidateMemory(value, GetPreset(cfg))
 	}
 
 	// Preset setting should be on top because CPUs/Memory config depend on it.
@@ -78,10 +78,10 @@ func RegisterSettings(cfg *Config) {
 	// Start command settings in config
 	cfg.AddSetting(Bundle, constants.DefaultBundlePath, ValidateBundlePath, SuccessfullyApplied,
 		fmt.Sprintf("Bundle path (string, default '%s')", constants.DefaultBundlePath))
-	cfg.AddSetting(CPUs, DefaultCPUs(cfg), validateCPUs, RequiresRestartMsg,
-		fmt.Sprintf("Number of CPU cores (must be greater than or equal to '%d')", DefaultCPUs(cfg)))
-	cfg.AddSetting(Memory, DefaultMem(cfg), validateMemory, RequiresRestartMsg,
-		fmt.Sprintf("Memory size in MiB (must be greater than or equal to '%d')", DefaultMem(cfg)))
+	cfg.AddSetting(CPUs, defaultCPUs(cfg), validateCPUs, RequiresRestartMsg,
+		fmt.Sprintf("Number of CPU cores (must be greater than or equal to '%d')", defaultCPUs(cfg)))
+	cfg.AddSetting(Memory, defaultMemory(cfg), validateMemory, RequiresRestartMsg,
+		fmt.Sprintf("Memory size in MiB (must be greater than or equal to '%d')", defaultMemory(cfg)))
 	cfg.AddSetting(DiskSize, constants.DefaultDiskSize, ValidateDiskSize, RequiresRestartMsg,
 		fmt.Sprintf("Total size in GiB of the disk (must be greater than or equal to '%d')", constants.DefaultDiskSize))
 	cfg.AddSetting(NameServer, "", ValidateIPAddress, SuccessfullyApplied,
@@ -124,16 +124,12 @@ func RegisterSettings(cfg *Config) {
 		"User defined kubeadmin password")
 }
 
-func DefaultCPUs(cfg Storage) int {
-	return constants.GetDefaultCPUs(IsOpenShift(cfg))
+func defaultCPUs(cfg Storage) int {
+	return constants.GetDefaultCPUs(GetPreset(cfg))
 }
 
-func DefaultMem(cfg Storage) int {
-	return constants.GetDefaultMemory(IsOpenShift(cfg))
-}
-
-func IsOpenShift(cfg Storage) bool {
-	return GetPreset(cfg) == preset.OpenShift
+func defaultMemory(cfg Storage) int {
+	return constants.GetDefaultMemory(GetPreset(cfg))
 }
 
 func GetPreset(config Storage) preset.Preset {

--- a/pkg/crc/config/settings.go
+++ b/pkg/crc/config/settings.go
@@ -73,7 +73,7 @@ func RegisterSettings(cfg *Config) {
 	}
 
 	// Preset setting should be on top because CPUs/Memory config depend on it.
-	cfg.AddSetting(Preset, string(preset.OpenShift), validatePreset, RequiresDeleteMsg,
+	cfg.AddSetting(Preset, preset.OpenShift, validatePreset, RequiresDeleteMsg,
 		fmt.Sprintf("Virtal machine preset (alpha feature - valid values are: %s or %s)", preset.Podman, preset.OpenShift))
 	// Start command settings in config
 	cfg.AddSetting(Bundle, constants.DefaultBundlePath, ValidateBundlePath, SuccessfullyApplied,

--- a/pkg/crc/config/settings.go
+++ b/pkg/crc/config/settings.go
@@ -149,12 +149,3 @@ func GetNetworkMode(config Storage) network.Mode {
 	}
 	return network.ParseMode(config.Get(NetworkMode).AsString())
 }
-
-func validatePreset(i interface{}) (bool, string) {
-	switch preset.Preset(cast.ToString(i)) {
-	case preset.Podman, preset.OpenShift:
-		return true, ""
-	default:
-		return false, fmt.Sprintf("Unknown preset. Only %s and %s are valid.", preset.Podman, preset.OpenShift)
-	}
-}

--- a/pkg/crc/config/settings.go
+++ b/pkg/crc/config/settings.go
@@ -133,7 +133,11 @@ func DefaultMem(cfg Storage) int {
 }
 
 func IsOpenShift(cfg Storage) bool {
-	return cfg.Get(Preset).AsString() == string(preset.OpenShift)
+	return GetPreset(cfg) == preset.OpenShift
+}
+
+func GetPreset(config Storage) preset.Preset {
+	return preset.ParsePreset(config.Get(Preset).AsString())
 }
 
 func defaultNetworkMode() network.Mode {

--- a/pkg/crc/config/validations.go
+++ b/pkg/crc/config/validations.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/code-ready/crc/pkg/crc/network"
+	crcpreset "github.com/code-ready/crc/pkg/crc/preset"
 	"github.com/code-ready/crc/pkg/crc/validation"
 	"github.com/spf13/cast"
 )
@@ -117,4 +118,12 @@ func ValidateYesNo(value interface{}) (bool, string) {
 		return true, ""
 	}
 	return false, "must be yes or no"
+}
+
+func validatePreset(value interface{}) (bool, string) {
+	_, err := crcpreset.ParsePresetE(cast.ToString(value))
+	if err != nil {
+		return false, fmt.Sprintf("Unknown preset. Only %s and %s are valid.", crcpreset.Podman, crcpreset.OpenShift)
+	}
+	return true, ""
 }

--- a/pkg/crc/config/validations.go
+++ b/pkg/crc/config/validations.go
@@ -42,24 +42,24 @@ func ValidateDiskSize(value interface{}) (bool, string) {
 }
 
 // ValidateCPUs checks if provided cpus count is valid in the config
-func ValidateCPUs(value interface{}, openshift bool) (bool, string) {
+func ValidateCPUs(value interface{}, preset crcpreset.Preset) (bool, string) {
 	v, err := cast.ToIntE(value)
 	if err != nil {
-		return false, fmt.Sprintf("requires integer value >= %d", constants.GetDefaultCPUs(openshift))
+		return false, fmt.Sprintf("requires integer value >= %d", constants.GetDefaultCPUs(preset))
 	}
-	if err := validation.ValidateCPUs(v, openshift); err != nil {
+	if err := validation.ValidateCPUs(v, preset); err != nil {
 		return false, err.Error()
 	}
 	return true, ""
 }
 
 // ValidateMemory checks if provided memory is valid in the config
-func ValidateMemory(value interface{}, openshift bool) (bool, string) {
+func ValidateMemory(value interface{}, preset crcpreset.Preset) (bool, string) {
 	v, err := cast.ToIntE(value)
 	if err != nil {
-		return false, fmt.Sprintf("requires integer value in MiB >= %d", constants.GetDefaultMemory(openshift))
+		return false, fmt.Sprintf("requires integer value in MiB >= %d", constants.GetDefaultMemory(preset))
 	}
-	if err := validation.ValidateMemory(v, openshift); err != nil {
+	if err := validation.ValidateMemory(v, preset); err != nil {
 		return false, err.Error()
 	}
 	return true, ""

--- a/pkg/crc/config/viper_config_test.go
+++ b/pkg/crc/config/viper_config_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/code-ready/crc/pkg/crc/preset"
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -18,7 +19,7 @@ const (
 
 func newTestConfig(configFile, envPrefix string) (*Config, error) {
 	validateCPUs := func(value interface{}) (bool, string) {
-		return ValidateCPUs(value, true)
+		return ValidateCPUs(value, preset.OpenShift)
 	}
 	storage, err := NewViperStorage(configFile, envPrefix)
 	if err != nil {
@@ -152,7 +153,7 @@ func TestViperConfigBindFlagSet(t *testing.T) {
 	configFile := filepath.Join(dir, "crc.json")
 
 	validateCPUs := func(value interface{}) (bool, string) {
-		return ValidateCPUs(value, true)
+		return ValidateCPUs(value, preset.OpenShift)
 	}
 	storage, err := NewViperStorage(configFile, "CRC")
 	require.NoError(t, err)

--- a/pkg/crc/constants/constants.go
+++ b/pkg/crc/constants/constants.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"runtime"
 
+	crcpreset "github.com/code-ready/crc/pkg/crc/preset"
 	"github.com/code-ready/crc/pkg/crc/version"
 )
 
@@ -154,16 +155,26 @@ func GetCRCWindowsTrayDownloadURL() string {
 	return fmt.Sprintf(CRCWindowsTrayDownloadURL, version.GetCRCWindowsTrayVersion())
 }
 
-func GetDefaultCPUs(openshift bool) int {
-	if openshift {
+func GetDefaultCPUs(preset crcpreset.Preset) int {
+	switch preset {
+	case crcpreset.OpenShift:
+		return 4
+	case crcpreset.Podman:
+		return 2
+	default:
+		// should not be reached
 		return 4
 	}
-	return 2
 }
 
-func GetDefaultMemory(openshift bool) int {
-	if openshift {
+func GetDefaultMemory(preset crcpreset.Preset) int {
+	switch preset {
+	case crcpreset.OpenShift:
+		return 9216
+	case crcpreset.Podman:
+		return 2048
+	default:
+		// should not be reached
 		return 9216
 	}
-	return 2048
 }

--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -724,11 +724,11 @@ func updateKubeconfig(ctx context.Context, ocConfig oc.Config, sshRunner *crcssh
 	return nil
 }
 
-func bundleMismatchWithPreset(preset string, bundleMetadata *bundle.CrcBundleInfo) error {
-	if preset != string(crcPreset.OpenShift) && bundleMetadata.IsOpenShift() {
+func bundleMismatchWithPreset(preset crcPreset.Preset, bundleMetadata *bundle.CrcBundleInfo) error {
+	if preset != crcPreset.OpenShift && bundleMetadata.IsOpenShift() {
 		return errors.Errorf("Preset %s is used but bundle is provided for %s preset", crcPreset.Podman, crcPreset.OpenShift)
 	}
-	if preset != string(crcPreset.Podman) && !bundleMetadata.IsOpenShift() {
+	if preset != crcPreset.Podman && !bundleMetadata.IsOpenShift() {
 		return errors.Errorf("Preset %s is used but bundle is provided for %s preset", crcPreset.OpenShift, crcPreset.Podman)
 	}
 	return nil

--- a/pkg/crc/machine/types/types.go
+++ b/pkg/crc/machine/types/types.go
@@ -4,6 +4,7 @@ import (
 	"github.com/code-ready/crc/pkg/crc/cluster"
 	"github.com/code-ready/crc/pkg/crc/machine/state"
 	"github.com/code-ready/crc/pkg/crc/network"
+	crcpreset "github.com/code-ready/crc/pkg/crc/preset"
 )
 
 type StartConfig struct {
@@ -25,7 +26,7 @@ type StartConfig struct {
 	KubeAdminPassword string
 
 	// Preset
-	Preset string
+	Preset crcpreset.Preset
 }
 
 type ClusterConfig struct {

--- a/pkg/crc/preflight/preflight.go
+++ b/pkg/crc/preflight/preflight.go
@@ -6,6 +6,7 @@ import (
 	crcConfig "github.com/code-ready/crc/pkg/crc/config"
 	"github.com/code-ready/crc/pkg/crc/errors"
 	"github.com/code-ready/crc/pkg/crc/logging"
+	crcpreset "github.com/code-ready/crc/pkg/crc/preset"
 )
 
 type Flags uint32
@@ -19,7 +20,7 @@ const (
 )
 
 var (
-	preset string
+	preset crcpreset.Preset
 )
 
 type CheckFunc func() error
@@ -161,7 +162,7 @@ func StartPreflightChecks(config crcConfig.Storage) error {
 	mode := crcConfig.GetNetworkMode(config)
 	trayAutostart := config.Get(crcConfig.AutostartTray).AsBool()
 	bundlePath := config.Get(crcConfig.Bundle).AsString()
-	preset = config.Get(crcConfig.Preset).AsString()
+	preset = crcConfig.GetPreset(config)
 	if err := doPreflightChecks(config, getPreflightChecks(experimentalFeatures, trayAutostart, mode, bundlePath, preset)); err != nil {
 		return &errors.PreflightError{Err: err}
 	}
@@ -174,7 +175,7 @@ func SetupHost(config crcConfig.Storage, checkOnly bool) error {
 	mode := crcConfig.GetNetworkMode(config)
 	trayAutostart := config.Get(crcConfig.AutostartTray).AsBool()
 	bundlePath := config.Get(crcConfig.Bundle).AsString()
-	preset = config.Get(crcConfig.Preset).AsString()
+	preset = crcConfig.GetPreset(config)
 	logging.Infof("Using bundle path %s", bundlePath)
 	return doFixPreflightChecks(config, getPreflightChecks(experimentalFeatures, trayAutostart, mode, bundlePath, preset), checkOnly)
 }

--- a/pkg/crc/preflight/preflight.go
+++ b/pkg/crc/preflight/preflight.go
@@ -6,7 +6,6 @@ import (
 	crcConfig "github.com/code-ready/crc/pkg/crc/config"
 	"github.com/code-ready/crc/pkg/crc/errors"
 	"github.com/code-ready/crc/pkg/crc/logging"
-	crcpreset "github.com/code-ready/crc/pkg/crc/preset"
 )
 
 type Flags uint32
@@ -17,10 +16,6 @@ const (
 	NoFix
 	CleanUpOnly
 	StartUpOnly
-)
-
-var (
-	preset crcpreset.Preset
 )
 
 type CheckFunc func() error
@@ -162,7 +157,7 @@ func StartPreflightChecks(config crcConfig.Storage) error {
 	mode := crcConfig.GetNetworkMode(config)
 	trayAutostart := config.Get(crcConfig.AutostartTray).AsBool()
 	bundlePath := config.Get(crcConfig.Bundle).AsString()
-	preset = crcConfig.GetPreset(config)
+	preset := crcConfig.GetPreset(config)
 	if err := doPreflightChecks(config, getPreflightChecks(experimentalFeatures, trayAutostart, mode, bundlePath, preset)); err != nil {
 		return &errors.PreflightError{Err: err}
 	}
@@ -175,7 +170,7 @@ func SetupHost(config crcConfig.Storage, checkOnly bool) error {
 	mode := crcConfig.GetNetworkMode(config)
 	trayAutostart := config.Get(crcConfig.AutostartTray).AsBool()
 	bundlePath := config.Get(crcConfig.Bundle).AsString()
-	preset = crcConfig.GetPreset(config)
+	preset := crcConfig.GetPreset(config)
 	logging.Infof("Using bundle path %s", bundlePath)
 	return doFixPreflightChecks(config, getPreflightChecks(experimentalFeatures, trayAutostart, mode, bundlePath, preset), checkOnly)
 }

--- a/pkg/crc/preflight/preflight.go
+++ b/pkg/crc/preflight/preflight.go
@@ -161,7 +161,7 @@ func StartPreflightChecks(config crcConfig.Storage) error {
 	mode := crcConfig.GetNetworkMode(config)
 	trayAutostart := config.Get(crcConfig.AutostartTray).AsBool()
 	bundlePath := config.Get(crcConfig.Bundle).AsString()
-	preset = config.Get(crcConfig.PresetConfigurationKey).AsString()
+	preset = config.Get(crcConfig.Preset).AsString()
 	if err := doPreflightChecks(config, getPreflightChecks(experimentalFeatures, trayAutostart, mode, bundlePath, preset)); err != nil {
 		return &errors.PreflightError{Err: err}
 	}
@@ -174,7 +174,7 @@ func SetupHost(config crcConfig.Storage, checkOnly bool) error {
 	mode := crcConfig.GetNetworkMode(config)
 	trayAutostart := config.Get(crcConfig.AutostartTray).AsBool()
 	bundlePath := config.Get(crcConfig.Bundle).AsString()
-	preset = config.Get(crcConfig.PresetConfigurationKey).AsString()
+	preset = config.Get(crcConfig.Preset).AsString()
 	logging.Infof("Using bundle path %s", bundlePath)
 	return doFixPreflightChecks(config, getPreflightChecks(experimentalFeatures, trayAutostart, mode, bundlePath, preset), checkOnly)
 }

--- a/pkg/crc/preflight/preflight_checks_common.go
+++ b/pkg/crc/preflight/preflight_checks_common.go
@@ -14,13 +14,13 @@ import (
 	"github.com/pkg/errors"
 )
 
-func bundleCheck(bundlePath, preset string) Check {
+func bundleCheck(bundlePath string) Check {
 	return Check{
 		configKeySuffix:  "check-bundle-extracted",
 		checkDescription: "Checking if CRC bundle is extracted in '$HOME/.crc'",
-		check:            checkBundleExtracted(bundlePath, preset),
+		check:            checkBundleExtracted(bundlePath),
 		fixDescription:   "Getting bundle for the CRC executable",
-		fix:              fixBundleExtracted(bundlePath, preset),
+		fix:              fixBundleExtracted(bundlePath),
 		flags:            SetupOnly,
 
 		labels: None,
@@ -58,7 +58,7 @@ var genericCleanupChecks = []Check{
 	},
 }
 
-func checkBundleExtracted(bundlePath, preset string) func() error {
+func checkBundleExtracted(bundlePath string) func() error {
 	return func() error {
 		logging.Infof("Checking if %s exists", bundlePath)
 		bundleName := filepath.Base(bundlePath)
@@ -71,7 +71,7 @@ func checkBundleExtracted(bundlePath, preset string) func() error {
 	}
 }
 
-func fixBundleExtracted(bundlePath, preset string) func() error {
+func fixBundleExtracted(bundlePath string) func() error {
 	// Should be removed after 1.19 release
 	// This check will ensure correct mode for `~/.crc/cache` directory
 	// in case it exists.

--- a/pkg/crc/preflight/preflight_checks_nonwin.go
+++ b/pkg/crc/preflight/preflight_checks_nonwin.go
@@ -12,6 +12,7 @@ import (
 	"github.com/code-ready/crc/pkg/crc/cache"
 	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/code-ready/crc/pkg/crc/logging"
+	crcpreset "github.com/code-ready/crc/pkg/crc/preset"
 	"github.com/code-ready/crc/pkg/crc/validation"
 	"github.com/code-ready/crc/pkg/crc/version"
 	crcos "github.com/code-ready/crc/pkg/os"
@@ -32,43 +33,45 @@ var nonWinPreflightChecks = []Check{
 	},
 }
 
-var genericPreflightChecks = []Check{
-	{
-		configKeySuffix:  "check-admin-helper-cached",
-		checkDescription: "Checking if crc-admin-helper executable is cached",
-		check:            checkAdminHelperExecutableCached,
-		fixDescription:   "Caching crc-admin-helper executable",
-		fix:              fixAdminHelperExecutableCached,
+func genericPreflightChecks(preset crcpreset.Preset) []Check {
+	return []Check{
+		{
+			configKeySuffix:  "check-admin-helper-cached",
+			checkDescription: "Checking if crc-admin-helper executable is cached",
+			check:            checkAdminHelperExecutableCached,
+			fixDescription:   "Caching crc-admin-helper executable",
+			fix:              fixAdminHelperExecutableCached,
 
-		labels: None,
-	},
-	{
-		configKeySuffix:  "check-obsolete-admin-helper",
-		checkDescription: "Checking for obsolete admin-helper executable",
-		check:            checkOldAdminHelperExecutableCached,
-		fixDescription:   "Removing obsolete admin-helper executable",
-		fix:              fixOldAdminHelperExecutableCached,
-	},
-	{
-		configKeySuffix:  "check-supported-cpu-arch",
-		checkDescription: "Checking if running on a supported CPU architecture",
-		check:            checkSupportedCPUArch,
-		fixDescription:   "CodeReady Containers is only supported on x86_64 hardware",
-		flags:            NoFix,
-
-		labels: None,
-	},
-	{
-		configKeySuffix:  "check-ram",
-		checkDescription: "Checking minimum RAM requirements",
-		check: func() error {
-			return validation.ValidateEnoughMemory(constants.GetDefaultMemory(preset))
+			labels: None,
 		},
-		fixDescription: fmt.Sprintf("crc requires at least %s to run", units.HumanSize(float64(constants.GetDefaultMemory(preset)*1024*1024))),
-		flags:          NoFix,
+		{
+			configKeySuffix:  "check-obsolete-admin-helper",
+			checkDescription: "Checking for obsolete admin-helper executable",
+			check:            checkOldAdminHelperExecutableCached,
+			fixDescription:   "Removing obsolete admin-helper executable",
+			fix:              fixOldAdminHelperExecutableCached,
+		},
+		{
+			configKeySuffix:  "check-supported-cpu-arch",
+			checkDescription: "Checking if running on a supported CPU architecture",
+			check:            checkSupportedCPUArch,
+			fixDescription:   "CodeReady Containers is only supported on x86_64 hardware",
+			flags:            NoFix,
 
-		labels: None,
-	},
+			labels: None,
+		},
+		{
+			configKeySuffix:  "check-ram",
+			checkDescription: "Checking minimum RAM requirements",
+			check: func() error {
+				return validation.ValidateEnoughMemory(constants.GetDefaultMemory(preset))
+			},
+			fixDescription: fmt.Sprintf("crc requires at least %s to run", units.HumanSize(float64(constants.GetDefaultMemory(preset)*1024*1024))),
+			flags:          NoFix,
+
+			labels: None,
+		},
+	}
 }
 
 func checkIfRunningAsNormalUser() error {

--- a/pkg/crc/preflight/preflight_checks_nonwin.go
+++ b/pkg/crc/preflight/preflight_checks_nonwin.go
@@ -73,7 +73,7 @@ var genericPreflightChecks = []Check{
 }
 
 func getDefaultMemory() int {
-	if preset == string(crcPreset.OpenShift) {
+	if preset == crcPreset.OpenShift {
 		return constants.GetDefaultMemory(true)
 	}
 	return constants.GetDefaultMemory(false)

--- a/pkg/crc/preflight/preflight_checks_nonwin.go
+++ b/pkg/crc/preflight/preflight_checks_nonwin.go
@@ -12,7 +12,6 @@ import (
 	"github.com/code-ready/crc/pkg/crc/cache"
 	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/code-ready/crc/pkg/crc/logging"
-	crcPreset "github.com/code-ready/crc/pkg/crc/preset"
 	"github.com/code-ready/crc/pkg/crc/validation"
 	"github.com/code-ready/crc/pkg/crc/version"
 	crcos "github.com/code-ready/crc/pkg/os"
@@ -63,20 +62,13 @@ var genericPreflightChecks = []Check{
 		configKeySuffix:  "check-ram",
 		checkDescription: "Checking minimum RAM requirements",
 		check: func() error {
-			return validation.ValidateEnoughMemory(getDefaultMemory())
+			return validation.ValidateEnoughMemory(constants.GetDefaultMemory(preset))
 		},
-		fixDescription: fmt.Sprintf("crc requires at least %s to run", units.HumanSize(float64(getDefaultMemory()*1024*1024))),
+		fixDescription: fmt.Sprintf("crc requires at least %s to run", units.HumanSize(float64(constants.GetDefaultMemory(preset)*1024*1024))),
 		flags:          NoFix,
 
 		labels: None,
 	},
-}
-
-func getDefaultMemory() int {
-	if preset == crcPreset.OpenShift {
-		return constants.GetDefaultMemory(true)
-	}
-	return constants.GetDefaultMemory(false)
 }
 
 func checkIfRunningAsNormalUser() error {

--- a/pkg/crc/preflight/preflight_darwin.go
+++ b/pkg/crc/preflight/preflight_darwin.go
@@ -144,7 +144,7 @@ func getChecks(mode network.Mode, bundlePath string, preset crcpreset.Preset) []
 	checks := []Check{}
 
 	checks = append(checks, nonWinPreflightChecks...)
-	checks = append(checks, genericPreflightChecks...)
+	checks = append(checks, genericPreflightChecks(preset)...)
 	checks = append(checks, genericCleanupChecks...)
 	checks = append(checks, hyperkitPreflightChecks(mode)...)
 	checks = append(checks, daemonSetupChecks...)

--- a/pkg/crc/preflight/preflight_darwin.go
+++ b/pkg/crc/preflight/preflight_darwin.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/code-ready/crc/pkg/crc/network"
+	"github.com/code-ready/crc/pkg/crc/preset"
 	crcpreset "github.com/code-ready/crc/pkg/crc/preset"
 	"github.com/code-ready/crc/pkg/crc/version"
 )
@@ -137,7 +138,7 @@ func (filter preflightFilter) SetTray(enable bool) {
 // Passing 'SystemNetworkingMode' to getPreflightChecks currently achieves this
 // as there are no user networking specific checks
 func getAllPreflightChecks() []Check {
-	return getPreflightChecks(true, true, network.SystemNetworkingMode, constants.DefaultBundlePath, "")
+	return getPreflightChecks(true, true, network.SystemNetworkingMode, constants.DefaultBundlePath, preset.OpenShift)
 }
 
 func getChecks(mode network.Mode, bundlePath string, preset crcpreset.Preset) []Check {

--- a/pkg/crc/preflight/preflight_darwin.go
+++ b/pkg/crc/preflight/preflight_darwin.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/code-ready/crc/pkg/crc/network"
+	crcpreset "github.com/code-ready/crc/pkg/crc/preset"
 	"github.com/code-ready/crc/pkg/crc/version"
 )
 
@@ -139,7 +140,7 @@ func getAllPreflightChecks() []Check {
 	return getPreflightChecks(true, true, network.SystemNetworkingMode, constants.DefaultBundlePath, "")
 }
 
-func getChecks(mode network.Mode, bundlePath, preset string) []Check {
+func getChecks(mode network.Mode, bundlePath string, preset crcpreset.Preset) []Check {
 	checks := []Check{}
 
 	checks = append(checks, nonWinPreflightChecks...)
@@ -154,7 +155,7 @@ func getChecks(mode network.Mode, bundlePath, preset string) []Check {
 	return checks
 }
 
-func getPreflightChecks(_ bool, trayAutostart bool, mode network.Mode, bundlePath, preset string) []Check {
+func getPreflightChecks(_ bool, trayAutostart bool, mode network.Mode, bundlePath string, preset crcpreset.Preset) []Check {
 	filter := newFilter()
 	filter.SetNetworkMode(mode)
 	filter.SetTray(trayAutostart)

--- a/pkg/crc/preflight/preflight_darwin.go
+++ b/pkg/crc/preflight/preflight_darwin.go
@@ -149,7 +149,7 @@ func getChecks(mode network.Mode, bundlePath, preset string) []Check {
 	checks = append(checks, daemonSetupChecks...)
 	checks = append(checks, resolverPreflightChecks...)
 	checks = append(checks, traySetupChecks...)
-	checks = append(checks, bundleCheck(bundlePath, preset))
+	checks = append(checks, bundleCheck(bundlePath))
 
 	return checks
 }

--- a/pkg/crc/preflight/preflight_darwin_test.go
+++ b/pkg/crc/preflight/preflight_darwin_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/code-ready/crc/pkg/crc/config"
 	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/code-ready/crc/pkg/crc/network"
+	"github.com/code-ready/crc/pkg/crc/preset"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -16,9 +17,9 @@ func TestCountConfigurationOptions(t *testing.T) {
 }
 
 func TestCountPreflights(t *testing.T) {
-	assert.Len(t, getPreflightChecks(true, false, network.SystemNetworkingMode, constants.DefaultBundlePath, ""), 17)
-	assert.Len(t, getPreflightChecks(true, true, network.SystemNetworkingMode, constants.DefaultBundlePath, ""), 17)
+	assert.Len(t, getPreflightChecks(true, false, network.SystemNetworkingMode, constants.DefaultBundlePath, preset.OpenShift), 17)
+	assert.Len(t, getPreflightChecks(true, true, network.SystemNetworkingMode, constants.DefaultBundlePath, preset.OpenShift), 17)
 
-	assert.Len(t, getPreflightChecks(true, false, network.UserNetworkingMode, constants.DefaultBundlePath, ""), 16)
-	assert.Len(t, getPreflightChecks(true, true, network.UserNetworkingMode, constants.DefaultBundlePath, ""), 16)
+	assert.Len(t, getPreflightChecks(true, false, network.UserNetworkingMode, constants.DefaultBundlePath, preset.OpenShift), 16)
+	assert.Len(t, getPreflightChecks(true, true, network.UserNetworkingMode, constants.DefaultBundlePath, preset.OpenShift), 16)
 }

--- a/pkg/crc/preflight/preflight_linux.go
+++ b/pkg/crc/preflight/preflight_linux.go
@@ -383,7 +383,7 @@ func getChecks(distro *linux.OsRelease, bundlePath, preset string) []Check {
 	checks = append(checks, dnsmasqPreflightChecks...)
 	checks = append(checks, libvirtNetworkPreflightChecks...)
 	checks = append(checks, vsockPreflightCheck)
-	checks = append(checks, bundleCheck(bundlePath, preset))
+	checks = append(checks, bundleCheck(bundlePath))
 
 	return checks
 }

--- a/pkg/crc/preflight/preflight_linux.go
+++ b/pkg/crc/preflight/preflight_linux.go
@@ -375,7 +375,7 @@ func getChecks(distro *linux.OsRelease, bundlePath string, preset crcpreset.Pres
 	var checks []Check
 	checks = append(checks, nonWinPreflightChecks...)
 	checks = append(checks, wsl2PreflightCheck)
-	checks = append(checks, genericPreflightChecks...)
+	checks = append(checks, genericPreflightChecks(preset)...)
 	checks = append(checks, genericCleanupChecks...)
 	checks = append(checks, libvirtPreflightChecks(distro)...)
 	checks = append(checks, ubuntuPreflightChecks...)

--- a/pkg/crc/preflight/preflight_linux.go
+++ b/pkg/crc/preflight/preflight_linux.go
@@ -9,6 +9,7 @@ import (
 	crcErrors "github.com/code-ready/crc/pkg/crc/errors"
 	"github.com/code-ready/crc/pkg/crc/logging"
 	"github.com/code-ready/crc/pkg/crc/network"
+	crcpreset "github.com/code-ready/crc/pkg/crc/preset"
 	crcos "github.com/code-ready/crc/pkg/os"
 	"github.com/code-ready/crc/pkg/os/linux"
 
@@ -354,13 +355,13 @@ func getAllPreflightChecks() []Check {
 	return filter.Apply(getChecks(distro(), "", ""))
 }
 
-func getPreflightChecks(_ bool, _ bool, networkMode network.Mode, bundlePath, preset string) []Check {
+func getPreflightChecks(_ bool, _ bool, networkMode network.Mode, bundlePath string, preset crcpreset.Preset) []Check {
 	usingSystemdResolved := checkSystemdResolvedIsRunning()
 
 	return getPreflightChecksForDistro(distro(), networkMode, usingSystemdResolved == nil, bundlePath, preset)
 }
 
-func getPreflightChecksForDistro(distro *linux.OsRelease, networkMode network.Mode, usingSystemdResolved bool, bundlePath, preset string) []Check {
+func getPreflightChecksForDistro(distro *linux.OsRelease, networkMode network.Mode, usingSystemdResolved bool, bundlePath string, preset crcpreset.Preset) []Check {
 	filter := newFilter()
 	filter.SetDistro(distro)
 	filter.SetSystemdUser(distro)
@@ -370,7 +371,7 @@ func getPreflightChecksForDistro(distro *linux.OsRelease, networkMode network.Mo
 	return filter.Apply(getChecks(distro, bundlePath, preset))
 }
 
-func getChecks(distro *linux.OsRelease, bundlePath, preset string) []Check {
+func getChecks(distro *linux.OsRelease, bundlePath string, preset crcpreset.Preset) []Check {
 	var checks []Check
 	checks = append(checks, nonWinPreflightChecks...)
 	checks = append(checks, wsl2PreflightCheck)

--- a/pkg/crc/preflight/preflight_linux.go
+++ b/pkg/crc/preflight/preflight_linux.go
@@ -6,9 +6,11 @@ import (
 	"os"
 	"strings"
 
+	"github.com/code-ready/crc/pkg/crc/constants"
 	crcErrors "github.com/code-ready/crc/pkg/crc/errors"
 	"github.com/code-ready/crc/pkg/crc/logging"
 	"github.com/code-ready/crc/pkg/crc/network"
+	"github.com/code-ready/crc/pkg/crc/preset"
 	crcpreset "github.com/code-ready/crc/pkg/crc/preset"
 	crcos "github.com/code-ready/crc/pkg/os"
 	"github.com/code-ready/crc/pkg/os/linux"
@@ -352,7 +354,7 @@ func getAllPreflightChecks() []Check {
 	filter.SetDistro(distro())
 	filter.SetSystemdUser(distro())
 
-	return filter.Apply(getChecks(distro(), "", ""))
+	return filter.Apply(getChecks(distro(), constants.DefaultBundlePath, preset.OpenShift))
 }
 
 func getPreflightChecks(_ bool, _ bool, networkMode network.Mode, bundlePath string, preset crcpreset.Preset) []Check {

--- a/pkg/crc/preflight/preflight_linux_test.go
+++ b/pkg/crc/preflight/preflight_linux_test.go
@@ -94,7 +94,7 @@ var checkListForDistros = []checkListForDistro{
 			{check: checkCrcNetworkManagerDispatcherFile},
 			{check: checkLibvirtCrcNetworkAvailable},
 			{check: checkLibvirtCrcNetworkActive},
-			{check: checkBundleExtracted(constants.DefaultBundlePath, "")},
+			{check: checkBundleExtracted(constants.DefaultBundlePath)},
 		},
 	},
 	{
@@ -132,7 +132,7 @@ var checkListForDistros = []checkListForDistro{
 			{check: checkCrcDnsmasqConfigFile},
 			{check: checkLibvirtCrcNetworkAvailable},
 			{check: checkLibvirtCrcNetworkActive},
-			{check: checkBundleExtracted(constants.DefaultBundlePath, "")},
+			{check: checkBundleExtracted(constants.DefaultBundlePath)},
 		},
 	},
 	{
@@ -164,7 +164,7 @@ var checkListForDistros = []checkListForDistro{
 			{check: checkDaemonSystemdService},
 			{check: checkDaemonSystemdSockets},
 			{check: checkVsock},
-			{check: checkBundleExtracted(constants.DefaultBundlePath, "")},
+			{check: checkBundleExtracted(constants.DefaultBundlePath)},
 		},
 	},
 	{
@@ -203,7 +203,7 @@ var checkListForDistros = []checkListForDistro{
 			{check: checkCrcNetworkManagerDispatcherFile},
 			{check: checkLibvirtCrcNetworkAvailable},
 			{check: checkLibvirtCrcNetworkActive},
-			{check: checkBundleExtracted(constants.DefaultBundlePath, "")},
+			{check: checkBundleExtracted(constants.DefaultBundlePath)},
 		},
 	},
 	{
@@ -241,7 +241,7 @@ var checkListForDistros = []checkListForDistro{
 			{check: checkCrcDnsmasqConfigFile},
 			{check: checkLibvirtCrcNetworkAvailable},
 			{check: checkLibvirtCrcNetworkActive},
-			{check: checkBundleExtracted(constants.DefaultBundlePath, "")},
+			{check: checkBundleExtracted(constants.DefaultBundlePath)},
 		},
 	},
 	{
@@ -273,7 +273,7 @@ var checkListForDistros = []checkListForDistro{
 			{check: checkDaemonSystemdService},
 			{check: checkDaemonSystemdSockets},
 			{check: checkVsock},
-			{check: checkBundleExtracted(constants.DefaultBundlePath, "")},
+			{check: checkBundleExtracted(constants.DefaultBundlePath)},
 		},
 	},
 	{
@@ -312,7 +312,7 @@ var checkListForDistros = []checkListForDistro{
 			{check: checkCrcNetworkManagerDispatcherFile},
 			{check: checkLibvirtCrcNetworkAvailable},
 			{check: checkLibvirtCrcNetworkActive},
-			{check: checkBundleExtracted(constants.DefaultBundlePath, "")},
+			{check: checkBundleExtracted(constants.DefaultBundlePath)},
 		},
 	},
 	{
@@ -350,7 +350,7 @@ var checkListForDistros = []checkListForDistro{
 			{check: checkCrcDnsmasqConfigFile},
 			{check: checkLibvirtCrcNetworkAvailable},
 			{check: checkLibvirtCrcNetworkActive},
-			{check: checkBundleExtracted(constants.DefaultBundlePath, "")},
+			{check: checkBundleExtracted(constants.DefaultBundlePath)},
 		},
 	},
 	{
@@ -382,7 +382,7 @@ var checkListForDistros = []checkListForDistro{
 			{check: checkDaemonSystemdService},
 			{check: checkDaemonSystemdSockets},
 			{check: checkVsock},
-			{check: checkBundleExtracted(constants.DefaultBundlePath, "")},
+			{check: checkBundleExtracted(constants.DefaultBundlePath)},
 		},
 	},
 	{
@@ -422,7 +422,7 @@ var checkListForDistros = []checkListForDistro{
 			{check: checkCrcNetworkManagerDispatcherFile},
 			{check: checkLibvirtCrcNetworkAvailable},
 			{check: checkLibvirtCrcNetworkActive},
-			{check: checkBundleExtracted(constants.DefaultBundlePath, "")},
+			{check: checkBundleExtracted(constants.DefaultBundlePath)},
 		},
 	},
 	{
@@ -461,7 +461,7 @@ var checkListForDistros = []checkListForDistro{
 			{check: checkCrcDnsmasqConfigFile},
 			{check: checkLibvirtCrcNetworkAvailable},
 			{check: checkLibvirtCrcNetworkActive},
-			{check: checkBundleExtracted(constants.DefaultBundlePath, "")},
+			{check: checkBundleExtracted(constants.DefaultBundlePath)},
 		},
 	},
 	{
@@ -494,7 +494,7 @@ var checkListForDistros = []checkListForDistro{
 			{check: checkDaemonSystemdSockets},
 			{configKeySuffix: "check-apparmor-profile-setup"},
 			{check: checkVsock},
-			{check: checkBundleExtracted(constants.DefaultBundlePath, "")},
+			{check: checkBundleExtracted(constants.DefaultBundlePath)},
 		},
 	},
 }

--- a/pkg/crc/preflight/preflight_linux_test.go
+++ b/pkg/crc/preflight/preflight_linux_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/code-ready/crc/pkg/crc/config"
 	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/code-ready/crc/pkg/crc/network"
+	"github.com/code-ready/crc/pkg/crc/preset"
 	crcos "github.com/code-ready/crc/pkg/os/linux"
 	"github.com/stretchr/testify/assert"
 )
@@ -508,7 +509,7 @@ func assertFuncEqual(t *testing.T, func1 interface{}, func2 interface{}) {
 }
 
 func assertExpectedPreflights(t *testing.T, distro *crcos.OsRelease, networkMode network.Mode, systemdResolved bool) {
-	preflights := getPreflightChecksForDistro(distro, networkMode, systemdResolved, constants.DefaultBundlePath, "")
+	preflights := getPreflightChecksForDistro(distro, networkMode, systemdResolved, constants.DefaultBundlePath, preset.OpenShift)
 	var expected checkListForDistro
 	for _, expected = range checkListForDistros {
 		if expected.distro == distro && expected.networkMode == networkMode && expected.systemdResolved == systemdResolved {

--- a/pkg/crc/preflight/preflight_windows.go
+++ b/pkg/crc/preflight/preflight_windows.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/code-ready/crc/pkg/crc/network"
+	"github.com/code-ready/crc/pkg/crc/preset"
 	crcpreset "github.com/code-ready/crc/pkg/crc/preset"
 	"github.com/code-ready/crc/pkg/os/windows/powershell"
 	"github.com/code-ready/crc/pkg/os/windows/win32"
@@ -147,7 +148,7 @@ func checkVsock() error {
 // Passing 'UserNetworkingMode' to getPreflightChecks currently achieves this
 // as there are no system networking specific checks
 func getAllPreflightChecks() []Check {
-	return getPreflightChecks(true, true, network.UserNetworkingMode, constants.DefaultBundlePath, "")
+	return getPreflightChecks(true, true, network.UserNetworkingMode, constants.DefaultBundlePath, preset.OpenShift)
 }
 
 func getChecks(bundlePath string, preset crcpreset.Preset) []Check {

--- a/pkg/crc/preflight/preflight_windows.go
+++ b/pkg/crc/preflight/preflight_windows.go
@@ -153,7 +153,7 @@ func getChecks(bundlePath, preset string) []Check {
 	checks := []Check{}
 	checks = append(checks, hypervPreflightChecks...)
 	checks = append(checks, vsockChecks...)
-	checks = append(checks, bundleCheck(bundlePath, preset))
+	checks = append(checks, bundleCheck(bundlePath))
 	checks = append(checks, genericCleanupChecks...)
 	return checks
 }

--- a/pkg/crc/preflight/preflight_windows.go
+++ b/pkg/crc/preflight/preflight_windows.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/code-ready/crc/pkg/crc/network"
+	crcpreset "github.com/code-ready/crc/pkg/crc/preset"
 	"github.com/code-ready/crc/pkg/os/windows/powershell"
 	"github.com/code-ready/crc/pkg/os/windows/win32"
 )
@@ -149,7 +150,7 @@ func getAllPreflightChecks() []Check {
 	return getPreflightChecks(true, true, network.UserNetworkingMode, constants.DefaultBundlePath, "")
 }
 
-func getChecks(bundlePath, preset string) []Check {
+func getChecks(bundlePath string, preset crcpreset.Preset) []Check {
 	checks := []Check{}
 	checks = append(checks, hypervPreflightChecks...)
 	checks = append(checks, vsockChecks...)
@@ -158,7 +159,7 @@ func getChecks(bundlePath, preset string) []Check {
 	return checks
 }
 
-func getPreflightChecks(_ bool, trayAutoStart bool, networkMode network.Mode, bundlePath, preset string) []Check {
+func getPreflightChecks(_ bool, trayAutoStart bool, networkMode network.Mode, bundlePath string, preset crcpreset.Preset) []Check {
 	filter := newFilter()
 	filter.SetNetworkMode(networkMode)
 

--- a/pkg/crc/preflight/preflight_windows_test.go
+++ b/pkg/crc/preflight/preflight_windows_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/code-ready/crc/pkg/crc/config"
 	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/code-ready/crc/pkg/crc/network"
+	"github.com/code-ready/crc/pkg/crc/preset"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -16,9 +17,9 @@ func TestCountConfigurationOptions(t *testing.T) {
 }
 
 func TestCountPreflights(t *testing.T) {
-	assert.Len(t, getPreflightChecks(false, false, network.SystemNetworkingMode, constants.DefaultBundlePath, ""), 15)
-	assert.Len(t, getPreflightChecks(true, true, network.SystemNetworkingMode, constants.DefaultBundlePath, ""), 15)
+	assert.Len(t, getPreflightChecks(false, false, network.SystemNetworkingMode, constants.DefaultBundlePath, preset.OpenShift), 15)
+	assert.Len(t, getPreflightChecks(true, true, network.SystemNetworkingMode, constants.DefaultBundlePath, preset.OpenShift), 15)
 
-	assert.Len(t, getPreflightChecks(false, false, network.UserNetworkingMode, constants.DefaultBundlePath, ""), 16)
-	assert.Len(t, getPreflightChecks(true, true, network.UserNetworkingMode, constants.DefaultBundlePath, ""), 16)
+	assert.Len(t, getPreflightChecks(false, false, network.UserNetworkingMode, constants.DefaultBundlePath, preset.OpenShift), 16)
+	assert.Len(t, getPreflightChecks(true, true, network.UserNetworkingMode, constants.DefaultBundlePath, preset.OpenShift), 16)
 }

--- a/pkg/crc/preset/preset.go
+++ b/pkg/crc/preset/preset.go
@@ -6,23 +6,35 @@ import (
 	"github.com/code-ready/crc/pkg/crc/logging"
 )
 
-type Preset string
+type Preset int
 
 const (
-	Podman    Preset = "podman"
-	OpenShift Preset = "openshift"
+	Podman Preset = iota
+	OpenShift
 )
+
+func (preset Preset) String() string {
+	switch preset {
+	case Podman:
+		return "podman"
+	case OpenShift:
+		return "openshift"
+	}
+
+	return "invalid"
+}
 
 func ParsePresetE(input string) (Preset, error) {
 	switch input {
-	case string(Podman):
+	case Podman.String():
 		return Podman, nil
-	case string(OpenShift):
+	case OpenShift.String():
 		return OpenShift, nil
 	default:
 		return OpenShift, fmt.Errorf("Cannot parse preset '%s'", input)
 	}
 }
+
 func ParsePreset(input string) Preset {
 	preset, err := ParsePresetE(input)
 	if err != nil {

--- a/pkg/crc/preset/preset.go
+++ b/pkg/crc/preset/preset.go
@@ -1,8 +1,33 @@
 package preset
 
+import (
+	"fmt"
+
+	"github.com/code-ready/crc/pkg/crc/logging"
+)
+
 type Preset string
 
 const (
 	Podman    Preset = "podman"
 	OpenShift Preset = "openshift"
 )
+
+func ParsePresetE(input string) (Preset, error) {
+	switch input {
+	case string(Podman):
+		return Podman, nil
+	case string(OpenShift):
+		return OpenShift, nil
+	default:
+		return OpenShift, fmt.Errorf("Cannot parse preset '%s'", input)
+	}
+}
+func ParsePreset(input string) Preset {
+	preset, err := ParsePresetE(input)
+	if err != nil {
+		logging.Errorf("unexpected preset mode %s, using default", input)
+		return OpenShift
+	}
+	return preset
+}

--- a/pkg/crc/validation/validation.go
+++ b/pkg/crc/validation/validation.go
@@ -12,22 +12,23 @@ import (
 	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/code-ready/crc/pkg/crc/logging"
 	"github.com/code-ready/crc/pkg/crc/machine/bundle"
+	crcpreset "github.com/code-ready/crc/pkg/crc/preset"
 	"github.com/docker/go-units"
 	"github.com/pbnjay/memory"
 )
 
 // ValidateCPUs checks if provided cpus count is valid
-func ValidateCPUs(value int, openshift bool) error {
-	if value < constants.GetDefaultCPUs(openshift) {
-		return fmt.Errorf("requires CPUs >= %d", constants.GetDefaultCPUs(openshift))
+func ValidateCPUs(value int, preset crcpreset.Preset) error {
+	if value < constants.GetDefaultCPUs(preset) {
+		return fmt.Errorf("requires CPUs >= %d", constants.GetDefaultCPUs(preset))
 	}
 	return nil
 }
 
 // ValidateMemory checks if provided Memory count is valid
-func ValidateMemory(value int, openshift bool) error {
-	if value < constants.GetDefaultMemory(openshift) {
-		return fmt.Errorf("requires memory in MiB >= %d", constants.GetDefaultMemory(openshift))
+func ValidateMemory(value int, preset crcpreset.Preset) error {
+	if value < constants.GetDefaultMemory(preset) {
+		return fmt.Errorf("requires memory in MiB >= %d", constants.GetDefaultMemory(preset))
 	}
 	return ValidateEnoughMemory(value)
 }


### PR DESCRIPTION
My initial goal was to do some cleanups in preflight, there was both a 'preset' global variable, and a 'preset' argument passed to several methods which is never used.
I ended up doing more changes along the way. There should be no behaviour change after this PR.