### PR TITLE
Daemon: Add containers.internal DNS record for podman-4.x to work

### DIFF
--- a/cmd/crc/cmd/daemon.go
+++ b/cmd/crc/cmd/daemon.go
@@ -93,6 +93,15 @@ var daemonCmd = &cobra.Command{
 						},
 					},
 				},
+				{
+					Name: "containers.internal.",
+					Records: []types.Record{
+						{
+							Name: "gateway",
+							IP:   net.ParseIP(hostVirtualIP),
+						},
+					},
+				},
 			},
 			Protocol: types.HyperKitProtocol,
 		}
@@ -150,7 +159,7 @@ func run(configuration *types.Configuration) error {
 		}
 	}()
 
-	networkListener, err := vn.Listen("tcp", fmt.Sprintf("%s:7777", hostVirtualIP))
+	networkListener, err := vn.Listen("tcp", fmt.Sprintf("%s:80", hostVirtualIP))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
With podman 4.x when user run the container with exposed port on mac/windows
then internally port is exposed to virtual network (using gvproxy) and for podman
3.x it was `host.crc.testing:7777` but now changed to `gateway.containers.internal`.

This PR is add the `gateway.containers.internal` DNS record so running the containers
with exposed port on crc also works as expected for podman 4.x

```
macos-amd64 git:(podman_4.x) ✗ podman run -d -p 8080:80 docker.io/httpd:2.4
766bb336d71402d4747d658f17f139f6d60b8fde238bb4aedd1aa45d96ae24de

[core@podman ~]$ curl gateway.containers.internal/services/forwarder/all | jq .
[
  {
    "local": "/Users/prkumar/.crc/machines/crc/docker.sock",
    "remote": "ssh-tunnel://core@192.168.127.2:22/run/podman/podman.sock?key=%2FUsers%2Fprkumar%2F.crc%2Fmachines%2Fcrc%2Fid_ecdsa",
    "protocol": "unix"
  },
  {
    "local": "127.0.0.1:2222",
    "remote": "192.168.127.2:22",
    "protocol": "tcp"
  },
  {
    "local": "127.0.0.1:9090",
    "remote": "192.168.127.2:9090",
    "protocol": "tcp"
  },
  {
    "local": ":8080",
    "remote": "192.168.127.2:8080",
    "protocol": "tcp"
  }
]
```