### PR TITLE
docs: Add documentation for runtime presets

### DIFF
--- a/docs/source/meta/product-attributes.adoc
+++ b/docs/source/meta/product-attributes.adoc
@@ -18,6 +18,8 @@
 :msw: Microsoft Windows
 :debian: Debian
 :ubuntu: Ubuntu
+:openshift: OpenShift
+:ocp: {openshift} Container Platform
 
 // Product naming
 :prod: CodeReady Containers

--- a/docs/source/topics/assembly_configuring-codeready-containers.adoc
+++ b/docs/source/topics/assembly_configuring-codeready-containers.adoc
@@ -5,4 +5,6 @@ include::con_about-codeready-containers-configuration.adoc[leveloffset=+1]
 
 include::proc_viewing-codeready-containers-configuration.adoc[leveloffset=+1]
 
+include::proc_changing-the-selected-preset.adoc[leveloffset=+1]
+
 include::proc_configuring-the-instance.adoc[leveloffset=+1]

--- a/docs/source/topics/assembly_using-codeready-containers.adoc
+++ b/docs/source/topics/assembly_using-codeready-containers.adoc
@@ -1,6 +1,8 @@
 [id="using-codeready-containers_{context}"]
 = Using {prod}
 
+include::con_about-presets.adoc[leveloffset=+1]
+
 include::proc_setting-up-codeready-containers.adoc[leveloffset=+1]
 
 include::proc_starting-the-instance.adoc[leveloffset=+1]

--- a/docs/source/topics/con_about-presets.adoc
+++ b/docs/source/topics/con_about-presets.adoc
@@ -1,0 +1,18 @@
+[id="about-presets_{context}"]
+= About presets
+
+[role="_abstract"]
+{prod} presets represent a managed container runtime and the lower bounds of system resources required by the instance to run it.
+{prod} offers presets for {ocp} and the Podman container runtime.
+
+On {msw} and {mac}, the {prod} guided installer prompts you for your desired preset.
+On Linux, the {ocp} preset is selected by default.
+You can change this selection using the [command]`{bin} config` command before running the [command]`{bin} setup` command.
+You can change your selected preset from the system tray on {msw} and {mac} or from the command line on all supported operating systems.
+Only one preset can be active at a time.
+
+[role="_additional-resources"]
+.Additional resources
+
+* For more information about the minimum system requirements for each preset, see link:{crc-gsg-url}#minimum-system-requirements_gsg[Minimum system requirements].
+* For more information on changing the selected preset, see link:{crc-gsg-url}#changing-the-selected-preset_gsg[Changing the selected preset].

--- a/docs/source/topics/proc_changing-the-selected-preset.adoc
+++ b/docs/source/topics/proc_changing-the-selected-preset.adoc
@@ -1,0 +1,31 @@
+[id="changing-the-selected-preset_{context}"]
+= Changing the selected preset
+
+[role="_abstract"]
+You can change the container runtime used for the {prod} instance by selecting the desired preset.
+
+On {msw} and {mac}, you can change the selected preset using the system tray or command line interface.
+On Linux, use the command line interface.
+
+[IMPORTANT]
+====
+You cannot change the preset of an existing {prod} instance.
+Preset changes are only applied when a {prod} instance is created.
+To enable preset changes, you must delete the existing instance and start a new one.
+====
+
+.Procedure
+
+* Change the selected preset from the command line:
++
+[subs="+quotes,attributes"]
+----
+$ {bin} config preset __<name>__
+----
++
+Valid preset names are `openshift` for {ocp} and `podman` for the Podman container runtime.
+
+[role="_additional-resources"]
+.Additional resources
+
+* For more information about the minimum system requirements for each preset, see link:{crc-gsg-url}#minimum-system-requirements_gsg[Minimum system requirements].

--- a/docs/source/topics/proc_installing-codeready-containers.adoc
+++ b/docs/source/topics/proc_installing-codeready-containers.adoc
@@ -1,8 +1,8 @@
 [id="installing-codeready-containers_{context}"]
 = Installing {prod}
 
-{prod} is available as a portable executable for {rhel} and {msw}.
-On {mac}, {prod} is available using a guided installer.
+{prod} is available as a portable executable for {rhel}.
+On {msw} and {mac}, {prod} is available using a guided installer.
 
 .Prerequisites
 

