### PR TITLE
Packaging: [Mac] Remove old CodeReady Containers folder from applications

### DIFF
--- a/packaging/darwin/postinstall.in
+++ b/packaging/darwin/postinstall.in
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+rm -fr  /Applications/CodeReady\ Containers.app || true
+
 chmod 755 "__INSTALL_PATH__"/crc
 
 [ -d /usr/local/bin ] || mkdir /usr/local/bin


### PR DESCRIPTION
This pr add removal logic in post script which remove old app directory
if user install new one (after renaming it to OpenShift Local).
