### PR TITLE
Windows: Make sure task exist before stop and removing it

### DIFF
--- a/pkg/crc/preflight/preflight_daemon_task_check_windows.go
+++ b/pkg/crc/preflight/preflight_daemon_task_check_windows.go
@@ -100,6 +100,12 @@ func fixDaemonTaskInstalled() error {
 }
 
 func removeDaemonTask() error {
+	// Return nil if the task does not exist
+	_, stderr, err := powershell.Execute("Get-ScheduledTask", "-TaskName", constants.DaemonTaskName)
+	if err != nil {
+		logging.Debugf("%s task is not installed: %v : %s", constants.DaemonTaskName, err, stderr)
+		return nil
+	}
 	if err := checkIfDaemonTaskRunning(); err == nil {
 		_, stderr, err := powershell.Execute("Stop-ScheduledTask", "-TaskName", constants.DaemonTaskName)
 		if err != nil {


### PR DESCRIPTION
As part of daemon task removal code we don't check if the task even
exist before we run stop on that and it caused issue when daemon process
is already running by manually or by different process (like tray app)

```
<= on one terminal  =>
$ crc daemon

<= on another terminal =>
$ crc setup
INFO Checking if daemon task is installed
DEBU Running 'Get-ScheduledTask -TaskName crcDaemon'
DEBU Command failed: exit status 1
DEBU stdout:
DEBU stderr: Get-ScheduledTask : No MSFT_ScheduledTask objects found with property 'TaskName' equal to 'crcDaemon'.  Verify the value of the property and retry.
At line:1 char:43
+ ... reference = 'SilentlyContinue'; Get-ScheduledTask -TaskName crcDaemon
+                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : ObjectNotFound: (crcDaemon:String) [Get-ScheduledTask], CimJobException
    + FullyQualifiedErrorId : CmdletizationQuery_NotFound_TaskName,Get-ScheduledTask

DEBU crcDaemon task is not installed: exit status 1 : Get-ScheduledTask : No MSFT_ScheduledTask objects found with property 'TaskName' equal to 'crcDaemon'.  Verify the value of the property and retry.
At line:1 char:43
+ ... reference = 'SilentlyContinue'; Get-ScheduledTask -TaskName crcDaemon
+                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : ObjectNotFound: (crcDaemon:String) [Get-ScheduledTask], CimJobException
    + FullyQualifiedErrorId : CmdletizationQuery_NotFound_TaskName,Get-ScheduledTask

DEBU exit status 1
INFO Installing the daemon task
DEBU Running 'Stop-ScheduledTask -TaskName crcDaemon'
DEBU Command failed: exit status 1
DEBU stdout:
DEBU stderr: Stop-ScheduledTask : The system cannot find the file specified.
At line:1 char:43
+ ... eference = 'SilentlyContinue'; Stop-ScheduledTask -TaskName crcDaemon
+                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : ObjectNotFound: (PS_ScheduledTask:Root/Microsoft/...S_ScheduledTask) [Stop-ScheduledTask], CimException
    + FullyQualifiedErrorId : HRESULT 0x80070002,Stop-ScheduledTask

DEBU unable to stop the crcDaemon task: exit status 1 : Stop-ScheduledTask : The system cannot find the file specified.
At line:1 char:43
+ ... eference = 'SilentlyContinue'; Stop-ScheduledTask -TaskName crcDaemon
+                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : ObjectNotFound: (PS_ScheduledTask:Root/Microsoft/...S_ScheduledTask) [Stop-ScheduledTask], CimException
    + FullyQualifiedErrorId : HRESULT 0x80070002,Stop-ScheduledTask

exit status 1
```

fixes: #3145

