### PR TITLE
Add CIFS/SMB based file sharing for windows 

### DIFF
--- a/cmd/crc/cmd/start.go
+++ b/cmd/crc/cmd/start.go
@@ -75,9 +75,9 @@ func runStart(ctx context.Context) (*types.StartResult, error) {
 		PullSecret:        cluster.NewInteractivePullSecretLoader(config),
 		KubeAdminPassword: config.Get(crcConfig.KubeAdminPassword).AsString(),
 		Preset:            crcConfig.GetPreset(config),
-		EnableSharedDirs:  crcConfig.ShouldEnableSharedDirs(config),
 		IngressHTTPPort:   config.Get(crcConfig.IngressHTTPPort).AsUInt(),
 		IngressHTTPSPort:  config.Get(crcConfig.IngressHTTPSPort).AsUInt(),
+		EnableSharedDirs:  config.Get(crcConfig.EnableSharedDirs).AsBool(),
 	}
 
 	client := newMachine()
@@ -94,6 +94,17 @@ func runStart(ctx context.Context) (*types.StartResult, error) {
 				Code: preflightFailedExitCode,
 			}
 		}
+	}
+
+	if runtime.GOOS == "windows" {
+		username, err := crcos.GetCurrentUsername()
+		if err != nil {
+			return nil, err
+		}
+
+		// config SharedDirPassword ('shared-dir-password') only exists in windows
+		startConfig.SharedDirPassword = config.Get(crcConfig.SharedDirPassword).AsString()
+		startConfig.SharedDirUsername = username
 	}
 
 	return client.Start(ctx, startConfig)

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/cavaliergopher/grab/v3 v3.0.1
 	github.com/cheggaaa/pb/v3 v3.0.8
 	github.com/code-ready/admin-helper v0.0.10
-	github.com/code-ready/machine v0.0.0-20220727160217-7bf0dd8c2d7b
+	github.com/code-ready/machine v0.0.0-20220927132822-3408fdecc41c
 	github.com/code-ready/vfkit v0.0.2
 	github.com/containers/gvisor-tap-vsock v0.4.1-0.20220908123107-8d91f6d62de2
 	github.com/containers/image/v5 v5.15.0

--- a/go.sum
+++ b/go.sum
@@ -243,8 +243,8 @@ github.com/cockroachdb/errors v1.2.4/go.mod h1:rQD95gz6FARkaKkQXUksEje/d9a6wBJoC
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
 github.com/code-ready/admin-helper v0.0.10 h1:J7z6cu8owR9UemZlHQXL2W1aCOfo1nGhY1YtYz2+aCo=
 github.com/code-ready/admin-helper v0.0.10/go.mod h1:8ACGWyeBXkVcQ53idgXhYzLGrK/+xjabcGVCtPtKaRQ=
-github.com/code-ready/machine v0.0.0-20220727160217-7bf0dd8c2d7b h1:Eev9Enne43B+k6s2gfYxaSh0f0/+owLbrAyk8+7eoeM=
-github.com/code-ready/machine v0.0.0-20220727160217-7bf0dd8c2d7b/go.mod h1:zeUHkDy+CASmOmTcbvv9m5SlkXmhp0MAtcs6f7EMp68=
+github.com/code-ready/machine v0.0.0-20220927132822-3408fdecc41c h1:cVthP8D5RUFAegEqrVWXiHUwRR+0dqN0mdOGYU6RJwU=
+github.com/code-ready/machine v0.0.0-20220927132822-3408fdecc41c/go.mod h1:zeUHkDy+CASmOmTcbvv9m5SlkXmhp0MAtcs6f7EMp68=
 github.com/code-ready/vfkit v0.0.2 h1:DA7wnPVXjs8bwa3ksNd8JtKzXsZ1oC1F7JanVoDyzCw=
 github.com/code-ready/vfkit v0.0.2/go.mod h1:rjWQeMUISswhWXeBp5LEzwVjv8aN3Gn1QxIHDCmxu40=
 github.com/codegangsta/cli v1.20.0/go.mod h1:/qJNoX69yVSKu5o4jLyXAENLRyk1uhi7zkbQ3slBdOA=

--- a/packaging/windows/product.wxs.template
+++ b/packaging/windows/product.wxs.template
@@ -38,6 +38,12 @@
                 Name="Path" />
         </Property>
 
