### PR TITLE
Add M1 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,9 @@ install: $(SOURCES)
 $(BUILD_DIR)/macos-amd64/crc: $(SOURCES)
 	GOARCH=amd64 GOOS=darwin go build -ldflags="$(LDFLAGS)" -o $(BUILD_DIR)/macos-amd64/crc $(GO_EXTRA_BUILDFLAGS) ./cmd/crc
 
+$(BUILD_DIR)/macos-arm64/crc: $(SOURCES)
+	GOARCH=arm64 GOOS=darwin go build -ldflags="$(LDFLAGS)" -o $(BUILD_DIR)/macos-arm64/crc $(GO_EXTRA_BUILDFLAGS) ./cmd/crc
+
 $(BUILD_DIR)/linux-amd64/crc: $(SOURCES)
 	GOOS=linux GOARCH=amd64 go build -ldflags="$(LDFLAGS)" -o $(BUILD_DIR)/linux-amd64/crc $(GO_EXTRA_BUILDFLAGS) ./cmd/crc
 
@@ -103,7 +106,7 @@ $(HOST_BUILD_DIR)/crc-embedder: $(SOURCES)
 	go build --tags="build" -ldflags="$(LDFLAGS)" -o $(HOST_BUILD_DIR)/crc-embedder $(GO_EXTRA_BUILDFLAGS) ./cmd/crc-embedder
 
 .PHONY: cross ## Cross compiles all binaries
-cross: $(BUILD_DIR)/macos-amd64/crc $(BUILD_DIR)/linux-amd64/crc $(BUILD_DIR)/windows-amd64/crc.exe
+cross: $(BUILD_DIR)/macos-arm64/crc $(BUILD_DIR)/macos-amd64/crc $(BUILD_DIR)/linux-amd64/crc $(BUILD_DIR)/windows-amd64/crc.exe
 
 .PHONY: containerized ## Cross compile from container
 containerized: clean
@@ -260,7 +263,7 @@ linux-release-binary: LDFLAGS += -X '$(REPOPATH)/pkg/crc/version.linuxReleaseBui
 linux-release-binary: $(BUILD_DIR)/linux-amd64/crc
 
 macos-release-binary: LDFLAGS+= -X '$(REPOPATH)/pkg/crc/version.installerBuild=true' $(RELEASE_VERSION_VARIABLES)
-macos-release-binary: $(BUILD_DIR)/macos-amd64/crc
+macos-release-binary: $(BUILD_DIR)/macos-arm64/crc $(BUILD_DIR)/macos-amd64/crc
 
 windows-release-binary: LDFLAGS+= -X '$(REPOPATH)/pkg/crc/version.installerBuild=true' $(RELEASE_VERSION_VARIABLES)
 windows-release-binary: $(BUILD_DIR)/windows-amd64/crc.exe

--- a/pkg/crc/config/settings.go
+++ b/pkg/crc/config/settings.go
@@ -55,8 +55,10 @@ func RegisterSettings(cfg *Config) {
 	}
 
 	// Preset setting should be on top because CPUs/Memory config depend on it.
-	cfg.AddSetting(Preset, string(preset.OpenShift), validatePreset, RequiresDeleteAndSetupMsg,
-		fmt.Sprintf("Virtual machine preset (alpha feature - valid values are: %s or %s)", preset.Podman, preset.OpenShift))
+	if runtime.GOOS != "darwin" || runtime.GOARCH != "arm64" {
+		cfg.AddSetting(Preset, string(preset.OpenShift), validatePreset, RequiresDeleteAndSetupMsg,
+			fmt.Sprintf("Virtual machine preset (alpha feature - valid values are: %s or %s)", preset.Podman, preset.OpenShift))
+	}
 	// Start command settings in config
 	cfg.AddSetting(Bundle, defaultBundlePath(cfg), validateBundlePath, SuccessfullyApplied,
 		fmt.Sprintf("Bundle path (string, default '%s')", defaultBundlePath(cfg)))
