### PR TITLE
Manually add default dns server to tap interface

### DIFF
--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -186,7 +186,7 @@ func (client *client) Start(ctx context.Context, startConfig types.StartConfig) 
 		if crcBundleMetadata.IsOpenShift() {
 			machineConfig.KubeConfig = crcBundleMetadata.GetKubeConfigPath()
 		}
-		if err := createHost(machineConfig); err != nil {
+		if err := createHost(machineConfig, crcBundleMetadata); err != nil {
 			return nil, errors.Wrap(err, "Error creating machine")
 		}
 	} else {
@@ -516,7 +516,7 @@ func (client *client) validateStartConfig(startConfig types.StartConfig) error {
 	return nil
 }
 
-func createHost(machineConfig config.MachineConfig) error {
+func createHost(machineConfig config.MachineConfig, crcBundleInfo *bundle.CrcBundleInfo) error {
 	api, cleanup := createLibMachineClient()
 	defer cleanup()
 
@@ -545,8 +545,10 @@ func createHost(machineConfig config.MachineConfig) error {
 	if err := crcssh.GenerateSSHKey(constants.GetPrivateKeyPath()); err != nil {
 		return fmt.Errorf("Error generating ssh key pair: %v", err)
 	}
-	if err := cluster.GenerateKubeAdminUserPassword(); err != nil {
-		return errors.Wrap(err, "Error generating new kubeadmin password")
+	if crcBundleInfo.IsOpenShift() {
+		if err := cluster.GenerateKubeAdminUserPassword(); err != nil {
+			return errors.Wrap(err, "Error generating new kubeadmin password")
+		}
 	}
 	if err := api.SetExists(vm.Name); err != nil {
 		return fmt.Errorf("Failed to record VM existence: %s", err)

--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -316,6 +317,12 @@ func (client *client) Start(ctx context.Context, startConfig types.StartConfig) 
 
 	if _, _, err := sshRunner.RunPrivileged("make root Podman socket accessible", "chmod 777 /run/podman/ /run/podman/podman.sock"); err != nil {
 		return nil, errors.Wrap(err, "Failed to change permissions to root podman socket")
+	}
+
+	if !vm.bundle.IsOpenShift() && runtime.GOOS != "darwin" {
+		if _, _, err := sshRunner.RunPrivileged("Add dns server to tap interface", "systemd-resolve --interface tap0 --set-dns 192.168.127.1"); err != nil {
+			return nil, errors.Wrap(err, "Failed to add dns server to tap interface")
+		}
 	}
 
 	if !vm.bundle.IsOpenShift() {


### PR DESCRIPTION
In case of user mode networking, vm deployed on windows and linux
have tap interface created which used for packets to send to vsock.
For podman bundles which are based on fedora 35, looks like the dns
server is not set to the tap device and all the query fails because
of it.

This patch manually add dns server `192.168.127.1` to tap interface.

```
$ route -n
Kernel IP routing table
Destination     Gateway         Genmask         Flags Metric Ref    Use
Iface
0.0.0.0         192.168.127.1   0.0.0.0         UG    0      0        0
  tap1
192.168.127.0   0.0.0.0         255.255.255.0   U     0      0        0
    tap1

$ dig +short google.com
142.250.195.14

$ curl google.com
curl: (6) Could not resolve host: google.com

$ resolvectl dns
Global:
Link 2 (tap0):

$ sudo systemd-resolve --interface tap0 --set-dns 192.168.127.1

$ resolvectl dns
Global:
Link 2 (tap0): 192.168.127.1

$ ping google.com
PING google.com (142.250.195.14) 56(84) bytes of data.
64 bytes from 142.250.195.14 (142.250.195.14): icmp_seq=1 ttl=64
   time=0.636 ms
64 bytes from 142.250.195.14 (142.250.195.14): icmp_seq=2 ttl=64
   time=1.13 ms
```