### PR TITLE
Revert "config: Force use of podman preset on M1 CPUs"

### DIFF
--- a/pkg/crc/config/settings.go
+++ b/pkg/crc/config/settings.go
@@ -56,10 +56,8 @@ func RegisterSettings(cfg *Config) {
 	}
 
 	// Preset setting should be on top because CPUs/Memory config depend on it.
-	if runtime.GOOS != "darwin" || runtime.GOARCH != "arm64" {
-		cfg.AddSetting(Preset, string(preset.OpenShift), validatePreset, RequiresDeleteAndSetupMsg,
-			fmt.Sprintf("Virtual machine preset (alpha feature - valid values are: %s, %s and %s)", preset.Podman, preset.OpenShift, preset.OKD))
-	}
+	cfg.AddSetting(Preset, string(preset.OpenShift), validatePreset, RequiresDeleteAndSetupMsg,
+		fmt.Sprintf("Virtual machine preset (alpha feature - valid values are: %s, %s and %s)", preset.Podman, preset.OpenShift, preset.OKD))
 	// Start command settings in config
 	cfg.AddSetting(Bundle, defaultBundlePath(cfg), validateBundlePath, SuccessfullyApplied,
 		fmt.Sprintf("Bundle path (string, default '%s')", defaultBundlePath(cfg)))
@@ -124,10 +122,6 @@ func defaultBundlePath(cfg Storage) string {
 }
 
 func GetPreset(config Storage) preset.Preset {
-	if runtime.GOOS == "darwin" && runtime.GOARCH == "arm64" {
-		return preset.Podman
-	}
-
 	return preset.ParsePreset(config.Get(Preset).AsString())
 }
 

--- a/pkg/crc/machine/bundle/constants.go
+++ b/pkg/crc/machine/bundle/constants.go
@@ -29,6 +29,8 @@ var bundleLocations = map[string]bundlesDownloadInfo{
 	},
 	"arm64": {
 		"darwin": {
+			preset.OpenShift: download.NewRemoteFile("https://storage.googleapis.com/crc-bundle-github-ci/crc_vfkit_4.10.23_arm64.crcbundle",
+				"1cd0f693dffc212ae94bca6e3b033897c3fd8546f1fb2bb2425bc8033ea9cee1"),
 			preset.Podman: download.NewRemoteFile("https://mirror.openshift.com/pub/openshift-v4/clients/crc/bundles/podman/4.1.0/crc_podman_vfkit_4.1.0_arm64.crcbundle",
 				"6674c016591ee56451741de754b14b754aaaf1a981e4a1fa922c238353988e9a"),
 		},


### PR DESCRIPTION
We now have a way to create ocp bundles for M1 so reverting this
PR.
This reverts commit b14fb9dd247e8860daa848e5966ca0aff1af46ec.

