### PR TITLE
Enable proxy use when using podman-remote

### DIFF
--- a/images/squid/Dockerfile
+++ b/images/squid/Dockerfile
@@ -30,7 +30,7 @@
 # (commonName must be set to 192.168.122.1 before running generate-certs.sh and building the container image)
 
 # Intermediate build image to generate the CA and certificate used for https
-FROM registry.centos.org/centos/centos:centos8 AS gencerts
+FROM quay.io/centos/centos:stream8 AS gencerts
 MAINTAINER CRC <devtools-cdk@redhat.com>
 
 RUN yum -y install openssl
@@ -41,7 +41,8 @@ RUN bash ./generate-certs.sh
 
 
 # Final squid container
-FROM registry.centos.org/centos/centos:centos8
+FROM quay.io/centos/centos:stream8
+
 MAINTAINER CRC <devtools-cdk@redhat.com>
 
 RUN yum -y install squid && \

--- a/pkg/crc/machine/machine.go
+++ b/pkg/crc/machine/machine.go
@@ -25,7 +25,7 @@ func getClusterConfig(bundleInfo *bundle.CrcBundleInfo) (*types.ClusterConfig, e
 	if err != nil {
 		return nil, fmt.Errorf("Error reading kubeadmin password from bundle %v", err)
 	}
-	proxyConfig, err := getProxyConfig(bundleInfo.ClusterInfo.BaseDomain)
+	proxyConfig, err := getProxyConfig(bundleInfo)
 	if err != nil {
 		return nil, err
 	}
@@ -65,13 +65,13 @@ func createLibMachineClient() (libmachine.API, func()) {
 	}
 }
 
-func getProxyConfig(baseDomainName string) (*network.ProxyConfig, error) {
+func getProxyConfig(bundleInfo *bundle.CrcBundleInfo) (*network.ProxyConfig, error) {
 	proxy, err := network.NewProxyConfig()
 	if err != nil {
 		return nil, err
 	}
-	if proxy.IsEnabled() {
-		proxy.AddNoProxy(fmt.Sprintf(".%s", baseDomainName))
+	if proxy.IsEnabled() && bundleInfo.IsOpenShift() {
+		proxy.AddNoProxy(fmt.Sprintf(".%s", bundleInfo.ClusterInfo.BaseDomain))
 	}
 
 	return proxy, nil

--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -345,7 +345,7 @@ func (client *client) Start(ctx context.Context, startConfig types.StartConfig) 
 		}, nil
 	}
 
-	proxyConfig, err := getProxyConfig(vm.bundle.ClusterInfo.BaseDomain)
+	proxyConfig, err := getProxyConfig(vm.bundle)
 	if err != nil {
 		return nil, errors.Wrap(err, "Error getting proxy configuration")
 	}

--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -430,7 +430,7 @@ func (client *client) Start(ctx context.Context, startConfig types.StartConfig) 
 		return nil, errors.Wrap(err, "Failed to update pull secret on the disk")
 	}
 
-	if err := ensureProxyIsConfiguredInOpenShift(ctx, ocConfig, sshRunner, proxyConfig, instanceIP); err != nil {
+	if err := ensureProxyIsConfiguredInOpenShift(ctx, ocConfig, sshRunner, proxyConfig); err != nil {
 		return nil, errors.Wrap(err, "Failed to update cluster proxy configuration")
 	}
 
@@ -642,7 +642,7 @@ func copyKubeconfigFileWithUpdatedUserClientCertAndKey(selfSignedCAKey *rsa.Priv
 	return updateClientCrtAndKeyToKubeconfig(clientKey, clientCert, srcKubeConfigPath, dstKubeConfigPath)
 }
 
-func ensureProxyIsConfiguredInOpenShift(ctx context.Context, ocConfig oc.Config, sshRunner *crcssh.Runner, proxy *network.ProxyConfig, instanceIP string) (err error) {
+func ensureProxyIsConfiguredInOpenShift(ctx context.Context, ocConfig oc.Config, sshRunner *crcssh.Runner, proxy *network.ProxyConfig) (err error) {
 	if !proxy.IsEnabled() {
 		return nil
 	}


### PR DESCRIPTION
**Fixes:** Issue #3166 

## Solution/Idea

At the moment, the proxy configuration done in crc is not used by podman-remote. This happens because we don't propagate the needed environment variable to the services podman uses in the VM.


## Proposed changes

This commit creates a /etc/environment.d/proxy-env.conf file which will be used automatically by systemd when it spawns podman.service for rootless use (ie through a systemd user instance)

This then adds a /etc/systemd/system/podman.service.d/proxy-env.conf file to achieve the same for podman.service used as root (in the main systemd instance).  This file re-uses the env vars defined in /etc/environment.d/proxy-env.conf

## Testing

1. `crc config set https-proxy ....`
2. `crc start` (can be podman or openshift bundle)
3. `eval $(./out/linux-amd64/crc podman-env)`
4. `podman-remote pull registry.access.redhat.com/ubi8`

-> check that this request goes through your proxy