### PR TITLE
Expose cockpit port(9090) in case of podman preset

### DIFF
--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -322,6 +322,9 @@ func (client *client) Start(ctx context.Context, startConfig types.StartConfig) 
 		// **************************
 		//  END OF PODMAN START CODE
 		// **************************
+		if err := dns.AddPodmanHosts(instanceIP); err != nil {
+			return nil, errors.Wrap(err, "Failed to add podman host dns entry")
+		}
 		return &types.StartResult{
 			Status: vmState,
 		}, nil

--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -244,7 +244,7 @@ func (client *client) Start(ctx context.Context, startConfig types.StartConfig) 
 	}
 
 	if client.useVSock() {
-		if err := exposePorts(); err != nil {
+		if err := exposePorts(startConfig.Preset); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/crc/services/dns/dns.go
+++ b/pkg/crc/services/dns/dns.go
@@ -141,3 +141,7 @@ func addOpenShiftHosts(serviceConfig services.ServicePostStartConfig) error {
 		serviceConfig.BundleMetadata.GetAppHostname("canary-openshift-ingress-canary"),
 		serviceConfig.BundleMetadata.GetAppHostname("default-route-openshift-image-registry"))
 }
+
+func AddPodmanHosts(ip string) error {
+	return adminhelper.UpdateHostsFile(ip, "podman.crc.testing")
+}


### PR DESCRIPTION
This patch open the port as per preset. In case of Openshift it is
unchanged and in case of podman it expose cockpit port 9090.
