### PR TITLE
Status: Add preset info to status cli/api

### DIFF
--- a/cmd/crc/cmd/status.go
+++ b/cmd/crc/cmd/status.go
@@ -11,6 +11,7 @@ import (
 	crcErrors "github.com/code-ready/crc/pkg/crc/errors"
 	"github.com/code-ready/crc/pkg/crc/machine"
 	"github.com/code-ready/crc/pkg/crc/machine/types"
+	"github.com/code-ready/crc/pkg/crc/preset"
 	"github.com/docker/go-units"
 	"github.com/spf13/cobra"
 )
@@ -40,6 +41,7 @@ type status struct {
 	DiskSize         int64                        `json:"diskSize,omitempty"`
 	CacheUsage       int64                        `json:"cacheUsage,omitempty"`
 	CacheDir         string                       `json:"cacheDir,omitempty"`
+	Preset           preset.Preset                `json:"preset"`
 }
 
 func runStatus(writer io.Writer, client machine.Client, cacheDir, outputFormat string) error {
@@ -77,6 +79,7 @@ func getStatus(client machine.Client, cacheDir string) *status {
 		DiskSize:         clusterStatus.DiskSize,
 		CacheUsage:       size,
 		CacheDir:         cacheDir,
+		Preset:           clusterStatus.Preset,
 	}
 }
 

