### PR TITLE
Fixes #3298 Changes Windows release preflight message

### DIFF
--- a/pkg/crc/preflight/preflight_windows.go
+++ b/pkg/crc/preflight/preflight_windows.go
@@ -25,7 +25,7 @@ var hypervPreflightChecks = []Check{
 	},
 	{
 		configKeySuffix:  "check-windows-version",
-		checkDescription: "Checking Windows 10 release",
+		checkDescription: "Checking Windows release",
 		check:            checkVersionOfWindowsUpdate,
 		flags:            StartUpOnly,
 

--- a/test/e2e/features/basic.feature
+++ b/test/e2e/features/basic.feature
@@ -76,7 +76,7 @@ Feature: Basic test
     Scenario: CRC setup on Windows
         When executing crc setup command succeeds
         Then stderr should contain "Extracting bundle from the CRC executable" if bundle is embedded
-        Then stderr should contain "Checking Windows 10 release"
+        Then stderr should contain "Checking Windows release"
         Then stderr should contain "Checking if Hyper-V is installed"
         Then stderr should contain "Checking if user is a member of the Hyper-V Administrators group"
         Then stderr should contain "Checking if the Hyper-V virtual switch exist"


### PR DESCRIPTION
**Fixes:** Issue #3298 

## Solution/Idea

Removes the specific mention of the Windows 10 as this check also works for Windows 11.


## Testing

1.  run 'setup' on Windows

or

1. run 'start' on Windows

