### PR TITLE
Add OKD as preset

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,11 +12,6 @@ CONTAINER_RUNTIME ?= podman
 TOOLS_DIR := tools
 include tools/tools.mk
 
-ifdef OKD_VERSION
-    OPENSHIFT_VERSION = $(OKD_VERSION)
-    CRC_VERSION := $(CRC_VERSION)-OKD
-endif
-
 # Go and compilation related variables
 BUILD_DIR ?= out
 SOURCE_DIRS = cmd pkg test
@@ -63,10 +58,6 @@ VERSION_VARIABLES := -X $(REPOPATH)/pkg/crc/version.crcVersion=$(CRC_VERSION) \
 	-X $(REPOPATH)/pkg/crc/version.podmanVersion=$(PODMAN_VERSION) \
 	-X $(REPOPATH)/pkg/crc/version.commitSha=$(COMMIT_SHA)
 RELEASE_VERSION_VARIABLES := -X $(REPOPATH)/pkg/crc/segment.WriteKey=cvpHsNcmGCJqVzf6YxrSnVlwFSAZaYtp
-
-ifdef OKD_VERSION
-	VERSION_VARIABLES := $(VERSION_VARIABLES) -X $(REPOPATH)/pkg/crc/version.okdBuild=true
-endif
 
 # https://golang.org/cmd/link/
 LDFLAGS := $(VERSION_VARIABLES) ${GO_EXTRA_LDFLAGS}

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ SHELL := /bin/bash
 
 OPENSHIFT_VERSION ?= 4.10.22
 PODMAN_VERSION ?= 4.1.1
+OKD_VERSION ?= 4.10.0-0.okd-2022-06-24-212905
 BUNDLE_EXTENSION = crcbundle
 CRC_VERSION = 2.6.0.999
 COMMIT_SHA=$(shell git rev-parse --short HEAD)
@@ -58,6 +59,7 @@ __check_defined = \
 # Linker flags
 VERSION_VARIABLES := -X $(REPOPATH)/pkg/crc/version.crcVersion=$(CRC_VERSION) \
 	-X $(REPOPATH)/pkg/crc/version.bundleVersion=$(OPENSHIFT_VERSION) \
+	-X $(REPOPATH)/pkg/crc/version.okdVersion=$(OKD_VERSION) \
 	-X $(REPOPATH)/pkg/crc/version.podmanVersion=$(PODMAN_VERSION) \
 	-X $(REPOPATH)/pkg/crc/version.commitSha=$(COMMIT_SHA)
 RELEASE_VERSION_VARIABLES := -X $(REPOPATH)/pkg/crc/segment.WriteKey=cvpHsNcmGCJqVzf6YxrSnVlwFSAZaYtp

--- a/cmd/crc/cmd/root.go
+++ b/cmd/crc/cmd/root.go
@@ -79,7 +79,7 @@ func runPrerun(cmd *cobra.Command) error {
 	}
 	logging.InitLogrus(logFile)
 
-	for _, str := range defaultVersion().lines() {
+	for _, str := range defaultVersion(crcConfig.GetPreset(config)).lines() {
 		logging.Debugf(str)
 	}
 	return nil

--- a/cmd/crc/cmd/version.go
+++ b/cmd/crc/cmd/version.go
@@ -7,6 +7,7 @@ import (
 
 	crcConfig "github.com/code-ready/crc/pkg/crc/config"
 	"github.com/code-ready/crc/pkg/crc/logging"
+	crcPreset "github.com/code-ready/crc/pkg/crc/preset"
 	crcversion "github.com/code-ready/crc/pkg/crc/version"
 	"github.com/spf13/cobra"
 )
@@ -21,7 +22,7 @@ var versionCmd = &cobra.Command{
 	Short: "Print version information",
 	Long:  "Print version information",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return runPrintVersion(os.Stdout, defaultVersion(), outputFormat)
+		return runPrintVersion(os.Stdout, defaultVersion(crcConfig.GetPreset(config)), outputFormat)
 	},
 }
 
