### PR TITLE
Preflight: Improve bundle download to recover from ctrl+c and resume

### DIFF
--- a/pkg/crc/preflight/preflight_checks_common.go
+++ b/pkg/crc/preflight/preflight_checks_common.go
@@ -95,6 +95,8 @@ func fixBundleExtracted(bundlePath string, preset preset.Preset) func() error {
 				/* This message needs to be improved when the bundle has been set in crc config for example */
 				return fmt.Errorf("%s is invalid or missing, run 'crc setup' to download the bundle", bundlePath)
 			}
+		}
+		if bundlePath == constants.GetDefaultBundlePath(preset) {
 			logging.Infof("Downloading %s", constants.GetDefaultBundle(preset))
 			if err := bundle.Download(preset); err != nil {
 				return err


### PR DESCRIPTION
Currently during the bundle download if user press `ctrl+c` or network
drop happen then `crc setup` fails to extract the bundle because downloaded
bundle is corrupt one and there is no sha256sum check in place. This PR adjust
the bundle download such that it always run in case user doesn't specify custom
bundle as part of setup command and download function have sha256sum verification
in place which take care of resuming the download in case it corrupted.

```
$ crc setup
...
INFO Downloading crc_podman_hyperkit_3.4.2.crcbundle
47.23 MiB / 683.84 MiB [-------->_________________________________________________________________________________________________________________] 6.91% 32.63 MiB p/s^C

$ crc setup
INFO Downloading crc_podman_hyperkit_3.4.2.crcbundle
122.70 MiB / 683.84 MiB [--------------------->__________________________________________________________________________________________________] 17.94% 26.95 MiB p/s^C

$ crc setup
INFO Downloading crc_podman_hyperkit_3.4.2.crcbundle
0 B / 683.84 MiB [________________________________________________________________________________________________________________________________________] 0.00% ? p/s
INFO Uncompressing /Users/prkumar/.crc/cache/crc_podman_hyperkit_3.4.2.crcbundle
crc-podman.qcow2: 515.87 MiB / 1.62 GiB [------------------------------------>_________________________________________________________________________________] 31.15%^C
```

fixes: #2860


