### PR TITLE
Fix `make test-rpmbuild`

### DIFF
--- a/cmd/crc/cmd/daemon_linux.go
+++ b/cmd/crc/cmd/daemon_linux.go
@@ -50,7 +50,7 @@ func listenersWithNames() (map[string][]net.Listener, error) {
 	for _, f := range files {
 		pc, err := net.FileListener(f)
 		if err != nil {
-			logging.Infof("got error %t %v", err, err)
+			logging.Debugf("socket-activation: net.FileListener() error, falling back to mdlayher/vsock.FileListener(): %v", err)
 			// net.FileListener does not support vsock, need to fallback to vsock-specific code
 			pc, err = vsock.FileListener(f)
 			if err != nil {

--- a/images/rpmbuild/Containerfile.in
+++ b/images/rpmbuild/Containerfile.in
@@ -1,4 +1,4 @@
-FROM registry.centos.org/centos
+FROM quay.io/centos/centos:stream8
 WORKDIR $APP_ROOT/src
 RUN yum -y install git-core rpm-build dnf-plugins-core 'dnf-command(builddep)'
 COPY . .


### PR DESCRIPTION
rpmbuild: Switch to centos-stream base image
    
 For `make test-rpmbuild`, we currently are using registry.centos.org/centos
as the base image, but this has started causing build errors lately:
    
 ```
    $ make test-rpmbuild
    podman build -f images/rpmbuild/Containerfile .
    STEP 1/6: FROM registry.centos.org/centos
    STEP 2/6: WORKDIR $APP_ROOT/src
    --> Using cache 7843ca52c49abdbf5bc2b56a55f32697442cc7251cdd69decce6108b26b0c546
    --> 7843ca52c49
    STEP 3/6: RUN yum -y install git-core rpm-build dnf-plugins-core 'dnf-command(builddep)'
    CentOS Linux 8 - AppStream                       63  B/s |  38  B     00:00
    Error: Failed to download metadata for repo 'appstream': Cannot prepare internal mirrorlist: No URLs in mirrorlist
    Error: error building at STEP "RUN yum -y install git-core rpm-build dnf-plugins-core 'dnf-command(builddep)'": error while running runtime: exit status 1
```
    
This commit switches to quay.io/centos/centos:stream8 instead which does not have such issues.
