### PR TITLE
e2e: Remove --bundle-version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -212,7 +212,7 @@ ifndef CRC_BINARY
 	CRC_BINARY = --crc-binary=$(GOPATH)/bin
 endif
 e2e:
-	@go test --timeout=180m $(REPOPATH)/test/e2e -v $(PULL_SECRET_FILE) $(BUNDLE_LOCATION) $(CRC_BINARY) --bundle-version=$(OPENSHIFT_VERSION) $(GODOG_OPTS) $(CLEANUP_HOME) $(INSTALLER_PATH) $(USER_PASSWORD)
+	@go test --timeout=180m $(REPOPATH)/test/e2e -v $(PULL_SECRET_FILE) $(BUNDLE_LOCATION) $(CRC_BINARY) $(GODOG_OPTS) $(CLEANUP_HOME) $(INSTALLER_PATH) $(USER_PASSWORD)
 
 .PHONY: e2e-stories e2e-story-health e2e-story-marketplace e2e-story-registry
 # cluster must already be running, crc must be in the path

--- a/images/build-e2e/entrypoint.sh
+++ b/images/build-e2e/entrypoint.sh
@@ -43,10 +43,6 @@ validate=true
     && echo "PULL_SECRET_FILE_PATH required" \
     && validate=false
 
-[[ -z "${BUNDLE_VERSION+x}" && -z "${BUNDLE_LOCATION+x}" ]] \
-    && echo "BUNDLE_VERSION or BUNDLE_LOCATION required" \
-    && validate=false
-
 [[ $validate == false ]] && exit 1
 
 # Define remote connection
@@ -110,7 +106,7 @@ fi
 if [[ ! -z "${BUNDLE_LOCATION+x}" ]]; then
     OPTIONS="--bundle-location=${BUNDLE_LOCATION} "
 else
-    OPTIONS="--bundle-location=\"\" --bundle-version=${BUNDLE_VERSION} "
+    OPTIONS="--bundle-location=\"\" "
 fi
 if [[ ${PLATFORM} == 'windows' ]]; then
     OPTIONS+="--pull-secret-file=C:\\Users\\${TARGET_HOST_USERNAME}\\crc-e2e\\pull-secret "

--- a/test/e2e/crcsuite/crcsuite.go
+++ b/test/e2e/crcsuite/crcsuite.go
@@ -28,7 +28,6 @@ var (
 	bundleEmbedded bool
 	bundleName     string
 	bundleLocation string
-	bundleVersion  string
 	pullSecretFile string
 	cleanupHome    bool
 )
@@ -116,10 +115,6 @@ func FeatureContext(s *godog.Suite) {
 		if bundleLocation == "" {
 			fmt.Println("Expecting the bundle to be embedded in the CRC executable.")
 			bundleEmbedded = true
-			if bundleVersion == "" {
-				fmt.Println("User must specify --bundle-version if bundle is embedded")
-				os.Exit(1)
-			}
 			bundleName = constants.GetDefaultBundle(preset.OpenShift)
 		} else {
 			bundleEmbedded = false
@@ -201,7 +196,6 @@ func ParseFlags() {
 	flag.StringVar(&bundleLocation, "bundle-location", "", "Path to the bundle to be used in tests")
 	flag.StringVar(&pullSecretFile, "pull-secret-file", "", "Path to the file containing pull secret")
 	flag.StringVar(&CRCExecutable, "crc-binary", "", "Path to the CRC executable to be tested")
-	flag.StringVar(&bundleVersion, "bundle-version", "", "Version of the bundle used in tests")
 	flag.BoolVar(&cleanupHome, "cleanup-home", true, "Try to remove crc home folder before starting the suite")
 
 	// Extend the context with tray when supported


### PR DESCRIPTION
It's unused after 457b52c1e 'Constants: Remove
GetBundleForOs/GetDefaultBundleForOs'