### PR TITLE
Used named pipe to expose podman sock on windows

### DIFF
--- a/cmd/crc/cmd/podman_env.go
+++ b/cmd/crc/cmd/podman_env.go
@@ -54,6 +54,8 @@ func runPodmanEnv() error {
 	// https://docs.docker.com/desktop/faqs/#how-do-i-connect-to-the-remote-docker-engine-api
 	if runtime.GOOS != "windows" {
 		fmt.Println(shell.GetEnvString(userShell, "DOCKER_HOST", fmt.Sprintf("unix://%s", constants.GetHostDockerSocketPath())))
+	} else {
+		fmt.Println(shell.GetEnvString(userShell, "DOCKER_HOST", "npipe:////./pipe/crc-podman"))
 	}
 	fmt.Println(shell.GenerateUsageHintWithComment(userShell, "crc podman-env"))
 	return nil

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.2
 	github.com/Masterminds/semver/v3 v3.1.1
-	github.com/Microsoft/go-winio v0.5.1
+	github.com/Microsoft/go-winio v0.5.2
 	github.com/RedHatQE/gowinx v0.0.3
 	github.com/StackExchange/wmi v1.2.1
 	github.com/YourFin/binappend v0.0.0-20181105185800-0add4bf0b9ad
@@ -78,3 +78,5 @@ replace (
 	k8s.io/client-go => github.com/openshift/kubernetes-client-go v0.0.0-20210826123502-7208c21f5119
 	k8s.io/kubectl => github.com/openshift/kubernetes-kubectl v0.0.0-20210730111826-9c6734b9d97d
 )
+
+replace github.com/containers/gvisor-tap-vsock => github.com/praveenkumar/gvisor-tap-vsock v0.3.1-0.20220223095915-137f40464097

--- a/go.sum
+++ b/go.sum
@@ -76,8 +76,9 @@ github.com/Microsoft/go-winio v0.4.17-0.20210211115548-6eac466e5fa3/go.mod h1:JP
 github.com/Microsoft/go-winio v0.4.17-0.20210324224401-5516f17a5958/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
 github.com/Microsoft/go-winio v0.4.17/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
 github.com/Microsoft/go-winio v0.5.0/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
-github.com/Microsoft/go-winio v0.5.1 h1:aPJp2QD7OOrhO5tQXqQoGSJc+DjDtWTGLOmNyAm6FgY=
 github.com/Microsoft/go-winio v0.5.1/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
+github.com/Microsoft/go-winio v0.5.2 h1:a9IhgEQBCUEk6QCdml9CiJGhAws+YwffDHEMp1VMrpA=
+github.com/Microsoft/go-winio v0.5.2/go.mod h1:WpS1mjBmmwHBEWmogvA2mj8546UReBk4v8QkMxJ6pZY=
 github.com/Microsoft/hcsshim v0.8.6/go.mod h1:Op3hHsoHPAvb6lceZHDtd9OkTew38wNoXnJs8iY7rUg=
 github.com/Microsoft/hcsshim v0.8.7-0.20190325164909-8abdbb8205e4/go.mod h1:Op3hHsoHPAvb6lceZHDtd9OkTew38wNoXnJs8iY7rUg=
 github.com/Microsoft/hcsshim v0.8.7/go.mod h1:OHd7sQqRFrYd3RmSgbgji+ctCwkbq2wbEYNSzOYtcBQ=
@@ -281,8 +282,6 @@ github.com/containernetworking/cni v0.8.0/go.mod h1:LGwApLUm2FpoOfxTDEeq8T9ipbpZ
 github.com/containernetworking/cni v0.8.1/go.mod h1:LGwApLUm2FpoOfxTDEeq8T9ipbpZ61X79hmU3w8FmsY=
 github.com/containernetworking/plugins v0.8.6/go.mod h1:qnw5mN19D8fIwkqW7oHHYDHVlzhJpcY6TQxn/fUyDDM=
 github.com/containernetworking/plugins v0.9.1/go.mod h1:xP/idU2ldlzN6m4p5LmGiwRDjeJr6FLK6vuiUwoH7P8=
-github.com/containers/gvisor-tap-vsock v0.3.1-0.20220214154721-84c937f8176f h1:QoXIUGrpjcIo0o3rdrdIm8rHSe4fqrSNJ4JXK+A49zo=
-github.com/containers/gvisor-tap-vsock v0.3.1-0.20220214154721-84c937f8176f/go.mod h1:O0zcIGzlj3KU+T5onpc/Q6C9qs9z8uHrlTHImdpzZ24=
 github.com/containers/image/v5 v5.15.0/go.mod h1:gzdBcooi6AFdiqfzirUqv90hUyHyI0MMdaqKzACKr2s=
 github.com/containers/libtrust v0.0.0-20190913040956-14b96171aa3b/go.mod h1:9rfv8iPl1ZP7aqh9YA68wnZv2NUDbXdcdPHVz0pFbPY=
 github.com/containers/ocicrypt v1.0.1/go.mod h1:MeJDzk1RJHv89LjsH0Sp5KTY3ZYkjXO/C+bKAeWFIrc=
@@ -990,6 +989,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSgv7Sy7s/s=
 github.com/pquerna/cachecontrol v0.0.0-20171018203845-0dec1b30a021/go.mod h1:prYjPmNq4d1NPVmpShWobRqXY3q7Vp+80DqgxxUrUIA=
+github.com/praveenkumar/gvisor-tap-vsock v0.3.1-0.20220223095915-137f40464097 h1:VxJCNQP36KGq7hybDv89XUn7WR3zXgn5me+etsSZgN8=
+github.com/praveenkumar/gvisor-tap-vsock v0.3.1-0.20220223095915-137f40464097/go.mod h1:wYrbzrUsp0JybRYQrsj/aGhfb0QXaOXMFSYz+K1GYPI=
 github.com/prometheus/client_golang v0.0.0-20180209125602-c332b6f63c06/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.3/go.mod h1:/TN21ttK/J9q6uSwhBd54HahCDft0ttaMvbicHlPoso=

--- a/pkg/crc/constants/constants.go
+++ b/pkg/crc/constants/constants.go
@@ -29,6 +29,7 @@ const (
 	CRCWindowsTrayDownloadURL = "https://github.com/code-ready/tray-electron/releases/download/%s/crc-tray-windows.zip"
 	DefaultContext            = "admin"
 	DaemonHTTPEndpoint        = "http://unix/api"
+	DefaultPodmanNamedPipe    = `\\.\pipe\crc-podman`
 
 	VSockGateway = "192.168.127.1"
 	VsockSSHPort = 2222

--- a/pkg/crc/machine/vsock.go
+++ b/pkg/crc/machine/vsock.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"net/url"
+	"runtime"
 	"strconv"
 
 	"github.com/code-ready/crc/pkg/crc/constants"
@@ -110,6 +111,12 @@ func vsockPorts(preset crcPreset.Preset) []types.ExposeRequest {
 				Remote:   net.JoinHostPort(virtualMachineIP, httpPort),
 			})
 	case crcPreset.Podman:
+		socketProtocol := types.UNIX
+		socketLocal := constants.GetHostDockerSocketPath()
+		if runtime.GOOS == "windows" {
+			socketProtocol = types.NPIPE
+			socketLocal = constants.DefaultPodmanNamedPipe
+		}
 		exposeRequest = append(exposeRequest,
 			types.ExposeRequest{
 				Protocol: "tcp",
@@ -117,8 +124,8 @@ func vsockPorts(preset crcPreset.Preset) []types.ExposeRequest {
 				Remote:   net.JoinHostPort(virtualMachineIP, cockpitPort),
 			},
 			types.ExposeRequest{
-				Protocol: "unix",
-				Local:    constants.GetHostDockerSocketPath(),
+				Protocol: socketProtocol,
+				Local:    socketLocal,
 				Remote:   getSSHTunnelURI(),
 			})
 	default:

--- a/vendor/github.com/Microsoft/go-winio/file.go
+++ b/vendor/github.com/Microsoft/go-winio/file.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package winio
@@ -141,6 +142,11 @@ func (f *win32File) closeHandle() {
 func (f *win32File) Close() error {
 	f.closeHandle()
 	return nil
+}
+
+// IsClosed checks if the file has been closed
+func (f *win32File) IsClosed() bool {
+	return f.closing.isSet()
 }
 
 // prepareIo prepares for a new IO operation.

--- a/vendor/github.com/Microsoft/go-winio/go.mod
+++ b/vendor/github.com/Microsoft/go-winio/go.mod
@@ -1,9 +1,8 @@
 module github.com/Microsoft/go-winio
 
-go 1.12
+go 1.13
 
 require (
-	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.7.0
 	golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c
 )

--- a/vendor/github.com/Microsoft/go-winio/go.sum
+++ b/vendor/github.com/Microsoft/go-winio/go.sum
@@ -1,14 +1,11 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
-github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sirupsen/logrus v1.7.0 h1:ShrD1U9pZB12TX0cVy0DtePoCH97K8EtX+mg7ZARUtM=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
-golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 h1:YyJpGZS1sBuBCzLAR1VEpK193GlqGZbnPFnPV/5Rsb4=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c h1:VwygUrnw9jn88c4u8GD3rZQbqrP/tgas88tPUbBxQrk=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/vendor/github.com/Microsoft/go-winio/pkg/guid/guid.go
+++ b/vendor/github.com/Microsoft/go-winio/pkg/guid/guid.go
@@ -14,8 +14,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"strconv"
-
-	"golang.org/x/sys/windows"
 )
 
 // Variant specifies which GUID variant (or "type") of the GUID. It determines
@@ -40,13 +38,6 @@ type Version uint8
 
 var _ = (encoding.TextMarshaler)(GUID{})
 var _ = (encoding.TextUnmarshaler)(&GUID{})
-
-// GUID represents a GUID/UUID. It has the same structure as
-// golang.org/x/sys/windows.GUID so that it can be used with functions expecting
-// that type. It is defined as its own type so that stringification and
-// marshaling can be supported. The representation matches that used by native
-// Windows code.
-type GUID windows.GUID
 
 // NewV4 returns a new version 4 (pseudorandom) GUID, as defined by RFC 4122.
 func NewV4() (GUID, error) {

--- a/vendor/github.com/Microsoft/go-winio/pkg/guid/guid_nonwindows.go
+++ b/vendor/github.com/Microsoft/go-winio/pkg/guid/guid_nonwindows.go
@@ -1,0 +1,15 @@
+// +build !windows
+
+package guid
+
+// GUID represents a GUID/UUID. It has the same structure as
+// golang.org/x/sys/windows.GUID so that it can be used with functions expecting
+// that type. It is defined as its own type as that is only available to builds
+// targeted at `windows`. The representation matches that used by native Windows
+// code.
+type GUID struct {
+	Data1 uint32
+	Data2 uint16
+	Data3 uint16
+	Data4 [8]byte
+}

--- a/vendor/github.com/Microsoft/go-winio/pkg/guid/guid_windows.go
+++ b/vendor/github.com/Microsoft/go-winio/pkg/guid/guid_windows.go
@@ -1,0 +1,10 @@
+package guid
+
+import "golang.org/x/sys/windows"
+
+// GUID represents a GUID/UUID. It has the same structure as
+// golang.org/x/sys/windows.GUID so that it can be used with functions expecting
+// that type. It is defined as its own type so that stringification and
+// marshaling can be supported. The representation matches that used by native
+// Windows code.
+type GUID windows.GUID

--- a/vendor/github.com/containers/gvisor-tap-vsock/pkg/sshclient/npipe_unsupported.go
+++ b/vendor/github.com/containers/gvisor-tap-vsock/pkg/sshclient/npipe_unsupported.go
@@ -9,6 +9,6 @@ import (
 	"net/url"
 )
 
-func listenNpipe(socketURI *url.URL) (net.Listener, error) {
+func ListenNpipe(socketURI *url.URL) (net.Listener, error) {
 	return nil, errors.New("named pipes are not supported by this platform")
 }

--- a/vendor/github.com/containers/gvisor-tap-vsock/pkg/sshclient/npipe_windows.go
+++ b/vendor/github.com/containers/gvisor-tap-vsock/pkg/sshclient/npipe_windows.go
@@ -16,7 +16,7 @@ import (
 // Allow built-in admins and system/kernel components
 const SddlDevObjSysAllAdmAll = "D:P(A;;GA;;;SY)(A;;GA;;;BA)"
 
-func listenNpipe(socketURI *url.URL) (net.Listener, error) {
+func ListenNpipe(socketURI *url.URL) (net.Listener, error) {
 	user, err := user.Current()
 	if err != nil {
 		return nil, err

--- a/vendor/github.com/containers/gvisor-tap-vsock/pkg/sshclient/ssh_forwarder.go
+++ b/vendor/github.com/containers/gvisor-tap-vsock/pkg/sshclient/ssh_forwarder.go
@@ -140,7 +140,7 @@ func setupProxy(ctx context.Context, socketURI *url.URL, dest *url.URL, identity
 			return &SSHForward{}, err
 		}
 	case "npipe":
-		listener, err = listenNpipe(socketURI)
+		listener, err = ListenNpipe(socketURI)
 		if err != nil {
 			return &SSHForward{}, err
 		}

--- a/vendor/github.com/containers/gvisor-tap-vsock/pkg/types/handshake.go
+++ b/vendor/github.com/containers/gvisor-tap-vsock/pkg/types/handshake.go
@@ -3,9 +3,10 @@ package types
 type TransportProtocol string
 
 const (
-	UDP  TransportProtocol = "udp"
-	TCP  TransportProtocol = "tcp"
-	UNIX TransportProtocol = "unix"
+	UDP   TransportProtocol = "udp"
+	TCP   TransportProtocol = "tcp"
+	UNIX  TransportProtocol = "unix"
+	NPIPE TransportProtocol = "npipe"
 )
 
 type ExposeRequest struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -9,7 +9,7 @@ github.com/Azure/go-ansiterm/winterm
 # github.com/Masterminds/semver/v3 v3.1.1
 ## explicit
 github.com/Masterminds/semver/v3
-# github.com/Microsoft/go-winio v0.5.1
+# github.com/Microsoft/go-winio v0.5.2
 ## explicit
 github.com/Microsoft/go-winio
 github.com/Microsoft/go-winio/pkg/guid
@@ -74,7 +74,7 @@ github.com/code-ready/machine/libmachine/drivers/plugin/localbinary
 github.com/code-ready/machine/libmachine/drivers/rpc
 github.com/code-ready/machine/libmachine/state
 github.com/code-ready/machine/libmachine/version
-# github.com/containers/gvisor-tap-vsock v0.3.1-0.20220214154721-84c937f8176f
+# github.com/containers/gvisor-tap-vsock v0.3.1-0.20220214154721-84c937f8176f => github.com/praveenkumar/gvisor-tap-vsock v0.3.1-0.20220223095915-137f40464097
 ## explicit
 github.com/containers/gvisor-tap-vsock/pkg/client
 github.com/containers/gvisor-tap-vsock/pkg/fs
@@ -703,3 +703,4 @@ sigs.k8s.io/yaml
 # k8s.io/apimachinery => github.com/openshift/kubernetes-apimachinery v0.0.0-20210730111815-c26349f8e2c9
 # k8s.io/client-go => github.com/openshift/kubernetes-client-go v0.0.0-20210826123502-7208c21f5119
 # k8s.io/kubectl => github.com/openshift/kubernetes-kubectl v0.0.0-20210730111826-9c6734b9d97d
+# github.com/containers/gvisor-tap-vsock => github.com/praveenkumar/gvisor-tap-vsock v0.3.1-0.20220223095915-137f40464097


### PR DESCRIPTION
With this PR now following is possible in windows.
```
n> .\crc.exe podman-env
$Env:PATH = "C:\Users\prkumar\.crc\bin\oc;$Env:PATH"
$Env:CONTAINER_SSHKEY = "C:\Users\prkumar\.crc\machines\crc\id_ecdsa"
$Env:CONTAINER_HOST =
"ssh://core@127.0.0.1:2222/run/user/1000/podman/podman.sock"
$Env:DOCKER_HOST = "npipe:////./pipe/crc-podman"

n> .\docker.exe info
Client:
 Context:    default
 Debug Mode: false

Server:
 Containers: 1
  Running: 1
  Paused: 0
  Stopped: 0
 Images: 1
 Server Version: 3.4.4
 Storage Driver: overlay
  Backing Filesystem: xfs
  Supports d_type: true
```

Note: This pr is using a fork of gvisor-tap-vsock repo and should be removed once
respective PR https://github.com/containers/gvisor-tap-vsock/pull/103 merged there.


