### PR TITLE
e2e fix bundle default path with blank spaces

### DIFF
--- a/test/e2e/crcsuite/crcsuite.go
+++ b/test/e2e/crcsuite/crcsuite.go
@@ -436,7 +436,7 @@ func SetConfigPropertyToValueSucceedsOrFails(property string, value string, expe
 	if value == "current bundle" {
 		if bundleEmbedded {
 			if installerBuild != "false" {
-				value = filepath.Join(cmd.GetCRCBinaryPath(), bundleName)
+				value = fmt.Sprintf(`"%s"`, filepath.Join(cmd.GetCRCBinaryPath(), bundleName))
 			} else {
 				value = filepath.Join(CRCHome, "cache", bundleName)
 			}


### PR DESCRIPTION
This is a following PR for #2901. Previous PR was merged before testing had the green pass. On macos and windows bundle path contains blank spaces, so it is required to pass the full path with quotes. 