### PR TITLE
rpm: Add support for building crc linux releases using rpmbuild

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -256,7 +256,7 @@ gen_release_info:
 
 .PHONY: release
 release: LDFLAGS += -X '$(REPOPATH)/pkg/crc/version.linuxReleaseBuild=true' $(RELEASE_VERSION_VARIABLES)
-release: cross-lint embed_bundle gen_release_info
+release: cross-lint embed_crc_helpers gen_release_info
 	mkdir $(RELEASE_DIR)
 
 	@mkdir -p $(BUILD_DIR)/crc-linux-$(CRC_VERSION)-amd64
@@ -267,8 +267,8 @@ release: cross-lint embed_bundle gen_release_info
 	
 	cd $(RELEASE_DIR) && sha256sum * > sha256sum.txt
 
-.PHONY: embed_bundle
-embed_bundle: clean cross $(HOST_BUILD_DIR)/crc-embedder
+.PHONY: embed_crc_helpers
+embed_crc_helpers: clean cross $(HOST_BUILD_DIR)/crc-embedder
 	$(HOST_BUILD_DIR)/crc-embedder embed --log-level debug --goos=linux $(BUILD_DIR)/linux-amd64/crc
 
 .PHONY: update-go-version

--- a/Makefile
+++ b/Makefile
@@ -333,8 +333,8 @@ $(GOPATH)/bin/gomod2rpmdeps:
 	pushd /tmp && GO111MODULE=on go get github.com/cfergeau/gomod2rpmdeps/cmd/gomod2rpmdeps && popd
 
 %.spec: %.spec.in $(GOPATH)/bin/gomod2rpmdeps
-	@$(GOPATH)/bin/gomod2rpmdeps | sed -e '/__BUNDLED_REQUIRES__/r /dev/stdin' \
-					   -e '/__BUNDLED_REQUIRES__/d' \
+	@$(GOPATH)/bin/gomod2rpmdeps | sed -e '/__BUNDLED_PROVIDES__/r /dev/stdin' \
+					   -e '/__BUNDLED_PROVIDES__/d' \
 					   -e 's/__VERSION__/'$(CRC_VERSION)'/g' \
 					   -e 's/__OPENSHIFT_VERSION__/'$(OPENSHIFT_VERSION)'/g' \
 				       $< >$@

--- a/Makefile
+++ b/Makefile
@@ -264,9 +264,9 @@ macos-release-binary: $(BUILD_DIR)/macos-amd64/crc
 windows-release-binary: LDFLAGS+= -X '$(REPOPATH)/pkg/crc/version.installerBuild=true' $(RELEASE_VERSION_VARIABLES)
 windows-release-binary: $(BUILD_DIR)/windows-amd64/crc.exe
 
-.PHONY: release
-release: LDFLAGS += -X '$(REPOPATH)/pkg/crc/version.linuxReleaseBuild=true' $(RELEASE_VERSION_VARIABLES)
-release: clean cross-lint embed_crc_helpers gen_release_info
+.PHONY: release linux-release
+release: clean linux-release macos-release-binary windows-release-binary check
+linux-release: clean lint linux-release-binary embed_crc_helpers gen_release_info
 	mkdir $(RELEASE_DIR)
 
 	@mkdir -p $(BUILD_DIR)/crc-linux-$(CRC_VERSION)-amd64
@@ -278,7 +278,7 @@ release: clean cross-lint embed_crc_helpers gen_release_info
 	cd $(RELEASE_DIR) && sha256sum * > sha256sum.txt
 
 .PHONY: embed_crc_helpers
-embed_crc_helpers: cross $(HOST_BUILD_DIR)/crc-embedder
+embed_crc_helpers: $(BUILD_DIR)/linux-amd64/crc $(HOST_BUILD_DIR)/crc-embedder
 	$(HOST_BUILD_DIR)/crc-embedder embed --log-level debug --goos=linux $(BUILD_DIR)/linux-amd64/crc
 
 .PHONY: update-go-version

--- a/Makefile
+++ b/Makefile
@@ -279,7 +279,11 @@ linux-release: clean lint linux-release-binary embed_crc_helpers gen_release_inf
 
 .PHONY: embed_crc_helpers
 embed_crc_helpers: $(BUILD_DIR)/linux-amd64/crc $(HOST_BUILD_DIR)/crc-embedder
