### PR TITLE
macos-pkg: apply required entitlements to vfkit binary during pkg build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -302,7 +302,10 @@ ifeq ($(CUSTOM_EMBED),false)
 	$(HOST_BUILD_DIR)/crc-embedder download $(EMBED_DOWNLOAD_DIR)
 endif
 
-packagedir: clean embed-download macos-release-binary
+packaging/vfkit-$(GOARCH).entitlements:
+	curl -sL https://raw.githubusercontent.com/code-ready/vfkit/main/vf.entitlements -o $@
+
+packagedir: clean embed-download macos-release-binary packaging/vfkit-$(GOARCH).entitlements
 	echo -n $(CRC_VERSION) > packaging/VERSION
 	sed -e 's/__VERSION__/'$(CRC_VERSION)'/g' -e 's@__INSTALL_PATH__@$(MACOS_INSTALL_PATH)@g' packaging/darwin/Distribution.in >packaging/darwin/Distribution
 	sed -e 's/__VERSION__/'$(CRC_VERSION)'/g' -e 's@__INSTALL_PATH__@$(MACOS_INSTALL_PATH)@g' packaging/darwin/welcome.html.in >packaging/darwin/Resources/welcome.html

--- a/packaging/.gitignore
+++ b/packaging/.gitignore
@@ -7,3 +7,4 @@ root/
 /VERSION
 /windows/msi/
 packaging/windows/product.wxs
+vfkit-*.entitlements

--- a/packaging/darwin/Resources/conclusion.html
+++ b/packaging/darwin/Resources/conclusion.html
@@ -7,7 +7,7 @@
 <div align="left" style="font-family: Helvetica; padding-left: 10px;">
     <br/>
     <p style="color: #020202; font-size: 12px;">Thanks for installing Red Hat OpenShift Local!</p>
-    <p style="color: #020202; font-size: 12px;">You can now open CodeReady Containers from the Applications folder.</b>.</p>
+    <p style="color: #020202; font-size: 12px;">You can now open OpenShift Local from the Applications folder.</b>.</p>
 </div>
 </body>
 </html>

--- a/packaging/package.sh
+++ b/packaging/package.sh
@@ -3,10 +3,22 @@ set -euxo pipefail
 
 BASEDIR=$(dirname "$0")
 OUTPUT=$1
-GOARCH=$(go env GOARCH)
 CODESIGN_IDENTITY=${CODESIGN_IDENTITY:-mock}
 PRODUCTSIGN_IDENTITY=${PRODUCTSIGN_IDENTITY:-mock}
 NO_CODESIGN=${NO_CODESIGN:-0}
+
+case "$(uname -m)" in
+    "x86_64")
+        GOARCH="amd64"
+        ;;
+    "arm64")
+        GOARCH="arm64"
+        ;;
+    *)
+        echo "Unknown arch, exiting"
+        exit 1
+        ;;
+esac
 
 function sign() {
   if [ "${NO_CODESIGN}" -eq "1" ]; then


### PR DESCRIPTION
although the required entitlements are already applied to the released vfkit
binary, they gets overwritten when codesiging again during the pkg build
process, so we download the entitlements file from code-ready/vfkit and re-apply
