### PR TITLE
Cluster Operator: Ignore 'RecentBackup' as operator status

### DIFF
--- a/pkg/crc/cluster/clusteroperator.go
+++ b/pkg/crc/cluster/clusteroperator.go
@@ -132,6 +132,8 @@ func getStatus(ctx context.Context, lister operatorLister, selector []string) (*
 				}
 			case "ManagementStateDegraded": // only for the network operator
 				continue
+			case "RecentBackup": // only for etcd operator
+				continue
 			default:
 				logging.Debugf("Unexpected operator status for %s: %s", c.ObjectMeta.Name, con.Type)
 			}


### PR DESCRIPTION
With 4.10 etcd operator have `RecentBackup` status which pops up
in the debug log during start. This patch will just ignore it.

```
INFO Starting OpenShift cluster... [waiting for the cluster to stabilize]
DEBU authentication operator not available, Reason: APIServerDeployment_NoPod::APIServices_PreconditionNotReady::OAuthServerDeployment_NoPod::OAuthServerRouteEndpointAccessibleController_EndpointUnavailable::OAuthServerServiceEndpointAccessibleController_EndpointUnavailable
DEBU Unexpected operator status for etcd: RecentBackup
DEBU node-tuning operator not available, Reason: TunedUnavailable
```

