### PR TITLE
e2e: Fix mismatch around cluster and instance

### DIFF
--- a/test/integration/resize_test.go
+++ b/test/integration/resize_test.go
@@ -44,7 +44,7 @@ var _ = Describe("vary VM parameters: memory cpus, disk", func() {
 		})
 
 		It("stop CRC", func() {
-			Expect(RunCRCExpectSuccess("stop", "-f")).To(MatchRegexp("[Ss]topped the OpenShift cluster"))
+			Expect(RunCRCExpectSuccess("stop", "-f")).To(MatchRegexp("[Ss]topped the instance"))
 		})
 
 	})
@@ -75,7 +75,7 @@ var _ = Describe("vary VM parameters: memory cpus, disk", func() {
 		})
 
 		It("stop CRC", func() {
-			Expect(RunCRCExpectSuccess("stop", "-f")).To(MatchRegexp("[Ss]topped the OpenShift cluster"))
+			Expect(RunCRCExpectSuccess("stop", "-f")).To(MatchRegexp("[Ss]topped the instance"))
 		})
 	})
 


### PR DESCRIPTION
It is missed during e2a76bbba5653a2c9046efce6753f075057cda06


