### PR TITLE
Doc-Builder: Add docs.github.com url to ignore list 

### DIFF
--- a/docs/source/topics/proc_troubleshooting-unknown-issues.adoc
+++ b/docs/source/topics/proc_troubleshooting-unknown-issues.adoc
@@ -64,5 +64,5 @@ The cluster takes a minimum of four minutes to start the necessary containers an
 If your issue is not resolved by this procedure, perform the following steps:
 
 . link:https://github.com/code-ready/crc/issues[Search open issues] for the issue that you are encountering.
-. If no existing issue addresses the encountered issue, link:https://github.com/code-ready/crc/issues/new[create an issue] and link:https://help.github.com/en/articles/file-attachments-on-issues-and-pull-requests[attach the [filename]*_~/.crc/crc.log_* file] to the created issue.
+. If no existing issue addresses the encountered issue, link:https://github.com/code-ready/crc/issues/new[create an issue] and link:https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/attaching-files[attach the [filename]*_~/.crc/crc.log_* file] to the created issue.
 The [filename]*_~/.crc/crc.log_* file has detailed debugging and troubleshooting information which can help diagnose the problem that you are experiencing.

--- a/images/docs-builder/links_ignorelist.json
+++ b/images/docs-builder/links_ignorelist.json
@@ -2,6 +2,7 @@
     "ignorePatterns": [
         { "pattern": "^https://api.crc.testing" },
         { "pattern": "^http://api.crc.testing" },
+        { "pattern": "^https://docs.github.com/.*$" },
         { "pattern": "https://console-openshift-console.apps-crc.testing" },
         { "pattern": "http://proxy.example.com" }
     ]


### PR DESCRIPTION
This pr try to solve following issue by adding docs.github.com
to ignore list.

```
FILE: ./source/topics/proc_troubleshooting-unknown-issues.adoc
[✓] https://github.com/code-ready/crc/issues
[✓] https://github.com/code-ready/crc/issues/new
[heavy_multiplication_x] https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/attaching-files

3 links checked.

ERROR: 1 dead links found!
[heavy_multiplication_x] https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/attaching-files → Status: 403
make: *** [Makefile:138: docs_check_links] Error 123
```

```
$ curl -I https://docs.github.com/
HTTP/2 403
x-azure-ref: 0fzhqYgAAAAA4TNP/TuUcR6h8UmZoI8OxRFhCMzBFREdFMDIxNQA1OTZkNzhhMi1jYTVmLTQ3OWQtYmNkYy0wODM1ODMzMTc0YjI=
accept-ranges: bytes
date: Thu, 28 Apr 2022 06:47:27 GMT
via: 1.1 varnish
x-served-by: cache-maa10249-MAA
x-cache: MISS
x-cache-hits: 0
x-timer: S1651128448.577384,VS0,VE51
strict-transport-security: max-age=31557600
```

- https://github.com/github/docs/issues/17358
