### PR TITLE
[Doc] Remove podman/docker dependency to access internal registry

### DIFF
--- a/docs/source/topics/proc_accessing-the-internal-openshift-registry.adoc
+++ b/docs/source/topics/proc_accessing-the-internal-openshift-registry.adoc
@@ -13,9 +13,6 @@ For more information, see link:{crc-gsg-url}#changing-the-selected-preset_gsg[Ch
 For more information, see link:{crc-gsg-url}#starting-the-instance_gsg[Starting the instance].
 * A working {openshift} CLI ([command]`oc`) command.
 For more information, see link:{crc-gsg-url}#accessing-the-openshift-cluster-with-oc_gsg[Accessing the {openshift} cluster with the {openshift} CLI].
-* An installation of [command]`podman` or [command]`docker`.
-** For Docker, add `default-route-openshift-image-registry.apps-crc.testing` as an insecure registry.
-For more information, see link:https://docs.docker.com/registry/insecure/[the Docker documentation].
 
 .Procedure
 
@@ -35,7 +32,7 @@ For demonstration purposes, the current user is assumed to be `kubeadmin`.
 +
 [subs="+quotes,attributes"]
 ----
-$ podman login -u kubeadmin -p $(oc whoami -t) default-route-openshift-image-registry.apps-crc.testing --tls-verify=false
+$ oc registry login --insecure=true
 ----
 
 . Create a new project:
@@ -45,25 +42,11 @@ $ podman login -u kubeadmin -p $(oc whoami -t) default-route-openshift-image-reg
 $ oc new-project demo
 ----
 
-. Pull an example container image:
+. Mirror an example container image:
 +
 [subs="+quotes,attributes"]
 ----
-$ podman pull quay.io/libpod/alpine
-----
-
-. Tag the image, including namespace details:
-+
-[subs="+quotes,attributes"]
-----
-$ podman tag alpine:latest default-route-openshift-image-registry.apps-crc.testing/demo/alpine:latest
-----
-
-. Push the container image to the internal registry:
-+
-[subs="+quotes,attributes"]
-----
-$ podman push default-route-openshift-image-registry.apps-crc.testing/demo/alpine:latest --tls-verify=false
+$ oc image mirror registry.access.redhat.com/ubi8/ubi:latest=default-route-openshift-image-registry.apps-crc.testing/demo/ubi8:latest --insecure=true --filter-by-os=linux/amd64
 ----
 
 . Get imagestreams and verify that the pushed image is listed:
@@ -77,7 +60,7 @@ $ oc get is
 +
 [subs="+quotes,attributes"]
 ----
-$ oc set image-lookup alpine
+$ oc set image-lookup ubi8
 ----
 +
 This setting allows the imagestream to be the source of images without having to provide the full URL to the internal registry.
@@ -86,5 +69,5 @@ This setting allows the imagestream to be the source of images without having to
 +
 [subs="+quotes,attributes"]
 ----
-$ oc run demo --image=alpine --command -- sleep 600s
+$ oc run demo --image=ubi8 --command -- sleep 600s
 ----


### PR DESCRIPTION
This patch uses `oc mirror` command to push image from remote container
registry to openshift internal registry and make it available to
imagestream. Recently user observed if ubi images are pulled using
podman then pushing it to internal registry have signature verification
error (https://github.com/containers/podman/issues/14558) for
mac/windows. This issue is recently fixed on podman remote clients but
still not released so better not to use podman/docker steps just to show
user around internal registry usage.