+        <Property Id="USERFOLDER">
+            <DirectorySearch Id="userProfileSearch" Depth="0" Path="[%USERPROFILE]" />
+        </Property>
+
+        <Property Id="SHAREDDIRNAME" Secure="yes">crc-dir0</Property>
+
         <util:Group Id="CrcUsersGroup" Name="crc-users" />
         <Directory Id="TARGETDIR" Name="SourceDir">
             <Directory Id="ProgramFiles64Folder">
@@ -101,6 +107,12 @@
             Before="AddUserToHypervAdminGroup" 
             Sequence="execute"/>
         <CustomAction Id="AddUserToHypervAdminGroup" BinaryKey="WixCA" DllEntry="WixQuietExec64" Execute="deferred" Impersonate="no" Return="ignore" />
+        <SetProperty Action="CACreateSMBShare"
+            Id="CreateSMBShare"
+            Value="&quot;[POWERSHELLEXE]&quot; -NonInteractive -ExecutionPolicy Bypass -NoProfile -Command &quot;New-SmbShare -Name '[SHAREDDIRNAME]' -Path '[USERFOLDER]' -FullAccess '[LogonUser]'&quot;"
+            Before="CreateSMBShare"
+            Sequence="execute"/>
+        <CustomAction Id="CreateSMBShare" BinaryKey="WixCA" DllEntry="WixQuietExec64" Execute="deferred" Impersonate="no" Return="check" />
         <SetProperty Action="CAEnableFileAndPrinterSharing"
             Id="EnableFileAndPrinterSharing"
             Value="&quot;[POWERSHELLEXE]&quot; -NonInteractive -ExecutionPolicy Bypass -NoProfile -Command &quot;Set-NetFirewallRule -DisplayGroup 'File And Printer Sharing' -Enabled True -Profile 'Private,Public'&quot;"
@@ -118,6 +130,7 @@
             <Custom Action="RemoveCrcGroupRollback" After="CreateCrcGroup"> NOT Installed AND NOT REMOVE~="ALL" AND NOT WIX_UPGRADE_DETECTED</Custom>
             <Custom Action="RemoveCrcDaemonTask" Before='RemoveFiles'>Installed AND NOT UPGRADINGPRODUCTCODE</Custom>
             <Custom Action="EnableFileAndPrinterSharing" After="AddUserToHypervAdminGroup"> NOT Installed AND NOT REMOVE~="ALL" AND NOT WIX_UPGRADE_DETECTED</Custom>
+            <Custom Action="CreateSMBShare" After="EnableFileAndPrinterSharing"> NOT Installed AND NOT REMOVE~="ALL" AND NOT WIX_UPGRADE_DETECTED</Custom>
             <ScheduleReboot After="InstallFinalize"> NOT Installed AND NOT REMOVE~="ALL" AND NOT WIX_UPGRADE_DETECTED</ScheduleReboot>
         </InstallExecuteSequence>
         <Feature Id="DefaultFeature" Level="1">
@@ -138,6 +151,7 @@
             <ProgressText Action="InstallHyperv">Installing Hyper-V</ProgressText>
             <ProgressText Action="AddUserToHypervAdminGroup">Adding user: [LogonUser] to Hyper-V Administrators group</ProgressText>
             <ProgressText Action="RemoveCrcDaemonTask">Removing crcDaemon task</ProgressText>
+            <ProgressText Action="CreateSMBShare">Creating share named: [SHAREDDIRNAME] for folder: [USERFOLDER]</ProgressText>
             <ProgressText Action="EnableFileAndPrinterSharing">Enabling file and printer Sharing</ProgressText>
         </UI>
         <Property Id="WIXUI_INSTALLDIR" Value="INSTALLDIR" />

--- a/packaging/windows/product.wxs.template
+++ b/packaging/windows/product.wxs.template
@@ -78,10 +78,10 @@
             </Directory>
             <Directory Id="ProgramMenuFolder">
                 <Component Id="StartMenuEntry" Guid="*">
-                    <Shortcut Id="TrayStartMenuEntry" 
-                            Name="Red Hat OpenShift Local" 
-                            Target="[INSTALLDIR]crc-tray.exe" 
-                            Icon="crcicon.ico" 
+                    <Shortcut Id="TrayStartMenuEntry"
+                            Name="Red Hat OpenShift Local"
+                            Target="[INSTALLDIR]crc-tray.exe"
+                            Icon="crcicon.ico"
                             WorkingDirectory="AppDataFolder">
                         <ShortcutProperty Key="System.AppUserModel.ID" Value="redhat.codereadycontainers.tray"/>
                     </Shortcut>
