### PR TITLE
Mac/Windows: Check if daemon able to serve after it starts

### DIFF
--- a/pkg/crc/preflight/preflight_checks_darwin.go
+++ b/pkg/crc/preflight/preflight_checks_darwin.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/code-ready/crc/pkg/crc/cache"
 	"github.com/code-ready/crc/pkg/crc/constants"
-	"github.com/code-ready/crc/pkg/crc/daemonclient"
 	"github.com/code-ready/crc/pkg/crc/logging"
 	"github.com/code-ready/crc/pkg/crc/network"
 	"github.com/code-ready/crc/pkg/crc/version"
@@ -278,13 +277,6 @@ func checkIfDaemonPlistFileExists() error {
 	return nil
 }
 
-func daemonRunning() bool {
-	if _, err := daemonclient.GetVersionFromDaemonAPI(); err != nil {
-		return false
-	}
-	return true
-}
-
 func fixDaemonPlistFileExists() error {
 	if err := olderDaemonVersionRunning(); err != nil {
 		if err := killDaemonProcess(); err != nil {
@@ -319,5 +311,5 @@ func fixPlistFileExists(agentConfig launchd.AgentConfig) error {
 		logging.Debugf("failed to restart launchd agent '%s': %v", agentConfig.Label, err.Error())
 		return err
 	}
-	return nil
+	return waitForDaemonRunning()
 }

--- a/pkg/crc/preflight/preflight_daemon_task_check_windows.go
+++ b/pkg/crc/preflight/preflight_daemon_task_check_windows.go
@@ -156,7 +156,7 @@ func fixDaemonTaskRunning() error {
 		logging.Debugf("unable to run the %s task: %v : %s", constants.DaemonTaskName, err, stderr)
 		return err
 	}
-	return nil
+	return waitForDaemonRunning()
 }
 
 func checkIfOlderTask() error {


### PR DESCRIPTION
This PR add time limit (15 sec) to make sure daemon able to serve
the requests after it is start because sometimes just after start
it takes time to serve.

fixes: #3148


