### PR TITLE
docs: Rename CodeReady Containers to "CRC"

### DIFF
--- a/docs/source/meta/product-attributes.adoc
+++ b/docs/source/meta/product-attributes.adoc
@@ -22,7 +22,7 @@
 :ocp: {openshift} Container Platform
 
 // Product naming
-:prod: CodeReady Containers
+:prod: CRC
 :rh-prod: {rh} {prod}
 :bin: crc
 


### PR DESCRIPTION
This is quite possibly the smallest pull request I have ever submitted. :wink: 

I double-checked the rendered content with the new name and discovered that no further disambiguation was necessary. Simply changing the related attribute provides us with an effective rename in the documentation without any rewriting.