### PR TITLE
SSH key replacement improvements

### DIFF
--- a/pkg/crc/cluster/cluster.go
+++ b/pkg/crc/cluster/cluster.go
@@ -342,7 +342,7 @@ func addProxyCACertToCluster(sshRunner *ssh.Runner, ocConfig oc.Config, proxy *n
 	// Replace the carriage return ("\n" or "\r\n") with literal `\n` string
 	re := regexp.MustCompile(`\r?\n`)
 	p := fmt.Sprintf(proxyCABundleTemplate, re.ReplaceAllString(proxy.ProxyCACert, `\n`), trustedCAName)
-	err := sshRunner.CopyData([]byte(p), proxyConfigMapFileName, 0644)
+	err := sshRunner.CopyDataPrivileged([]byte(p), proxyConfigMapFileName, 0644)
 	if err != nil {
 		return err
 	}
@@ -378,7 +378,7 @@ func EnsurePullSecretPresentOnInstanceDisk(sshRunner *ssh.Runner, pullSecret Pul
 	if err != nil {
 		return err
 	}
-	return sshRunner.CopyData([]byte(content), vmPullSecretPath, 0600)
+	return sshRunner.CopyDataPrivileged([]byte(content), vmPullSecretPath, 0600)
 }
 
 func WaitForPullSecretPresentOnInstanceDisk(ctx context.Context, sshRunner *ssh.Runner) error {

--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -626,9 +626,7 @@ func updateSSHKeyPair(sshRunner *crcssh.Runner) error {
 	}
 
 	logging.Info("Updating authorized keys...")
-	// CopyData uses sudo and we need to use it
-	// because of https://bugzilla.redhat.com/show_bug.cgi?id=1956739
-	err = sshRunner.CopyDataPrivileged(publicKey, "/home/core/.ssh/authorized_keys", 0644)
+	err = sshRunner.CopyData(publicKey, "/home/core/.ssh/authorized_keys", 0644)
 	if err != nil {
 		return err
 	}

--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -763,7 +763,7 @@ func ensureRoutesControllerIsRunning(sshRunner *crcssh.Runner, ocConfig oc.Confi
 	if err != nil {
 		return err
 	}
-	if err := sshRunner.CopyDataPrivileged(bin, "/tmp/routes-controller.json", 0444); err != nil {
+	if err := sshRunner.CopyData(bin, "/tmp/routes-controller.json", 0444); err != nil {
 		return err
 	}
 	_, _, err = ocConfig.RunOcCommand("apply", "-f", "/tmp/routes-controller.json")
@@ -811,13 +811,8 @@ func updateCockpitConsoleBearerToken(sshRunner *crcssh.Runner) error {
 		return fmt.Errorf("failed to write cockpit bearer token: %w", err)
 	}
 
-	if err := sshRunner.CopyDataPrivileged([]byte(token), "/home/core/cockpit-bearer-token", 0600); err != nil {
+	if err := sshRunner.CopyData([]byte(token), "/home/core/cockpit-bearer-token", 0600); err != nil {
 		return fmt.Errorf("failed to set token for cockpit: %w", err)
-	}
-
-	_, _, err := sshRunner.RunPrivileged("chown cockpit-bearer-token file to core", "chown core:core /home/core/cockpit-bearer-token")
-	if err != nil {
-		return fmt.Errorf("failed to change ownership of cockpit-bearer-token to core user: %w", err)
 	}
 
 	return nil

--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -628,7 +628,7 @@ func updateSSHKeyPair(sshRunner *crcssh.Runner) error {
 	logging.Info("Updating authorized keys...")
 	// CopyData uses sudo and we need to use it
 	// because of https://bugzilla.redhat.com/show_bug.cgi?id=1956739
-	err = sshRunner.CopyData(publicKey, "/home/core/.ssh/authorized_keys", 0644)
+	err = sshRunner.CopyDataPrivileged(publicKey, "/home/core/.ssh/authorized_keys", 0644)
 	if err != nil {
 		return err
 	}
@@ -669,7 +669,7 @@ func configurePodmanProxy(ctx context.Context, sshRunner *crcssh.Runner, proxy *
 		proxyEnv.WriteString(fmt.Sprintf("no_proxy=%s\n", proxy.GetNoProxyString()))
 		proxyEnv.WriteString(fmt.Sprintf("NO_PROXY=%s\n", proxy.GetNoProxyString()))
 	}
-	err = sshRunner.CopyData([]byte(proxyEnv.String()), "/etc/environment.d/proxy-env.conf", 0644)
+	err = sshRunner.CopyDataPrivileged([]byte(proxyEnv.String()), "/etc/environment.d/proxy-env.conf", 0644)
 	if err != nil {
 		return err
 	}
@@ -679,7 +679,7 @@ func configurePodmanProxy(ctx context.Context, sshRunner *crcssh.Runner, proxy *
 		return err
 	}
 	podmanServiceConf := "[Service]\nEnvironmentFile=/etc/environment.d/proxy-env.conf\n"
-	err = sshRunner.CopyData([]byte(podmanServiceConf), "/etc/systemd/system/podman.service.d/proxy-env.conf", 0644)
+	err = sshRunner.CopyDataPrivileged([]byte(podmanServiceConf), "/etc/systemd/system/podman.service.d/proxy-env.conf", 0644)
 	if err != nil {
 		return err
 	}
@@ -763,7 +763,7 @@ func ensureRoutesControllerIsRunning(sshRunner *crcssh.Runner, ocConfig oc.Confi
 	if err != nil {
 		return err
 	}
-	if err := sshRunner.CopyData(bin, "/tmp/routes-controller.json", 0444); err != nil {
+	if err := sshRunner.CopyDataPrivileged(bin, "/tmp/routes-controller.json", 0444); err != nil {
 		return err
 	}
 	_, _, err = ocConfig.RunOcCommand("apply", "-f", "/tmp/routes-controller.json")
@@ -811,7 +811,7 @@ func updateCockpitConsoleBearerToken(sshRunner *crcssh.Runner) error {
 		return fmt.Errorf("failed to write cockpit bearer token: %w", err)
 	}
 
-	if err := sshRunner.CopyData([]byte(token), "/home/core/cockpit-bearer-token", 0600); err != nil {
+	if err := sshRunner.CopyDataPrivileged([]byte(token), "/home/core/cockpit-bearer-token", 0600); err != nil {
 		return fmt.Errorf("failed to set token for cockpit: %w", err)
 	}
 

--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -630,7 +630,10 @@ func updateSSHKeyPair(sshRunner *crcssh.Runner) error {
 	if err != nil {
 		return err
 	}
-	return err
+
+	/* This is specific to the podman bundle, but is required to drop the 'default' ssh key */
+	_, _, _ = sshRunner.Run("rm", "/home/core/.ssh/authorized_keys.d/ignition")
+	return nil
 }
 
 func copyKubeconfigFileWithUpdatedUserClientCertAndKey(selfSignedCAKey *rsa.PrivateKey, selfSignedCACert *x509.Certificate, srcKubeConfigPath, dstKubeConfigPath string) error {

--- a/pkg/crc/network/nameservers.go
+++ b/pkg/crc/network/nameservers.go
@@ -34,7 +34,7 @@ func GetResolvValuesFromInstance(sshRunner *ssh.Runner) (*ResolvFileValues, erro
 func CreateResolvFileOnInstance(sshRunner *ssh.Runner, resolvFileValues ResolvFileValues) error {
 	resolvFile, _ := CreateResolvFile(resolvFileValues)
 
-	err := sshRunner.CopyData([]byte(resolvFile), "/etc/resolv.conf", 0644)
+	err := sshRunner.CopyDataPrivileged([]byte(resolvFile), "/etc/resolv.conf", 0644)
 	if err != nil {
 		return fmt.Errorf("Error creating /etc/resolv on instance: %s", err.Error())
 	}

--- a/pkg/crc/services/dns/template.go
+++ b/pkg/crc/services/dns/template.go
@@ -50,7 +50,7 @@ func createDnsmasqDNSConfig(serviceConfig services.ServicePostStartConfig) error
 		return err
 	}
 
-	return serviceConfig.SSHRunner.CopyData([]byte(dnsConfig), "/var/srv/dnsmasq.conf", 0644)
+	return serviceConfig.SSHRunner.CopyDataPrivileged([]byte(dnsConfig), "/var/srv/dnsmasq.conf", 0644)
 }
 
 func createDNSConfigFile(values dnsmasqConfFileValues, tmpl string) (string, error) {

--- a/pkg/crc/ssh/ssh_test.go
+++ b/pkg/crc/ssh/ssh_test.go
@@ -34,7 +34,7 @@ func TestRunner(t *testing.T) {
 	clientKeyFile := filepath.Join(dir, "private.key")
 	writePrivateKey(t, clientKeyFile, clientKey)
 
-	cancel, runner, _ := createListnerAndSSHServer(t, clientKey, clientKeyFile)
+	cancel, runner, _ := createListenerAndSSHServer(t, clientKey, clientKeyFile)
 
 	assert.NoError(t, err)
 	defer runner.Close()
@@ -46,7 +46,7 @@ func TestRunner(t *testing.T) {
 	// Expect error when sending data over close ssh server channel
 	assert.Error(t, runner.CopyDataPrivileged([]byte(`hello world`), "/hello", 0644))
 
-	_, runner, totalConn := createListnerAndSSHServer(t, clientKey, clientKeyFile)
+	_, runner, totalConn := createListenerAndSSHServer(t, clientKey, clientKeyFile)
 	assert.NoError(t, runner.CopyDataPrivileged([]byte(`hello world`), "/hello", 0644))
 	assert.NoError(t, runner.CopyDataPrivileged([]byte(`hello world`), "/hello", 0644))
 	assert.NoError(t, runner.CopyDataPrivileged([]byte(`hello world`), "/hello", 0644))
@@ -54,7 +54,7 @@ func TestRunner(t *testing.T) {
 	assert.Equal(t, 1, *totalConn)
 }
 
-func createListnerAndSSHServer(t *testing.T, clientKey *ecdsa.PrivateKey, clientKeyFile string) (context.CancelFunc, *Runner, *int) {
+func createListenerAndSSHServer(t *testing.T, clientKey *ecdsa.PrivateKey, clientKeyFile string) (context.CancelFunc, *Runner, *int) {
 	listener, err := net.Listen("tcp", "127.0.0.1:")
 	require.NoError(t, err)
 	addr := listener.Addr().String()


### PR DESCRIPTION
This removes a no longer needed workaround for MCO bug when we change ~/.ssh/authorized_keys, and also removes the default ssh key when using the podman bundle.