### PR TITLE
Start: Switch between preset without a delete

### DIFF
--- a/pkg/crc/machine/delete.go
+++ b/pkg/crc/machine/delete.go
@@ -2,7 +2,9 @@ package machine
 
 import (
 	"os"
+	"path/filepath"
 
+	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/code-ready/crc/pkg/crc/logging"
 	"github.com/pkg/errors"
 )
@@ -23,6 +25,10 @@ func (client *client) Delete() error {
 		if err := unexposePorts(); err != nil {
 			return err
 		}
+	}
+	presetDir := filepath.Join(constants.MachineInstanceDir, client.GetPreset().String())
+	if err := os.RemoveAll(presetDir); err != nil {
+		return errors.Wrapf(err, "Not able to remove %s", presetDir)
 	}
 
 	if err := cleanKubeconfig(getGlobalKubeConfigPath(), getGlobalKubeConfigPath()); err != nil {

--- a/pkg/os/util.go
+++ b/pkg/os/util.go
@@ -119,3 +119,67 @@ func RunningInTerminal() bool {
 func RunningUsingSSH() bool {
 	return os.Getenv("SSH_TTY") != ""
 }
+
+// CopyDirectory recursively copies a src directory to a destination.
+func CopyDirectory(src, dst string) error {
+	entries, err := ioutil.ReadDir(src)
+	if err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		sourcePath := filepath.Join(src, entry.Name())
+		destPath := filepath.Join(dst, entry.Name())
+
+		fileInfo, err := os.Stat(sourcePath)
+		if err != nil {
+			return err
+		}
+
+		switch fileInfo.Mode() & os.ModeType {
+		case os.ModeDir:
+			if err := createDir(destPath, 0755); err != nil {
+				return err
+			}
+			if err := CopyDirectory(sourcePath, destPath); err != nil {
+				return err
+			}
+		case os.ModeSymlink:
+			if err := copySymLink(sourcePath, destPath); err != nil {
+				return err
+			}
+		default:
+			if err := CopyFileContents(sourcePath, destPath, fileInfo.Mode()); err != nil {
+				return err
+			}
+		}
+
+		isSymlink := entry.Mode()&os.ModeSymlink != 0
+		if !isSymlink {
+			if err := os.Chmod(destPath, entry.Mode()); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func createDir(dir string, perm os.FileMode) error {
+	if FileExists(dir) {
+		return nil
+	}
+
+	if err := os.MkdirAll(dir, perm); err != nil {
+		return fmt.Errorf("failed to create directory: '%s', error: '%s'", dir, err.Error())
+	}
+
+	return nil
+}
+
+// copySymLink copies a symbolic link from src to dst.
+func copySymLink(src, dst string) error {
+	link, err := os.Readlink(src)
+	if err != nil {
+		return err
+	}
+	return os.Symlink(link, dst)
+}


### PR DESCRIPTION
This PR adds a symlink creation function which create the symlink
to respective preset before creating the instance. It will allow
user to switch preset without deleting the existing vm but it has
to be stopped first.

/hold

This need to be tested on windows and some more checks are required before it become mergeable. 
- We do need to check if any of preset in running state before starting the preset.
- Handle the situation if user already have `~/.crc/machine/crc` folder and didn't deleted before this change.