@@ -39,11 +40,11 @@ type version struct {
 	PodmanVersion    string `json:"podmanVersion"`
 }
 
-func defaultVersion() *version {
+func defaultVersion(preset crcPreset.Preset) *version {
 	return &version{
 		Version:          crcversion.GetCRCVersion(),
 		Commit:           crcversion.GetCommitSha(),
-		OpenshiftVersion: crcversion.GetBundleVersion(),
+		OpenshiftVersion: crcversion.GetBundleVersion(preset),
 		PodmanVersion:    crcversion.GetPodmanVersion(),
 	}
 }

--- a/pkg/crc/api/api_client_test.go
+++ b/pkg/crc/api/api_client_test.go
@@ -50,7 +50,7 @@ func TestVersion(t *testing.T) {
 		t,
 		apiClient.VersionResult{
 			CrcVersion:       version.GetCRCVersion(),
-			OpenshiftVersion: version.GetBundleVersion(),
+			OpenshiftVersion: version.GetBundleVersion(preset.OpenShift),
 			CommitSha:        version.GetCommitSha(),
 			PodmanVersion:    version.GetPodmanVersion(),
 		},

--- a/pkg/crc/api/api_http_test.go
+++ b/pkg/crc/api/api_http_test.go
@@ -14,6 +14,7 @@ import (
 	crcConfig "github.com/code-ready/crc/pkg/crc/config"
 	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/code-ready/crc/pkg/crc/machine/fakemachine"
+	"github.com/code-ready/crc/pkg/crc/preset"
 	"github.com/code-ready/crc/pkg/crc/version"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -265,7 +266,7 @@ var testCases = []testCase{
 	// version
 	{
 		request:  get("version"),
-		response: jSon(fmt.Sprintf(`{"CrcVersion":"%s","CommitSha":"%s","OpenshiftVersion":"%s","PodmanVersion":"%s"}`, version.GetCRCVersion(), version.GetCommitSha(), version.GetBundleVersion(), version.GetPodmanVersion())),
+		response: jSon(fmt.Sprintf(`{"CrcVersion":"%s","CommitSha":"%s","OpenshiftVersion":"%s","PodmanVersion":"%s"}`, version.GetCRCVersion(), version.GetCommitSha(), version.GetBundleVersion(preset.OpenShift), version.GetPodmanVersion())),
 	},
 
 	// version never fails

--- a/pkg/crc/api/handlers.go
+++ b/pkg/crc/api/handlers.go
@@ -123,7 +123,7 @@ func (h *Handler) GetVersion(c *context) error {
 	return c.JSON(http.StatusOK, &client.VersionResult{
 		CrcVersion:       version.GetCRCVersion(),
 		CommitSha:        version.GetCommitSha(),
-		OpenshiftVersion: version.GetBundleVersion(),
+		OpenshiftVersion: version.GetBundleVersion(crcConfig.GetPreset(h.Config)),
 		PodmanVersion:    version.GetPodmanVersion(),
 	})
 }

--- a/pkg/crc/cluster/pullsecret.go
+++ b/pkg/crc/cluster/pullsecret.go
@@ -15,7 +15,6 @@ import (
 	"github.com/code-ready/crc/pkg/crc/logging"
 	"github.com/code-ready/crc/pkg/crc/preset"
 	"github.com/code-ready/crc/pkg/crc/validation"
-	crcversion "github.com/code-ready/crc/pkg/crc/version"
 	crcos "github.com/code-ready/crc/pkg/os"
 
 	"github.com/AlecAivazis/survey/v2"
@@ -77,8 +76,8 @@ func NewNonInteractivePullSecretLoader(config crcConfig.Storage, path string) Pu
 }
 
 func (loader *nonInteractivePullSecretLoader) Value() (string, error) {
-	// If crc is built from an OKD bundle or podman bundle is used, then use the fake pull secret in contants.
-	if crcversion.IsOkdBuild() || crcConfig.GetPreset(loader.config) == preset.Podman {
+	// If crc is built from an OKD bundle or podman bundle is used, then use the fake pull secret in constants.
+	if crcConfig.GetPreset(loader.config) == preset.OKD || crcConfig.GetPreset(loader.config) == preset.Podman {
 		return constants.OkdPullSecret, nil
 	}
 

--- a/pkg/crc/config/settings.go
+++ b/pkg/crc/config/settings.go
@@ -57,7 +57,7 @@ func RegisterSettings(cfg *Config) {
 	// Preset setting should be on top because CPUs/Memory config depend on it.
 	if runtime.GOOS != "darwin" || runtime.GOARCH != "arm64" {
 		cfg.AddSetting(Preset, string(preset.OpenShift), validatePreset, RequiresDeleteAndSetupMsg,
-			fmt.Sprintf("Virtual machine preset (alpha feature - valid values are: %s or %s)", preset.Podman, preset.OpenShift))
+			fmt.Sprintf("Virtual machine preset (alpha feature - valid values are: %s, %s and %s)", preset.Podman, preset.OpenShift, preset.OKD))
 	}
 	// Start command settings in config
 	cfg.AddSetting(Bundle, defaultBundlePath(cfg), validateBundlePath, SuccessfullyApplied,

--- a/pkg/crc/constants/constants.go
+++ b/pkg/crc/constants/constants.go
@@ -92,9 +92,9 @@ func defaultBundleForOs(preset crcpreset.Preset) map[string]string {
 		}
 	}
 	return map[string]string{
-		"darwin":  fmt.Sprintf("crc_vfkit_%s_%s.crcbundle", version.GetBundleVersion(), runtime.GOARCH),
-		"linux":   fmt.Sprintf("crc_libvirt_%s_%s.crcbundle", version.GetBundleVersion(), runtime.GOARCH),
-		"windows": fmt.Sprintf("crc_hyperv_%s_%s.crcbundle", version.GetBundleVersion(), runtime.GOARCH),
+		"darwin":  fmt.Sprintf("crc_vfkit_%s_%s.crcbundle", version.GetBundleVersion(preset), runtime.GOARCH),
+		"linux":   fmt.Sprintf("crc_libvirt_%s_%s.crcbundle", version.GetBundleVersion(preset), runtime.GOARCH),
+		"windows": fmt.Sprintf("crc_hyperv_%s_%s.crcbundle", version.GetBundleVersion(preset), runtime.GOARCH),
 	}
 }
 

--- a/pkg/crc/constants/constants.go
+++ b/pkg/crc/constants/constants.go
@@ -186,7 +186,7 @@ func GetCRCWindowsTrayDownloadURL() string {
 
 func GetDefaultCPUs(preset crcpreset.Preset) int {
 	switch preset {
-	case crcpreset.OpenShift:
+	case crcpreset.OpenShift, crcpreset.OKD:
 		return 4
 	case crcpreset.Podman:
 		return 2
@@ -198,7 +198,7 @@ func GetDefaultCPUs(preset crcpreset.Preset) int {
 
 func GetDefaultMemory(preset crcpreset.Preset) int {
 	switch preset {
-	case crcpreset.OpenShift:
+	case crcpreset.OpenShift, crcpreset.OKD:
 		return 9216
 	case crcpreset.Podman:
 		return 2048

--- a/pkg/crc/image/image.go
+++ b/pkg/crc/image/image.go
@@ -85,13 +85,14 @@ func getLayerPath(m *v1.Manifest, index int, mediaType string) (string, error) {
 }
 
 func getImageName(preset crcpreset.Preset) string {
-	if preset == crcpreset.Podman {
+	switch preset {
+	case crcpreset.Podman:
 		return "podman-bundle"
-	}
-	if version.IsOkdBuild() {
+	case crcpreset.OKD:
 		return "okd-bundle"
+	default:
+		return "openshift-bundle"
 	}
-	return "openshift-bundle"
 }
 
 func PullBundle(preset crcpreset.Preset) error {

--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -793,7 +793,7 @@ func updateKubeconfig(ctx context.Context, ocConfig oc.Config, sshRunner *crcssh
 }
 
 func bundleMismatchWithPreset(preset crcPreset.Preset, bundleMetadata *bundle.CrcBundleInfo) error {
-	if preset != crcPreset.OpenShift && bundleMetadata.IsOpenShift() {
+	if preset == crcPreset.Podman && bundleMetadata.IsOpenShift() {
 		return errors.Errorf("Preset %s is used but bundle is provided for %s preset", crcPreset.Podman, crcPreset.OpenShift)
 	}
 	if preset != crcPreset.Podman && !bundleMetadata.IsOpenShift() {

--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -169,7 +169,7 @@ func (client *client) Start(ctx context.Context, startConfig types.StartConfig) 
 		}
 
 		if crcBundleMetadata.IsOpenShift() {
-			logging.Infof("Creating CRC VM for OpenShift %s...", crcBundleMetadata.GetOpenshiftVersion())
+			logging.Infof("Creating CRC VM for %s %s...", startConfig.Preset, crcBundleMetadata.GetOpenshiftVersion())
 		} else {
 			logging.Infof("Creating CRC VM for Podman %s...", crcBundleMetadata.GetPodmanVersion())
 		}
@@ -242,7 +242,7 @@ func (client *client) Start(ctx context.Context, startConfig types.StartConfig) 
 	}
 
 	if vm.bundle.IsOpenShift() {
-		logging.Infof("Starting CRC VM for OpenShift %s...", vm.bundle.GetOpenshiftVersion())
+		logging.Infof("Starting CRC VM for %s %s...", startConfig.Preset, vm.bundle.GetOpenshiftVersion())
 	}
 
 	if client.useVSock() {
@@ -401,7 +401,7 @@ func (client *client) Start(ctx context.Context, startConfig types.StartConfig) 
 		return nil, errors.Wrap(err, "Failed to check certificate validity")
 	}
 
-	logging.Info("Starting OpenShift kubelet service")
+	logging.Info("Starting kubelet service")
 	sd := systemd.NewInstanceSystemdCommander(sshRunner)
 	if err := sd.Start("kubelet"); err != nil {
 		return nil, errors.Wrap(err, "Error starting kubelet")
@@ -486,7 +486,7 @@ func (client *client) Start(ctx context.Context, startConfig types.StartConfig) 
 		return nil, errors.Wrap(err, "Failed to update kubeconfig file")
 	}
 
-	logging.Info("Starting OpenShift cluster... [waiting for the cluster to stabilize]")
+	logging.Infof("Starting %s instance... [waiting for the cluster to stabilize]", startConfig.Preset)
 	if err := cluster.WaitForClusterStable(ctx, instanceIP, constants.KubeconfigFilePath, proxyConfig); err != nil {
 		logging.Errorf("Cluster is not ready: %v", err)
 	}

--- a/pkg/crc/machine/vsock.go
+++ b/pkg/crc/machine/vsock.go
@@ -93,7 +93,7 @@ func vsockPorts(preset crcPreset.Preset) []types.ExposeRequest {
 		},
 	}
 	switch preset {
-	case crcPreset.OpenShift:
+	case crcPreset.OpenShift, crcPreset.OKD:
 		exposeRequest = append(exposeRequest,
 			types.ExposeRequest{
 				Protocol: "tcp",

--- a/pkg/crc/preflight/preflight_checks_common.go
+++ b/pkg/crc/preflight/preflight_checks_common.go
@@ -13,7 +13,6 @@ import (
 	"github.com/code-ready/crc/pkg/crc/machine/bundle"
 	crcpreset "github.com/code-ready/crc/pkg/crc/preset"
 	"github.com/code-ready/crc/pkg/crc/validation"
-	"github.com/code-ready/crc/pkg/crc/version"
 	"github.com/pkg/errors"
 )
 
@@ -102,7 +101,7 @@ func fixBundleExtracted(bundlePath string, preset crcpreset.Preset) func() error
 			logging.Infof("Downloading %s", constants.GetDefaultBundle(preset))
 			// In case of OKD or podman bundle then pull the bundle image from quay
 			// otherwise use mirror location to download the bundle.
-			if version.IsOkdBuild() || preset == crcpreset.Podman {
+			if preset == crcpreset.OKD || preset == crcpreset.Podman {
 				if err := image.PullBundle(preset); err != nil {
 					return err
 				}

--- a/pkg/crc/preset/preset.go
+++ b/pkg/crc/preset/preset.go
@@ -11,6 +11,7 @@ type Preset string
 const (
 	Podman    Preset = "podman"
 	OpenShift Preset = "openshift"
+	OKD       Preset = "okd"
 )
 
 func (preset Preset) String() string {
@@ -19,6 +20,8 @@ func (preset Preset) String() string {
 		return string(Podman)
 	case OpenShift:
 		return string(OpenShift)
+	case OKD:
+		return string(OKD)
 	}
 	return "invalid"
 }
@@ -29,6 +32,8 @@ func ParsePresetE(input string) (Preset, error) {
 		return Podman, nil
 	case OpenShift.String():
 		return OpenShift, nil
+	case OKD.String():
+		return OKD, nil
 	default:
 		return OpenShift, fmt.Errorf("Cannot parse preset '%s'", input)
 	}

--- a/pkg/crc/version/version.go
+++ b/pkg/crc/version/version.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/code-ready/crc/pkg/crc/logging"
+	crcPreset "github.com/code-ready/crc/pkg/crc/preset"
 )
 
 // The following variables are private fields and should be set when compiling with ldflags, for example --ldflags="-X github.com/code-ready/crc/pkg/version.crcVersion=vX.Y.Z
@@ -66,7 +67,7 @@ func GetCommitSha() string {
 	return commitSha
 }
 
-func GetBundleVersion() string {
+func GetBundleVersion(_ crcPreset.Preset) string {
 	return bundleVersion
 }
 

--- a/pkg/crc/version/version.go
+++ b/pkg/crc/version/version.go
@@ -28,8 +28,6 @@ var (
 	// Podman version for podman specific bundles
 	podmanVersion = "0.0.0-unset"
 
-	okdBuild = "false"
-
 	okdVersion = "0.0.0-unset"
 	// will always be false on linux
 	// will be true for releases on macos and windows
@@ -81,10 +79,6 @@ func GetPodmanVersion() string {
 
 func GetAdminHelperVersion() string {
 	return crcAdminHelperVersion
-}
-
-func IsOkdBuild() bool {
-	return okdBuild == "true"
 }
 
 func GetTrayVersion() string {

--- a/pkg/crc/version/version.go
+++ b/pkg/crc/version/version.go
@@ -30,6 +30,7 @@ var (
 
 	okdBuild = "false"
 
+	okdVersion = "0.0.0-unset"
 	// will always be false on linux
 	// will be true for releases on macos and windows
 	// will be false for git builds on macos and windows
@@ -67,8 +68,11 @@ func GetCommitSha() string {
 	return commitSha
 }
 
-func GetBundleVersion(_ crcPreset.Preset) string {
-	return bundleVersion
+func GetBundleVersion(preset crcPreset.Preset) string {
+	if preset == crcPreset.OpenShift {
+		return bundleVersion
+	}
+	return okdVersion
 }
 
 func GetPodmanVersion() string {


### PR DESCRIPTION
## Solution/Idea

This PR adds okd as preset so now with same crc binary user can choose to run ocp or okd. Default preset still be Openshift.

## Proposed changes

List main as well as consequential changes you introduced or had to introduce.
- Add okd as preset

## Testing
- crc config set preset okd
- crc setup => should download the okd bundle
- crc start => should provision the okd cluster.
