### PR TITLE
API: Add preset info as part of machine client

### DIFF
--- a/pkg/crc/machine/client.go
+++ b/pkg/crc/machine/client.go
@@ -8,6 +8,7 @@ import (
 	"github.com/code-ready/crc/pkg/crc/machine/state"
 	"github.com/code-ready/crc/pkg/crc/machine/types"
 	"github.com/code-ready/crc/pkg/crc/network"
+	crcPreset "github.com/code-ready/crc/pkg/crc/preset"
 	"github.com/kofalt/go-memoize"
 )
 
@@ -24,6 +25,7 @@ type Client interface {
 	Stop() (state.State, error)
 	IsRunning() (bool, error)
 	GenerateBundle(forceStop bool) error
+	GetPreset() crcPreset.Preset
 }
 
 type client struct {
@@ -45,6 +47,10 @@ func NewClient(name string, debug bool, config crcConfig.Storage) Client {
 
 func (client *client) GetName() string {
 	return client.name
+}
+
+func (client *client) GetPreset() crcPreset.Preset {
+	return crcConfig.GetPreset(client.config)
 }
 
 func (client *client) useVSock() bool {

--- a/pkg/crc/machine/fakemachine/client.go
+++ b/pkg/crc/machine/fakemachine/client.go
@@ -116,3 +116,7 @@ func (c *Client) Exists() (bool, error) {
 func (c *Client) IsRunning() (bool, error) {
 	return true, nil
 }
+
+func (c *Client) GetPreset() preset.Preset {
+	return preset.OpenShift
+}

--- a/pkg/crc/machine/sync.go
+++ b/pkg/crc/machine/sync.go
@@ -9,6 +9,7 @@ import (
 	"github.com/code-ready/crc/pkg/crc/logging"
 	"github.com/code-ready/crc/pkg/crc/machine/state"
 	"github.com/code-ready/crc/pkg/crc/machine/types"
+	crcPreset "github.com/code-ready/crc/pkg/crc/preset"
 )
 
 const startCancelTimeout = 15 * time.Second
@@ -168,11 +169,13 @@ func (s *Synchronized) Status() (*types.ClusterStatusResult, error) {
 		return &types.ClusterStatusResult{
 			CrcStatus:       state.Starting,
 			OpenshiftStatus: types.OpenshiftStarting,
+			Preset:          s.underlying.GetPreset(),
 		}, nil
 	case Stopping, Deleting:
 		return &types.ClusterStatusResult{
 			CrcStatus:       state.Stopping,
 			OpenshiftStatus: types.OpenshiftStopping,
+			Preset:          s.underlying.GetPreset(),
 		}, nil
 	default:
 		return s.underlying.Status()
@@ -185,4 +188,8 @@ func (s *Synchronized) IsRunning() (bool, error) {
 
 func (s *Synchronized) GenerateBundle(forceStop bool) error {
 	return s.underlying.GenerateBundle(forceStop)
+}
+
+func (s *Synchronized) GetPreset() crcPreset.Preset {
+	return s.underlying.GetPreset()
 }

--- a/pkg/crc/machine/sync_test.go
+++ b/pkg/crc/machine/sync_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/code-ready/crc/pkg/crc/machine/state"
 	"github.com/code-ready/crc/pkg/crc/machine/types"
+	crcPreset "github.com/code-ready/crc/pkg/crc/preset"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -168,4 +169,8 @@ func (m *waitingMachine) Stop() (state.State, error) {
 
 func (m *waitingMachine) GenerateBundle(forceStop bool) error {
 	return errors.New("not implemented")
+}
+
+func (m *waitingMachine) GetPreset() crcPreset.Preset {
+	return crcPreset.OpenShift
 }


### PR DESCRIPTION
Using this patch, status api should now return the preset info
as part of starting/stopping/deleting state.

```
{
  CrcStatus: 'Stopping',
  OpenshiftStatus: 'Stopping',
  OpenshiftVersion: '',
  PodmanVersion: '',
  DiskUse: 0,
  DiskSize: 0,
  Error: '',
  Success: true,
  Preset: 'openshift'
}
```

fixes: #2905