### PR TITLE
Daemon changes to make podman cni plugin to work with crc

### DIFF
--- a/cmd/crc/cmd/daemon.go
+++ b/cmd/crc/cmd/daemon.go
@@ -82,6 +82,10 @@ var daemonCmd = &cobra.Command{
 					Name: "crc.testing.",
 					Records: []types.Record{
 						{
+							Name: "host",
+							IP:   net.ParseIP(hostVirtualIP),
+						},
+						{
 							Name: "gateway",
 							IP:   net.ParseIP("192.168.127.1"),
 						},
@@ -107,22 +111,12 @@ var daemonCmd = &cobra.Command{
 		}
 		if config.Get(crcConfig.HostNetworkAccess).AsBool() {
 			log.Debugf("Enabling host network access")
-			for i := range virtualNetworkConfig.DNS {
-				zone := &virtualNetworkConfig.DNS[i]
-				if zone.Name != "crc.testing." {
-					continue
-				}
-				log.Debugf("Adding \"host\" -> %s DNS record to crc.testing. zone", hostVirtualIP)
-
-				zone.Records = append(zone.Records, types.Record{Name: "host", IP: net.ParseIP(hostVirtualIP)})
-			}
-
 			if virtualNetworkConfig.NAT == nil {
 				virtualNetworkConfig.NAT = make(map[string]string)
 			}
 			virtualNetworkConfig.NAT[hostVirtualIP] = "127.0.0.1"
-			virtualNetworkConfig.GatewayVirtualIPs = []string{hostVirtualIP}
 		}
+		virtualNetworkConfig.GatewayVirtualIPs = []string{hostVirtualIP}
 		err := run(&virtualNetworkConfig)
 		return err
 	},


### PR DESCRIPTION
With this patch and the bundle from https://github.com/code-ready/snc/pull/489 PR should able to work with podman-machine cni plugin and add/remove the port mapping.

```
$ curl host.crc.testing:7777/services/forwarder/all | jq .
[
  {
    "local": ":2222",
    "remote": "192.168.127.2:22"
  },
  {
    "local": ":6443",
    "remote": "192.168.127.2:6443"
  },
  {
    "local": ":443",
    "remote": "192.168.127.2:443"
  },
  {
    "local": ":80",
    "remote": "192.168.127.2:80"
  }
]

<crc_vm> $ podman run -d -p 8080:80 docker.io/httpd:2.4
a29368f56624112de0a1e00c51875a2e9d3125ce6d08991dfec9cfe09c8bb394

$ curl host.crc.testing:7777/services/forwarder/all | jq .
[
  {
    "local": ":443",
    "remote": "192.168.127.2:443"
  },
  {
    "local": ":80",
    "remote": "192.168.127.2:80"
  },
  {
    "local": "0.0.0.0:8080",
    "remote": "192.168.127.2:8080"
  },
  {
    "local": ":2222",
    "remote": "192.168.127.2:22"
  },
  {
    "local": ":6443",
    "remote": "192.168.127.2:6443"
  }
]
```