### PR TITLE
Detect mismatch of bundle version from Makefile and bundle/constant.go

### DIFF
--- a/pkg/crc/machine/bundle/metadata.go
+++ b/pkg/crc/machine/bundle/metadata.go
@@ -268,6 +268,13 @@ func Download(preset preset.Preset) error {
 	if err != nil {
 		return err
 	}
+	bundleNameFromURI, err := downloadInfo.GetSourceFilename()
+	if err != nil {
+		return err
+	}
+	if constants.GetDefaultBundle(preset) != bundleNameFromURI {
+		return fmt.Errorf("expected %s but found %s in Makefile", bundleNameFromURI, constants.GetDefaultBundle(preset))
+	}
 	if _, err := downloadInfo.Download(constants.GetDefaultBundlePath(preset), 0664); err != nil {
 		return err
 	}

--- a/pkg/download/download.go
+++ b/pkg/download/download.go
@@ -4,7 +4,9 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"net/http"
+	"net/url"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/code-ready/crc/pkg/crc/logging"
@@ -95,4 +97,12 @@ func (r *RemoteFile) Download(bundlePath string, mode os.FileMode) (string, erro
 
 func (r *RemoteFile) GetSha256Sum() string {
 	return r.sha256sum
+}
+
+func (r *RemoteFile) GetSourceFilename() (string, error) {
+	u, err := url.Parse(r.uri)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Base(u.Path), nil
 }


### PR DESCRIPTION
This PR detect sync of the `OPENSHIFT_VERSION` and `PODMAN_VERSION` from the
makefile to bundle locations which is part of `bundle/constants.go` and
error out when it is out of sync.

If the Makefile have 4.10.13 openshift version but this is not
synced to mirror then on main branch following will happen.

```
$ crc setup
[...]
INFO Checking if /home/prkumar/.crc/cache/crc_libvirt_4.10.13_amd64.crcbundle exists
INFO Getting bundle for the CRC executable
INFO Downloading crc_libvirt_4.10.13_amd64.crcbundle
expected crc_libvirt_4.10.12_amd64.crcbundle but found crc_libvirt_4.10.13_amd64.crcbundle in Makefile
```

**Fixes:** Issue #3174 

