### PR TITLE
Mac: Enable daemon service to run as soon as user login

### DIFF
--- a/pkg/os/launchd/launchd_darwin.go
+++ b/pkg/os/launchd/launchd_darwin.go
@@ -41,6 +41,8 @@ const (
 		<string>{{ $value }}</string>
 		{{ end }}
 	</dict>
+	<key>RunAtLoad</key>
+	<true/>
 </dict>
 </plist>
 `
@@ -112,12 +114,12 @@ func CheckPlist(config AgentConfig) error {
 
 // LoadPlist loads a launchd agents' plist file
 func LoadPlist(label string) error {
-	return runLaunchCtl("load", getPlistPath(label))
+	return runLaunchCtl("load", "-w", getPlistPath(label))
 }
 
 // UnloadPlist Unloads a launchd agent's service
 func UnloadPlist(label string) error {
-	return runLaunchCtl("unload", getPlistPath(label))
+	return runLaunchCtl("unload", "-w", getPlistPath(label))
 }
 
 // RemovePlist removes a launchd agent plist config file


### PR DESCRIPTION
Without this PR following scenario happen
- User installed the crc first time and do the setup
- As part of the setup crc daemon is started by launchd
- User reboot
- Tray autostart with reboot but `crc setup --check-only` fails
because `launchd agent 'com.redhat.crc.daemon' is not running`.

With this PR, check for daemon task running should first validate
if an existing process of `crc daemon` is running and the version
it get from the api should be same as the binary then task running
check succeed. So this PR will makes `crc setup --check-only` work
again with tray autostart.