### PR TITLE
Windows: Add task trigger to start daemon task when user logs in

### DIFF
--- a/pkg/crc/preflight/preflight_checks_darwin.go
+++ b/pkg/crc/preflight/preflight_checks_darwin.go
@@ -174,9 +174,6 @@ func getDaemonConfig() (*launchd.AgentConfig, error) {
 }
 
 func checkIfDaemonPlistFileExists() error {
-	if err := olderDaemonVersionRunning(); err != nil {
-		return err
-	}
 	daemonConfig, err := getDaemonConfig()
 	if err != nil {
 		return err
@@ -191,7 +188,7 @@ func checkIfDaemonPlistFileExists() error {
 }
 
 func fixDaemonPlistFileExists() error {
-	if err := olderDaemonVersionRunning(); err != nil {
+	if daemonRunning() {
 		if err := killDaemonProcess(); err != nil {
 			return err
 		}

--- a/pkg/crc/preflight/preflight_checks_nonlinux.go
+++ b/pkg/crc/preflight/preflight_checks_nonlinux.go
@@ -63,18 +63,6 @@ func isDaemonProcess(cmdLine []string) bool {
 	return false
 }
 
-func olderDaemonVersionRunning() error {
-	// Here daemonclient.GetVersionFromDaemonAPI() can return the error
-	// if the daemon is not running or daemon version API is not responding
-	// in both situation we can't check if daemon is running with an older
-	// version of crc or not, so we are just ignoring the error from it.
-	v, err := daemonclient.GetVersionFromDaemonAPI()
-	if err != nil {
-		return nil
-	}
-	return daemonclient.CheckIfOlderVersion(v)
-}
-
 func daemonRunning() bool {
 	if _, err := daemonclient.GetVersionFromDaemonAPI(); err != nil {
 		return false

--- a/pkg/crc/preflight/preflight_daemon_task_check_windows.go
+++ b/pkg/crc/preflight/preflight_daemon_task_check_windows.go
@@ -134,9 +134,6 @@ func removeDaemonTask() error {
 }
 
 func checkIfDaemonTaskRunning() error {
-	if err := olderDaemonVersionRunning(); err != nil {
-		return err
-	}
 	stdout, stderr, err := powershell.Execute(fmt.Sprintf(`(Get-ScheduledTask -TaskName "%s").State`, constants.DaemonTaskName))
 	if err != nil {
 		logging.Debugf("%s task is not running: %v : %s", constants.DaemonTaskName, err, stderr)
@@ -149,7 +146,7 @@ func checkIfDaemonTaskRunning() error {
 }
 
 func fixDaemonTaskRunning() error {
-	if err := olderDaemonVersionRunning(); err != nil {
+	if daemonRunning() {
 		if err := killDaemonProcess(); err != nil {
 			return err
 		}

--- a/pkg/crc/preflight/preflight_daemon_task_check_windows.go
+++ b/pkg/crc/preflight/preflight_daemon_task_check_windows.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 
 	"github.com/code-ready/crc/pkg/crc/constants"
-	"github.com/code-ready/crc/pkg/crc/daemonclient"
 	"github.com/code-ready/crc/pkg/crc/logging"
 	"github.com/code-ready/crc/pkg/crc/version"
 	"github.com/code-ready/crc/pkg/os/windows/powershell"
@@ -135,16 +134,9 @@ func removeDaemonTask() error {
 }
 
 func checkIfDaemonTaskRunning() error {
-	// First check if a daemon process is running and then check if
-	// the running daemon process is of older version, this way  we
-	// return nil if a daemon process is running that is not old
-	if _, err := daemonclient.GetVersionFromDaemonAPI(); err == nil {
-		if err := olderDaemonVersionRunning(); err != nil {
-			return err
-		}
-		return nil
+	if err := olderDaemonVersionRunning(); err != nil {
+		return err
 	}
-
 	stdout, stderr, err := powershell.Execute(fmt.Sprintf(`(Get-ScheduledTask -TaskName "%s").State`, constants.DaemonTaskName))
 	if err != nil {
 		logging.Debugf("%s task is not running: %v : %s", constants.DaemonTaskName, err, stderr)

--- a/tools/bin/.gitignore
+++ b/tools/bin/.gitignore
@@ -1,1 +1,2 @@
 golangci-lint
+golangci-lint.exe


### PR DESCRIPTION
**Fixes:** Issue #3105 

This PR add a task tigger for crcDaemon task to make sure the task
runs as soon as user login after reboot/logout.


## Testing
- crc cleanup
- crc setup
 
=== Reboot the system===
- crc setup --check-only  => this shouldn't fail
