### PR TITLE
pkg: build single pkg installer using fat binaries

### DIFF
--- a/.github/workflows/macos-installer.yml
+++ b/.github/workflows/macos-installer.yml
@@ -36,9 +36,9 @@ jobs:
         with:
           go-version: ${{ matrix.go }}
       - name: Build macOS installer
-        run: make NO_CODESIGN=1 out/macos-amd64/crc-macos-amd64.pkg
+        run: make NO_CODESIGN=1 out/macos-universal/crc-macos-installer.pkg
       - name: Install crc pkg
-        run: sudo installer -pkg out/macos-amd64/crc-macos-amd64.pkg -target /
+        run: sudo installer -pkg out/macos-universal/crc-macos-installer.pkg -target /
       - name: Set podman preset as part of config
         run: crc config set preset podman
       - name: Run crc setup command

--- a/packaging/.gitignore
+++ b/packaging/.gitignore
@@ -8,4 +8,4 @@ root/
 /ARCH
 /windows/msi/
 packaging/windows/product.wxs
-vfkit-*.entitlements
+vfkit.entitlements

--- a/packaging/darwin/Distribution.in
+++ b/packaging/darwin/Distribution.in
@@ -8,6 +8,7 @@
     <options customize="never" allow-external-scripts="no"/>
     <domains enable_localSystem="true" />
     <options rootVolumeOnly="true"/>
