### PR TITLE
Fix several windows github actions failures

### DIFF
--- a/.github/workflows/macos-installer.yml
+++ b/.github/workflows/macos-installer.yml
@@ -50,5 +50,5 @@ jobs:
       - name: Upload macOS installer artifact
         uses: actions/upload-artifact@v2
         with:
-          name: macOS Installer
+          name: macOS Installer (${{ matrix.os }})
           path: "./out/macos-amd64/crc-macos-amd64.pkg"

--- a/.github/workflows/make-check-win.yml
+++ b/.github/workflows/make-check-win.yml
@@ -17,6 +17,8 @@ jobs:
         go:
           - 1.17
     steps:
+      - name: Downgrade mingw to workaround https://github.com/golang/go/issues/46099
+        run: choco install mingw --version 10.2.0 --allow-downgrade
       - name: Check out repository code
         uses: actions/checkout@v2
       - name: Set up Go

--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -31,5 +31,5 @@ jobs:
       - name: Upload windows installer artifact
         uses: actions/upload-artifact@v2
         with:
-          name: Windows Installer
+          name: Windows Installer (${{ matrix.os }})
           path: "./out/windows-amd64/crc-windows-installer.zip"

--- a/Makefile
+++ b/Makefile
@@ -242,12 +242,12 @@ fmt:
 # Run golangci-lint against code
 .PHONY: lint cross-lint
 lint: $(TOOLS_BINDIR)/golangci-lint
-	$(TOOLS_BINDIR)/golangci-lint run
+	"$(TOOLS_BINDIR)"/golangci-lint run
 
 cross-lint: $(TOOLS_BINDIR)/golangci-lint
-	GOOS=darwin $(TOOLS_BINDIR)/golangci-lint run
-	GOOS=linux $(TOOLS_BINDIR)/golangci-lint run
-	GOARCH=amd64 GOOS=windows $(TOOLS_BINDIR)/golangci-lint run
+	GOOS=darwin "$(TOOLS_BINDIR)"/golangci-lint run
+	GOOS=linux "$(TOOLS_BINDIR)"/golangci-lint run
+	GOARCH=amd64 GOOS=windows "$(TOOLS_BINDIR)"/golangci-lint run
 
 .PHONY: gen_release_info
 gen_release_info:
@@ -308,7 +308,7 @@ packaging/vfkit.entitlements:
 
 macos-universal-binary: macos-release-binary $(TOOLS_BINDIR)/makefat
 	mkdir -p out/macos-universal
-	cd $(BUILD_DIR) && $(TOOLS_BINDIR)/makefat macos-universal/crc macos-amd64/crc macos-arm64/crc
+	cd $(BUILD_DIR) && "$(TOOLS_BINDIR)"/makefat macos-universal/crc macos-amd64/crc macos-arm64/crc
 
 packagedir: clean embed-download macos-universal-binary packaging/vfkit.entitlements
 	echo -n $(CRC_VERSION) > packaging/VERSION
@@ -339,7 +339,7 @@ $(BUILD_DIR)/macos-universal/crc-macos-installer.tar: packagedir
 	cd $(@D) && sha256sum $(@F)>$(@F).sha256sum
 
 %.spec: %.spec.in $(TOOLS_BINDIR)/gomod2rpmdeps
-	@$(TOOLS_BINDIR)/gomod2rpmdeps | sed -e '/__BUNDLED_PROVIDES__/r /dev/stdin' \
+	@"$(TOOLS_BINDIR)"/gomod2rpmdeps | sed -e '/__BUNDLED_PROVIDES__/r /dev/stdin' \
 					   -e '/__BUNDLED_PROVIDES__/d' \
 					   -e 's/__VERSION__/'$(CRC_VERSION)'/g' \
 					   -e 's/__OPENSHIFT_VERSION__/'$(OPENSHIFT_VERSION)'/g' \

--- a/tools/tools.mk
+++ b/tools/tools.mk
@@ -1,10 +1,10 @@
 TOOLS_BINDIR = $(realpath $(TOOLS_DIR)/bin)
 
 $(TOOLS_BINDIR)/makefat: $(TOOLS_DIR)/go.mod
-	cd $(TOOLS_DIR) && GOBIN=$(TOOLS_BINDIR) go install github.com/randall77/makefat
+	cd $(TOOLS_DIR) && GOBIN="$(TOOLS_BINDIR)" go install github.com/randall77/makefat
 
 $(TOOLS_BINDIR)/golangci-lint: $(TOOLS_DIR)/go.mod
-	cd $(TOOLS_DIR) && GOBIN=$(TOOLS_BINDIR) go install github.com/golangci/golangci-lint/cmd/golangci-lint
+	cd $(TOOLS_DIR) && GOBIN="$(TOOLS_BINDIR)" go install github.com/golangci/golangci-lint/cmd/golangci-lint
 
 $(TOOLS_BINDIR)/gomod2rpmdeps: $(TOOLS_DIR)/go.mod
-	cd $(TOOLS_DIR) && GOBIN=$(TOOLS_BINDIR) go install github.com/cfergeau/gomod2rpmdeps/cmd/gomod2rpmdeps
+	cd $(TOOLS_DIR) && GOBIN="$(TOOLS_BINDIR)" go install github.com/cfergeau/gomod2rpmdeps/cmd/gomod2rpmdeps


### PR DESCRIPTION
The bigger issue is some golang/mingw bug described in https://github.com/golang/go/issues/46099
This is worked around by downgrading mingw. But I've been hitting quite a few download issues when trying to downgrade mingw, so let's see how reliable this is.
Then this fixes some issue with golangci-lint and GOBIN not being set to an absolute path
The last commit is a tentative fix for some intermittent issues when uploading the installer artifacts. I'm not sure this will fix anything at all, but it's worth trying and see if the failures still happen.