### PR TITLE
docs: bump minimum required memory specs

### DIFF
--- a/docs/source/topics/ref_minimum-system-requirements.adoc
+++ b/docs/source/topics/ref_minimum-system-requirements.adoc
@@ -16,7 +16,7 @@ Depending on the desired container runtime, {prod} requires the following system
 === For {ocp}
 
 * 4 physical CPU cores
-* 9 GB of free memory
+* 11 GB of free memory
 * 35 GB of storage space
 
 [NOTE]


### PR DESCRIPTION
The pre-flight validation checks currently enforce 9216 KiB for the VM and this is hardcoded in the codebase. I tried on a bare-metal host with 10 MB physical memory and installation was not successful as the host was heavily swapping and this led to timeouts. For the record: https://github.com/code-ready/crc/discussions/3067

Let's set a higher number, I am starting with 11 GB but let me know if you think it should be bumped up to more traditional 16 GB.
