### PR TITLE
Constants: Creates cache and bin directories as part of EnsureBaseDirectoriesExist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ release/
 *.crcbundle
 packaging/tmp
 packaging/*.pkg
+tmp-embed/

--- a/pkg/crc/constants/constants.go
+++ b/pkg/crc/constants/constants.go
@@ -119,9 +119,16 @@ func GetHomeDir() string {
 	return homeDir
 }
 
-// EnsureBaseDirectoryExists create the ~/.crc directory if it is not present
+// EnsureBaseDirectoriesExist creates ~/.crc, ~/.crc/bin and ~/.crc/cache directories if it is not present
 func EnsureBaseDirectoriesExist() error {
-	return os.MkdirAll(CrcBaseDir, 0750)
+	baseDirectories := []string{CrcBaseDir, MachineCacheDir, crcBinDir}
+	for _, baseDir := range baseDirectories {
+		err := os.MkdirAll(baseDir, 0750)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func IsRelease() bool {


### PR DESCRIPTION
Fixes: #3116 

As of now we only create `$HOME/.crc` directory as part of root init function and
other child directories are created on demand like cache is created when bundle is
download and extracted. Recently we observed that required child directory (bin) is not
exist when creating a symlink. It is easy to miss to check for well known crc clild
directory when writing code and assumed it should be always there to consume.

We have identified `$HOME/.crc`, `$HOME/.crc/bin` and `$HOME/.crc/cache` are needed
directories to `crc` to work so this commit create those as part of init function from
root.


## Testing
* rm -fr ~/.crc
* install crc using installer
* Try to run the setup (either from cli or from tray)
* setup should succeed

Note:
While this issue is macOS specific, this needs to be run on all platforms 
