### PR TITLE
extend the response from API to also send default value for config 

### DIFF
--- a/pkg/crc/api/api_http_test.go
+++ b/pkg/crc/api/api_http_test.go
@@ -287,7 +287,7 @@ var testCases = []testCase{
 	// config
 	{
 		request:  get("config?cpus"),
-		response: jSon(`{"Configs":{"cpus":4}}`),
+		response: jSon(`{"Configs":{"cpus":{"value":4,"isDefault":true,"defaultValue":4}}}`),
 	},
 	{
 		request:  post("config?cpus").withBody("xx"),
@@ -299,7 +299,7 @@ var testCases = []testCase{
 	},
 	{
 		request:  get("config?cpus").withBody("xx"),
-		response: jSon(`{"Configs":{"cpus":4}}`),
+		response: jSon(`{"Configs":{"cpus":{"value":4,"isDefault":true,"defaultValue":4}}}`),
 	},
 
 	// logs
@@ -365,8 +365,9 @@ var testCases = []testCase{
 
 	// config
 	{
-		request:  get("config?cpus"),
-		response: jSon(`{"Configs":{"cpus":4}}`),
+		request: get("config?cpus"),
+		// order of the fields are important
+		response: jSon(`{"Configs":{"cpus":{"value":4,"isDefault":true,"defaultValue":4}}}`),
 	},
 }
 

--- a/pkg/crc/api/client/types.go
+++ b/pkg/crc/api/client/types.go
@@ -40,7 +40,13 @@ type SetOrUnsetConfigResult struct {
 
 // getConfigResult struct is used to return the result of getconfig command
 type GetConfigResult struct {
-	Configs map[string]interface{}
+	Configs map[string]SettingValue
+}
+
+type SettingValue struct {
+	Value        interface{} `json:"value"`
+	IsDefault    bool        `json:"isDefault"`
+	DefaultValue interface{} `json:"defaultValue"`
 }
 
 type StartConfig struct {

--- a/pkg/crc/config/config.go
+++ b/pkg/crc/config/config.go
@@ -59,6 +59,14 @@ func (c *Config) AddSetting(name string, defValue interface{}, validationFn Vali
 	}
 }
 
+func (c *Config) GetSetting(name string) (Setting, error) {
+	if s, ok := c.settingsByName[name]; ok {
+		return s, nil
+	}
+
+	return Setting{}, fmt.Errorf("Setting with name: '%s' does not exist", name)
+}
+
 // Set sets the value for a given config key
 func (c *Config) Set(key string, value interface{}) (string, error) {
 	setting, ok := c.settingsByName[key]

--- a/pkg/crc/config/config.go
+++ b/pkg/crc/config/config.go
@@ -52,7 +52,7 @@ func (c *Config) AllSettings() []Setting {
 func (c *Config) AddSetting(name string, defValue interface{}, validationFn ValidationFnType, callbackFn SetFn, help string) {
 	c.settingsByName[name] = Setting{
 		Name:         name,
-		defaultValue: defValue,
+		DefaultValue: defValue,
 		validationFn: validationFn,
 		callbackFn:   callbackFn,
 		Help:         help,
@@ -73,7 +73,7 @@ func (c *Config) Set(key string, value interface{}) (string, error) {
 
 	var castValue interface{}
 	var err error
-	switch setting.defaultValue.(type) {
+	switch setting.DefaultValue.(type) {
 	case int:
 		castValue, err = cast.ToIntE(value)
 		if err != nil {
@@ -122,10 +122,10 @@ func (c *Config) Get(key string) SettingValue {
 	}
 	value := c.storage.Get(key)
 	if value == nil {
-		value = setting.defaultValue
+		value = setting.DefaultValue
 	}
 	var err error
-	switch setting.defaultValue.(type) {
+	switch setting.DefaultValue.(type) {
 	case int:
 		value, err = cast.ToIntE(value)
 		if err != nil {
@@ -156,6 +156,6 @@ func (c *Config) Get(key string) SettingValue {
 	}
 	return SettingValue{
 		Value:     value,
-		IsDefault: reflect.DeepEqual(setting.defaultValue, value),
+		IsDefault: reflect.DeepEqual(setting.DefaultValue, value),
 	}
 }

--- a/pkg/crc/config/types.go
+++ b/pkg/crc/config/types.go
@@ -15,7 +15,7 @@ type Schema interface {
 
 type Setting struct {
 	Name         string
-	defaultValue interface{}
+	DefaultValue interface{}
 	validationFn ValidationFnType
 	callbackFn   SetFn
 	Help         string


### PR DESCRIPTION
Fixes #2869 
e.g response for a single config `cpus`:
```json
{
  "Configs": {
    "cpus": {
      "value": 2,
      "isDefault": true,
      "defaultValue": 2
    }
  }
}
```

**Note: This will also need changes on the tray**