--- a/cmd/crc/cmd/status_test.go
+++ b/cmd/crc/cmd/status_test.go
@@ -54,7 +54,8 @@ func TestJsonStatus(t *testing.T) {
   "diskUsage": 10000000000,
   "diskSize": 20000000000,
   "cacheUsage": 10000,
-  "cacheDir": "%s"
+  "cacheDir": "%s",
+  "preset": "openshift"
 }
 `
 	assert.Equal(t, fmt.Sprintf(expected, strings.ReplaceAll(cacheDir, `\`, `\\`)), out.String())
@@ -84,7 +85,8 @@ func TestJsonStatusWithError(t *testing.T) {
 
 	expected := `{
   "success": false,
-  "error": "broken"
+  "error": "broken",
+  "preset": ""
 }
 `
 	assert.Equal(t, expected, out.String())

--- a/pkg/crc/api/api_client_test.go
+++ b/pkg/crc/api/api_client_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/code-ready/crc/pkg/crc/machine/fakemachine"
 	"github.com/code-ready/crc/pkg/crc/machine/types"
+	"github.com/code-ready/crc/pkg/crc/preset"
 	"github.com/code-ready/crc/pkg/crc/version"
 	"github.com/stretchr/testify/assert"
 )
@@ -71,6 +72,7 @@ func TestStatus(t *testing.T) {
 			DiskUse:          int64(10000000000),
 			DiskSize:         int64(20000000000),
 			Success:          true,
+			Preset:           preset.OpenShift,
 		},
 		statusResult,
 	)

--- a/pkg/crc/api/api_http_test.go
+++ b/pkg/crc/api/api_http_test.go
@@ -228,7 +228,7 @@ var testCases = []testCase{
 	// status
 	{
 		request:  get("status"),
-		response: jSon(`{"CrcStatus":"Running","OpenshiftStatus":"Running","OpenshiftVersion":"4.5.1","DiskUse":10000000000,"DiskSize":20000000000,"Error":"","Success":true}`),
+		response: jSon(`{"CrcStatus":"Running","OpenshiftStatus":"Running","OpenshiftVersion":"4.5.1","DiskUse":10000000000,"DiskSize":20000000000,"Error":"","Success":true,"Preset":"openshift"}`),
 	},
 
 	// status with failure

--- a/pkg/crc/api/client/types.go
+++ b/pkg/crc/api/client/types.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"github.com/code-ready/crc/pkg/crc/machine/types"
+	"github.com/code-ready/crc/pkg/crc/preset"
 )
 
 type VersionResult struct {
@@ -32,6 +33,7 @@ type ClusterStatusResult struct {
 	DiskSize         int64
 	Error            string
 	Success          bool
+	Preset           preset.Preset
 }
 
 type ConsoleResult struct {

--- a/pkg/crc/api/handlers.go
+++ b/pkg/crc/api/handlers.go
@@ -57,6 +57,7 @@ func (h *Handler) Status(c *context) error {
 		DiskUse:          res.DiskUse,
 		DiskSize:         res.DiskSize,
 		Success:          true,
+		Preset:           res.Preset,
 	})
 }
 

--- a/pkg/crc/machine/fakemachine/client.go
+++ b/pkg/crc/machine/fakemachine/client.go
@@ -7,6 +7,7 @@ import (
 	"github.com/code-ready/crc/pkg/crc/machine/state"
 	"github.com/code-ready/crc/pkg/crc/machine/types"
 	"github.com/code-ready/crc/pkg/crc/network"
+	"github.com/code-ready/crc/pkg/crc/preset"
 )
 
 func NewClient() *Client {
@@ -104,6 +105,7 @@ func (c *Client) Status() (*types.ClusterStatusResult, error) {
 		PodmanVersion:    "3.3.1",
 		DiskUse:          10_000_000_000,
 		DiskSize:         20_000_000_000,
+		Preset:           preset.OpenShift,
 	}, nil
 }
 

--- a/pkg/crc/machine/status.go
+++ b/pkg/crc/machine/status.go
@@ -9,6 +9,7 @@ import (
 	"github.com/code-ready/crc/pkg/crc/logging"
 	"github.com/code-ready/crc/pkg/crc/machine/state"
 	"github.com/code-ready/crc/pkg/crc/machine/types"
+	"github.com/code-ready/crc/pkg/crc/preset"
 	"github.com/pkg/errors"
 )
 
@@ -37,8 +38,10 @@ func (client *client) Status() (*types.ClusterStatusResult, error) {
 		if vm.bundle.IsOpenShift() {
 			clusterStatusResult.OpenshiftStatus = types.OpenshiftStopped
 			clusterStatusResult.OpenshiftVersion = vm.bundle.GetOpenshiftVersion()
+			clusterStatusResult.Preset = preset.OpenShift
 		} else {
 			clusterStatusResult.PodmanVersion = vm.bundle.GetPodmanVersion()
+			clusterStatusResult.Preset = preset.Podman
 		}
 		return clusterStatusResult, nil
 	}
@@ -57,8 +60,10 @@ func (client *client) Status() (*types.ClusterStatusResult, error) {
 	if vm.bundle.IsOpenShift() {
 		clusterStatusResult.OpenshiftStatus = getOpenShiftStatus(context.Background(), ip)
 		clusterStatusResult.OpenshiftVersion = vm.bundle.GetOpenshiftVersion()
+		clusterStatusResult.Preset = preset.OpenShift
 	} else {
 		clusterStatusResult.PodmanVersion = vm.bundle.GetPodmanVersion()
+		clusterStatusResult.Preset = preset.Podman
 	}
 	return clusterStatusResult, nil
 }

--- a/pkg/crc/machine/types/types.go
+++ b/pkg/crc/machine/types/types.go
@@ -60,6 +60,7 @@ type ClusterStatusResult struct {
 	PodmanVersion    string
 	DiskUse          int64
 	DiskSize         int64
+	Preset           crcpreset.Preset
 }
 
 type OpenshiftStatus string


### PR DESCRIPTION
With this patch status should have preset info.
```
$ ./crc status -ojson
{
  "success": true,
  "crcStatus": "Running",
  "podmanVersion": "3.4.1",
  "diskUsage": 1819049984,
  "diskSize": 32737570816,
  "cacheUsage": 60192582304,
  "cacheDir": "/home/prkumar/.crc/cache",
  "preset": "podman"
}

$ curl -X GET --unix-socket ~/.crc/crc-http.sock http:/c/api/status  | jq .
{
  "CrcStatus": "Running",
  "OpenshiftStatus": "",
  "OpenshiftVersion": "",
  "DiskUse": 1819029504,
  "DiskSize": 32737570816,
  "Error": "",
  "Success": true,
  "Preset": "podman"
}

```