@@ -101,10 +101,10 @@
         <CustomAction Id="RemoveCrcDaemonTask" BinaryKey="WixCA" DllEntry="WixQuietExec" Execute="deferred" Impersonate="no" Return="ignore" />
         <SetProperty Action="CAInstallHyperv" Id="InstallHyperv" Value='"[System64Folder]dism.exe" /online /enable-feature /featureName:microsoft-hyper-v-all /NoRestart /quiet' Before="InstallHyperv" Sequence="execute"/>
         <CustomAction Id="InstallHyperv" BinaryKey="WixCA" DllEntry="WixQuietExec64" Execute="deferred" Impersonate="no" Return="ignore" />
-        <SetProperty Action="CAAddUserToHypervAdminGroup" 
-            Id="AddUserToHypervAdminGroup" 
-            Value="&quot;[POWERSHELLEXE]&quot; -NonInteractive -ExecutionPolicy Bypass -NoProfile -Command &quot;Add-LocalGroupMember -Member [LogonUser] -SID S-1-5-32-578&quot;" 
-            Before="AddUserToHypervAdminGroup" 
+        <SetProperty Action="CAAddUserToHypervAdminGroup"
+            Id="AddUserToHypervAdminGroup"
+            Value="&quot;[POWERSHELLEXE]&quot; -NonInteractive -ExecutionPolicy Bypass -NoProfile -Command &quot;Add-LocalGroupMember -Member [LogonUser] -SID S-1-5-32-578&quot;"
+            Before="AddUserToHypervAdminGroup"
             Sequence="execute"/>
         <CustomAction Id="AddUserToHypervAdminGroup" BinaryKey="WixCA" DllEntry="WixQuietExec64" Execute="deferred" Impersonate="no" Return="ignore" />
         <SetProperty Action="CACreateSMBShare"

--- a/packaging/windows/product.wxs.template
+++ b/packaging/windows/product.wxs.template
@@ -101,6 +101,12 @@
             Before="AddUserToHypervAdminGroup" 
             Sequence="execute"/>
         <CustomAction Id="AddUserToHypervAdminGroup" BinaryKey="WixCA" DllEntry="WixQuietExec64" Execute="deferred" Impersonate="no" Return="ignore" />
+        <SetProperty Action="CAEnableFileAndPrinterSharing"
+            Id="EnableFileAndPrinterSharing"
+            Value="&quot;[POWERSHELLEXE]&quot; -NonInteractive -ExecutionPolicy Bypass -NoProfile -Command &quot;Set-NetFirewallRule -DisplayGroup 'File And Printer Sharing' -Enabled True -Profile 'Private,Public'&quot;"
+            Before="EnableFileAndPrinterSharing"
+            Sequence="execute"/>
+        <CustomAction Id="EnableFileAndPrinterSharing" BinaryKey="WixCA" DllEntry="WixQuietExec64" Execute="deferred" Impersonate="no" Return="check" />
 
         <util:CloseApplication Id = "TrayRunning" Description="Please exit Red Hat OpenShift Local from tray and run the installation again." Target="crc-tray.exe" RebootPrompt="no" PromptToContinue="yes" />
 
@@ -111,6 +117,7 @@
             <Custom Action="InstallHyperv" Before="CreateCrcGroup"> NOT Installed AND NOT REMOVE~="ALL" AND NOT WIX_UPGRADE_DETECTED</Custom>
             <Custom Action="RemoveCrcGroupRollback" After="CreateCrcGroup"> NOT Installed AND NOT REMOVE~="ALL" AND NOT WIX_UPGRADE_DETECTED</Custom>
             <Custom Action="RemoveCrcDaemonTask" Before='RemoveFiles'>Installed AND NOT UPGRADINGPRODUCTCODE</Custom>
+            <Custom Action="EnableFileAndPrinterSharing" After="AddUserToHypervAdminGroup"> NOT Installed AND NOT REMOVE~="ALL" AND NOT WIX_UPGRADE_DETECTED</Custom>
             <ScheduleReboot After="InstallFinalize"> NOT Installed AND NOT REMOVE~="ALL" AND NOT WIX_UPGRADE_DETECTED</ScheduleReboot>
         </InstallExecuteSequence>
         <Feature Id="DefaultFeature" Level="1">
