### PR TITLE
[Msi electron tray] add AppUserModelID to the shortcuts

### DIFF
--- a/packaging/windows/WixUI_HK.wxs
+++ b/packaging/windows/WixUI_HK.wxs
@@ -74,7 +74,7 @@
 
       <UIRef Id="WixUI_Common" />
 
-      <CustomAction Id="CA_Set_WIXUI_EXITDIALOGOPTIONALTEXT" Property="WIXUI_EXITDIALOGOPTIONALTEXT" Value="To finish installation of  [ProductName] please restart your computer. After restart Open PowerShell or Command Prompt and run the command 'crc.exe setup' to setup your environment."/>
+      <CustomAction Id="CA_Set_WIXUI_EXITDIALOGOPTIONALTEXT" Property="WIXUI_EXITDIALOGOPTIONALTEXT" Value="To finish installation of  [ProductName] please restart your computer."/>
       <CustomAction Id="CA_Set_WIXUI_EXITDIALOGOPTIONALTEXT_NOREBOOT" Property="WIXUI_EXITDIALOGOPTIONALTEXT" Value="Suceesfully installed [ProductName]. You can now start [ProductName] from the Start menu."/>
       <InstallUISequence>
          <Custom Action="CA_Set_WIXUI_EXITDIALOGOPTIONALTEXT" After="FindRelatedProducts"><![CDATA[NOT WIX_UPGRADE_DETECTED]]></Custom>

--- a/packaging/windows/product.wxs.template
+++ b/packaging/windows/product.wxs.template
@@ -64,15 +64,27 @@
             </Directory>
             <Directory Id="StartupFolder">
                 <Component Id="TrayStartup" Guid="*">
-                    <Shortcut Id="TrayStartupShortcut" Name="CodeReady Containers" Target="[INSTALLDIR]crc-tray.exe" Icon="crcicon.ico" WorkingDirectory="AppDataFolder"/>
+                    <Shortcut Id="TrayStartupShortcut" 
+                            Name="CodeReady Containers" 
+                            Target="[INSTALLDIR]crc-tray.exe" 
+                            Icon="crcicon.ico" 
+                            WorkingDirectory="AppDataFolder">
+                        <ShortcutProperty Key="System.AppUserModel.ID" Value="redhat.codereadycontainers.tray"/>
+                    </Shortcut>
                     <RemoveFile Id="RemoveTrayShortCut" Name="CodeReady Containers" On="uninstall"/>
                     <RegistryValue Root="HKCU" Key="Software\Red Hat\CodeReady Containers" Name="installed" Type="integer" Value="1" KeyPath="yes"/>
                 </Component>
             </Directory>
             <Directory Id="ProgramMenuFolder">
                 <Component Id="StartMenuEntry" Guid="*">
-                    <Shortcut Id="TrayStartMenuEntry" Name="CodeReady Containers" Target="[INSTALLDIR]crc-tray.exe" Icon="crcicon.ico" WorkingDirectory="AppDataFolder"/>
-                    <RemoveFile Id="RemoveStartMenuEntry" Name="CodeReady Containers" On="uninstall"/>
+                    <Shortcut Id="TrayStartMenuEntry" 
+                            Name="CodeReady Containers" 
+                            Target="[INSTALLDIR]crc-tray.exe" 
+                            Icon="crcicon.ico" 
+                            WorkingDirectory="AppDataFolder">
+                        <ShortcutProperty Key="System.AppUserModel.ID" Value="redhat.codereadycontainers.tray"/>
+                    </Shortcut>
+                    <RemoveFile Id="RemoveStartMenuEntry" Name="CodeReady Containers" On="uninstall" />
                     <RegistryValue Root="HKCU" Key="Software\Red Hat\CodeReady Containers" Name="startmenu" Type="integer" Value="1" KeyPath="yes"/>
                 </Component>
             </Directory>


### PR DESCRIPTION
The notifications on windows now correctly shows the name "CodeReady Containers" instead of the appid
![image](https://user-images.githubusercontent.com/8885742/148738663-c6660ea9-203d-4785-8bc2-4f5d85fcb7c7.png)
