### PR TITLE
Git Workflow: Add action-tmate to mac git workflow

### DIFF
--- a/.github/workflows/macos-installer.yml
+++ b/.github/workflows/macos-installer.yml
@@ -5,6 +5,12 @@ on:
       - "main"
       - "old-main"
   pull_request: {}
+  workflow_dispatch:
+    inputs:
+      debug_enabled:
+        description: 'Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)'
+        required: false
+        default: false
 jobs:
   build:
     runs-on: ${{ matrix.os }}
@@ -17,6 +23,13 @@ jobs:
         go:
           - 1.16
     steps:
+      # Enable tmate debugging of manually-triggered workflows if the input option was provided
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled }}
+        with:
+          limit-access-to-actor: true
+        timeout-minutes: 30
       - name: Check out repository code
         uses: actions/checkout@v2
       - name: Set up Go

--- a/.github/workflows/macos-installer.yml
+++ b/.github/workflows/macos-installer.yml
@@ -38,6 +38,16 @@ jobs:
           go-version: ${{ matrix.go }}
       - name: Build macOS installer
         run: make NO_CODESIGN=1 out/macos-amd64/crc-macos-amd64.pkg
+      - name: Install crc pkg
+        run: sudo installer -pkg out/macos-amd64/crc-macos-amd64.pkg -target /
+      - name: Set podman preset as part of config
+        run: crc config set preset podman
+      - name: Run crc setup command
+        run: crc setup
+      - name: Wait 10 sec for the daemon to serve
+        run: sleep 10
+      - name: Run crc with podman preset
+        run: crc start
       - name: Upload macOS installer artifact
         uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
This GitHub Action offers us a direct way to interact with the
host system on which the actual scripts (Actions) will run.

- https://github.com/mxschmitt/action-tmate