### PR TITLE
Update the kernel args to instance config during stop

### DIFF
--- a/pkg/crc/machine/driver_linux.go
+++ b/pkg/crc/machine/driver_linux.go
@@ -38,6 +38,10 @@ func updateDriverConfig(host *host.Host, driver *machineLibvirt.Driver) error {
 	return host.UpdateConfig(driverData)
 }
 
+func updateKernelArgs(vm *virtualMachine) error {
+	return nil
+}
+
 /*
 func (r *RPCServerDriver) SetConfigRaw(data []byte, _ *struct{}) error {
 	return json.Unmarshal(data, &r.ActualDriver)

--- a/pkg/crc/machine/driver_windows.go
+++ b/pkg/crc/machine/driver_windows.go
@@ -33,3 +33,7 @@ func updateDriverConfig(host *host.Host, driver *machineHyperv.Driver) error {
 	}
 	return host.UpdateConfig(driverData)
 }
+
+func updateKernelArgs(vm *virtualMachine) error {
+	return nil
+}

--- a/pkg/crc/machine/stop.go
+++ b/pkg/crc/machine/stop.go
@@ -23,6 +23,9 @@ func (client *client) Stop() (state.State, error) {
 			logging.Debugf("%v", err)
 		}
 	}
+	if err := updateKernelArgs(vm); err != nil {
+		logging.Debugf("%v", err)
+	}
 	logging.Info("Stopping the instance, this may take a few minutes...")
 	if err := vm.Stop(); err != nil {
 		status, stateErr := vm.State()


### PR DESCRIPTION
This PR is going to update the kernel paramater to instance config
when stop operation happen.

In mac we use kernel parameter as part of vfkit driver to start
the instance but during the reboot it changes because of MCO and
we are getting error during `start => stop => start` operation.

```
systemctl[787]: Failed to switch root: Specified switch root path '/sysroot' does not seem to be an OS tree. os-release file is missing.
```

ostree changes from (`boot.0` => `boot.1`)
```
ostree=/ostree/boot.0/rhcos/b6f1ba590ef2df8e30bd88833fd145bfbbd424eca8ad235f573f2a136f09b0d6/0
```
to
```
ostree=/ostree/boot.1/rhcos/b6f1ba590ef2df8e30bd88833fd145bfbbd424eca8ad235f573f2a136f09b0d6/0
```

As part of the MCO logs
```
Bootloader updated; bootconfig swap: yes; bootversion: boot.1.1, deployment count change: -1
```