@@ -116,6 +118,10 @@ func defaultBundlePath(cfg Storage) string {
 }
 
 func GetPreset(config Storage) preset.Preset {
+	if runtime.GOOS == "darwin" && runtime.GOARCH == "arm64" {
+		return preset.Podman
+	}
+
 	return preset.ParsePreset(config.Get(Preset).AsString())
 }
 

--- a/pkg/crc/constants/constants.go
+++ b/pkg/crc/constants/constants.go
@@ -25,7 +25,7 @@ const (
 	CrcLandingPageURL         = "https://console.redhat.com/openshift/create/local" // #nosec G101
 	DefaultPodmanURLBase      = "https://storage.googleapis.com/libpod-master-releases"
 	DefaultAdminHelperCliBase = "https://github.com/code-ready/admin-helper/releases/download/0.0.10"
-	CRCMacTrayDownloadURL     = "https://github.com/code-ready/tray-electron/releases/download/%s/crc-tray-macos.tar.gz"
+	CRCMacTrayDownloadURL     = "https://github.com/code-ready/tray-electron/releases/download/%s/crc-tray-macos-%s.tar.gz"
 	CRCWindowsTrayDownloadURL = "https://github.com/code-ready/tray-electron/releases/download/%s/crc-tray-windows.zip"
 	DefaultContext            = "admin"
 	DaemonHTTPEndpoint        = "http://unix/api"
@@ -158,7 +158,7 @@ func GetKubeAdminPasswordPath() string {
 
 // TODO: follow the same pattern as oc and podman above
 func GetCRCMacTrayDownloadURL() string {
-	return fmt.Sprintf(CRCMacTrayDownloadURL, version.GetTrayVersion())
+	return fmt.Sprintf(CRCMacTrayDownloadURL, version.GetTrayVersion(), runtime.GOARCH)
 }
 
 func GetCRCWindowsTrayDownloadURL() string {

--- a/pkg/crc/machine/bundle/constants.go
+++ b/pkg/crc/machine/bundle/constants.go
@@ -27,4 +27,10 @@ var bundleLocations = map[string]bundlesDownloadInfo{
 				"e2a55c818b8d2f071f4cc0d26aba11f0a852aebdb7588a08eb96bd41faea0ef4"),
 		},
 	},
+	"arm64": {
+		"darwin": {
+			preset.Podman: download.NewRemoteFile("https://mirror.openshift.com/pub/openshift-v4/clients/crc/bundles/podman/4.0.2/crc_podman_vfkit_4.0.2_arm64.crcbundle",
+				"2c03258fdc75805d9f57e6f1b4d32d82e16a2bddadb3207888e36d9b06ad4008"),
+		},
+	},
 }

--- a/pkg/crc/preflight/preflight_checks_nonwin.go
+++ b/pkg/crc/preflight/preflight_checks_nonwin.go
@@ -192,11 +192,12 @@ func fixOldAdminHelperExecutableCached() error {
 }
 
 func checkSupportedCPUArch() error {
-	if runtime.GOARCH != "amd64" {
-		logging.Debugf("GOARCH is %s", runtime.GOARCH)
-		return fmt.Errorf("CRC can only run on AMD64/Intel64 CPUs")
+	logging.Debugf("GOARCH is %s GOOS is %s", runtime.GOARCH, runtime.GOOS)
+	// Only supported arches are amd64, and arm64 on macOS
+	if runtime.GOARCH == "amd64" || (runtime.GOARCH == "arm64" && runtime.GOOS == "darwin") {
+		return nil
 	}
-	return nil
+	return fmt.Errorf("CRC can only run on AMD64/Intel64 CPUs and M1 CPUs")
 }
 
 func runtimeExecutablePath() (string, error) {


### PR DESCRIPTION
This PR adds podman-only M1 support to crc.
After the switch to vfkit, only minor adjustments are needed (add path to arm64 bundle, reject use of openshift bundle on arm64, ...)