### PR TITLE
API: Add podman version to status result

### DIFF
--- a/pkg/crc/api/api_client_test.go
+++ b/pkg/crc/api/api_client_test.go
@@ -69,6 +69,7 @@ func TestStatus(t *testing.T) {
 			CrcStatus:        "Running",
 			OpenshiftStatus:  "Running",
 			OpenshiftVersion: "4.5.1",
+			PodmanVersion:    "3.3.1",
 			DiskUse:          int64(10000000000),
 			DiskSize:         int64(20000000000),
 			Success:          true,

--- a/pkg/crc/api/api_http_test.go
+++ b/pkg/crc/api/api_http_test.go
@@ -228,7 +228,7 @@ var testCases = []testCase{
 	// status
 	{
 		request:  get("status"),
-		response: jSon(`{"CrcStatus":"Running","OpenshiftStatus":"Running","OpenshiftVersion":"4.5.1","DiskUse":10000000000,"DiskSize":20000000000,"Error":"","Success":true,"Preset":"openshift"}`),
+		response: jSon(`{"CrcStatus":"Running","OpenshiftStatus":"Running","OpenshiftVersion":"4.5.1","PodmanVersion":"3.3.1","DiskUse":10000000000,"DiskSize":20000000000,"Error":"","Success":true,"Preset":"openshift"}`),
 	},
 
 	// status with failure

--- a/pkg/crc/api/client/types.go
+++ b/pkg/crc/api/client/types.go
@@ -29,6 +29,7 @@ type ClusterStatusResult struct {
 	CrcStatus        string
 	OpenshiftStatus  string
 	OpenshiftVersion string
+	PodmanVersion    string
 	DiskUse          int64
 	DiskSize         int64
 	Error            string

--- a/pkg/crc/api/handlers.go
+++ b/pkg/crc/api/handlers.go
@@ -84,7 +84,7 @@ func (h *Handler) PowerOff(c *context) error {
 }
 
 func (h *Handler) Start(c *context) error {
-	crcConfig.RegisterSettings(h.Config)
+	crcConfig.UpdateDefaults(h.Config)
 	var parsedArgs client.StartConfig
 	if len(c.requestBody) > 0 {
 		if err := c.Bind(&parsedArgs); err != nil {
@@ -217,7 +217,7 @@ func (h *Handler) UnsetConfig(c *context) error {
 }
 
 func (h *Handler) GetConfig(c *context) error {
-	crcConfig.RegisterSettings(h.Config)
+	crcConfig.UpdateDefaults(h.Config)
 	queries := c.url.Query()
 	var req client.GetOrUnsetConfigRequest
 	for key := range queries {

--- a/pkg/crc/api/handlers.go
+++ b/pkg/crc/api/handlers.go
@@ -54,6 +54,7 @@ func (h *Handler) Status(c *context) error {
 		CrcStatus:        string(res.CrcStatus),
 		OpenshiftStatus:  string(res.OpenshiftStatus),
 		OpenshiftVersion: res.OpenshiftVersion,
+		PodmanVersion:    res.PodmanVersion,
 		DiskUse:          res.DiskUse,
 		DiskSize:         res.DiskSize,
 		Success:          true,

--- a/pkg/crc/config/settings.go
+++ b/pkg/crc/config/settings.go
@@ -157,3 +157,7 @@ func GetNetworkMode(config Storage) network.Mode {
 	}
 	return network.ParseMode(config.Get(NetworkMode).AsString())
 }
+
+func UpdateDefaults(cfg *Config) {
+	RegisterSettings(cfg)
+}


### PR DESCRIPTION
This patch will add podman version to crc status result so that
during api status request it have version info.
```
$ curl -X GET --unix-socket ~/.crc/crc-http.sock http:/c/api/status  | jq .
{
  "CrcStatus": "Stopped",
  "OpenshiftStatus": "",
  "OpenshiftVersion": "",
  "PodmanVersion": "3.4.1",
  "DiskUse": 0,
  "DiskSize": 0,
  "Error": "",
  "Success": true
}
```