### PR TITLE
CI: Add integration test binary to final image

### DIFF
--- a/images/openshift-ci/Dockerfile
+++ b/images/openshift-ci/Dockerfile
@@ -9,6 +9,7 @@ RUN make release
 FROM registry.centos.org/centos/centos:8
 COPY --from=builder /go/src/github.com/code-ready/crc /opt/crc
 COPY --from=builder /go/src/github.com/code-ready/crc/out/linux-amd64/crc /bin/crc
+COPY --from=builder /go/src/github.com/code-ready/crc/out/linux-amd64/e2e.test /bin/e2e.test
 COPY --from=builder /go/src/github.com/code-ready/crc/images/openshift-ci/mock-nss.sh /bin/mock-nss.sh
 COPY --from=builder /go/src/github.com/code-ready/crc/images/openshift-ci/google-cloud-sdk.repo /etc/yum.repos.d/google-cloud-sdk.repo
 


### PR DESCRIPTION
We should directly use integration test binary against the built
crc binary to perform the integration test on the openshift CI. Instead
of dumping the complete crc directory to final image and running `make
release`.

With this commit I am not removing the old crc directory dump to make
sure CI is green and then on openshift/release repo we can use this to
make sure it works with e2e test binary.