+ifeq ($(CUSTOM_EMBED),false)
 	$(HOST_BUILD_DIR)/crc-embedder embed --log-level debug --goos=linux $(BUILD_DIR)/linux-amd64/crc
+else
+	$(HOST_BUILD_DIR)/crc-embedder embed --log-level debug --cache-dir=$(EMBED_DOWNLOAD_DIR) --no-download --goos=linux $(BUILD_DIR)/linux-amd64/crc
+endif
 
 .PHONY: update-go-version
 update-go-version:

--- a/Makefile
+++ b/Makefile
@@ -256,7 +256,7 @@ gen_release_info:
 
 .PHONY: release
 release: LDFLAGS += -X '$(REPOPATH)/pkg/crc/version.linuxReleaseBuild=true' $(RELEASE_VERSION_VARIABLES)
-release: cross-lint embed_crc_helpers gen_release_info
+release: clean cross-lint embed_crc_helpers gen_release_info
 	mkdir $(RELEASE_DIR)
 
 	@mkdir -p $(BUILD_DIR)/crc-linux-$(CRC_VERSION)-amd64
@@ -268,7 +268,7 @@ release: cross-lint embed_crc_helpers gen_release_info
 	cd $(RELEASE_DIR) && sha256sum * > sha256sum.txt
 
 .PHONY: embed_crc_helpers
-embed_crc_helpers: clean cross $(HOST_BUILD_DIR)/crc-embedder
+embed_crc_helpers: cross $(HOST_BUILD_DIR)/crc-embedder
 	$(HOST_BUILD_DIR)/crc-embedder embed --log-level debug --goos=linux $(BUILD_DIR)/linux-amd64/crc
 
 .PHONY: update-go-version

--- a/images/openshift-ci/Dockerfile
+++ b/images/openshift-ci/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /go/src/github.com/code-ready/crc
 COPY . .
 RUN make release
 
-FROM registry.centos.org/centos/centos:8
+FROM quay.io/centos/centos:stream8
 COPY --from=builder /go/src/github.com/code-ready/crc /opt/crc
 COPY --from=builder /go/src/github.com/code-ready/crc/out/linux-amd64/crc /bin/crc
 COPY --from=builder /go/src/github.com/code-ready/crc/images/openshift-ci/mock-nss.sh /bin/mock-nss.sh

--- a/images/rpmbuild/Containerfile.in
+++ b/images/rpmbuild/Containerfile.in
@@ -1,6 +1,8 @@
 FROM quay.io/centos/centos:stream8
 WORKDIR $APP_ROOT/src
-RUN yum -y install git-core rpm-build dnf-plugins-core 'dnf-command(builddep)'
+RUN yum -y install git-core rpm-build dnf-plugins-core 'dnf-command(builddep)' \
+        https://github.com/code-ready/admin-helper/releases/download/v0.0.9/crc-admin-helper-0.0.9-1.el8.x86_64.rpm \
+	https://github.com/code-ready/machine-driver-libvirt/releases/download/0.13.1/crc-driver-libvirt-0.13.1-1.el8.x86_64.rpm
 COPY . .
 RUN mkdir -p ~/rpmbuild/SOURCES/ && \
     git archive --format=tar --prefix=crc-__VERSION__-__OPENSHIFT_VERSION__/ HEAD | gzip >~/rpmbuild/SOURCES/crc-__VERSION__.tar.gz

--- a/packaging/rpm/crc.spec.in
+++ b/packaging/rpm/crc.spec.in
@@ -9,6 +9,8 @@ Version:                __VERSION__
 # debuginfo is not supported on RHEL with Go packages
 %global debug_package %{nil}
 %global _enable_debug_package 0