@@ -131,6 +138,7 @@
             <ProgressText Action="InstallHyperv">Installing Hyper-V</ProgressText>
             <ProgressText Action="AddUserToHypervAdminGroup">Adding user: [LogonUser] to Hyper-V Administrators group</ProgressText>
             <ProgressText Action="RemoveCrcDaemonTask">Removing crcDaemon task</ProgressText>
+            <ProgressText Action="EnableFileAndPrinterSharing">Enabling file and printer Sharing</ProgressText>
         </UI>
         <Property Id="WIXUI_INSTALLDIR" Value="INSTALLDIR" />
         <!-- this should help to propagate env var changes -->

--- a/pkg/crc/api/api_client_test.go
+++ b/pkg/crc/api/api_client_test.go
@@ -185,6 +185,11 @@ func TestConfigGetAll(t *testing.T) {
 	assert.NoError(t, err)
 	configs := make(map[string]interface{})
 	for k, v := range client.config.AllConfigs() {
+		// since we filter out secret configs at the config api handler level
+		// we need exclude them from AllConfigs
+		if v.IsSecret {
+			continue
+		}
 		// This is required because of https://pkg.go.dev/encoding/json#Unmarshal
 		// Unmarshal stores float64 for JSON numbers in case of interface.
 		switch v := v.Value.(type) {

--- a/pkg/crc/api/handlers.go
+++ b/pkg/crc/api/handlers.go
@@ -119,7 +119,7 @@ func getStartConfig(cfg crcConfig.Storage, args client.StartConfig) types.StartC
 		IngressHTTPPort:   cfg.Get(crcConfig.IngressHTTPPort).AsUInt(),
 		IngressHTTPSPort:  cfg.Get(crcConfig.IngressHTTPSPort).AsUInt(),
 		Preset:            crcConfig.GetPreset(cfg),
-		EnableSharedDirs:  crcConfig.ShouldEnableSharedDirs(cfg),
+		EnableSharedDirs:  cfg.Get(crcConfig.EnableSharedDirs).AsBool(),
 	}
 }
 

--- a/pkg/crc/config/callbacks.go
+++ b/pkg/crc/config/callbacks.go
@@ -33,6 +33,11 @@ func RequiresCRCSetup(key string, _ interface{}) string {
 		"Please run 'crc setup' for this configuration to take effect.", key)
 }
 
