### PR TITLE
machine: Fix upload of /tmp/routes-controller.json

### DIFF
--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -764,7 +764,7 @@ func ensureRoutesControllerIsRunning(sshRunner *crcssh.Runner, ocConfig oc.Confi
 	if err != nil {
 		return err
 	}
-	if err := sshRunner.CopyData(bin, "/tmp/routes-controller.json", 0444); err != nil {
+	if err := sshRunner.CopyData(bin, "/tmp/routes-controller.json", 0644); err != nil {
 		return err
 	}
 	_, _, err = ocConfig.RunOcCommand("apply", "-f", "/tmp/routes-controller.json")


### PR DESCRIPTION
After the CopyData/CopyDataPrivileged changes, copying
routes-controller.json to the VM fails with 'Permission denied'.
This seems to be related to the file being created as 0444, and the copy
now being done as a regular user rather than through sudo. This commit
changes the permissions of the uploaded file to 0644 to fix this issue.