+    <options hostArchitectures="x86_64,arm64" />
     <installation-check script="installCheck();"/>
     <script>
 function installCheck() {

--- a/packaging/package.sh
+++ b/packaging/package.sh
@@ -37,11 +37,10 @@ function signAppBundle() {
 binDir="${BASEDIR}/root/Applications/Red Hat OpenShift Local.app/Contents/Resources"
 
 version=$(cat "${BASEDIR}/VERSION")
-arch=$(cat "${BASEDIR}/ARCH")
 
 sign "${binDir}/crc"
 sign "${binDir}/crc-admin-helper-darwin"
-sign "${binDir}/vfkit-${arch}"
+sign "${binDir}/vfkit"
 
 signAppBundle "${BASEDIR}/root/Applications/Red Hat OpenShift Local.app"
 
@@ -61,7 +60,7 @@ productbuild --distribution "${BASEDIR}/darwin/Distribution" \
 rm "${OUTPUT}/crc.pkg"
 
 if [ ! "${NO_CODESIGN}" -eq "1" ]; then
-  productsign --sign "${PRODUCTSIGN_IDENTITY}" "${OUTPUT}/crc-unsigned.pkg" "${OUTPUT}/crc-macos-${arch}.pkg"
+  productsign --sign "${PRODUCTSIGN_IDENTITY}" "${OUTPUT}/crc-unsigned.pkg" "${OUTPUT}/crc-macos-installer.pkg"
 else
-  mv "${OUTPUT}/crc-unsigned.pkg" "${OUTPUT}/crc-macos-${arch}.pkg"
+  mv "${OUTPUT}/crc-unsigned.pkg" "${OUTPUT}/crc-macos-installer.pkg"
 fi

--- a/packaging/package.sh
+++ b/packaging/package.sh
@@ -16,7 +16,7 @@ function sign() {
   if [ -f "${entitlements}" ]; then
       opts="--entitlements ${entitlements}"
   fi
-  codesign --deep --sign "${CODESIGN_IDENTITY}" --options runtime --force ${opts} "$1"
+  codesign --deep --sign "${CODESIGN_IDENTITY}" --options runtime --timestamp --force ${opts} "$1"
 }
 
 function signAppBundle() {
@@ -30,8 +30,8 @@ function signAppBundle() {
   fi
 
   frameworks=$(find "$1"/Contents/Frameworks -depth -type d -name "*.framework" -or -name "*.dylib" -or -type f -perm +111)
-  echo "${frameworks}" | xargs -t -I % codesign --deep --sign "${CODESIGN_IDENTITY}" --options runtime % || true
-  codesign --deep --sign "${CODESIGN_IDENTITY}" --options runtime --force --entitlements "${entitlements}" "$1"
+  echo "${frameworks}" | xargs -t -I % codesign --deep --sign "${CODESIGN_IDENTITY}" --options runtime --timestamp % || true
+  codesign --deep --sign "${CODESIGN_IDENTITY}" --options runtime --timestamp --force --entitlements "${entitlements}" "$1"
 }
 
 binDir="${BASEDIR}/root/Applications/Red Hat OpenShift Local.app/Contents/Resources"

--- a/packaging/package.sh
+++ b/packaging/package.sh
@@ -31,6 +31,12 @@ function signAppBundle() {
 
   frameworks=$(find "$1"/Contents/Frameworks -depth -type d -name "*.framework" -or -name "*.dylib" -or -type f -perm +111)
   echo "${frameworks}" | xargs -t -I % codesign --deep --sign "${CODESIGN_IDENTITY}" --options runtime --timestamp % || true
+
+  # sign the .app bundles inside $1/Contents/Frameworks
+  frameworks=$(find "$1"/Contents/Frameworks -depth -type d -name "*.app" -perm +111)
+  echo "${frameworks}" | xargs -t -I % codesign --deep --sign "${CODESIGN_IDENTITY}" --options runtime --timestamp --force % || true
+
+  # finally sign $1 app bundle
   codesign --deep --sign "${CODESIGN_IDENTITY}" --options runtime --timestamp --force --entitlements "${entitlements}" "$1"
 }
 

--- a/pkg/crc/constants/constants.go
+++ b/pkg/crc/constants/constants.go
@@ -25,7 +25,7 @@ const (
 	CrcLandingPageURL         = "https://console.redhat.com/openshift/create/local" // #nosec G101
 	DefaultPodmanURLBase      = "https://storage.googleapis.com/libpod-master-releases"
 	DefaultAdminHelperCliBase = "https://github.com/code-ready/admin-helper/releases/download/0.0.10"
-	CRCMacTrayDownloadURL     = "https://github.com/code-ready/tray-electron/releases/download/%s/crc-tray-macos-%s.tar.gz"
+	CRCMacTrayDownloadURL     = "https://github.com/code-ready/tray-electron/releases/download/%s/crc-tray-macos.tar.gz"
 	CRCWindowsTrayDownloadURL = "https://github.com/code-ready/tray-electron/releases/download/%s/crc-tray-windows.zip"
 	DefaultContext            = "admin"
 	DaemonHTTPEndpoint        = "http://unix/api"
@@ -158,7 +158,7 @@ func GetKubeAdminPasswordPath() string {
 
 // TODO: follow the same pattern as oc and podman above
 func GetCRCMacTrayDownloadURL() string {
-	return fmt.Sprintf(CRCMacTrayDownloadURL, version.GetTrayVersion(), runtime.GOARCH)
+	return fmt.Sprintf(CRCMacTrayDownloadURL, version.GetTrayVersion())
 }
 
 func GetCRCWindowsTrayDownloadURL() string {

--- a/pkg/crc/constants/constants.go
+++ b/pkg/crc/constants/constants.go
@@ -24,7 +24,7 @@ const (
 	DaemonLogFile             = "crcd.log"
 	CrcLandingPageURL         = "https://console.redhat.com/openshift/create/local" // #nosec G101
 	DefaultPodmanURLBase      = "https://storage.googleapis.com/libpod-master-releases"
-	DefaultAdminHelperCliBase = "https://github.com/code-ready/admin-helper/releases/download/0.0.10"
+	DefaultAdminHelperCliBase = "https://github.com/code-ready/admin-helper/releases/download/v0.0.11"
 	CRCMacTrayDownloadURL     = "https://github.com/code-ready/tray-electron/releases/download/%s/crc-tray-macos.tar.gz"
 	CRCWindowsTrayDownloadURL = "https://github.com/code-ready/tray-electron/releases/download/%s/crc-tray-windows.zip"
 	DefaultContext            = "admin"

--- a/pkg/crc/machine/vfkit/constants.go
+++ b/pkg/crc/machine/vfkit/constants.go
@@ -5,14 +5,13 @@ package vfkit
 
 import (
 	"fmt"
-	"runtime"
 )
 
 const (
 	VfkitVersion = "0.0.1"
+	VfkitCommand = "vfkit"
 )
 
 var (
-	VfkitCommand     = fmt.Sprintf("vfkit-%s", runtime.GOARCH)
 	VfkitDownloadURL = fmt.Sprintf("https://github.com/code-ready/vfkit/releases/download/v%s/%s", VfkitVersion, VfkitCommand)
 )

--- a/pkg/crc/version/version.go
+++ b/pkg/crc/version/version.go
@@ -43,7 +43,7 @@ var (
 const (
 	releaseInfoLink = "https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/crc/latest/release-info.json"
 	// Tray version to be embedded in executable
-	crcTrayElectronVersion = "1.2.6"
+	crcTrayElectronVersion = "1.2.7"
 )
 
 type CrcReleaseInfo struct {


### PR DESCRIPTION
instead of building two pkg installers for arm and x86
this create one universal pkg installer using macos universal
binaries for tray, admin-helper and vfkit

we expect admin-helper, tray and vfkit universal binaries are
avaiable to download on their respective github releases
