### PR TITLE
Make user mode networking default for dev build

### DIFF
--- a/pkg/crc/config/settings.go
+++ b/pkg/crc/config/settings.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"runtime"
 
 	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/code-ready/crc/pkg/crc/network"
@@ -119,7 +120,7 @@ func GetPreset(config Storage) preset.Preset {
 }
 
 func defaultNetworkMode() network.Mode {
-	if version.IsInstaller() {
+	if runtime.GOOS != "linux" {
 		return network.UserNetworkingMode
 	}
 	return network.SystemNetworkingMode


### PR DESCRIPTION
As of now we support system mode and user mode networking for all platform and in
windows/mac user mode is default for releases and system mode for dev builds. This
create bit confusion and also dev forget to test what is going to delivered with release
so this PR will make it default for both release and dev side.

