### PR TITLE
build: fix signing arm64 pkg on an amd64 mac

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -312,6 +312,7 @@ packaging/vfkit-$(GOARCH).entitlements:
 
 packagedir: clean embed-download macos-release-binary packaging/vfkit-$(GOARCH).entitlements
 	echo -n $(CRC_VERSION) > packaging/VERSION
+	echo -n $(GOARCH) > packaging/ARCH
 	sed -e 's/__VERSION__/'$(CRC_VERSION)'/g' -e 's@__INSTALL_PATH__@$(MACOS_INSTALL_PATH)@g' packaging/darwin/Distribution.in >packaging/darwin/Distribution
 	sed -e 's/__VERSION__/'$(CRC_VERSION)'/g' -e 's@__INSTALL_PATH__@$(MACOS_INSTALL_PATH)@g' packaging/darwin/welcome.html.in >packaging/darwin/Resources/welcome.html
 	sed -e 's/__VERSION__/'$(CRC_VERSION)'/g' -e 's@__INSTALL_PATH__@$(MACOS_INSTALL_PATH)@g' packaging/darwin/postinstall.in >packaging/darwin/scripts/postinstall

--- a/packaging/.gitignore
+++ b/packaging/.gitignore
@@ -5,6 +5,7 @@ root/
 /darwin/Resources/welcome.html
 /darwin/scripts/postinstall
 /VERSION
+/ARCH
 /windows/msi/
 packaging/windows/product.wxs
 vfkit-*.entitlements

--- a/packaging/package.sh
+++ b/packaging/package.sh
@@ -7,19 +7,6 @@ CODESIGN_IDENTITY=${CODESIGN_IDENTITY:-mock}
 PRODUCTSIGN_IDENTITY=${PRODUCTSIGN_IDENTITY:-mock}
 NO_CODESIGN=${NO_CODESIGN:-0}
 
-case "$(uname -m)" in
-    "x86_64")
-        GOARCH="amd64"
-        ;;
-    "arm64")
-        GOARCH="arm64"
-        ;;
-    *)
-        echo "Unknown arch, exiting"
-        exit 1
-        ;;
-esac
-
 function sign() {
   if [ "${NO_CODESIGN}" -eq "1" ]; then
     return
@@ -50,10 +37,11 @@ function signAppBundle() {
 binDir="${BASEDIR}/root/Applications/Red Hat OpenShift Local.app/Contents/Resources"
 
 version=$(cat "${BASEDIR}/VERSION")
+arch=$(cat "${BASEDIR}/ARCH")
 
 sign "${binDir}/crc"
 sign "${binDir}/crc-admin-helper-darwin"
-sign "${binDir}/vfkit-${GOARCH}"
+sign "${binDir}/vfkit-${arch}"
 
 signAppBundle "${BASEDIR}/root/Applications/Red Hat OpenShift Local.app"
 
@@ -73,7 +61,7 @@ productbuild --distribution "${BASEDIR}/darwin/Distribution" \
 rm "${OUTPUT}/crc.pkg"
 
 if [ ! "${NO_CODESIGN}" -eq "1" ]; then
-  productsign --sign "${PRODUCTSIGN_IDENTITY}" "${OUTPUT}/crc-unsigned.pkg" "${OUTPUT}/crc-macos-${GOARCH}.pkg"
+  productsign --sign "${PRODUCTSIGN_IDENTITY}" "${OUTPUT}/crc-unsigned.pkg" "${OUTPUT}/crc-macos-${arch}.pkg"
 else
-  mv "${OUTPUT}/crc-unsigned.pkg" "${OUTPUT}/crc-macos-${GOARCH}.pkg"
+  mv "${OUTPUT}/crc-unsigned.pkg" "${OUTPUT}/crc-macos-${arch}.pkg"
 fi


### PR DESCRIPTION
signing can be done on both variants of mac
currently the script fails due to depending
on host arch for forming names of vfkit and
the entitlement file and the finale pkg

instead of depending on host architecure we
write the target arch to a file and provide
it inside the tarball for the script to ref
and construct these file names
