### PR TITLE
Segment: Send error to debug log instead stderr

### DIFF
--- a/pkg/crc/segment/segment.go
+++ b/pkg/crc/segment/segment.go
@@ -250,7 +250,7 @@ func (l *loggingAdapter) Logf(format string, args ...interface{}) {
 }
 
 func (l *loggingAdapter) Errorf(format string, args ...interface{}) {
-	logging.Errorf(format, args...)
+	logging.Debugf(format, args...)
 }
 
 func errorType(err error) string {


### PR DESCRIPTION
Currently segment logger which we attach is sending error to stderr
using `logging.Errorf`. With this PR it is send to debug using `logging.Debugf`
which will avoid confusion for the users in case there is issue to accessing
the segment api due to network connectivity or in general.

```
---- Current Scenario -----
ERRO sending request - Post "https://api.segment.io/v1/batch": dial tcp: lookup api.segment.io: no such host
ERRO 1 messages dropped because they failed to be sent and the client was closed

--- With this PR ----
DEBU sending request - Post "https://api.segment.io/v1/batch": dial tcp: lookup api.segment.io: no such host
DEBU 1 messages dropped because they failed to be sent and the client was closed
```
