### PR TITLE
Daemon: Move daemon running check to daemon client package

### DIFF
--- a/cmd/crc/cmd/daemon_darwin.go
+++ b/cmd/crc/cmd/daemon_darwin.go
@@ -32,9 +32,5 @@ func checkIfDaemonIsRunning() (bool, error) {
 	return checkDaemonVersion()
 }
 
-func daemonNotRunningMessage() string {
-	return genericDaemonNotRunningMessage
-}
-
 func startupDone() {
 }

--- a/cmd/crc/cmd/daemon_linux.go
+++ b/cmd/crc/cmd/daemon_linux.go
@@ -124,10 +124,6 @@ func httpListener() (net.Listener, error) {
 	return ln, nil
 }
 
-func daemonNotRunningMessage() string {
-	return genericDaemonNotRunningMessage
-}
-
 func startupDone() {
 	_, _ = daemon.SdNotify(false, daemon.SdNotifyReady)
 }

--- a/cmd/crc/cmd/daemon_windows.go
+++ b/cmd/crc/cmd/daemon_windows.go
@@ -6,7 +6,6 @@ import (
 	"github.com/Microsoft/go-winio"
 	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/code-ready/crc/pkg/crc/logging"
-	crcversion "github.com/code-ready/crc/pkg/crc/version"
 	"github.com/containers/gvisor-tap-vsock/pkg/transport"
 )
 
@@ -37,9 +36,6 @@ func checkIfDaemonIsRunning() (bool, error) {
 }
 
 func daemonNotRunningMessage() string {
-	if crcversion.IsInstaller() {
-		return "Is CodeReady Containers tray application running? Cannot reach daemon API"
-	}
 	return genericDaemonNotRunningMessage
 }
 

--- a/cmd/crc/cmd/daemon_windows.go
+++ b/cmd/crc/cmd/daemon_windows.go
@@ -35,9 +35,5 @@ func checkIfDaemonIsRunning() (bool, error) {
 	return checkDaemonVersion()
 }
 
-func daemonNotRunningMessage() string {
-	return genericDaemonNotRunningMessage
-}
-
 func startupDone() {
 }

--- a/cmd/crc/cmd/start.go
+++ b/cmd/crc/cmd/start.go
@@ -25,7 +25,6 @@ import (
 	crcversion "github.com/code-ready/crc/pkg/crc/version"
 	crcos "github.com/code-ready/crc/pkg/os"
 	"github.com/code-ready/crc/pkg/os/shell"
-	pkgerrors "github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -315,19 +314,13 @@ func commandLinePrefix(shell string) string {
 	return "$"
 }
 
-const genericDaemonNotRunningMessage = "Is 'crc daemon' running? Cannot reach daemon API"
-
 func checkDaemonStarted() error {
 	if crcConfig.GetNetworkMode(config) == network.SystemNetworkingMode {
 		return nil
 	}
-	daemonClient := daemonclient.New()
-	version, err := daemonClient.APIClient.Version()
+	v, err := daemonclient.GetVersionFromDaemonAPI()
 	if err != nil {
-		return pkgerrors.Wrap(err, daemonNotRunningMessage())
+		return err
 	}
-	if version.CrcVersion != crcversion.GetCRCVersion() {
-		return fmt.Errorf("The executable version (%s) doesn't match the daemon version (%s)", crcversion.GetCRCVersion(), version.CrcVersion)
-	}
-	return nil
+	return daemonclient.CheckIfOlderVersion(v)
 }

--- a/pkg/crc/daemonclient/client.go
+++ b/pkg/crc/daemonclient/client.go
@@ -1,11 +1,16 @@
 package daemonclient
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/code-ready/crc/pkg/crc/api/client"
+	crcversion "github.com/code-ready/crc/pkg/crc/version"
 	networkclient "github.com/containers/gvisor-tap-vsock/pkg/client"
+	pkgerrors "github.com/pkg/errors"
 )
+
+const genericDaemonNotRunningMessage = "Is 'crc daemon' running? Cannot reach daemon API"
 
 type Client struct {
 	NetworkClient *networkclient.Client
@@ -21,4 +26,20 @@ func New() *Client {
 			Transport: transport(),
 		}, "http://unix/api"),
 	}
+}
+
+func GetVersionFromDaemonAPI() (*client.VersionResult, error) {
+	apiClient := client.New(&http.Client{Transport: transport()}, "http://unix/api")
+	version, err := apiClient.Version()
+	if err != nil {
+		return nil, pkgerrors.Wrap(err, genericDaemonNotRunningMessage)
+	}
+	return &version, nil
+}
+
+func CheckIfOlderVersion(version *client.VersionResult) error {
+	if version.CrcVersion != crcversion.GetCRCVersion() {
+		return fmt.Errorf("The executable version (%s) doesn't match the daemon version (%s)", crcversion.GetCRCVersion(), version.CrcVersion)
+	}
+	return nil
 }


### PR DESCRIPTION
This move will help us to consume, daemon running check in the
preflight to make decision around if we need to start the daemon
as part of preflight or use the existing one.

