### PR TITLE
Delete: Send podman connection remove error to debug log

### DIFF
--- a/pkg/crc/machine/delete.go
+++ b/pkg/crc/machine/delete.go
@@ -28,10 +28,10 @@ func (client *client) Delete() error {
 
 	// Remove the podman system connection for crc
 	if err := podman.RemoveRootlessSystemConnection(); err != nil {
-		return err
+		logging.Debugf("Failed to remove podman rootless system connection: %v", err)
 	}
 	if err := podman.RemoveRootfulSystemConnection(); err != nil {
-		return err
+		logging.Debugf("Failed to remove podman rootful system connection: %v", err)
 	}
 
 	if err := cleanKubeconfig(getGlobalKubeConfigPath(), getGlobalKubeConfigPath()); err != nil {


### PR DESCRIPTION
**Fixes:** Issue #3123 

In case of openshift preset there is no crc system connections are
created so during delete following error appear in windows.
```
DEBU Running 'Hyper-V\Get-VM crc | Select-Object -ExpandProperty State'
DEBU Running 'Hyper-V\Remove-VM crc -Force'
DEBU Running 'C:\Users\prkumar\.crc\bin\oc\podman.exe system connection
remove crc'
DEBU Command failed: exit status 1
DEBU stdout:
DEBU stderr: time="2022-04-22T16:29:27+05:30" level=error msg="The
handle is invalid."
failed to remove podman system connection exit status 1:
time="2022-04-22T16:29:27+05:30" level=error msg="The handle is
invalid."
```

This pr send the error to debug logs and not block the delete
operation.


