### PR TITLE
Remove bundle from mac and windows installer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -272,7 +272,7 @@ HYPERV_BUNDLENAME = $(BUNDLE_DIR)/crc_hyperv_$(OPENSHIFT_VERSION).$(BUNDLE_EXTEN
 .PHONY: embed_bundle check_bundledir
 check_bundledir:
 ifeq ($(MOCK_BUNDLE),true)
-	touch $(HYPERKIT_BUNDLENAME) $(HYPERV_BUNDLENAME)
+	touch $(HYPERV_BUNDLENAME)
 endif
 	@$(call check_defined, BUNDLE_DIR, "Embedding bundle requires BUNDLE_DIR set to a directory containing CRC bundles for all hypervisors")
 
@@ -290,7 +290,7 @@ goversioncheck:
 TRAY_RELEASE ?= packaging/tmp/crc-tray-macos.tar.gz
 
 packagedir: LDFLAGS+= -X '$(REPOPATH)/pkg/crc/version.installerBuild=true' $(RELEASE_VERSION_VARIABLES)
-packagedir: clean check_bundledir $(BUILD_DIR)/macos-amd64/crc $(HOST_BUILD_DIR)/crc-embedder
+packagedir: clean $(BUILD_DIR)/macos-amd64/crc $(HOST_BUILD_DIR)/crc-embedder
 	echo -n $(CRC_VERSION) > packaging/VERSION
 	sed -e 's/__VERSION__/'$(CRC_VERSION)'/g' -e 's@__INSTALL_PATH__@$(MACOS_INSTALL_PATH)@g' packaging/darwin/Distribution.in >packaging/darwin/Distribution
 	sed -e 's/__VERSION__/'$(CRC_VERSION)'/g' -e 's@__INSTALL_PATH__@$(MACOS_INSTALL_PATH)@g' packaging/darwin/welcome.html.in >packaging/darwin/Resources/welcome.html
@@ -305,7 +305,6 @@ packagedir: clean check_bundledir $(BUILD_DIR)/macos-amd64/crc $(HOST_BUILD_DIR)
 
 	mv packaging/tmp/* packaging/root/"$(MACOS_INSTALL_PATH)"
 
-	cp $(HYPERKIT_BUNDLENAME) packaging/root/"$(MACOS_INSTALL_PATH)"
 	cp $(BUILD_DIR)/macos-amd64/crc packaging/root/"$(MACOS_INSTALL_PATH)"
 	cp LICENSE packaging/darwin/Resources/LICENSE.txt
 	pkgbuild --analyze --root packaging/root packaging/components.plist

--- a/Makefile
+++ b/Makefile
@@ -269,13 +269,7 @@ release: cross-lint embed_bundle gen_release_info
 HYPERKIT_BUNDLENAME = $(BUNDLE_DIR)/crc_hyperkit_$(OPENSHIFT_VERSION).$(BUNDLE_EXTENSION)
 HYPERV_BUNDLENAME = $(BUNDLE_DIR)/crc_hyperv_$(OPENSHIFT_VERSION).$(BUNDLE_EXTENSION)
 
-.PHONY: embed_bundle check_bundledir
-check_bundledir:
-ifeq ($(MOCK_BUNDLE),true)
-	touch $(HYPERV_BUNDLENAME)
-endif
-	@$(call check_defined, BUNDLE_DIR, "Embedding bundle requires BUNDLE_DIR set to a directory containing CRC bundles for all hypervisors")
-
+.PHONY: embed_bundle
 embed_bundle: clean cross $(HOST_BUILD_DIR)/crc-embedder
 	$(HOST_BUILD_DIR)/crc-embedder embed --log-level debug --goos=linux $(BUILD_DIR)/linux-amd64/crc
 
@@ -340,7 +334,7 @@ BUNDLE_NAME=crc_hyperv_$(OPENSHIFT_VERSION).$(BUNDLE_EXTENSION)
 
 .PHONY: msidir
 msidir: LDFLAGS+= -X '$(REPOPATH)/pkg/crc/version.installerBuild=true' $(RELEASE_VERSION_VARIABLES)
-msidir: clean $(HOST_BUILD_DIR)/crc-embedder $(HOST_BUILD_DIR)/GenMsiWxs $(BUILD_DIR)/windows-amd64/crc.exe check_bundledir $(PACKAGE_DIR)/product.wxs.template
+msidir: clean $(HOST_BUILD_DIR)/crc-embedder $(HOST_BUILD_DIR)/GenMsiWxs $(BUILD_DIR)/windows-amd64/crc.exe $(PACKAGE_DIR)/product.wxs.template
 	mkdir -p $(PACKAGE_DIR)/msi
 	$(HOST_BUILD_DIR)/crc-embedder download $(PACKAGE_DIR)/msi 
 	cp $(HOST_BUILD_DIR)/crc.exe $(PACKAGE_DIR)/msi/$(CRC_EXE)
@@ -348,9 +342,7 @@ msidir: clean $(HOST_BUILD_DIR)/crc-embedder $(HOST_BUILD_DIR)/GenMsiWxs $(BUILD
 ifeq ($(MOCK_BUNDLE),true)
 	touch $(PACKAGE_DIR)/msi/$(BUNDLE_NAME)
 endif
-	cp $(HYPERV_BUNDLENAME) $(PACKAGE_DIR)/msi
-	$(HOST_BUILD_DIR)/GenMsiWxs $(PACKAGE_DIR)/msi/$(BUNDLE_NAME)
-	rm $(PACKAGE_DIR)/msi/$(BUNDLE_NAME)
+	$(HOST_BUILD_DIR)/GenMsiWxs
 	cp -r $(PACKAGE_DIR)/Resources $(PACKAGE_DIR)/msi/
 	cp $(PACKAGE_DIR)/*.wxs $(PACKAGE_DIR)/msi
 	rm $(PACKAGE_DIR)/product.wxs

--- a/packaging/windows/gen_msi_wxs.go
+++ b/packaging/windows/gen_msi_wxs.go
@@ -1,39 +1,25 @@
 package main
 
 import (
-	"errors"
-	"fmt"
-	"io"
 	"log"
 	"os"
-	"path/filepath"
 	"strings"
 	"text/template"
 )
 
-const chunkSize = 1024 * 1024 * 1024 // 1GiB chunk size
-
 var crcVersion = "unset" // version set at compile time
 
 func main() {
-	if len(os.Args) != 2 {
+	if len(os.Args) != 1 {
 		log.Fatal("Split takes only one argument (the file to split)")
 	}
 
-	parts, err := split(os.Args[1])
-	if err != nil {
-		for _, part := range parts {
-			os.Remove(part)
-		}
-		log.Fatal(err.Error())
-	}
-
-	if err := generateWxsFromTemplate(filepath.Base(os.Args[1]), parts); err != nil {
+	if err := generateWxsFromTemplate(); err != nil {
 		log.Fatalf("Wxs generation failed: %s", err)
 	}
 }
 
-func generateWxsFromTemplate(bundleName string, parts []string) error {
+func generateWxsFromTemplate() error {
 	tmpl := template.New("product.wxs.template")
 	tmpl.Funcs(template.FuncMap{
 		"strjoin": strings.Join,
@@ -44,17 +30,10 @@ func generateWxsFromTemplate(bundleName string, parts []string) error {
 		return err
 	}
 	type templateData struct {
-		BundleName string
-		Version    string
-		Parts      []string
+		Version string
 	}
 	tmplData := templateData{
-		BundleName: bundleName,
-		Version:    crcVersion,
-		Parts:      []string{},
-	}
-	for _, part := range parts {
-		tmplData.Parts = append(tmplData.Parts, filepath.Base(part))
+		Version: crcVersion,
 	}
 
 	f, err := os.OpenFile("packaging/windows/product.wxs", os.O_CREATE|os.O_RDWR, 0644)
@@ -63,34 +42,4 @@ func generateWxsFromTemplate(bundleName string, parts []string) error {
 	}
 	defer f.Close()
 	return tmpl.Execute(f, tmplData)
-}
-
-func split(filePath string) ([]string, error) {
-	splitFiles := []string{}
-	bundle, err := os.Open(filePath)
-	if err != nil {
-		return nil, err
-	}
-	defer bundle.Close()
-	bundleName := filepath.Base(filePath)
-	for i := 1; ; i++ {
-		partFileName := fmt.Sprintf("%s.%d", bundleName, i)
-		partFile, err := os.Create(filepath.Join(filepath.Dir(filePath), partFileName))
-		if err != nil {
-			return splitFiles, err
-		}
-		splitFiles = append(splitFiles, partFileName)
-		defer partFile.Close()
-		n, err := io.CopyN(partFile, bundle, chunkSize)
-		fmt.Printf("Copied %d bytes from %s to %s\n", n, bundleName, partFileName)
-		if err != nil {
-			if errors.Is(err, io.EOF) {
-				return splitFiles, nil
-			}
-			return splitFiles, err
-		}
-		if err = partFile.Close(); err != nil {
-			return splitFiles, err
-		}
-	}
 }

--- a/packaging/windows/product.wxs.template
+++ b/packaging/windows/product.wxs.template
@@ -1,12 +1,9 @@
 <?xml version="1.0"?>
-<?define crcBundleName="{{.BundleName}}"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi"
     xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
     <Product Id="*" UpgradeCode="53DE5BFA-0E53-44E7-8D4F-07E37E59A9AB" Name="CodeReady Containers" Version="{{.Version}}" Manufacturer="Red Hat Inc." Language="1033">
         <Package Id ="*" InstallerVersion="300" Compressed="yes" Description="CodeReady Containers {{.Version}}" Comments="This installs CodeReady Containers {{.Version}}" InstallScope="perMachine" />
-        {{range $index, $element := .Parts}}
-        <Media Id="{{inc $index}}" EmbedCab="{{if eq (inc $index) (len $.Parts)}}yes{{else}}no{{end}}" Cabinet="cab{{inc $index}}.cab" />
-        {{end}}
+	    <Media Id="1" EmbedCab="yes" Cabinet="cab1.cab"/>
         <MajorUpgrade AllowDowngrades="yes" />
         <WixVariable Id="WixUIBannerBmp" Value=".\Resources\banner.png"/>
         <WixVariable Id="WixUIDialogBmp" Value=".\Resources\background.png"/>
@@ -37,21 +34,16 @@
         <Directory Id="TARGETDIR" Name="SourceDir">
             <Directory Id="ProgramFiles64Folder">
                 <Directory Id="INSTALLDIR" Name="CodeReady Containers">
-                    {{range $index, $element := .Parts}}
-                    <Component Id="CrcBundlePart{{inc $index}}" Guid="*">
-                        <File Id="CrcBundlePart{{inc $index}}" Source="SourceDir\$(var.crcBundleName).{{inc $index}}" KeyPath="yes" DiskId="{{inc $index}}" />
-                    </Component>
-                    {{end}}
                     <Component Id="CrcExe" Guid="*">
-                        <File Id="CrcExe" Source="SourceDir\crc.exe" KeyPath="yes" DiskId="{{len .Parts}}" />
+                        <File Id="CrcExe" Source="SourceDir\crc.exe" KeyPath="yes" DiskId="1" />
                     </Component>
                     <Component Id="AdminHelper" Guid="*">
-                        <File Id="AdminHelper" Source="SourceDir\crc-admin-helper-windows.exe" KeyPath="yes" DiskId="{{len .Parts}}" />
+                        <File Id="AdminHelper" Source="SourceDir\crc-admin-helper-windows.exe" KeyPath="yes" DiskId="1" />
                         <ServiceInstall Name="CodeReadyContainersAdminHelper" Description="Perform administrative tasks for the user" Arguments="daemon" DisplayName="CodeReady Containers Admin Helper" ErrorControl="normal" Start="auto" Type="ownProcess" />
                         <ServiceControl Id="StartAdminHelperService" Name="CodeReadyContainersAdminHelper" Start='install' Stop='both' Remove='uninstall' />
                     </Component>
                     <Component Id="CrcTray" Guid="*">
-                        <File Id="CrcTray" Source="SourceDir\crc-tray.exe" KeyPath="yes" DiskId="{{len .Parts}}" />
+                        <File Id="CrcTray" Source="SourceDir\crc-tray.exe" KeyPath="yes" DiskId="1" />
                         <RemoveFile Id="RemoveInstallFiles" Name="*.*" On="uninstall" />
                     </Component>
                     <Component Id="AddUserToCrcUsers" Guid="0C793EE7-109A-474B-9651-77E0A83BAF2D" KeyPath="yes">
@@ -86,10 +78,6 @@
                 </Component>
             </Directory>
         </Directory>
-        <SetProperty Action="CAJoinBundle" Id="JoinBundle" Value='"[System64Folder]cmd.exe" /c cd /d "[INSTALLDIR]" &amp;&amp; copy /b {{strjoin .Parts "+"}} $(var.crcBundleName)' Before="JoinBundle" Sequence="execute"/>
-        <CustomAction Id="JoinBundle" BinaryKey="WixCA" DllEntry="WixQuietExec" Execute="deferred" Impersonate="no" />
-        <SetProperty Action="CARemoveParts" Id="RemoveParts" Value='"[System64Folder]cmd.exe" /c cd /d "[INSTALLDIR]" &amp;&amp; del /f /q {{strjoin .Parts " "}}' Before="RemoveParts" Sequence="execute"/>
-        <CustomAction Id="RemoveParts" BinaryKey="WixCA" DllEntry="WixQuietExec" Execute="deferred" Impersonate="no" />
 
         <SetProperty Action="CACreateCrcUsersGroup" Id="CreateCrcGroup" Value='"[System64Folder]cmd.exe" /c net localgroup crc-users /comment:"Group for CodeReady Containers users" /add' Before="CreateCrcGroup" Sequence="execute"/>
         <CustomAction Id="CreateCrcGroup" BinaryKey="WixCA" DllEntry="WixQuietExec" Execute="deferred" Impersonate="no" Return="ignore" />
@@ -107,19 +95,14 @@
         <util:CloseApplication Id = "TrayRunning" Description="Please exit CodeReady Containers from tray and run the installation again." Target="crc-tray.exe" RebootPrompt="no" PromptToContinue="yes" />
 
         <InstallExecuteSequence>
-            <Custom Action="JoinBundle" After="InstallFiles">NOT Installed AND NOT PATCH</Custom>
-            <Custom Action="RemoveParts" After="JoinBundle">NOT Installed AND NOT PATCH</Custom>
             <Custom Action="CreateCrcGroup" Before="ConfigureUsers"> NOT Installed AND NOT REMOVE~="ALL" AND NOT WIX_UPGRADE_DETECTED</Custom>
             <Custom Action="AddUserToHypervAdminGroup" After="InstallHyperv"> NOT Installed AND NOT REMOVE~="ALL" AND NOT WIX_UPGRADE_DETECTED</Custom>
             <Custom Action="RemoveCrcGroup" After="RemoveFolders"> Installed AND NOT PATCH AND REMOVE~="ALL" AND NOT UPGRADINGPRODUCTCODE</Custom>
-            <Custom Action="InstallHyperv" After="RemoveParts"> NOT Installed AND NOT REMOVE~="ALL" AND NOT WIX_UPGRADE_DETECTED</Custom>
-            <Custom Action="RemoveCrcGroupRollback" Before="CreateCrcGroup"> NOT Installed AND NOT REMOVE~="ALL" AND NOT WIX_UPGRADE_DETECTED</Custom>
+            <Custom Action="InstallHyperv" Before="CreateCrcGroup"> NOT Installed AND NOT REMOVE~="ALL" AND NOT WIX_UPGRADE_DETECTED</Custom>
+            <Custom Action="RemoveCrcGroupRollback" After="CreateCrcGroup"> NOT Installed AND NOT REMOVE~="ALL" AND NOT WIX_UPGRADE_DETECTED</Custom>
             <ScheduleReboot After="InstallFinalize"> NOT Installed AND NOT REMOVE~="ALL" AND NOT WIX_UPGRADE_DETECTED</ScheduleReboot>
         </InstallExecuteSequence>
         <Feature Id="DefaultFeature" Level="1">
-            {{range $index, $element := .Parts}}
-            <ComponentRef Id="CrcBundlePart{{inc $index}}"/>
-            {{end}}
             <ComponentRef Id="CrcExe" />
             <ComponentRef Id="CrcTray" />
             <ComponentRef Id="AdminHelper" />
@@ -133,8 +116,6 @@
             <UIRef Id="WixUI_ErrorProgressText"/>
             <!-- Define the installer UI -->
             <UIRef Id="WixUI_HK"/>
-            <ProgressText Action="JoinBundle">Combining bundle parts</ProgressText>
-            <ProgressText Action="RemoveParts">Removing bundle parts after combining</ProgressText>
             <ProgressText Action="CreateCrcGroup">Creating crc-users group</ProgressText>
             <ProgressText Action="RemoveCrcGroup">Removing crc-users group</ProgressText>
             <ProgressText Action="InstallHyperv">Installing Hyper-V</ProgressText>

--- a/pkg/crc/constants/constants.go
+++ b/pkg/crc/constants/constants.go
@@ -97,9 +97,6 @@ var (
 )
 
 func GetDefaultBundlePath(preset crcpreset.Preset) string {
-	if version.IsInstaller() {
-		return filepath.Join(version.InstallPath(), GetDefaultBundle(preset))
-	}
 	return filepath.Join(MachineCacheDir, GetDefaultBundle(preset))
 }
 


### PR DESCRIPTION
This patch remove the bundle as part of installer for mac/windows
platform and now it will be downloaded as part of `crc setup` command.

This patch also remove the default bundle path from installed directory
to crc cache directory so user not face permission issue to download it.
