### PR TITLE
E2e fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -208,7 +208,7 @@ ifndef PULL_SECRET_FILE
 	PULL_SECRET_FILE = --pull-secret-file=$(HOME)/Downloads/crc-pull-secret
 endif
 ifndef BUNDLE_LOCATION
-	BUNDLE_LOCATION = --bundle-location=$(HOME)/Downloads/crc_libvirt_$(OPENSHIFT_VERSION).$(BUNDLE_EXTENSION)
+	BUNDLE_LOCATION = --bundle-location=$(HOME)/Downloads/crc_libvirt_$(OPENSHIFT_VERSION)_$(GOARCH).$(BUNDLE_EXTENSION)
 endif
 ifndef CRC_BINARY
 	CRC_BINARY = --crc-binary=$(GOPATH)/bin

--- a/Makefile
+++ b/Makefile
@@ -160,15 +160,15 @@ clean: clean_docs clean_macos_package clean_windows_msi
 
 .PHONY: build_e2e
 build_e2e: $(SOURCES)
-	GOOS=linux   go test ./test/e2e/ -c -o $(BUILD_DIR)/linux-amd64/e2e.test
-	GOOS=windows go test ./test/e2e/ -c -o $(BUILD_DIR)/windows-amd64/e2e.test.exe
-	GOOS=darwin  go test ./test/e2e/ -c -o $(BUILD_DIR)/macos-amd64/e2e.test
+	GOOS=linux   go test ./test/e2e/ --ldflags="$(VERSION_VARIABLES)" -c -o $(BUILD_DIR)/linux-amd64/e2e.test
+	GOOS=windows go test ./test/e2e/ --ldflags="$(VERSION_VARIABLES)" -c -o $(BUILD_DIR)/windows-amd64/e2e.test.exe
+	GOOS=darwin  go test ./test/e2e/ --ldflags="$(VERSION_VARIABLES)" -c -o $(BUILD_DIR)/macos-amd64/e2e.test
 
 .PHONY: build_integration
 build_integration: $(SOURCES)
-	GOOS=linux   go test ./test/integration/ -c -o $(BUILD_DIR)/linux-amd64/integration.test
-	GOOS=windows go test --ldflags="-X $(REPOPATH)/pkg/crc/version.installerBuild=true" ./test/integration/ -c -o $(BUILD_DIR)/windows-amd64/integration.test.exe
-	GOOS=darwin  go test --ldflags="-X $(REPOPATH)/pkg/crc/version.installerBuild=true" ./test/integration/ -c -o $(BUILD_DIR)/macos-amd64/integration.test
+	GOOS=linux   go test ./test/integration/ --ldflags="$(VERSION_VARIABLES)" -c -o $(BUILD_DIR)/linux-amd64/integration.test
+	GOOS=windows go test --ldflags="-X $(REPOPATH)/pkg/crc/version.installerBuild=true $(VERSION_VARIABLES)" ./test/integration/ -c -o $(BUILD_DIR)/windows-amd64/integration.test.exe
+	GOOS=darwin  go test --ldflags="-X $(REPOPATH)/pkg/crc/version.installerBuild=true $(VERSION_VARIABLES)" ./test/integration/ -c -o $(BUILD_DIR)/macos-amd64/integration.test
 
 #  Build the container image for e2e
 .PHONY: containerized_e2e
@@ -214,18 +214,18 @@ ifndef CRC_BINARY
 	CRC_BINARY = --crc-binary=$(GOPATH)/bin
 endif
 e2e:
-	@go test --timeout=180m $(REPOPATH)/test/e2e -v $(PULL_SECRET_FILE) $(BUNDLE_LOCATION) $(CRC_BINARY) $(GODOG_OPTS) $(CLEANUP_HOME) $(INSTALLER_PATH) $(USER_PASSWORD)
+	@go test --timeout=180m $(REPOPATH)/test/e2e --ldflags="$(VERSION_VARIABLES)" -v $(PULL_SECRET_FILE) $(BUNDLE_LOCATION) $(CRC_BINARY) $(GODOG_OPTS) $(CLEANUP_HOME) $(INSTALLER_PATH) $(USER_PASSWORD)
 
 .PHONY: e2e-stories e2e-story-health e2e-story-marketplace e2e-story-registry
 # cluster must already be running, crc must be in the path
 e2e-stories: install e2e-story-health e2e-story-marketplace e2e-story-registry
 
 e2e-story-health: install
-	@go test $(REPOPATH)/test/e2e -v --godog.tags="$(GOOS) && ~@startstop && @story_health" --cleanup-home=false
+	@go test $(REPOPATH)/test/e2e --ldflags="$(VERSION_VARIABLES)" -v --godog.tags="$(GOOS) && ~@startstop && @story_health" --cleanup-home=false
 e2e-story-marketplace: install
