### PR TITLE
Use podman system connection to add remote uri to podman config

### DIFF
--- a/cmd/crc/cmd/podman_env.go
+++ b/cmd/crc/cmd/podman_env.go
@@ -38,9 +38,9 @@ func runPodmanEnv() error {
 		return err
 	}
 
-	socket := "/run/user/1000/podman/podman.sock"
+	socket := constants.RootlessPodmanSocket
 	if root {
-		socket = "/run/podman/podman.sock"
+		socket = constants.RootfulPodmanSocket
 	}
 	fmt.Println(shell.GetPathEnvString(userShell, constants.CrcOcBinDir))
 	fmt.Println(shell.GetEnvString(userShell, "CONTAINER_SSHKEY", connectionDetails.SSHKeys[0]))

--- a/pkg/crc/constants/constants.go
+++ b/pkg/crc/constants/constants.go
@@ -30,6 +30,8 @@ const (
 	DefaultContext            = "admin"
 	DaemonHTTPEndpoint        = "http://unix/api"
 	DefaultPodmanNamedPipe    = `\\.\pipe\crc-podman`
+	RootlessPodmanSocket      = "/run/user/1000/podman/podman.sock"
+	RootfulPodmanSocket       = "/run/podman/podman.sock"
 
 	VSockGateway = "192.168.127.1"
 	VsockSSHPort = 2222

--- a/pkg/crc/machine/delete.go
+++ b/pkg/crc/machine/delete.go
@@ -4,6 +4,7 @@ import (
 	"os"
 
 	"github.com/code-ready/crc/pkg/crc/logging"
+	"github.com/code-ready/crc/pkg/crc/podman"
 	"github.com/pkg/errors"
 )
 
@@ -23,6 +24,14 @@ func (client *client) Delete() error {
 		if err := unexposePorts(); err != nil {
 			return err
 		}
+	}
+
+	// Remove the podman system connection for crc
+	if err := podman.RemoveRootlessSystemConnection(); err != nil {
+		return err
+	}
+	if err := podman.RemoveRootfulSystemConnection(); err != nil {
+		return err
 	}
 
 	if err := cleanKubeconfig(getGlobalKubeConfigPath(), getGlobalKubeConfigPath()); err != nil {

--- a/pkg/crc/podman/podman.go
+++ b/pkg/crc/podman/podman.go
@@ -1,0 +1,65 @@
+package podman
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/code-ready/crc/pkg/crc/constants"
+	crcos "github.com/code-ready/crc/pkg/os"
+)
+
+const (
+	rootlessConn = "crc"
+	rootfulConn  = "crc-root"
+)
+
+var podmanExecutablePath = filepath.Join(constants.CrcOcBinDir, constants.PodmanRemoteExecutableName)
+
+func run(args ...string) (string, string, error) {
+	return crcos.RunWithDefaultLocale(podmanExecutablePath, args...)
+}
+
+func addSystemConnection(name, identity, uri string) error {
+	if _, stderr, err := run("system", "connection", "add", "--identity", identity, name, uri); err != nil {
+		return fmt.Errorf("failed to add podman system connection %v: %s", err, stderr)
+	}
+	return nil
+}
+
+func AddRootlessSystemConnection(sshIdentity, uri string) error {
+	return addSystemConnection(rootlessConn, sshIdentity, uri)
+}
+
+func AddRootfulSystemConnection(sshIdentity, uri string) error {
+	return addSystemConnection(rootfulConn, sshIdentity, uri)
+}
+
+func removeSystemConnection(name string) error {
+	if _, stderr, err := run("system", "connection", "remove", name); err != nil {
+		return fmt.Errorf("failed to remove podman system connection %v: %s", err, stderr)
+	}
+	return nil
+}
+
+func RemoveRootlessSystemConnection() error {
+	return removeSystemConnection(rootlessConn)
+}
+
+func RemoveRootfulSystemConnection() error {
+	return removeSystemConnection(rootfulConn)
+}
+
+func makeSystemConnectionDefault(name string) error {
+	if _, stderr, err := run("system", "connection", "default", name); err != nil {
+		return fmt.Errorf("failed to make %s podman system connection as default %v: %s", name, err, stderr)
+	}
+	return nil
+}
+
+func MakeRootlessSystemConnectionDefault() error {
+	return makeSystemConnectionDefault(rootlessConn)
+}
+
+func MakeRootfulSystemConnectionDefault() error {
+	return makeSystemConnectionDefault(rootfulConn)
+}


### PR DESCRIPTION
As of now user have to do `eval $(crc podman-env)` to export podman
connection specific environment variable to current shell session.
Podman cli have `system connection` command which manage the ssh
destination information for podman configuration which consumed
by podman client.

With this PR now if a user have podman-remote client binary to path
then after `crc start` they can directly use podman commands without
executing current `eval` command. `podman-env` command option still
there to support backward compatibility and also exposing moby specific
environment variable. It will still make sense if user don't have podman
remote binary in the path.

```
✗ ./crc start
[...]
podman runtime is currently configured in rootless mode. If your containers
require root permissions, or if you run into compatibility
issues with non-podman clients, you can switch using the following commands:

  $ eval $(crc podman-env --root)
  $ podman COMMAND

✗ podman system connection ls
Name                         URI                                                         Identity                                    Default
crc                          ssh://core@127.0.0.1:2222/run/user/1000/podman/podman.sock  /Users/prkumar/.crc/machines/crc/id_ecdsa   true
crc-root                     ssh://core@127.0.0.1:2222/run/podman/podman.sock            /Users/prkumar/.crc/machines/crc/id_ecdsa   false

✗ ./crc podman-env --root
export PATH="/Users/prkumar/.crc/bin/oc:$PATH"
export DOCKER_HOST="unix:///Users/prkumar/.crc/machines/crc/docker.sock"

✗ podman system connection ls
Name                         URI                                                         Identity                                    Default
crc                          ssh://core@127.0.0.1:2222/run/user/1000/podman/podman.sock  /Users/prkumar/.crc/machines/crc/id_ecdsa   false
crc-root                     ssh://core@127.0.0.1:2222/run/podman/podman.sock            /Users/prkumar/.crc/machines/crc/id_ecdsa   true

✗ podman info
host:
  arch: amd64
  buildahVersion: 1.23.1
  cgroupControllers:
```