### PR TITLE
ci: Try again to use latest google-cloud-sdk rpm

### DIFF
--- a/images/openshift-ci/Dockerfile
+++ b/images/openshift-ci/Dockerfile
@@ -16,7 +16,7 @@ RUN yum update -y && \
     yum install --setopt=tsflags=nodocs -y \
     genisoimage \
     gettext \
-    google-cloud-sdk-365.0.1 \
+    google-cloud-sdk \
     libvirt-client \
     libvirt-libs \
     nss_wrapper \


### PR DESCRIPTION
build -366 was problematic, there is now a -369 build, let's see if it
works better.

I'm filing this PR to get CI to run against it.