### PR TITLE
Add config option to enable or disable shared directories 

### DIFF
--- a/cmd/crc/cmd/start.go
+++ b/cmd/crc/cmd/start.go
@@ -74,6 +74,7 @@ func runStart(ctx context.Context) (*types.StartResult, error) {
 		PullSecret:        cluster.NewInteractivePullSecretLoader(config),
 		KubeAdminPassword: config.Get(crcConfig.KubeAdminPassword).AsString(),
 		Preset:            crcConfig.GetPreset(config),
+		EnableSharedDirs:  crcConfig.ShouldEnableSharedDirs(config),
 	}
 
 	client := newMachine()

--- a/pkg/crc/api/handlers.go
+++ b/pkg/crc/api/handlers.go
@@ -116,6 +116,7 @@ func getStartConfig(cfg crcConfig.Storage, args client.StartConfig) types.StartC
 		PullSecret:        cluster.NewNonInteractivePullSecretLoader(cfg, args.PullSecretFile),
 		KubeAdminPassword: cfg.Get(crcConfig.KubeAdminPassword).AsString(),
 		Preset:            crcConfig.GetPreset(cfg),
+		EnableSharedDirs:  crcConfig.ShouldEnableSharedDirs(cfg),
 	}
 }
 

--- a/pkg/crc/config/settings.go
+++ b/pkg/crc/config/settings.go
@@ -145,6 +145,14 @@ func GetNetworkMode(config Storage) network.Mode {
 	return network.ParseMode(config.Get(NetworkMode).AsString())
 }
 
+func ShouldEnableSharedDirs(config Storage) bool {
+	// Shared dirs are not implemented for windows
+	if runtime.GOOS == "windows" {
+		return false
+	}
+	return config.Get(EnableSharedDirs).AsBool()
+}
+
 func UpdateDefaults(cfg *Config) {
 	RegisterSettings(cfg)
 }

--- a/pkg/crc/config/settings.go
+++ b/pkg/crc/config/settings.go
@@ -30,6 +30,7 @@ const (
 	AutostartTray           = "autostart-tray"
 	KubeAdminPassword       = "kubeadmin-password"
 	Preset                  = "preset"
+	EnableSharedDirs        = "enable-shared-dirs"
 )
 
 func RegisterSettings(cfg *Config) {
@@ -76,6 +77,11 @@ func RegisterSettings(cfg *Config) {
 		"Disable update check (true/false, default: false)")
 	cfg.AddSetting(ExperimentalFeatures, false, ValidateBool, SuccessfullyApplied,
 		"Enable experimental features (true/false, default: false)")
+	// shared dir is not implemented for windows yet
+	if runtime.GOOS == "darwin" || runtime.GOOS == "linux" {
+		cfg.AddSetting(EnableSharedDirs, true, ValidateBool, SuccessfullyApplied,
+			"Enable shared directories which mounts host's $HOME at /home in the CRC VM (true/false, default: true)")
+	}
 
 	if !version.IsInstaller() {
 		cfg.AddSetting(NetworkMode, string(defaultNetworkMode()), network.ValidateMode, network.SuccessfullyAppliedMode,

--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -367,9 +367,10 @@ func (client *client) Start(ctx context.Context, startConfig types.StartConfig) 
 			return nil, errors.Wrap(err, "Failed to add nameserver to the VM")
 		}
 	}
-
-	if err := configureSharedDirs(vm, sshRunner); err != nil {
-		return nil, err
+	if startConfig.EnableSharedDirs {
+		if err := configureSharedDirs(vm, sshRunner); err != nil {
+			return nil, err
+		}
 	}
 
 	if _, _, err := sshRunner.RunPrivileged("make root Podman socket accessible", "chmod 777 /run/podman/ /run/podman/podman.sock"); err != nil {

--- a/pkg/crc/machine/types/types.go
+++ b/pkg/crc/machine/types/types.go
@@ -28,6 +28,9 @@ type StartConfig struct {
 
 	// Preset
 	Preset crcpreset.Preset
+
+	// Shared dirs
+	EnableSharedDirs bool
 }
 
 type ClusterConfig struct {


### PR DESCRIPTION
This adds a new config option 'enable-shared-dirs' for linux and
macOS which will be used to control the behavior of automounting
the user's $HOME dir on the crc vm during start, config type  is
bool and the default value is true

We are adding this to provide the user an option to disable this
feature if they face any issues, in our testing we found  issues
with RHEL 8.5 and libvirt 8.0.0 where 'crc start' errors out as:

```
level=warning msg="Failed to create the VM: virError(Code=67, Domain=10, Message='unsupported configuration: 'virtiofs' requires shared memory')"
```

Fixes #3285 