### PR TITLE
Fix release json sample file to have correct podman version

### DIFF
--- a/release-info.json.sample
+++ b/release-info.json.sample
@@ -2,8 +2,8 @@
 	"version": {
 		"crcVersion": "@CRC_VERSION@",
 		"gitSha": "@GIT_COMMIT_SHA@",
-		"openshiftVersion": "@OPENSHIFT_VERSION@"
-		"podmanVersion": "@PODMAN_VERSION"
+		"openshiftVersion": "@OPENSHIFT_VERSION@",
+		"podmanVersion": "@PODMAN_VERSION@"
 	},
 	"links": {
 	    "linux": "https://developers.redhat.com/content-gateway/file/pub/openshift-v4/clients/crc/@CRC_VERSION@/crc-linux-amd64.tar.xz",


### PR DESCRIPTION
This should fix following issue.
```
11:23 $ cat release-info.json
{
	"version": {
		"crcVersion": "1.99.4",
		"gitSha": "ddf596cf",
		"openshiftVersion": "4.9.18"
		"podmanVersion": "@PODMAN_VERSION"
	},
	"links": {
	    "linux": "https://developers.redhat.com/content-gateway/file/pub/openshift-v4/clients/crc/1.99.4/crc-linux-amd64.tar.xz",
	    "darwin": "https://developers.redhat.com/content-gateway/file/pub/openshift-v4/clients/crc/1.99.4/crc-macos-amd64.pkg",
	    "windows": "https://developers.redhat.com/content-gateway/file/pub/openshift-v4/clients/crc/1.99.4/crc-windows-installer.zip"
	}
}

11:23 $ cat release-info.json | jq .
parse error: Expected separator between values at line 6, column 17
```
