### PR TITLE
Update URLs from cloud to console.redhat.com

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -34,7 +34,7 @@ You can manually change your preference about usage data collection by running `
 
 === Getting CRC
 
-CRC binaries with an embedded OpenShift disk image can be downloaded from link:https://cloud.redhat.com/openshift/create/local[this page].
+CRC binaries with an embedded OpenShift disk image can be downloaded from link:https://console.redhat.com/openshift/create/local[this page].
 
 === Using CRC
 

--- a/pkg/crc/constants/constants.go
+++ b/pkg/crc/constants/constants.go
@@ -22,7 +22,7 @@ const (
 	ConfigFile                = "crc.json"
 	LogFile                   = "crc.log"
 	DaemonLogFile             = "crcd.log"
-	CrcLandingPageURL         = "https://cloud.redhat.com/openshift/create/local" // #nosec G101
+	CrcLandingPageURL         = "https://console.redhat.com/openshift/create/local" // #nosec G101
 	DefaultPodmanURLBase      = "https://storage.googleapis.com/libpod-master-releases"
 	DefaultAdminHelperCliBase = "https://github.com/code-ready/admin-helper/releases/download/0.0.10"
 	CRCMacTrayDownloadURL     = "https://github.com/code-ready/tray-electron/releases/download/%s/crc-tray-macos.tar.gz"


### PR DESCRIPTION
## Solution
Last year cloud.redhat.com was changed to console.redhat.com as can be seen in https://cloud.redhat.com/blog/check-out-our-new-look

This can be easily checked: 

    $ curl -I https://cloud.redhat.com/openshift/create/local
    HTTP/2 302 
    content-length: 0
    date: Thu, 19 May 2022 14:16:06 GMT
    (...)
    location: https://console.redhat.com/openshift/create/local