--- a/docs/source/topics/proc_setting-up-codeready-containers.adoc
+++ b/docs/source/topics/proc_setting-up-codeready-containers.adoc
@@ -24,9 +24,22 @@ Always run the [command]`{bin}` executable with your user account.
 
 .Procedure
 
+. (Optional) On Linux, the {ocp} preset is selected by default.
+To select the the Podman container runtime preset:
++
+[subs="+quotes,attributes"]
+----
+$ {bin} config set preset podman
+----
+
 . Set up your host machine for {prod}:
 +
 [subs="+quotes,attributes"]
 ----
 $ {bin} setup
 ----
+
+[role="_additional-resources"]
+.Additional resources
+
+* For more information about the available container runtime presets, see link:{crc-gsg-url}#about-presets_gsg[About presets].

--- a/docs/source/topics/proc_setting-up-codeready-containers.adoc
+++ b/docs/source/topics/proc_setting-up-codeready-containers.adoc
@@ -1,9 +1,10 @@
 [id="setting-up-codeready-containers_{context}"]
 = Setting up {prod}
 
+[role="_abstract"]
 The [command]`{bin} setup` command performs operations to set up the environment of your host machine for the {prod} instance.
 
-This procedure creates the [filename]*_~/.crc_* directory if it does not already exist.
+The [command]`{bin} setup` command creates the [filename]*_~/.crc_* directory if it does not already exist.
 
 [WARNING]
 ====

--- a/docs/source/topics/proc_setting-up-remote-server.adoc
+++ b/docs/source/topics/proc_setting-up-remote-server.adoc
@@ -45,7 +45,7 @@ $ sudo firewall-cmd --add-service=kube-apiserver --permanent
 $ sudo firewall-cmd --reload
 ----
 
-. For SELinux, allow HAProxy to listen on TCP port 6443 to serve kube-apiserver on this port:
+. For SELinux, allow HAProxy to listen on TCP port 6443 to serve `kube-apiserver` on this port:
 +
 ----
 $ sudo semanage port -a -t http_port_t -p tcp 6443

--- a/docs/source/topics/ref_minimum-system-requirements.adoc
+++ b/docs/source/topics/ref_minimum-system-requirements.adoc
@@ -1,27 +1,36 @@
 [id="minimum-system-requirements_{context}"]
 = Minimum system requirements
 
+[role="_abstract"]
 {prod} has the following minimum hardware and operating system requirements.
 
 [id="minimum-system-requirements-hardware_{context}"]
 == Hardware requirements
 
-{prod} requires the following system resources:
+{prod} is supported only on AMD64 and Intel 64 processor architectures.
+{prod} does not support the ARM-based M1 architecture.
+{prod} does not support nested virtualization.
+
+Depending on the desired container runtime, {prod} requires the following system resources:
+
+=== For {ocp}
 
 * 4 physical CPU cores
 * 9 GB of free memory
 * 35 GB of storage space
 
-{prod} is supported only on AMD64 and Intel 64 processor architectures.
-{prod} does not support the ARM-based M1 architecture.
-{prod} does not support nested virtualization.
-
 [NOTE]
 ====
-The OpenShift cluster requires these minimum resources to run in the {prod} instance.
+The {ocp} cluster requires these minimum resources to run in the {prod} instance.
 Some workloads may require more resources.
 To assign more resources to the {prod} instance, see link:{crc-gsg-url}#configuring-the-instance_gsg[Configuring the instance].
 ====
+
+=== For the Podman container runtime
+
+* 2 physical CPU cores
+* 2 GB of free memory
+* 35 GB of storage space
 
 [id="minimum-system-requirements-operating-system_{context}"]
 == Operating system requirements


### PR DESCRIPTION
## Solution/Idea

Add documentation for the use and configuration of container runtime presets.

Note that this PR also contains the introduction of the `{openshift}` and `{ocp}` attributes and fixes a few small errors I encountered while updating the content. These changes have all been isolated to their own commits.

## Proposed changes

1. Add a new module to conceptually define presets.
2. Add a new module for configuring the desired preset.
3. Modify the minimum system requirements to reflect the resources needed by each preset.
4. Modify `crc setup` documentation to include information about selecting the `podman` preset for Linux users.