### PR TITLE
MacOS Tray: Fix the tray name for plist file

### DIFF
--- a/pkg/crc/constants/constants_darwin.go
+++ b/pkg/crc/constants/constants_darwin.go
@@ -19,7 +19,7 @@ var (
 
 func TrayExecutablePath() string {
 	if version.IsInstaller() {
-		return filepath.Clean(filepath.Join(version.InstallPath(), "..", "MacOS", "CodeReady Containers"))
+		return filepath.Clean(filepath.Join(version.InstallPath(), "..", "MacOS", "crc-tray"))
 	}
 	// Should not be reached, tray is only supported on installer builds
 	return filepath.Clean(filepath.Join(BinDir(), "CodeReady Containers"))

--- a/pkg/crc/preflight/preflight_checks_tray_darwin.go
+++ b/pkg/crc/preflight/preflight_checks_tray_darwin.go
@@ -11,6 +11,7 @@ import (
 	"github.com/code-ready/crc/pkg/crc/daemonclient"
 	crcerrors "github.com/code-ready/crc/pkg/crc/errors"
 	"github.com/code-ready/crc/pkg/crc/logging"
+	"github.com/code-ready/crc/pkg/crc/version"
 	"github.com/code-ready/crc/pkg/os/launchd"
 )
 
@@ -72,6 +73,9 @@ func unLoadDaemonAgent() error {
 }
 
 func checkIfTrayAgentRunning() error {
+	if version.IsInstaller() {
+		return nil
+	}
 	if !launchd.AgentRunning(trayAgentLabel) {
 		return fmt.Errorf("Tray is not running")
 	}
@@ -97,6 +101,9 @@ func fixPlistFileExists(agentConfig launchd.AgentConfig) error {
 		return err
 	}
 	// load plist
+	if version.IsInstaller() {
+		return nil
+	}
 	if err := launchd.LoadPlist(agentConfig.Label); err != nil {
 		logging.Debug("failed while creating plist:", err.Error())
 		return err


### PR DESCRIPTION
Currently plist file is using old name of tray and that's the reason
it was not loaded during the setup or removed during the cleanup.

With released binary now `crc cleanup` unload and remove the plist file for tray.
```
DEBU Running 'crc cleanup'
INFO Unload CodeReady Containers tray
DEBU Running 'launchctl unload /Users/prkumar/Library/LaunchAgents/crc.tray.plist'
INFO Removing launchd configuration for tray
INFO Removing /etc/resolver/testing file
INFO Unload CodeReady Containers daemon
```


**Fixes:** #2947