-	@go test $(REPOPATH)/test/e2e -v --godog.tags="$(GOOS) && ~@startstop && @story_marketplace" --cleanup-home=false
+	@go test $(REPOPATH)/test/e2e --ldflags="$(VERSION_VARIABLES)" -v --godog.tags="$(GOOS) && ~@startstop && @story_marketplace" --cleanup-home=false
 e2e-story-registry: install
-	@go test $(REPOPATH)/test/e2e -v --godog.tags="$(GOOS) && ~@startstop && @story_registry" --cleanup-home=false
+	@go test $(REPOPATH)/test/e2e --ldflags="$(VERSION_VARIABLES)" -v --godog.tags="$(GOOS) && ~@startstop && @story_registry" --cleanup-home=false
 
 
 .PHONY: fmt

--- a/test/e2e/features/story_registry.feature
+++ b/test/e2e/features/story_registry.feature
@@ -20,9 +20,9 @@ Feature: Local image to image-registry
         Given executing "oc new-project testproj-img" succeeds
         When executing "oc registry login --insecure=true" succeeds
         Then stdout should contain "Saved credentials for default-route-openshift-image-registry.apps-crc.testing"
-         And executing "oc image mirror registry.access.redhat.com/ubi8/httpd-24:latest=default-route-openshift-image-registry.apps-crc.testing/testproj-img/httpd-24:latest --insecure=true --filter-by-os=linux/amd64" succeeds
-         And executing "oc set image-lookup httpd-24" 
-         
+        And executing "oc image mirror registry.access.redhat.com/ubi8/httpd-24:latest=default-route-openshift-image-registry.apps-crc.testing/testproj-img/httpd-24:latest --insecure=true --filter-by-os=linux/amd64" succeeds
+        And executing "oc set image-lookup httpd-24"
+
 
     Scenario: Deploy the image
         Given executing "oc new-app testproj-img/httpd-24:latest" succeeds
@@ -31,7 +31,7 @@ Feature: Local image to image-registry
         When executing "oc get pods" succeeds
         Then stdout should contain "Running"
         When executing "oc logs deployment/httpd-24" succeeds
-        Then stdout should contain "Apache"
+        Then stdout should contain "httpd"
 
     @startstop
     Scenario: Clean up

--- a/test/e2e/features/story_registry.feature
+++ b/test/e2e/features/story_registry.feature
@@ -19,10 +19,8 @@ Feature: Local image to image-registry
     Scenario: Mirror image to OpenShift image registry
         Given executing "oc new-project testproj-img" succeeds
         When executing "oc registry login --insecure=true" succeeds
-        Then stdout should contain "Saved credentials for default-route-openshift-image-registry.apps-crc.testing"
-        And executing "oc image mirror registry.access.redhat.com/ubi8/httpd-24:latest=default-route-openshift-image-registry.apps-crc.testing/testproj-img/httpd-24:latest --insecure=true --filter-by-os=linux/amd64" succeeds
-        And executing "oc set image-lookup httpd-24"
-
+        Then executing "oc image mirror registry.access.redhat.com/ubi8/httpd-24:latest=default-route-openshift-image-registry.apps-crc.testing/testproj-img/httpd-24:latest --insecure=true --filter-by-os=linux/amd64" succeeds
+        And executing "oc set image-lookup httpd-24" succeeds
 
     Scenario: Deploy the image
         Given executing "oc new-app testproj-img/httpd-24:latest" succeeds


### PR DESCRIPTION
3 fixes to instabilities (or stable fails) in e2e tests. Tagging @adrianriobo as we discussed these before I compiled them here.

The first one addresses this fail in `config.feature`: 
```
"Step setting config property "bundle" to value "current bundle" succeeds: command 'crc config set bundle /home/cloud-user/.crc/cache/crc_libvirt_0.0.0-unset_amd64.crcbundle', expected to succeed, exited with exit code: 1 Command stdout: Command stderr: level=debug msg="CRC version: 2.7.1+a8e9854\n" level=debug msg="OpenShift version: 4.11.0\n" level=debug msg="Podman version: 4.1.1\n" level=debug msg="Running 'crc config set'" Value '/home/cloud-user/.crc/cache/crc_libvirt_0.0.0-unset_amd64.crcbundle' for configuration property 'bundle' is invalid, reason: file '/home/cloud-user/.crc/cache/crc_libvirt_0.0.0-unset_amd64.crcbundle' does not exist "
```
The second one addresses this fail in `story_registry.feature`: 
```
Step stdout should contain "Apache": output did not match. Expected: 'Apache', Actual: '=> sourcing 10-set-mpm.sh ... => sourcing 20-copy-config.sh ... => sourcing 40-ssl-certs.sh ... ---> Generating SSL key pair for httpd...'
```
The third one removes  an unnecessary line (that caused issue >1x) and finishes the Step to fit the template.

