### PR TITLE
docs: Add OpenShift preset as a prerequisite to applicable procedures

### DIFF
--- a/docs/source/topics/proc_accessing-the-internal-openshift-registry.adoc
+++ b/docs/source/topics/proc_accessing-the-internal-openshift-registry.adoc
@@ -7,6 +7,8 @@ To access the internal OpenShift registry, follow these steps.
 
 .Prerequisites
 
+* {prod} is configured to use the {openshift} preset.
+For more information, see link:{crc-gsg-url}#changing-the-selected-preset_gsg[Changing the selected preset].
 * A running {prod} instance.
 For more information, see link:{crc-gsg-url}#starting-the-instance_gsg[Starting the instance].
 * A working OpenShift CLI ([command]`oc`) command.

--- a/docs/source/topics/proc_accessing-the-openshift-cluster-with-oc.adoc
+++ b/docs/source/topics/proc_accessing-the-openshift-cluster-with-oc.adoc
@@ -5,6 +5,8 @@ Access the OpenShift cluster by using the OpenShift CLI ([command]`oc`).
 
 .Prerequisites
 
+* {prod} is configured to use the {openshift} preset.
+For more information, see link:{crc-gsg-url}#changing-the-selected-preset_gsg[Changing the selected preset].
 * A running {prod} instance.
 For more information, see link:{crc-gsg-url}#starting-the-instance_gsg[Starting the instance].
 

--- a/docs/source/topics/proc_accessing-the-openshift-web-console.adoc
+++ b/docs/source/topics/proc_accessing-the-openshift-web-console.adoc
@@ -9,6 +9,8 @@ Use the `kubeadmin` user only for administrative tasks such as creating new user
 
 .Prerequisites
 
+* {prod} is configured to use the {openshift} preset.
+For more information, see link:{crc-gsg-url}#changing-the-selected-preset_gsg[Changing the selected preset].
 * A running {prod} instance.
 For more information, see link:{crc-gsg-url}#starting-the-instance_gsg[Starting the instance].
 

--- a/docs/source/topics/proc_deploying-sample-application-with-odo.adoc
+++ b/docs/source/topics/proc_deploying-sample-application-with-odo.adoc
@@ -8,6 +8,8 @@ This procedure deploys a sample application to the OpenShift cluster running in 
 
 * You have installed [command]`odo`.
 For more information, see link:{odo-docs-url-installing}[Installing `odo`] in the [command]`odo` documentation.
+* {prod} is configured to use the {openshift} preset.
+For more information, see link:{crc-gsg-url}#changing-the-selected-preset_gsg[Changing the selected preset].
 * The {prod} instance is running.
 For more information, see link:{crc-gsg-url}#starting-the-instance_gsg[Starting the instance].
 

--- a/docs/source/topics/proc_setting-up-remote-server.adoc
+++ b/docs/source/topics/proc_setting-up-remote-server.adoc
@@ -16,6 +16,8 @@ Exposing an insecure server on the internet has many security implications.
 
 * {prod} is installed and set up on the remote server.
 For more information, see link:{crc-gsg-url}#installing-codeready-containers_gsg[Installing {prod}] and link:{crc-gsg-url}#setting-up-codeready-containers_gsg[Setting up {prod}].
+* {prod} is configured to use the {openshift} preset on the remote server.
+For more information, see link:{crc-gsg-url}#changing-the-selected-preset_gsg[Changing the selected preset].
 * Your user account has `sudo` permissions on the remote server.
 
 .Procedure


### PR DESCRIPTION
This is a simple PR to add use of the `openshift` preset as a prerequisite to certain procedures which depend on the use of an OpenShift cluster.