### PR TITLE
ubuntu: Fix apparmor rule for podman preset

### DIFF
--- a/pkg/crc/preflight/preflight_ubuntu_linux.go
+++ b/pkg/crc/preflight/preflight_ubuntu_linux.go
@@ -51,7 +51,7 @@ func checkAppArmorExceptionIsPresent(reader reader) func() error {
 	}
 }
 
-// Add the exception `cacheDir/*/crc.qcow2 rk` in AppArmor template
+// Add the exception `cacheDir/*/crc*.qcow2 rk` in AppArmor template
 func addAppArmorExceptionForQcowDisks(reader reader, writer writer) func() error {
 	return replaceInAppArmorTemplate(reader, writer, appArmorHeader, expectedLines())
 }
@@ -77,6 +77,6 @@ func replaceInAppArmorTemplate(reader reader, writer writer, before string, afte
 }
 
 func expectedLines() string {
-	line := fmt.Sprintf("  %s rk,", filepath.Join(constants.MachineCacheDir, "*", "crc.qcow2"))
+	line := fmt.Sprintf("  %s rk,", filepath.Join(constants.MachineCacheDir, "*", "crc*.qcow2"))
 	return fmt.Sprintf("%s\n%s\n", appArmorHeader, line)
 }

--- a/pkg/crc/preflight/preflight_ubuntu_linux_test.go
+++ b/pkg/crc/preflight/preflight_ubuntu_linux_test.go
@@ -19,7 +19,7 @@ profile LIBVIRT_TEMPLATE flags=(attach_disconnected) {
 }`
 	expected = `#include <tunables/global>
 profile LIBVIRT_TEMPLATE flags=(attach_disconnected) {
-  ` + constants.MachineCacheDir + `/*/crc.qcow2 rk,
+  ` + constants.MachineCacheDir + `/*/crc*.qcow2 rk,
 
   #include <abstractions/libvirt-qemu>
 }`


### PR DESCRIPTION
On Ubuntu, crc's preflights add an apparmor rule to allow the use of
cacheDir/*/crc.qcow2 by libvirt. With podman bundles, the file is named
`crc-podman.qcow2`, which causes `crc start` to fail with permission
errors.