### PR TITLE
Fix help.github.com link checks

### DIFF
--- a/images/docs-builder/Dockerfile
+++ b/images/docs-builder/Dockerfile
@@ -12,7 +12,7 @@ RUN gem install asciidoctor && \
 
 COPY entrypoint.sh /sbin/entrypoint.sh
 RUN chmod 755 /sbin/entrypoint.sh
-COPY links_ignorelist.json /links_ignorelist.json
+COPY asciidoc-link-check-config.json /asciidoc-link-check-config.json
 
 VOLUME /docs
 WORKDIR /docs

--- a/images/docs-builder/asciidoc-link-check-config.json
+++ b/images/docs-builder/asciidoc-link-check-config.json
@@ -5,5 +5,4 @@
         { "pattern": "https://console-openshift-console.apps-crc.testing" },
         { "pattern": "http://proxy.example.com" }
     ]
-
 }

--- a/images/docs-builder/asciidoc-link-check-config.json
+++ b/images/docs-builder/asciidoc-link-check-config.json
@@ -4,5 +4,13 @@
         { "pattern": "^http://api.crc.testing" },
         { "pattern": "https://console-openshift-console.apps-crc.testing" },
         { "pattern": "http://proxy.example.com" }
+    ],
+    "httpHeaders": [
+        {
+          "urls": ["https://help.github.com"],
+          "headers": {
+            "Accept-Encoding": "gzip, deflate"
+          }
+        }
     ]
 }

--- a/images/docs-builder/entrypoint.sh
+++ b/images/docs-builder/entrypoint.sh
@@ -13,7 +13,7 @@ case $1 in
 		;;
 	docs_check_links)
 		echo "Checking if all links are alive in docs source"
-		find . -name \*.adoc | xargs -n1 asciidoc-link-check -c /links_ignorelist.json -q
+		find . -name \*.adoc | xargs -n1 asciidoc-link-check -c /asciidoc-link-check-config.json -q
 		;;
 	docs_serve)
 		cd build


### PR DESCRIPTION
For some reason, help.github.com will only serve compressed content, and
will reply with a 403 error without any "Accept-encoding" headers.
This causes 'make docs_check_links' to report help.github.com links as being
dead.
This issue is tracked in https://github.com/github/docs/issues/17358

For this fix to work, quay.io/crcont/docs-builder:latest must be rebuilt
and pushed to quay.
This can be rebuilt and tested locally with:

$ (cd images/docs-builder && podman build -t quay.io/crcont/docs-builder:latest .)
$ make docs_check_links