### PR TITLE
RFC: Hide libMachineAPIClient/CrcBundleMetadata/libmachine.Host from `pkg/crc/machine`

### DIFF
--- a/pkg/crc/machine/console.go
+++ b/pkg/crc/machine/console.go
@@ -10,7 +10,7 @@ func (client *client) GetConsoleURL() (*types.ConsoleResult, error) {
 	// Here we are only checking if the VM exist and not the status of the VM.
 	// We might need to improve and use crc status logic, only
 	// return if the Openshift is running as part of status.
-	vm, err := loadVirtualMachine(client.name)
+	vm, err := loadVirtualMachine(client.name, client.useVSock())
 	if err != nil {
 		return nil, errors.Wrap(err, "Cannot load machine")
 	}

--- a/pkg/crc/machine/console.go
+++ b/pkg/crc/machine/console.go
@@ -1,7 +1,6 @@
 package machine
 
 import (
-	"github.com/code-ready/crc/pkg/crc/machine/state"
 	"github.com/code-ready/crc/pkg/crc/machine/types"
 	"github.com/pkg/errors"
 )
@@ -17,9 +16,9 @@ func (client *client) GetConsoleURL() (*types.ConsoleResult, error) {
 	}
 	defer vm.Close()
 
-	vmState, err := vm.Driver.GetState()
+	vmState, err := vm.State()
 	if err != nil {
-		return nil, errors.Wrap(err, "Error getting the state of the virtual machine")
+		return nil, errors.Wrap(err, "Error getting the state for virtual machine")
 	}
 
 	clusterConfig, err := getClusterConfig(vm.bundle)
@@ -29,6 +28,6 @@ func (client *client) GetConsoleURL() (*types.ConsoleResult, error) {
 
 	return &types.ConsoleResult{
 		ClusterConfig: *clusterConfig,
-		State:         state.FromMachine(vmState),
+		State:         vmState,
 	}, nil
 }

--- a/pkg/crc/machine/delete.go
+++ b/pkg/crc/machine/delete.go
@@ -8,19 +8,13 @@ import (
 )
 
 func (client *client) Delete() error {
-	libMachineAPIClient, cleanup := createLibMachineClient()
-	defer cleanup()
-	host, err := libMachineAPIClient.Load(client.name)
-
+	vm, err := loadVirtualMachine(client.name)
 	if err != nil {
 		return errors.Wrap(err, "Cannot load machine")
 	}
+	defer vm.Close()
 
-	if err := host.Driver.Remove(); err != nil {
-		return errors.Wrap(err, "Driver cannot remove machine")
-	}
-
-	if err := libMachineAPIClient.Remove(client.name); err != nil {
+	if err := vm.Remove(); err != nil {
 		return errors.Wrap(err, "Cannot remove machine")
 	}
 

--- a/pkg/crc/machine/delete.go
+++ b/pkg/crc/machine/delete.go
@@ -8,7 +8,7 @@ import (
 )
 
 func (client *client) Delete() error {
-	vm, err := loadVirtualMachine(client.name)
+	vm, err := loadVirtualMachine(client.name, client.useVSock())
 	if err != nil {
 		return errors.Wrap(err, "Cannot load machine")
 	}

--- a/pkg/crc/machine/generate_bundle.go
+++ b/pkg/crc/machine/generate_bundle.go
@@ -106,7 +106,7 @@ func (client *client) GenerateBundle(forceStop bool) error {
 }
 
 func loadVM(client *client) (*bundle.CrcBundleInfo, *crcssh.Runner, error) {
-	vm, err := loadVirtualMachine(client.name)
+	vm, err := loadVirtualMachine(client.name, client.useVSock())
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "Cannot load machine")
 	}
@@ -120,11 +120,7 @@ func loadVM(client *client) (*bundle.CrcBundleInfo, *crcssh.Runner, error) {
 		return nil, nil, errors.New("machine is not running")
 	}
 
-	instanceIP, err := getIP(vm.Host, client.useVSock())
-	if err != nil {
-		return nil, nil, errors.Wrap(err, "Error getting the IP")
-	}
-	sshRunner, err := crcssh.CreateRunner(instanceIP, getSSHPort(client.useVSock()), vm.bundle.GetSSHKeyPath(), constants.GetPrivateKeyPath(), constants.GetRsaPrivateKeyPath())
+	sshRunner, err := vm.SSHRunner()
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "Error creating the ssh client")
 	}

--- a/pkg/crc/machine/ip.go
+++ b/pkg/crc/machine/ip.go
@@ -7,19 +7,19 @@ import (
 )
 
 func (client *client) ConnectionDetails() (*types.ConnectionDetails, error) {
-	vm, err := loadVirtualMachine(client.name)
+	vm, err := loadVirtualMachine(client.name, client.useVSock())
 	if err != nil {
 		return nil, errors.Wrap(err, "Cannot load machine")
 	}
 	defer vm.Close()
 
-	ip, err := getIP(vm.Host, client.useVSock())
+	ip, err := vm.IP()
 	if err != nil {
 		return nil, errors.Wrap(err, "Cannot get IP")
 	}
 	return &types.ConnectionDetails{
 		IP:          ip,
-		SSHPort:     getSSHPort(client.useVSock()),
+		SSHPort:     vm.SSHPort(),
 		SSHUsername: constants.DefaultSSHUser,
 		SSHKeys:     []string{constants.GetPrivateKeyPath(), constants.GetRsaPrivateKeyPath(), vm.bundle.GetSSHKeyPath()},
 	}, nil

--- a/pkg/crc/machine/machine.go
+++ b/pkg/crc/machine/machine.go
@@ -10,7 +10,6 @@ import (
 	"github.com/code-ready/crc/pkg/crc/machine/types"
 	"github.com/code-ready/crc/pkg/crc/network"
 	"github.com/code-ready/crc/pkg/libmachine"
-	"github.com/code-ready/crc/pkg/libmachine/host"
 	"github.com/code-ready/machine/libmachine/drivers"
 )
 
@@ -63,20 +62,6 @@ func createLibMachineClient() (libmachine.API, func()) {
 	return client, func() {
 		client.Close()
 	}
-}
-
-func getSSHPort(vsockNetwork bool) int {
-	if vsockNetwork {
-		return constants.VsockSSHPort
-	}
-	return constants.DefaultSSHPort
-}
-
-func getIP(h *host.Host, vsockNetwork bool) (string, error) {
-	if vsockNetwork {
-		return "127.0.0.1", nil
-	}
-	return h.Driver.GetIP()
 }
 
 func getProxyConfig(baseDomainName string) (*network.ProxyConfig, error) {

--- a/pkg/crc/machine/poweroff.go
+++ b/pkg/crc/machine/poweroff.go
@@ -3,15 +3,13 @@ package machine
 import "github.com/pkg/errors"
 
 func (client *client) PowerOff() error {
-	libMachineAPIClient, cleanup := createLibMachineClient()
-	defer cleanup()
-
-	host, err := libMachineAPIClient.Load(client.name)
+	vm, err := loadVirtualMachine(client.name)
 	if err != nil {
 		return errors.Wrap(err, "Cannot load machine")
 	}
+	defer vm.Close()
 
-	if err := host.Kill(); err != nil {
+	if err := vm.Kill(); err != nil {
 		return errors.Wrap(err, "Cannot kill machine")
 	}
 	return nil

--- a/pkg/crc/machine/poweroff.go
+++ b/pkg/crc/machine/poweroff.go
@@ -3,7 +3,7 @@ package machine
 import "github.com/pkg/errors"
 
 func (client *client) PowerOff() error {
-	vm, err := loadVirtualMachine(client.name)
+	vm, err := loadVirtualMachine(client.name, client.useVSock())
 	if err != nil {
 		return errors.Wrap(err, "Cannot load machine")
 	}

--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -193,7 +193,7 @@ func (client *client) Start(ctx context.Context, startConfig types.StartConfig) 
 		telemetry.SetStartType(ctx, telemetry.StartStartType)
 	}
 
-	vm, err := loadVirtualMachine(client.name)
+	vm, err := loadVirtualMachine(client.name, client.useVSock())
 	if err != nil {
 		return nil, errors.Wrap(err, "Error loading machine")
 	}
@@ -266,12 +266,12 @@ func (client *client) Start(ctx context.Context, startConfig types.StartConfig) 
 		return nil, errors.Wrap(err, "CodeReady Containers VM is not running")
 	}
 
-	instanceIP, err := getIP(vm.Host, client.useVSock())
+	instanceIP, err := vm.IP()
 	if err != nil {
 		return nil, errors.Wrap(err, "Error getting the IP")
 	}
 	logging.Infof("CodeReady Containers instance is running with IP %s", instanceIP)
-	sshRunner, err := crcssh.CreateRunner(instanceIP, getSSHPort(client.useVSock()), vm.bundle.GetSSHKeyPath(), constants.GetPrivateKeyPath(), constants.GetRsaPrivateKeyPath())
+	sshRunner, err := vm.SSHRunner()
 	if err != nil {
 		return nil, errors.Wrap(err, "Error creating the ssh client")
 	}
@@ -494,7 +494,7 @@ func (client *client) Start(ctx context.Context, startConfig types.StartConfig) 
 }
 
 func (client *client) IsRunning() (bool, error) {
-	vm, err := loadVirtualMachine(client.name)
+	vm, err := loadVirtualMachine(client.name, client.useVSock())
 	if err != nil {
 		return false, errors.Wrap(err, "Cannot load machine")
 	}

--- a/pkg/crc/machine/status.go
+++ b/pkg/crc/machine/status.go
@@ -11,7 +11,6 @@ import (
 	"github.com/code-ready/crc/pkg/crc/machine/state"
 	"github.com/code-ready/crc/pkg/crc/machine/types"
 	crcssh "github.com/code-ready/crc/pkg/crc/ssh"
-	libmachinestate "github.com/code-ready/machine/libmachine/state"
 	"github.com/pkg/errors"
 )
 
@@ -28,14 +27,14 @@ func (client *client) Status() (*types.ClusterStatusResult, error) {
 	}
 	defer vm.Close()
 
-	vmStatus, err := vm.Driver.GetState()
+	vmStatus, err := vm.State()
 	if err != nil {
 		return nil, errors.Wrap(err, "Cannot get machine state")
 	}
 
-	if vmStatus != libmachinestate.Running {
+	if vmStatus != state.Running {
 		clusterStatusResult := &types.ClusterStatusResult{
-			CrcStatus: state.FromMachine(vmStatus),
+			CrcStatus: vmStatus,
 		}
 		if vm.bundle.IsOpenShift() {
 			clusterStatusResult.OpenshiftStatus = types.OpenshiftStopped

--- a/pkg/crc/machine/stop.go
+++ b/pkg/crc/machine/stop.go
@@ -23,17 +23,17 @@ func (client *client) Stop() (state.State, error) {
 	}
 	logging.Info("Stopping the OpenShift cluster, this may take a few minutes...")
 	if err := vm.Stop(); err != nil {
-		status, stateErr := vm.Driver.GetState()
+		status, stateErr := vm.State()
 		if stateErr != nil {
 			logging.Debugf("Cannot get VM status after stopping it: %v", stateErr)
 		}
-		return state.FromMachine(status), errors.Wrap(err, "Cannot stop machine")
+		return status, errors.Wrap(err, "Cannot stop machine")
 	}
-	status, err := vm.Driver.GetState()
+	status, err := vm.State()
 	if err != nil {
 		return state.Error, errors.Wrap(err, "Cannot get VM status")
 	}
-	return state.FromMachine(status), nil
+	return status, nil
 }
 
 // This should be removed after https://bugzilla.redhat.com/show_bug.cgi?id=1965992

--- a/pkg/crc/machine/virtualmachine.go
+++ b/pkg/crc/machine/virtualmachine.go
@@ -1,0 +1,74 @@
+package machine
+
+import (
+	"fmt"
+
+	"github.com/code-ready/crc/pkg/crc/constants"
+	"github.com/code-ready/crc/pkg/crc/machine/bundle"
+	"github.com/code-ready/crc/pkg/libmachine"
+	libmachinehost "github.com/code-ready/crc/pkg/libmachine/host"
+	"github.com/pkg/errors"
+)
+
+type virtualMachine struct {
+	name string
+	*libmachinehost.Host
+	bundle *bundle.CrcBundleInfo
+	api    libmachine.API
+}
+
+type MissingHostError struct {
+	name string
+}
+
+func errMissingHost(name string) *MissingHostError {
+	return &MissingHostError{name: name}
+}
+
+func (err *MissingHostError) Error() string {
+	return fmt.Sprintf("no such libmachine vm: %s", err.name)
+}
+
+func loadVirtualMachine(name string) (*virtualMachine, error) {
+	apiClient := libmachine.NewClient(constants.MachineBaseDir)
+	exists, err := apiClient.Exists(name)
+	if err != nil {
+		return nil, errors.Wrap(err, "Cannot check if machine exists")
+	}
+	if !exists {
+		return nil, errMissingHost(name)
+	}
+
+	libmachineHost, err := apiClient.Load(name)
+	if err != nil {
+		return nil, errors.Wrap(err, "Cannot load machine")
+	}
+
+	crcBundleMetadata, err := getBundleMetadataFromDriver(libmachineHost.Driver)
+	if err != nil {
+		return nil, errors.Wrap(err, "Error loading bundle metadata")
+	}
+
+	return &virtualMachine{
+		name:   name,
+		Host:   libmachineHost,
+		bundle: crcBundleMetadata,
+		api:    apiClient,
+	}, nil
+}
+
+func (vm *virtualMachine) Close() error {
+	return vm.api.Close()
+}
+
+func (vm *virtualMachine) Remove() error {
+	if err := vm.Driver.Remove(); err != nil {
+		return errors.Wrap(err, "Driver cannot remove machine")
+	}
+
+	if err := vm.api.Remove(vm.name); err != nil {
+		return errors.Wrap(err, "Cannot remove machine")
+	}
+
+	return nil
+}

--- a/pkg/crc/machine/virtualmachine.go
+++ b/pkg/crc/machine/virtualmachine.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/code-ready/crc/pkg/crc/machine/bundle"
+	"github.com/code-ready/crc/pkg/crc/machine/state"
 	"github.com/code-ready/crc/pkg/libmachine"
 	libmachinehost "github.com/code-ready/crc/pkg/libmachine/host"
 	"github.com/pkg/errors"
@@ -71,4 +72,12 @@ func (vm *virtualMachine) Remove() error {
 	}
 
 	return nil
+}
+
+func (vm *virtualMachine) State() (state.State, error) {
+	vmStatus, err := vm.Driver.GetState()
+	if err != nil {
+		return state.Error, err
+	}
+	return state.FromMachine(vmStatus), nil
 }


### PR DESCRIPTION
At the moment, a lot of the code in `pkg/crc/machine` is doing:
```
       libMachineAPIClient, cleanup := createLibMachineClient()
       defer cleanup()

       host, err := libMachineAPIClient.Load(client.name)
       if err != nil {
               return nil, nil, errors.Wrap(err, "Cannot load machine")
       }

       crcBundleMetadata, err := getBundleMetadataFromDriver(host.Driver)
       if err != nil {
               return nil, nil, errors.Wrap(err, "Error loading bundle metadata")
       }
```

Sometimes this code only needs `crcBundelMetadata`, sometimes it also needs `host` (to get the VM IP for example), and some other times, `libMachineAPIClient` is also needed in order to create/remove the VM
This is all quite noisy, and exposes some relatively low-level details to code more focused on crc/OpenShift logic.
This commit tries to hide this code from `machine` by adding a `virtualMachine` concept which can be seen as abstracting the `~/.crc/machines/crc` directory.
Apart from making code in `pkg/crc/machine` easier to follow, this should also make it easier to split some methods in this package, which could be useful for the podman work.





