### PR TITLE
Daemon API: Reregister the settings as part of start/get api call

### DIFF
--- a/pkg/crc/api/api_http.go
+++ b/pkg/crc/api/api_http.go
@@ -8,7 +8,7 @@ import (
 	"github.com/code-ready/crc/pkg/crc/machine"
 )
 
-func NewMux(config crcConfig.Storage, machine machine.Client, logger Logger, telemetry Telemetry) http.Handler {
+func NewMux(config *crcConfig.Config, machine machine.Client, logger Logger, telemetry Telemetry) http.Handler {
 	handler := NewHandler(config, machine, logger, telemetry)
 
 	server := newServerWithRoutes(handler)

--- a/pkg/crc/api/handlers.go
+++ b/pkg/crc/api/handlers.go
@@ -17,7 +17,7 @@ import (
 type Handler struct {
 	Logger    Logger
 	Client    machine.Client
-	Config    crcConfig.Storage
+	Config    *crcConfig.Config
 	Telemetry Telemetry
 }
 
@@ -36,7 +36,7 @@ func (h *Handler) Logs(c *context) error {
 	})
 }
 
-func NewHandler(config crcConfig.Storage, machine machine.Client, logger Logger, telemetry Telemetry) *Handler {
+func NewHandler(config *crcConfig.Config, machine machine.Client, logger Logger, telemetry Telemetry) *Handler {
 	return &Handler{
 		Client:    machine,
 		Config:    config,
@@ -83,6 +83,7 @@ func (h *Handler) PowerOff(c *context) error {
 }
 
 func (h *Handler) Start(c *context) error {
+	crcConfig.RegisterSettings(h.Config)
 	var parsedArgs client.StartConfig
 	if len(c.requestBody) > 0 {
 		if err := c.Bind(&parsedArgs); err != nil {
@@ -215,6 +216,7 @@ func (h *Handler) UnsetConfig(c *context) error {
 }
 
 func (h *Handler) GetConfig(c *context) error {
+	crcConfig.RegisterSettings(h.Config)
 	queries := c.url.Query()
 	var req client.GetOrUnsetConfigRequest
 	for key := range queries {

--- a/pkg/crc/api/helpers_test.go
+++ b/pkg/crc/api/helpers_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/code-ready/crc/pkg/crc/preflight"
 )
 
-func setupNewInMemoryConfig() config.Storage {
+func setupNewInMemoryConfig() *config.Config {
 	storage := config.NewEmptyInMemoryStorage()
 	cfg := config.New(&skipPreflights{
 		storage: storage,


### PR DESCRIPTION
As of now daemon use the initial config settings during the initial
start and then when user try to update the config which need reregister
to get default values (in case of preset), it doesn't updated in config
Storage API side. User get different result for `config view` from cli
and daemon side.

```
// Initial start of the tray with following config
✗ crc config view
- consent-telemetry                     : no

// Check the defaults using api request
✗ curl -X GET --unix-socket ~/.crc/crc-http.sock http:/c/api/config | jq .
{
  "Success": true,
  "Error": "",
  "Configs": {
    "autostart-tray": true,
    "bundle": "/Users/prkumar/.crc/cache/crc_hyperkit_4.9.10.crcbundle",
    "consent-telemetry": "no",
    "cpus": 4,
    "disable-update-check": false,
    "disk-size": 31,
    "memory": 9216,
    "preset": "openshift",
    ...
  }
}

// Use podman preset
✗ crc config set preset podman
✗ crc config view
- consent-telemetry                     : no
- preset                                : podman

// Again check the defaults using api
✗ curl -X GET --unix-socket ~/.crc/crc-http.sock http:/c/api/config | jq .
{
  "Success": true,
  "Error": "",
  "Configs": {
    "autostart-tray": true,
    "bundle": "/Users/prkumar/.crc/cache/crc_hyperkit_4.9.10.crcbundle",   => no change
    "consent-telemetry": "no",
    "cpus": 4,  => no change
    "disable-update-check": false,
    "disk-size": 31,
    "memory": 9216, => no change
    "preset": "podman",
    ...
  }
}
```

This patch is going to use `Config` type and then reregister the setting
before start or get call from the API.

fixes: #2887
