### PR TITLE
[wip] [test] move the code checking if scheduled task exists in a separate function

### DIFF
--- a/pkg/crc/preflight/preflight_daemon_task_check_windows.go
+++ b/pkg/crc/preflight/preflight_daemon_task_check_windows.go
@@ -100,7 +100,7 @@ func fixDaemonTaskInstalled() error {
 }
 
 func removeDaemonTask() error {
-	if err := checkIfDaemonTaskRunning(); err == nil {
+	if err := checkIfDaemonScheduledTaskRunning(); err == nil {
 		_, stderr, err := powershell.Execute("Stop-ScheduledTask", "-TaskName", constants.DaemonTaskName)
 		if err != nil {
 			logging.Debugf("unable to stop the %s task: %v : %s", constants.DaemonTaskName, err, stderr)
@@ -128,6 +128,10 @@ func checkIfDaemonTaskRunning() error {
 		return nil
 	}
 
+	return checkIfDaemonScheduledTaskRunning()
+}
+
+func checkIfDaemonScheduledTaskRunning() error {
 	stdout, stderr, err := powershell.Execute(fmt.Sprintf(`(Get-ScheduledTask -TaskName "%s").State`, constants.DaemonTaskName))
 	if err != nil {
 		logging.Debugf("%s task is not running: %v : %s", constants.DaemonTaskName, err, stderr)


### PR DESCRIPTION
this allows to only check for the scheduled task and return nil
if a daemon process is running

this prevents an error during setup where it was trying to remove
a non existing crcDaemon task as checkIfDaemonTaskRunning fnction
was wrongly returning nil because of a running daemon process


**Fixes:** Issue #N

**Relates to:** Issue #N, PR #N, ...

## Solution/Idea

Describe in plain English what you solved and how. For instance, _Added `start` command to CRC so the user can create a VM and set-up a single-node OpenShift cluster on it with one command. It requires blablabla..._

## Proposed changes

List main as well as consequential changes you introduced or had to introduce.

1. Add `start` command.
2. Add `setup` as prerequisite to `start`.
3. ...

## Testing

What is the _bottom-line_ functionality that needs testing? Describe in pseudo-code or in English. Use verifiable statements that tie your changes to existing functionality.

1. `start` succeeds first time after `setup` succeeded
2. stdout contains ... if `start` succeeded
3. stderr contains ... after `start` failed
4. `status` returns ... if `start` succeeded
5. `status` returns ... if `start` failed
6. `start` fails after `start` succeeded or after `status` says CRC is `Running`
7. ...
