### PR TITLE
ignore error when removing tray related launchd plist file

### DIFF
--- a/pkg/crc/preflight/preflight_darwin.go
+++ b/pkg/crc/preflight/preflight_darwin.go
@@ -74,7 +74,8 @@ var trayLaunchdCleanupChecks = []Check{
 		fixDescription:   "Removing old launchd config for tray autostart",
 		fix: func() error {
 			_ = os.Remove(filepath.Join(constants.GetHomeDir(), "Library", "LaunchAgents", "crc.tray.plist"))
-			return os.Remove(filepath.Join(constants.GetHomeDir(), "Library", "LaunchAgents", "crc.daemon.plist"))
+			_ = os.Remove(filepath.Join(constants.GetHomeDir(), "Library", "LaunchAgents", "crc.daemon.plist"))
+			return nil
 		},
 
 		labels: labels{Os: Darwin},


### PR DESCRIPTION
this solves the following error from `crc setup`:
```
remove /Users/prkumar/Library/LaunchAgents/crc.daemon.plist: no such file or directory
```
