### PR TITLE
bundle: Don't extract container image layer twice

### DIFF
--- a/pkg/crc/image/image.go
+++ b/pkg/crc/image/image.go
@@ -113,11 +113,6 @@ func PullBundle(preset crcpreset.Preset) error {
 	if err != nil {
 		return err
 	}
-	_, err = extract.Uncompress(filepath.Join(destDir, imgLayer), constants.MachineCacheDir, true)
-	if err != nil {
-		return err
-	}
-
 	fileList, err := extract.Uncompress(filepath.Join(destDir, imgLayer), constants.MachineCacheDir, true)
 	if err != nil {
 		return err


### PR DESCRIPTION
The same code is repeated twice, probably because of a rebase issue.