### PR TITLE
[WIP] Print JSON status of preflight checks

### DIFF
--- a/cmd/crc/cmd/setup.go
+++ b/cmd/crc/cmd/setup.go
@@ -74,7 +74,7 @@ func runSetup(arguments []string) error {
 		err = exec.CodeExitError{
 			Err:  err,
 			Code: preflightFailedExitCode,
-		}
+		} 
 	}
 
 	return render(&setupResult{

--- a/cmd/crc/cmd/setup.go
+++ b/cmd/crc/cmd/setup.go
@@ -24,6 +24,7 @@ func init() {
 	setupCmd.Flags().Bool(crcConfig.ExperimentalFeatures, false, "Allow the use of experimental features")
 	setupCmd.Flags().StringP(crcConfig.Bundle, "b", constants.GetDefaultBundlePath(crcConfig.GetPreset(config)), "Bundle to use for VM")
 	setupCmd.Flags().BoolVar(&checkOnly, "check-only", false, "Only run the preflight checks, don't try to fix any misconfiguration")
+	setupCmd.Flags().Bool(crcConfig.JSONStream, false, "Write o/p stream in JSON format to Stdout")
 	addOutputFormatFlag(setupCmd)
 	rootCmd.AddCommand(setupCmd)
 }

--- a/cmd/crc/cmd/setup.go
+++ b/cmd/crc/cmd/setup.go
@@ -37,11 +37,16 @@ var setupCmd = &cobra.Command{
 		if err := viper.BindFlagSet(cmd.Flags()); err != nil {
 			return err
 		}
+
 		return runSetup(args)
 	},
 }
 
 func runSetup(arguments []string) error {
+	if config.Get(crcConfig.JSONStream).AsBool() {
+		constants.JSONStream = true
+	}
+
 	if config.Get(crcConfig.ConsentTelemetry).AsString() == "" {
 		fmt.Println("CodeReady Containers is constantly improving and we would like to know more about usage (more details at https://developers.redhat.com/article/tool-data-collection)")
 		fmt.Println("Your preference can be changed manually if desired using 'crc config set consent-telemetry <yes/no>'")

--- a/pkg/crc/config/settings.go
+++ b/pkg/crc/config/settings.go
@@ -32,6 +32,7 @@ const (
 	AutostartTray           = "autostart-tray"
 	KubeAdminPassword       = "kubeadmin-password"
 	Preset                  = "preset"
+	JSONStream              = "json-stream"
 )
 
 func RegisterSettings(cfg *Config) {
@@ -96,6 +97,8 @@ func RegisterSettings(cfg *Config) {
 		"Disable update check (true/false, default: false)")
 	cfg.AddSetting(ExperimentalFeatures, false, ValidateBool, SuccessfullyApplied,
 		"Enable experimental features (true/false, default: false)")
+	cfg.AddSetting(JSONStream, false, ValidateBool, SuccessfullyApplied,
+		"Write o/p stream of setup command in JSON format to Stdout")
 
 	if !version.IsInstaller() {
 		cfg.AddSetting(NetworkMode, string(defaultNetworkMode()), network.ValidateMode, network.SuccessfullyAppliedMode,

--- a/pkg/crc/constants/constants.go
+++ b/pkg/crc/constants/constants.go
@@ -94,6 +94,7 @@ var (
 	MachineInstanceDir = filepath.Join(MachineBaseDir, "machines")
 	DaemonSocketPath   = filepath.Join(CrcBaseDir, "crc.sock")
 	KubeconfigFilePath = filepath.Join(MachineInstanceDir, DefaultName, "kubeconfig")
+	JSONStream         = false
 )
 
 func GetDefaultBundlePath(preset crcpreset.Preset) string {

--- a/pkg/crc/preflight/preflight.go
+++ b/pkg/crc/preflight/preflight.go
@@ -76,7 +76,7 @@ func printJSONResult(res *checkResult) {
 	defer func() {
 		id++
 	}()
-	bin, err := json.MarshalIndent(res, "", "  ")
+	bin, err := json.Marshal(res)
 	if err != nil {
 		panic("error while encoding to JSON")
 	}
@@ -184,7 +184,7 @@ func doFixPreflightChecks(config crcConfig.Storage, checks []Check, checkOnly bo
 			"total": len(checksToRun),
 		}
 
-		j, err := json.MarshalIndent(total, "", "  ")
+		j, err := json.Marshal(total)
 		if err != nil {
 			panic("error while encoding to JSON")
 		}

--- a/pkg/download/download.go
+++ b/pkg/download/download.go
@@ -19,12 +19,14 @@ import (
 )
 
 type stats struct {
-	TotalBytes     int64 `json:"totalBytes"`
-	CompletedBytes int64 `json:"completedBytes"`
+	Type           string `json:"type"`
+	Filename       string `json:"filename"`
+	TotalBytes     int64  `json:"totalBytes"`
+	CompletedBytes int64  `json:"completedBytes"`
 }
 
 func getStatsJSON(d *stats) string {
-	bin, err := json.MarshalIndent(d, "", "  ")
+	bin, err := json.Marshal(d)
 	if err != nil {
 		panic("error while encoding to JSON")
 	}
@@ -52,7 +54,7 @@ loop:
 		case <-t.C:
 			bar.SetCurrent(resp.BytesComplete())
 			if constants.JSONStream {
-				fmt.Fprintln(os.Stdout, getStatsJSON(&stats{resp.Size(), resp.BytesComplete()}))
+				fmt.Fprintln(os.Stdout, getStatsJSON(&stats{"download", resp.Filename, resp.Size(), resp.BytesComplete()}))
 			}
 		case <-resp.Done:
 			break loop


### PR DESCRIPTION
Fixes #2935 

This is based on the initial changes done by @cfergeau at https://github.com/cfergeau/crc/commit/447677bd37c6c2ecf3c0055a799cbc7b86f005a8

```
## o/p of `crc setup`
PS C:\Users\anath\redhat\crc> crc setup --json-stream 2> txt
{
  "type": "check",
  "description": "Checking if current user is in Hyper-V Admins group",
  "result": "passed",
  "error": null
}
{
  "type": "check",
  "description": "Checking if CRC bundle is extracted in '$HOME/.crc'",
  "result": "failed",
  "error": {}
}
{
  "totalBytes": 650263232,
  "completedBytes": 255386044
}
{
  "totalBytes": 650263232,
  "completedBytes": 257664726
}
{
  "totalBytes": 650263232,
  "completedBytes": 260318934
}
```