+func RequiresCleanupAndSetupMsg(key string, _ interface{}) string {
+	return fmt.Sprintf("Changes to configuration property '%s' are only applied during 'crc setup'.\n"+
+		"Please run 'crc cleanup' followed by 'crc setup' for this configuration to take effect.", key)
+}
+
 func RequiresHTTPPortChangeWarning(key string, value interface{}) string {
 	return fmt.Sprintf("Changes to configuration property '%s' will break OpenShift HTTP routes.\n"+
 		"In order to access OpenShift applications through HTTP URLs "+

--- a/pkg/crc/config/settings.go
+++ b/pkg/crc/config/settings.go
@@ -107,7 +107,7 @@ func RegisterSettings(cfg *Config) {
 			fmt.Sprintf("Network mode (%s or %s)", network.UserNetworkingMode, network.SystemNetworkingMode))
 	}
 
-	cfg.AddSetting(HostNetworkAccess, false, validateHostNetworkAccess, SuccessfullyApplied,
+	cfg.AddSetting(HostNetworkAccess, false, validateHostNetworkAccess, RequiresCleanupAndSetupMsg,
 		"Allow TCP/IP connections from the CRC VM to services running on the host (true/false, default: false)")
 	// Proxy Configuration
 	cfg.AddSetting(HTTPProxy, "", ValidateHTTPProxy, SuccessfullyApplied,

--- a/pkg/crc/errors/maskederror.go
+++ b/pkg/crc/errors/maskederror.go
@@ -1,0 +1,16 @@
+package errors
+
+import (
+	"strings"
+)
+
+const mask = "*****"
+
+type MaskedSecretError struct {
+	Err    error
+	Secret string
+}
+
+func (err *MaskedSecretError) Error() string {
+	return strings.ReplaceAll(err.Err.Error(), err.Secret, mask)
+}

--- a/pkg/crc/errors/maskederror_test.go
+++ b/pkg/crc/errors/maskederror_test.go
@@ -1,0 +1,16 @@
+package errors
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMaskedError(t *testing.T) {
+	err := errors.New("The password is: pass@122")
+	maskedErr := &MaskedSecretError{err, "pass@122"}
+	expectedErrMsg := fmt.Sprintf("The password is: %s", mask)
+	assert.EqualError(t, maskedErr, expectedErrMsg)
+}

--- a/pkg/crc/machine/config/config.go
+++ b/pkg/crc/machine/config/config.go
@@ -7,15 +7,17 @@ type MachineConfig struct {
 	BundleName string
 
 	// Virtual machine configuration
-	Name            string
-	Memory          int
-	CPUs            int
-	DiskSize        int
-	ImageSourcePath string
-	ImageFormat     string
-	SSHKeyPath      string
-	KubeConfig      string
-	SharedDirs      []string
+	Name              string
+	Memory            int
+	CPUs              int
+	DiskSize          int
+	ImageSourcePath   string
+	ImageFormat       string
+	SSHKeyPath        string
+	KubeConfig        string
+	SharedDirs        []string
+	SharedDirPassword string
+	SharedDirUsername string
 
 	// macOS specific configuration
 	KernelCmdLine string

--- a/pkg/crc/machine/config/driver.go
+++ b/pkg/crc/machine/config/driver.go
@@ -1,8 +1,6 @@
 package config
 
 import (
-	"fmt"
-
 	"github.com/code-ready/machine/libmachine/drivers"
 )
 
@@ -17,13 +15,4 @@ func InitVMDriverFromMachineConfig(machineConfig MachineConfig, driver *drivers.
 	driver.BundleName = machineConfig.BundleName
 	driver.ImageSourcePath = machineConfig.ImageSourcePath
 	driver.ImageFormat = machineConfig.ImageFormat
-
-	for i, dir := range machineConfig.SharedDirs {
-		sharedDir := drivers.SharedDir{
-			Source: dir,
-			Target: dir,
-			Tag:    fmt.Sprintf("dir%d", i),
-		}
-		driver.SharedDirs = append(driver.SharedDirs, sharedDir)
-	}
 }

--- a/pkg/crc/machine/driver.go
+++ b/pkg/crc/machine/driver.go
@@ -57,3 +57,19 @@ func setDiskSize(host *host.Host, diskSizeGiB int) error {
 
 	return updateDriverValue(host, diskSizeSetter)
 }
+
+func setSharedDirPassword(host *host.Host, password string) error {
+	driver, err := loadDriverConfig(host)
+	if err != nil {
+		return err
+	}
+
+	if len(driver.SharedDirs) == 0 {
+		return nil
+	}
+
+	for i := range driver.SharedDirs {
+		driver.SharedDirs[i].Password = password
+	}
+	return updateDriverStruct(host, driver)
+}

--- a/pkg/crc/machine/driver_darwin.go
+++ b/pkg/crc/machine/driver_darwin.go
@@ -11,6 +11,7 @@ import (
 	machineVf "github.com/code-ready/crc/pkg/drivers/vfkit"
 	"github.com/code-ready/crc/pkg/libmachine"
 	"github.com/code-ready/crc/pkg/libmachine/host"
+	"github.com/code-ready/machine/libmachine/drivers"
 )
 
 func newHost(api libmachine.API, machineConfig config.MachineConfig) (*host.Host, error) {
@@ -63,4 +64,8 @@ func updateKernelArgs(vm *virtualMachine) error {
 		return err
 	}
 	return vm.api.Save(vm.Host)
+}
+
+func updateDriverStruct(host *host.Host, driver *machineVf.Driver) error {
+	return drivers.ErrNotImplemented
 }

--- a/pkg/crc/machine/driver_linux.go
+++ b/pkg/crc/machine/driver_linux.go
@@ -10,6 +10,7 @@ import (
 	"github.com/code-ready/crc/pkg/libmachine"
 	"github.com/code-ready/crc/pkg/libmachine/host"
 	machineLibvirt "github.com/code-ready/machine/drivers/libvirt"
+	"github.com/code-ready/machine/libmachine/drivers"
 )
 
 func newHost(api libmachine.API, machineConfig config.MachineConfig) (*host.Host, error) {
@@ -47,3 +48,7 @@ func (r *RPCServerDriver) SetConfigRaw(data []byte, _ *struct{}) error {
 	return json.Unmarshal(data, &r.ActualDriver)
 }
 */
+
+func updateDriverStruct(host *host.Host, driver *machineLibvirt.Driver) error {
+	return drivers.ErrNotImplemented
+}

--- a/pkg/crc/machine/driver_windows.go
+++ b/pkg/crc/machine/driver_windows.go
@@ -37,3 +37,8 @@ func updateDriverConfig(host *host.Host, driver *machineHyperv.Driver) error {
 func updateKernelArgs(vm *virtualMachine) error {
 	return nil
 }
+
+func updateDriverStruct(host *host.Host, driver *machineHyperv.Driver) error {
+	host.Driver = driver
+	return nil
+}

--- a/pkg/crc/machine/hyperv/driver_windows.go
+++ b/pkg/crc/machine/hyperv/driver_windows.go
@@ -1,11 +1,15 @@
 package hyperv
 
 import (
+	"path/filepath"
+	"strings"
+
 	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/code-ready/crc/pkg/crc/machine/config"
 	"github.com/code-ready/crc/pkg/crc/network"
 	"github.com/code-ready/crc/pkg/drivers/hyperv"
 	winnet "github.com/code-ready/crc/pkg/os/windows/network"
+	"github.com/code-ready/machine/libmachine/drivers"
 )
 
 func CreateHost(machineConfig config.MachineConfig) *hyperv.Driver {
@@ -23,5 +27,35 @@ func CreateHost(machineConfig config.MachineConfig) *hyperv.Driver {
 		hypervDriver.VirtualSwitch = switchName
 	}
 
+	hypervDriver.SharedDirs = configureShareDirs(machineConfig)
 	return hypervDriver
+}
+
+// converts a path like c:\users\crc to /mnt/c/users/crc
+func convertToUnixPath(path string) string {
+	/* podman internally converts windows style paths like C:\Users\crc  to
+	 * /mnt/c/Users/crc so it expects the shared folder to be mounted under
+	 * '/mnt' instead of '/' like in the case of macOS and linux
+	 * see: https://github.com/containers/podman/blob/468aa6478c73e4acd8708ce8bb0bb5a056f329c2/pkg/specgen/winpath.go#L24-L59
+	 */
+	path = filepath.ToSlash(path)
+	if len(path) > 1 && path[1] == ':' {
+		return ("/mnt/" + strings.ToLower(path[0:1]) + path[2:])
+	}
+	return path
+}
+
+func configureShareDirs(machineConfig config.MachineConfig) []drivers.SharedDir {
+	var sharedDirs []drivers.SharedDir
+	for _, dir := range machineConfig.SharedDirs {
+		sharedDir := drivers.SharedDir{
+			Source:   dir,
+			Target:   convertToUnixPath(dir),
+			Tag:      "crc-dir0", // smb share 'crc-dir0' is created in the msi
+			Type:     "cifs",
+			Username: machineConfig.SharedDirUsername,
+		}
+		sharedDirs = append(sharedDirs, sharedDir)
+	}
+	return sharedDirs
 }

--- a/pkg/crc/machine/hyperv/driver_windows_test.go
+++ b/pkg/crc/machine/hyperv/driver_windows_test.go
@@ -1,0 +1,12 @@
+package hyperv
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConvertToUnixPath(t *testing.T) {
+	assert.Equal(t, "/mnt/c/Users/crc", convertToUnixPath("C:\\Users\\crc"))
+	assert.Equal(t, "/mnt/d/Users/crc", convertToUnixPath("d:\\Users\\crc"))
+}

--- a/pkg/crc/machine/libvirt/driver_linux.go
+++ b/pkg/crc/machine/libvirt/driver_linux.go
@@ -1,10 +1,13 @@
 package libvirt
 
 import (
+	"fmt"
+
 	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/code-ready/crc/pkg/crc/machine/config"
 	"github.com/code-ready/crc/pkg/crc/network"
 	"github.com/code-ready/machine/drivers/libvirt"
+	"github.com/code-ready/machine/libmachine/drivers"
 )
 
 func CreateHost(machineConfig config.MachineConfig) *libvirt.Driver {
@@ -20,5 +23,21 @@ func CreateHost(machineConfig config.MachineConfig) *libvirt.Driver {
 	}
 
 	libvirtDriver.StoragePool = DefaultStoragePool
+	libvirtDriver.SharedDirs = configureShareDirs(machineConfig)
+
 	return libvirtDriver
+}
+
+func configureShareDirs(machineConfig config.MachineConfig) []drivers.SharedDir {
+	var sharedDirs []drivers.SharedDir
+	for i, dir := range machineConfig.SharedDirs {
+		sharedDir := drivers.SharedDir{
+			Source: dir,
+			Target: dir,
+			Tag:    fmt.Sprintf("dir%d", i),
+			Type:   "virtiofs",
+		}
+		sharedDirs = append(sharedDirs, sharedDir)
+	}
+	return sharedDirs
 }

--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -173,10 +173,13 @@ func configureSharedDirs(vm *virtualMachine, sshRunner *crcssh.Runner) error {
 			}
 		}
 		logging.Debugf("Mounting tag %s at %s", mount.Tag, mount.Target)
-		//FIXME: do not hardcode this
-		mount.Type = "virtiofs"
-		if _, _, err := sshRunner.RunPrivileged(fmt.Sprintf("Mounting %s", mount.Target), "mount", "-o", "context=\"system_u:object_r:container_file_t:s0\"", "-t", mount.Type, mount.Tag, mount.Target); err != nil {
-			return err
+		switch mount.Type {
+		case "virtiofs":
+			if _, _, err := sshRunner.RunPrivileged(fmt.Sprintf("Mounting %s", mount.Target), "mount", "-o", "context=\"system_u:object_r:container_file_t:s0\"", "-t", mount.Type, mount.Tag, mount.Target); err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf("Unknown Shared dir type requested: %s", mount.Type)
 		}
 	}
 

--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -189,6 +189,10 @@ func configureSharedDirs(vm *virtualMachine, sshRunner *crcssh.Runner) error {
 		case "cifs":
 			smbUncPath := fmt.Sprintf("//%s/%s", hostVirtualIP, mount.Tag)
 			if _, _, err := sshRunner.RunPrivate("sudo", "mount", "-o", fmt.Sprintf("rw,uid=core,gid=core,username='%s',password='%s'", mount.Username, mount.Password), "-t", mount.Type, smbUncPath, mount.Target); err != nil {
+				err = &crcerrors.MaskedSecretError{
+					Err:    err,
+					Secret: mount.Password,
+				}
 				return fmt.Errorf("Failed to mount CIFS/SMB share '%s' please make sure configured password is correct: %w", mount.Tag, err)
 			}
 		default:

--- a/pkg/crc/machine/types/types.go
+++ b/pkg/crc/machine/types/types.go
@@ -30,7 +30,9 @@ type StartConfig struct {
 	Preset crcpreset.Preset
 
 	// Shared dirs
-	EnableSharedDirs bool
+	EnableSharedDirs  bool
+	SharedDirPassword string
+	SharedDirUsername string
 
 	// Ports to access openshift routes
 	IngressHTTPPort  uint

--- a/pkg/crc/machine/vfkit/driver_darwin.go
+++ b/pkg/crc/machine/vfkit/driver_darwin.go
@@ -1,12 +1,14 @@
 package vfkit
 
 import (
+	"fmt"
 	"path/filepath"
 
 	"github.com/code-ready/crc/pkg/crc/constants"
 	"github.com/code-ready/crc/pkg/crc/machine/config"
 	"github.com/code-ready/crc/pkg/crc/network"
 	"github.com/code-ready/crc/pkg/drivers/vfkit"
+	"github.com/code-ready/machine/libmachine/drivers"
 )
 
 func CreateHost(machineConfig config.MachineConfig) *vfkit.Driver {
@@ -22,5 +24,21 @@ func CreateHost(machineConfig config.MachineConfig) *vfkit.Driver {
 	vfDriver.VirtioNet = machineConfig.NetworkMode == network.SystemNetworkingMode
 	vfDriver.VsockPath = constants.TapSocketPath
 
+	vfDriver.SharedDirs = configureShareDirs(machineConfig)
+
 	return vfDriver
+}
+
+func configureShareDirs(machineConfig config.MachineConfig) []drivers.SharedDir {
+	var sharedDirs []drivers.SharedDir
+	for i, dir := range machineConfig.SharedDirs {
+		sharedDir := drivers.SharedDir{
+			Source: dir,
+			Target: dir,
+			Tag:    fmt.Sprintf("dir%d", i),
+			Type:   "virtiofs",
+		}
+		sharedDirs = append(sharedDirs, sharedDir)
+	}
+	return sharedDirs
 }

--- a/pkg/crc/machine/vsock.go
+++ b/pkg/crc/machine/vsock.go
@@ -76,6 +76,7 @@ func listOpenPorts(daemonClient *daemonclient.Client) ([]types.ExposeRequest, er
 
 const (
 	virtualMachineIP = "192.168.127.2"
+	hostVirtualIP    = "192.168.127.254"
 	internalSSHPort  = "22"
 	localIP          = "127.0.0.1"
 	remoteHTTPPort   = "80"

--- a/pkg/drivers/hyperv/hyperv_windows.go
+++ b/pkg/drivers/hyperv/hyperv_windows.go
@@ -373,3 +373,12 @@ func (d *Driver) GetIP() (string, error) {
 
 	return resp[0], nil
 }
+
+func (d *Driver) GetSharedDirs() ([]drivers.SharedDir, error) {
+	for _, dir := range d.SharedDirs {
+		if !smbShareExists(dir.Tag) {
+			return []drivers.SharedDir{}, nil
+		}
+	}
+	return d.SharedDirs, nil
+}

--- a/pkg/drivers/hyperv/powershell_windows.go
+++ b/pkg/drivers/hyperv/powershell_windows.go
@@ -95,3 +95,10 @@ func quote(text string) string {
 func toMb(value int) string {
 	return fmt.Sprintf("%dMB", value)
 }
+
+func smbShareExists(name string) bool {
+	if err := cmd(fmt.Sprintf("Get-SmbShare -Name %s", name)); err != nil {
+		return false
+	}
+	return true
+}

--- a/pkg/os/util_unix.go
+++ b/pkg/os/util_unix.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"os/user"
 	"strconv"
 	"strings"
 
@@ -36,4 +37,12 @@ func RemoveFileAsRoot(reason, filepath string) error {
 	}
 	_, _, err := RunPrivileged(reason, "rm", "-fr", filepath)
 	return err
+}
+
+func GetCurrentUsername() (string, error) {
+	u, err := user.Current()
+	if err != nil {
+		return "", err
+	}
+	return u.Username, nil
 }

--- a/pkg/os/util_windows.go
+++ b/pkg/os/util_windows.go
@@ -2,7 +2,10 @@ package os
 
 import (
 	"bytes"
+	"errors"
 	"io/ioutil"
+	"os/user"
+	"strings"
 
 	"golang.org/x/text/encoding/unicode"
 	"golang.org/x/text/transform"
@@ -27,4 +30,16 @@ func ReadFileUTF16LE(filename string) ([]byte, error) {
 	unicodeReader := transform.NewReader(bytes.NewReader(raw), utf16bom)
 	decoded, err := ioutil.ReadAll(unicodeReader)
 	return decoded, err
+}
+
+func GetCurrentUsername() (string, error) {
+	u, err := user.Current()
+	if err != nil {
+		return "", err
+	}
+	userAndDomain := strings.Split(u.Username, "\\")
+	if len(userAndDomain) > 1 {
+		return userAndDomain[1], nil
+	}
+	return "", errors.New("unable to find the username of current user")
 }

--- a/vendor/github.com/code-ready/machine/libmachine/drivers/base.go
+++ b/vendor/github.com/code-ready/machine/libmachine/drivers/base.go
@@ -30,6 +30,8 @@ type SharedDir struct {
 	Tag      string
 	Target   string
 	Type     string
+	Username string
+	Password string `json:"-"`
 }
 
 // DriverName returns the name of the driver

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -82,7 +82,7 @@ github.com/cheggaaa/pb/v3/termutil
 github.com/code-ready/admin-helper/pkg/client
 github.com/code-ready/admin-helper/pkg/hosts
 github.com/code-ready/admin-helper/pkg/types
-# github.com/code-ready/machine v0.0.0-20220727160217-7bf0dd8c2d7b
+# github.com/code-ready/machine v0.0.0-20220927132822-3408fdecc41c
 ## explicit; go 1.17
 github.com/code-ready/machine/drivers/libvirt
 github.com/code-ready/machine/libmachine/drivers


### PR DESCRIPTION
Needs https://github.com/code-ready/machine/pull/66

## Solution/Idea

the default CIFS/SMB feature provided from windows
can be used to share directories over the  network
we can use it to share files between host and  crc
vm

Adds the following config options:
- `enable-shared-dirs` (was present on macOS and linux now added to windows)
- `smb-share-password` 

## Testing
0. use the `msi` from this PR to install `crc`
1. run `crc config set enable-shared-dirs true` and follow the instructions from the validation msg (it should ask to configure `smb-share-password` first)
2. run `crc config set preset podman` and `crc setup`
3. `crc start` with podman preset and bundle from https://github.com/code-ready/snc/pull/565 should succeed (download from openshift CI artifacts)
4. container with a volume mount should work, e.g: `podman run -v /mnt/home/crc/conf:/etc/http/conf httpd`