### PR TITLE
Change CodeReady Containers to CRC in extended test folder

### DIFF
--- a/test/extended/crc/ux/installer/applescripts/install.applescript
+++ b/test/extended/crc/ux/installer/applescripts/install.applescript
@@ -1,6 +1,6 @@
 on run {installerPath, adminPassword}
     set installer to installerPath as POSIX file
-    set installerWindow to "Install CodeReady Containers"
+    set installerWindow to "Install CRC"
     tell application "Finder" to open installer
     delay 1
     tell application "System Events"

--- a/test/extended/crc/ux/installer/applescripts/install.applescript
+++ b/test/extended/crc/ux/installer/applescripts/install.applescript
@@ -1,6 +1,6 @@
 on run {installerPath, adminPassword}
     set installer to installerPath as POSIX file
-    set installerWindow to "Install CRC"
+    set installerWindow to "Install OpenShift Local"
     tell application "Finder" to open installer
     delay 1
     tell application "System Events"

--- a/test/extended/crc/ux/installer/installer_windows.go
+++ b/test/extended/crc/ux/installer/installer_windows.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	installerWindowTitle string = "CodeReady Containers Setup"
+	installerWindowTitle string = "CRC Setup"
 
 	installerStartTime time.Duration = 20 * time.Second
 	elementClickTime   time.Duration = 2 * time.Second

--- a/test/extended/crc/ux/installer/installer_windows.go
+++ b/test/extended/crc/ux/installer/installer_windows.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	installerWindowTitle string = "CRC Setup"
+	installerWindowTitle string = "OpenShift Local Setup"
 
 	installerStartTime time.Duration = 20 * time.Second
 	elementClickTime   time.Duration = 2 * time.Second

--- a/test/extended/crc/ux/notification/notification_windows.go
+++ b/test/extended/crc/ux/notification/notification_windows.go
@@ -15,11 +15,11 @@ type gowinxHandler struct {
 }
 
 const (
-	startMessage  string = "CodeReady Containers Cluster has started"
+	startMessage  string = "CRC Cluster has started"
 	stopMessage   string = "Cluster stopped"
 	deleteMessage string = "Cluster deleted"
 
-	notificationGroupName string = "CodeReady Containers"
+	notificationGroupName string = "CRC"
 )
 
 func NewNotification() Notification {

--- a/test/extended/crc/ux/notification/notification_windows.go
+++ b/test/extended/crc/ux/notification/notification_windows.go
@@ -15,11 +15,11 @@ type gowinxHandler struct {
 }
 
 const (
-	startMessage  string = "CRC Cluster has started"
+	startMessage  string = "OpenShift Local Cluster has started"
 	stopMessage   string = "Cluster stopped"
 	deleteMessage string = "Cluster deleted"
 
-	notificationGroupName string = "CRC"
+	notificationGroupName string = "OpenShift Local"
 )
 
 func NewNotification() Notification {

--- a/test/extended/crc/ux/tray/tray_windows.go
+++ b/test/extended/crc/ux/tray/tray_windows.go
@@ -25,7 +25,7 @@ type gowinxHandler struct {
 const (
 	trayAssemblyName string = "crc-tray.exe"
 
-	notificationIcon string = "CRC"
+	notificationIcon string = "OpenShift Local"
 	contextMenu      string = "menu"
 	loginMenu        string = "loginMenu"
 

--- a/test/extended/crc/ux/tray/tray_windows.go
+++ b/test/extended/crc/ux/tray/tray_windows.go
@@ -25,7 +25,7 @@ type gowinxHandler struct {
 const (
 	trayAssemblyName string = "crc-tray.exe"
 
-	notificationIcon string = "CodeReady Containers"
+	notificationIcon string = "CRC"
 	contextMenu      string = "menu"
 	loginMenu        string = "loginMenu"
 


### PR DESCRIPTION
Follow-up to PR #3136

Before:
```bash
$ grep -nr "CodeReady" ./test/
./test/extended/crc/ux/installer/applescripts/install.applescript:3:    set installerWindow to "Install CodeReady Containers"
./test/extended/crc/ux/installer/installer_windows.go:16:	installerWindowTitle string = "CodeReady Containers Setup"
./test/extended/crc/ux/notification/notification_windows.go:18:	startMessage  string = "CodeReady Containers Cluster has started"
./test/extended/crc/ux/notification/notification_windows.go:22:	notificationGroupName string = "CodeReady Containers"
./test/extended/crc/ux/tray/tray_windows.go:28:	notificationIcon string = "CodeReady Containers"
```
After:
```bash
$ grep -nr "CodeReady" ./test/
$
```