### PR TITLE
Windows: Remove an existing task as part of fixDaemonTaskInstalled

### DIFF
--- a/pkg/crc/preflight/preflight_daemon_task_check_windows.go
+++ b/pkg/crc/preflight/preflight_daemon_task_check_windows.go
@@ -3,6 +3,7 @@ package preflight
 import (
 	"bytes"
 	"encoding/xml"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -44,6 +45,7 @@ var (
   </Actions>
 </Task>
 `
+	errOlderVersion = fmt.Errorf("expected %s task to be on version '%s'", constants.DaemonTaskName, version.GetCRCVersion())
 )
 
 func genDaemonTaskInstallTemplate(crcVersion, daemonCommand string) (string, error) {
@@ -71,6 +73,10 @@ func checkIfDaemonTaskInstalled() error {
 }
 
 func fixDaemonTaskInstalled() error {
+	// Remove older task if exist
+	if err := removeDaemonTask(); err != nil {
+		return err
+	}
 	// prepare the task script
 	binPath, err := os.Executable()
 	if err != nil {
@@ -101,7 +107,7 @@ func removeDaemonTask() error {
 			return err
 		}
 	}
-	if err := checkIfDaemonTaskInstalled(); err == nil {
+	if err := checkIfDaemonTaskInstalled(); err == nil || errors.Is(err, errOlderVersion) {
 		_, stderr, err := powershell.Execute("Unregister-ScheduledTask", "-TaskName", constants.DaemonTaskName, "-Confirm:$false")
 		if err != nil {
 			logging.Debugf("unable to unregister the %s task: %v : %s", constants.DaemonTaskName, err, stderr)
@@ -141,7 +147,7 @@ func checkIfOlderTask() error {
 		return fmt.Errorf("%s task is not running: %v : %s", constants.DaemonTaskName, err, stderr)
 	}
 	if strings.TrimSpace(stdout) != version.GetCRCVersion() {
-		return fmt.Errorf("expected %s task to be on version '%s' but got '%s'", constants.DaemonTaskName, version.GetCRCVersion(), stdout)
+		return fmt.Errorf("%w but got '%s'", errOlderVersion, stdout)
 	}
 	return nil
 }


### PR DESCRIPTION
This patch should resolve following flow
- User installed crc-2.1.0 version and during setup task installed with
  version 2.1.0
- New version 2.2.0 arrive and user try to do setup then it fails with
  following error
  ```
  DEBU expected crcDaemon task to be on version '2.1.0' but got '2.0.1
  '
  INFO Installing the daemon task

  failed to register crcDaemon task, exit status 1:
  Register-ScheduledTask : Cannot create a file when that file already
  exists.
  At line:1 char:43
  + ... yContinue'; Register-ScheduledTask -Xml '<?xml version="1.0"
    encoding ...
    +
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
        + CategoryInfo          : ResourceExists:
	  (PS_ScheduledTask:Root/Microsoft/...S_ScheduledTask)
	  [Register-ScheduledTask], CimException
	      + FullyQualifiedErrorId : HRESULT
		0x800700b7,Register-ScheduledTask
  ```

This patch make sure if the older version is running and matches with
errOlderVersion then remove the existing task.


