### PR TITLE
delete: Ignore errors loading bundle metadata

### DIFF
--- a/pkg/crc/machine/delete.go
+++ b/pkg/crc/machine/delete.go
@@ -9,7 +9,7 @@ import (
 
 func (client *client) Delete() error {
 	vm, err := loadVirtualMachine(client.name, client.useVSock())
-	if err != nil {
+	if err != nil && !errors.Is(err, errInvalidBundleMetadata) {
 		return errors.Wrap(err, "Cannot load machine")
 	}
 	defer vm.Close()

--- a/pkg/crc/machine/virtualmachine.go
+++ b/pkg/crc/machine/virtualmachine.go
@@ -32,6 +32,8 @@ func (err *MissingHostError) Error() string {
 	return fmt.Sprintf("no such libmachine vm: %s", err.name)
 }
 
+var errInvalidBundleMetadata = errors.New("Error loading bundle metadata")
+
 func loadVirtualMachine(name string, useVSock bool) (*virtualMachine, error) {
 	apiClient := libmachine.NewClient(constants.MachineBaseDir)
 	exists, err := apiClient.Exists(name)
@@ -49,7 +51,7 @@ func loadVirtualMachine(name string, useVSock bool) (*virtualMachine, error) {
 
 	crcBundleMetadata, err := getBundleMetadataFromDriver(libmachineHost.Driver)
 	if err != nil {
-		return nil, errors.Wrap(err, "Error loading bundle metadata")
+		err = errInvalidBundleMetadata
 	}
 
 	return &virtualMachine{
@@ -58,7 +60,7 @@ func loadVirtualMachine(name string, useVSock bool) (*virtualMachine, error) {
 		bundle: crcBundleMetadata,
 		api:    apiClient,
 		vsock:  useVSock,
-	}, nil
+	}, err
 }
 
 func (vm *virtualMachine) Close() error {


### PR DESCRIPTION
commit 60dcd9ffa8446 introduced a regression with `crc delete`, if a
crc VM exists, but ~/.crc/cache is removed, then `crc delete` will error
out [1] instead of ignoring the error and sucessfully deleting the VM.

This commit adds a specific error for bundle loading issues so that
Delete() can ignore these errors.

This fixes https://github.com/code-ready/crc/issues/2891

[1] `Cannot load machine: Error loading bundle metadata: could not find
cached bundle info in /home/prkumar/.crc/cache/crc_podman_libvirt_3.4.1:
stat /home/prkumar/.crc/cache/crc_podman_libvirt_3.4.1: no such file or
directory`