### PR TITLE
docs: Update `odo` usage information

### DIFF
--- a/docs/source/topics/proc_deploying-sample-application-with-odo.adoc
+++ b/docs/source/topics/proc_deploying-sample-application-with-odo.adoc
@@ -37,18 +37,20 @@ $ mkdir sample-app
 $ cd sample-app
 ----
 
-. Create a component from a sample application on GitHub:
+. Clone an example Node.js application:
 +
 [subs="+quotes,attributes"]
 ----
-$ odo create nodejs --s2i --git https://github.com/openshift/nodejs-ex
+$ git clone https://github.com/openshift/nodejs-ex
+$ cd nodejs-ex
 ----
+
+. Add a `nodejs` component to the application:
 +
-[NOTE]
-====
-Creating a component from a remote Git repository will rebuild the application each time you run the [command]`odo push` command.
-To create a component from a local Git repository, see link:{odo-docs-url-single-component}[Creating a single-component application with `odo`] in the [command]`odo` documentation.
-====
+[subs="+quotes,attributes"]
+----
+$ odo create nodejs
+----
 
 . Create a URL and add an entry to the local configuration file:
 +


### PR DESCRIPTION
The procedure for using `odo` to deploy a sample application is out of date. This PR changes the procedure to be in line with the current version.

Note that we will likely have to update this information again sometime soon, as `odo` plans to release a new major version in the near future.

**Note:** I tested this procedure personally using `crc` and `odo`, and it works as expected.