### PR TITLE
docs: fix crc preset set command

### DIFF
--- a/docs/source/topics/proc_changing-the-selected-preset.adoc
+++ b/docs/source/topics/proc_changing-the-selected-preset.adoc
@@ -20,7 +20,7 @@ To enable preset changes, you must delete the existing instance and start a new 
 +
 [subs="+quotes,attributes"]
 ----
-$ {bin} config preset __<name>__
+$ {bin} config set preset __<name>__
 ----
 +
 Valid preset names are `openshift` for {ocp} and `podman` for the Podman container runtime.


### PR DESCRIPTION
## Fix crc command for selected preset

Original command in the documentation `$ crc config preset <name>`
The correct command must be with `set` subcommand: `$ crc config set preset <name>`

