### PR TITLE
Update golangci-lint to latest version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ CRC_VERSION = 1.99.1
 COMMIT_SHA=$(shell git rev-parse --short HEAD)
 MACOS_INSTALL_PATH = /Applications/CodeReady Containers.app/Contents/Resources
 CONTAINER_RUNTIME ?= podman
-GOLANGCI_LINT_VERSION = v1.43.0
+GOLANGCI_LINT_VERSION = v1.44.0
 
 ifdef OKD_VERSION
     OPENSHIFT_VERSION = $(OKD_VERSION)

--- a/Makefile
+++ b/Makefile
@@ -234,7 +234,7 @@ fmt:
 .PHONY: golangci-lint
 golangci-lint:
 	@if $(GOPATH)/bin/golangci-lint version 2>&1 | grep -vq $(GOLANGCI_LINT_VERSION); then\
-		pushd /tmp && GO111MODULE=on go get github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION) && popd; \
+		go install -mod=mod github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION); \
 	fi
 
 # Run golangci-lint against code

--- a/pkg/crc/cache/cache.go
+++ b/pkg/crc/cache/cache.go
@@ -136,7 +136,7 @@ func (c *Cache) CacheExecutable() error {
 	// Copy the requested asset into its final destination
 	err = os.MkdirAll(c.destDir, 0750)
 	if err != nil {
-		return errors.Wrap(err, "Cannot create the target directory.")
+		return errors.Wrap(err, "cannot create the target directory")
 	}
 
 	for _, extractedFilePath := range extractedFiles {


### PR DESCRIPTION
This also changes the way golangci-lint is installed when it's not available.