### PR TITLE
Doc Deploy: Use main branch instead master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,4 +131,4 @@ workflows:
             - build_docs
           filters:
             branches:
-              only: master
+              only: main


### PR DESCRIPTION
This allow us to publish the docs from main branch instead of master.
