### PR TITLE
go-mod: Update the gvisor-tap

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/code-ready/admin-helper v0.0.7
 	github.com/code-ready/clicumber v0.0.0-20210201104241-cecb794bdf9a
 	github.com/code-ready/machine v0.0.0-20210616065635-eff475d32b9a
-	github.com/containers/gvisor-tap-vsock v0.3.1-0.20220214154721-84c937f8176f
+	github.com/containers/gvisor-tap-vsock v0.3.1-0.20220228052040-b735d4413359
 	github.com/coreos/go-systemd/v22 v22.3.2
 	github.com/cucumber/godog v0.9.0
 	github.com/cucumber/messages-go/v10 v10.0.3
@@ -36,7 +36,7 @@ require (
 	github.com/kofalt/go-memoize v0.0.0-20210721235729-46a601ff34b8
 	github.com/kr/pretty v0.3.0 // indirect
 	github.com/mattn/go-colorable v0.1.11
-	github.com/mdlayher/vsock v1.1.0
+	github.com/mdlayher/vsock v1.1.1
 	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d // indirect
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.18.1
@@ -78,5 +78,3 @@ replace (
 	k8s.io/client-go => github.com/openshift/kubernetes-client-go v0.0.0-20210826123502-7208c21f5119
 	k8s.io/kubectl => github.com/openshift/kubernetes-kubectl v0.0.0-20210730111826-9c6734b9d97d
 )
-
-replace github.com/containers/gvisor-tap-vsock => github.com/praveenkumar/gvisor-tap-vsock v0.3.1-0.20220223095915-137f40464097

--- a/go.sum
+++ b/go.sum
@@ -282,6 +282,8 @@ github.com/containernetworking/cni v0.8.0/go.mod h1:LGwApLUm2FpoOfxTDEeq8T9ipbpZ
 github.com/containernetworking/cni v0.8.1/go.mod h1:LGwApLUm2FpoOfxTDEeq8T9ipbpZ61X79hmU3w8FmsY=
 github.com/containernetworking/plugins v0.8.6/go.mod h1:qnw5mN19D8fIwkqW7oHHYDHVlzhJpcY6TQxn/fUyDDM=
 github.com/containernetworking/plugins v0.9.1/go.mod h1:xP/idU2ldlzN6m4p5LmGiwRDjeJr6FLK6vuiUwoH7P8=
+github.com/containers/gvisor-tap-vsock v0.3.1-0.20220228052040-b735d4413359 h1:T7JiG0uYNUDHh9CYsZvaWxIZ++qBeFEa/0UU2jK2LTg=
+github.com/containers/gvisor-tap-vsock v0.3.1-0.20220228052040-b735d4413359/go.mod h1:2doIPVewqnPburiEJzr4SgUDOWKo/IsvBpPJQki8CXs=
 github.com/containers/image/v5 v5.15.0/go.mod h1:gzdBcooi6AFdiqfzirUqv90hUyHyI0MMdaqKzACKr2s=
 github.com/containers/libtrust v0.0.0-20190913040956-14b96171aa3b/go.mod h1:9rfv8iPl1ZP7aqh9YA68wnZv2NUDbXdcdPHVz0pFbPY=
 github.com/containers/ocicrypt v1.0.1/go.mod h1:MeJDzk1RJHv89LjsH0Sp5KTY3ZYkjXO/C+bKAeWFIrc=
@@ -827,8 +829,8 @@ github.com/mdlayher/raw v0.0.0-20191009151244-50f2db8cc065 h1:aFkJ6lx4FPip+S+Uw4
 github.com/mdlayher/raw v0.0.0-20191009151244-50f2db8cc065/go.mod h1:7EpbotpCmVZcu+KCX4g9WaRNuu11uyhiW7+Le1dKawg=
 github.com/mdlayher/socket v0.2.0 h1:EY4YQd6hTAg2tcXF84p5DTHazShE50u5HeBzBaNgjkA=
 github.com/mdlayher/socket v0.2.0/go.mod h1:QLlNPkFR88mRUNQIzRBMfXxwKal8H7u1h3bL1CV+f0E=
-github.com/mdlayher/vsock v1.1.0 h1:2k9udP/hUkLUOboGxXMHOk4f0GWWZwS3IuE3Ee/YYfk=
-github.com/mdlayher/vsock v1.1.0/go.mod h1:nsVhPsVuBBwAKh6i6PzdNoke6/TNYTjkxoRKAp/+pXs=
+github.com/mdlayher/vsock v1.1.1 h1:8lFuiXQnmICBrCIIA9PMgVSke6Fg6V4+r0v7r55k88I=
+github.com/mdlayher/vsock v1.1.1/go.mod h1:Y43jzcy7KM3QB+/FK15pfqGxDMCMzUXWegEfIbSM18U=
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
 github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d h1:5PJl274Y63IEHC+7izoQE9x6ikvDFZS2mDVS3drnohI=
 github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
@@ -989,8 +991,6 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSgv7Sy7s/s=
 github.com/pquerna/cachecontrol v0.0.0-20171018203845-0dec1b30a021/go.mod h1:prYjPmNq4d1NPVmpShWobRqXY3q7Vp+80DqgxxUrUIA=
-github.com/praveenkumar/gvisor-tap-vsock v0.3.1-0.20220223095915-137f40464097 h1:VxJCNQP36KGq7hybDv89XUn7WR3zXgn5me+etsSZgN8=
-github.com/praveenkumar/gvisor-tap-vsock v0.3.1-0.20220223095915-137f40464097/go.mod h1:wYrbzrUsp0JybRYQrsj/aGhfb0QXaOXMFSYz+K1GYPI=
 github.com/prometheus/client_golang v0.0.0-20180209125602-c332b6f63c06/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.3/go.mod h1:/TN21ttK/J9q6uSwhBd54HahCDft0ttaMvbicHlPoso=

--- a/vendor/github.com/mdlayher/vsock/CHANGELOG.md
+++ b/vendor/github.com/mdlayher/vsock/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## v1.1.1
+
+- [Bug Fix] [commit](https://github.com/mdlayher/vsock/commit/ead86435c244d5d6baad549a6df0557ada3f4401):
+  fix build on non-UNIX platforms such as Windows. This is a no-op change on
+  Linux but provides a friendlier experience for non-Linux users.
+
 ## v1.1.0
 
 - [New API] [commit](https://github.com/mdlayher/vsock/commit/44cd82dc5f7de644436f22236b111ab97fa9a14f):

--- a/vendor/github.com/mdlayher/vsock/conn_linux.go
+++ b/vendor/github.com/mdlayher/vsock/conn_linux.go
@@ -8,6 +8,11 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+// A conn is the net.Conn implementation for connection-oriented VM sockets.
+// We can use socket.Conn directly on Linux to implement all of the necessary
+// methods.
+type conn = socket.Conn
+
 // dial is the entry point for Dial on Linux.
 func dial(cid, port uint32, _ *Config) (*Conn, error) {
 	// TODO(mdlayher): Config default nil check and initialize. Pass options to

--- a/vendor/github.com/mdlayher/vsock/go.mod
+++ b/vendor/github.com/mdlayher/vsock/go.mod
@@ -1,10 +1,11 @@
 module github.com/mdlayher/vsock
 
-go 1.13
+go 1.17
 
 require (
 	github.com/google/go-cmp v0.5.7
 	github.com/mdlayher/socket v0.2.0
 	golang.org/x/net v0.0.0-20190503192946-f4e77d36d62c
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/sys v0.0.0-20220204135822-1c1b9b1eba6a
 )

--- a/vendor/github.com/mdlayher/vsock/vsock.go
+++ b/vendor/github.com/mdlayher/vsock/vsock.go
@@ -9,8 +9,6 @@ import (
 	"strings"
 	"syscall"
 	"time"
-
-	"github.com/mdlayher/socket"
 )
 
 const (
@@ -197,7 +195,7 @@ var (
 
 // A Conn is a VM sockets implementation of a net.Conn.
 type Conn struct {
-	c      *socket.Conn
+	c      *conn
 	local  *Addr
 	remote *Addr
 }

--- a/vendor/github.com/mdlayher/vsock/vsock_others.go
+++ b/vendor/github.com/mdlayher/vsock/vsock_others.go
@@ -8,13 +8,13 @@ import (
 	"net"
 	"os"
 	"runtime"
+	"syscall"
 	"time"
 )
 
 // errUnimplemented is returned by all functions on platforms that
 // cannot make use of VM sockets.
-var errUnimplemented = fmt.Errorf("vsock: not implemented on %s/%s",
-	runtime.GOOS, runtime.GOARCH)
+var errUnimplemented = fmt.Errorf("vsock: not implemented on %s", runtime.GOOS)
 
 func fileListener(_ *os.File) (*Listener, error)       { return nil, errUnimplemented }
 func listen(_, _ uint32, _ *Config) (*Listener, error) { return nil, errUnimplemented }
@@ -27,6 +27,18 @@ func (*listener) Close() error                  { return errUnimplemented }
 func (*listener) SetDeadline(_ time.Time) error { return errUnimplemented }
 
 func dial(_, _ uint32, _ *Config) (*Conn, error) { return nil, errUnimplemented }
+
+type conn struct{}
+
+func (*conn) Close() error                          { return errUnimplemented }
+func (*conn) CloseRead() error                      { return errUnimplemented }
+func (*conn) CloseWrite() error                     { return errUnimplemented }
+func (*conn) Read(_ []byte) (int, error)            { return 0, errUnimplemented }
+func (*conn) Write(_ []byte) (int, error)           { return 0, errUnimplemented }
+func (*conn) SetDeadline(_ time.Time) error         { return errUnimplemented }
+func (*conn) SetReadDeadline(_ time.Time) error     { return errUnimplemented }
+func (*conn) SetWriteDeadline(_ time.Time) error    { return errUnimplemented }
+func (*conn) SyscallConn() (syscall.RawConn, error) { return nil, errUnimplemented }
 
 func contextID() (uint32, error) { return 0, errUnimplemented }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -74,7 +74,7 @@ github.com/code-ready/machine/libmachine/drivers/plugin/localbinary
 github.com/code-ready/machine/libmachine/drivers/rpc
 github.com/code-ready/machine/libmachine/state
 github.com/code-ready/machine/libmachine/version
-# github.com/containers/gvisor-tap-vsock v0.3.1-0.20220214154721-84c937f8176f => github.com/praveenkumar/gvisor-tap-vsock v0.3.1-0.20220223095915-137f40464097
+# github.com/containers/gvisor-tap-vsock v0.3.1-0.20220228052040-b735d4413359
 ## explicit
 github.com/containers/gvisor-tap-vsock/pkg/client
 github.com/containers/gvisor-tap-vsock/pkg/fs
@@ -236,7 +236,7 @@ github.com/mattn/go-isatty
 github.com/mattn/go-runewidth
 # github.com/mdlayher/socket v0.2.0
 github.com/mdlayher/socket
-# github.com/mdlayher/vsock v1.1.0
+# github.com/mdlayher/vsock v1.1.1
 ## explicit
 github.com/mdlayher/vsock
 # github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d
@@ -703,4 +703,3 @@ sigs.k8s.io/yaml
 # k8s.io/apimachinery => github.com/openshift/kubernetes-apimachinery v0.0.0-20210730111815-c26349f8e2c9
 # k8s.io/client-go => github.com/openshift/kubernetes-client-go v0.0.0-20210826123502-7208c21f5119
 # k8s.io/kubectl => github.com/openshift/kubernetes-kubectl v0.0.0-20210730111826-9c6734b9d97d
-# github.com/containers/gvisor-tap-vsock => github.com/praveenkumar/gvisor-tap-vsock v0.3.1-0.20220223095915-137f40464097


### PR DESCRIPTION
This now remove the fork we are using for npipe<=>unix mapping for
windows.