+# disable stripping of binaries/... as this interferes with the embedding used by crc
+%global __os_install_post /usr/lib/rpm/brp-compress %{nil}
 
 %global common_description %{expand:
 CodeReady Container's executable}

--- a/packaging/rpm/crc.spec.in
+++ b/packaging/rpm/crc.spec.in
@@ -1,5 +1,6 @@
 # https://github.com/code-ready/admin-helper
 %global goipath         github.com/code-ready/crc
+%global goname          crc
 Version:                __VERSION__
 %global 	 	openshift_suffix -__OPENSHIFT_VERSION__
 
@@ -59,7 +60,7 @@ install -m 0755 -vd                     %{buildroot}%{_bindir}
 install -m 0755 -vp %{gobuilddir}/src/%{goipath}/out/linux-amd64/crc %{buildroot}%{_bindir}/
 
 install -d %{buildroot}%{_datadir}/%{name}-redistributable/{linux,macos,windows}
-install -m 0755 -vp %{gobuilddir}/src/%{goipath}/out/linux-amd64/crc %{buildroot}%{_datadir}/%{name}-redistributable/linux/
+install -m 0755 -vp %{gobuilddir}/src/%{goipath}/release/* %{buildroot}%{_datadir}/%{name}-redistributable/linux/
 install -m 0755 -vp %{gobuilddir}/src/%{goipath}/out/windows-amd64/crc.exe %{buildroot}%{_datadir}/%{name}-redistributable/windows/
 install -m 0755 -vp %{gobuilddir}/src/%{goipath}/out/macos-amd64/crc %{buildroot}%{_datadir}/%{name}-redistributable/macos/
 

--- a/packaging/rpm/crc.spec.in
+++ b/packaging/rpm/crc.spec.in
@@ -37,7 +37,7 @@ BuildRequires: make
 BuildRequires: crc-admin-helper
 BuildRequires: crc-driver-libvirt
 
-__BUNDLED_REQUIRES__
+__BUNDLED_PROVIDES__
 
 %description
 %{common_description}

--- a/packaging/rpm/crc.spec.in
+++ b/packaging/rpm/crc.spec.in
@@ -34,6 +34,9 @@ BuildRequires: git-core
 BuildRequires: go-srpm-macros
 BuildRequires: make
 
+BuildRequires: crc-admin-helper
+BuildRequires: crc-driver-libvirt
+
 __BUNDLED_REQUIRES__
 
 %description
@@ -52,7 +55,11 @@ ln -fs "$(pwd)" "%{gobuilddir}/src/%{goipath}"
 
 %build
 export GOFLAGS="-mod=vendor"
-make GO_EXTRA_LDFLAGS="-B 0x$(head -c20 /dev/urandom|od -An -tx1|tr -d ' \n')" GO_EXTRA_BUILDFLAGS="" cross
+mkdir embed-files
+cp /usr/bin/crc-driver-libvirt embed-files
+cp /usr/bin/crc-admin-helper embed-files/crc-admin-helper-linux
+make GO_EXTRA_LDFLAGS="-B 0x$(head -c20 /dev/urandom|od -An -tx1|tr -d ' \n')" GO_EXTRA_BUILDFLAGS="" CUSTOM_EMBED=true EMBED_DOWNLOAD_DIR=embed-files/ linux-release
+make GO_EXTRA_LDFLAGS="-B 0x$(head -c20 /dev/urandom|od -An -tx1|tr -d ' \n')" GO_EXTRA_BUILDFLAGS="" macos-release-binary windows-release-binary
 
 %install
 # with fedora macros: gopkginstall

--- a/pkg/compress/compress_test.go
+++ b/pkg/compress/compress_test.go
@@ -28,7 +28,7 @@ func testCompress(t *testing.T, baseDir string) {
 	// This is useful to check that the top-level directory of the archive
 	// was created with the correct permissions, and was not created by the
 	// `os.MkdirAll(0750)` call at the beginning of `untarFile`
-	require.NoError(t, os.Chmod(baseDir, 0700))
+	require.NoError(t, os.Chmod(baseDir, 0755))
 	require.NoError(t, Compress(baseDir, testArchiveName))
 	defer os.Remove(testArchiveName)
 
@@ -42,7 +42,7 @@ func testCompress(t *testing.T, baseDir string) {
 	_, d := filepath.Split(baseDir)
 	fi, err := os.Stat(filepath.Join(destDir, d))
 	require.NoError(t, err)
-	fMode := os.FileMode(0700)
+	fMode := os.FileMode(0755)
 	if runtime.GOOS == "windows" {
 		// https://golang.org/pkg/os/#Chmod
 		fMode = os.FileMode(0777)


### PR DESCRIPTION
At the moment, linux releases are built on a crc-specific jenkins instance. This PR improves the rpm spec file in crc source so that it can be used to generate a linux release tarball.
It also builds windows/macos binaries with the proper release flags, which could then be reused in the build process for their respective installers.