### PR TITLE
[cherry-pick] Improve crc stop message for already stopped cluster

### DIFF
--- a/pkg/crc/machine/stop.go
+++ b/pkg/crc/machine/stop.go
@@ -9,6 +9,9 @@ import (
 )
 
 func (client *client) Stop() (state.State, error) {
+	if running, _ := client.IsRunning(); !running {
+		return state.Error, errors.New("Cluster is already stopped")
+	}
 	vm, err := loadVirtualMachine(client.name, client.useVSock())
 	if err != nil {
 		return state.Error, errors.Wrap(err, "Cannot load machine")


### PR DESCRIPTION
It'll check if machine is already stopped before attempting
to perform the cluster stop related tasks

If a machine is already stopped it prints the following:

```
$ crc stop
Cluster is not running
```