### PR TITLE
Version: use GetBundleVersion for any type of preset

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ __check_defined = \
 
 # Linker flags
 VERSION_VARIABLES := -X $(REPOPATH)/pkg/crc/version.crcVersion=$(CRC_VERSION) \
-	-X $(REPOPATH)/pkg/crc/version.bundleVersion=$(OPENSHIFT_VERSION) \
+	-X $(REPOPATH)/pkg/crc/version.ocpVersion=$(OPENSHIFT_VERSION) \
 	-X $(REPOPATH)/pkg/crc/version.okdVersion=$(OKD_VERSION) \
 	-X $(REPOPATH)/pkg/crc/version.podmanVersion=$(PODMAN_VERSION) \
 	-X $(REPOPATH)/pkg/crc/version.commitSha=$(COMMIT_SHA)

--- a/cmd/crc/cmd/version.go
+++ b/cmd/crc/cmd/version.go
@@ -45,7 +45,7 @@ func defaultVersion(preset crcPreset.Preset) *version {
 		Version:          crcversion.GetCRCVersion(),
 		Commit:           crcversion.GetCommitSha(),
 		OpenshiftVersion: crcversion.GetBundleVersion(preset),
-		PodmanVersion:    crcversion.GetPodmanVersion(),
+		PodmanVersion:    crcversion.GetBundleVersion(crcPreset.Podman),
 	}
 }
 

--- a/pkg/crc/api/api_client_test.go
+++ b/pkg/crc/api/api_client_test.go
@@ -52,7 +52,7 @@ func TestVersion(t *testing.T) {
 			CrcVersion:       version.GetCRCVersion(),
 			OpenshiftVersion: version.GetBundleVersion(preset.OpenShift),
 			CommitSha:        version.GetCommitSha(),
-			PodmanVersion:    version.GetPodmanVersion(),
+			PodmanVersion:    version.GetBundleVersion(preset.Podman),
 		},
 		vr,
 	)

--- a/pkg/crc/api/api_http_test.go
+++ b/pkg/crc/api/api_http_test.go
@@ -266,7 +266,7 @@ var testCases = []testCase{
 	// version
 	{
 		request:  get("version"),
-		response: jSon(fmt.Sprintf(`{"CrcVersion":"%s","CommitSha":"%s","OpenshiftVersion":"%s","PodmanVersion":"%s"}`, version.GetCRCVersion(), version.GetCommitSha(), version.GetBundleVersion(preset.OpenShift), version.GetPodmanVersion())),
+		response: jSon(fmt.Sprintf(`{"CrcVersion":"%s","CommitSha":"%s","OpenshiftVersion":"%s","PodmanVersion":"%s"}`, version.GetCRCVersion(), version.GetCommitSha(), version.GetBundleVersion(preset.OpenShift), version.GetBundleVersion(preset.Podman))),
 	},
 
 	// version never fails

--- a/pkg/crc/api/handlers.go
+++ b/pkg/crc/api/handlers.go
@@ -11,6 +11,7 @@ import (
 	"github.com/code-ready/crc/pkg/crc/machine"
 	"github.com/code-ready/crc/pkg/crc/machine/types"
 	"github.com/code-ready/crc/pkg/crc/preflight"
+	"github.com/code-ready/crc/pkg/crc/preset"
 	"github.com/code-ready/crc/pkg/crc/version"
 )
 
@@ -125,7 +126,7 @@ func (h *Handler) GetVersion(c *context) error {
 		CrcVersion:       version.GetCRCVersion(),
 		CommitSha:        version.GetCommitSha(),
 		OpenshiftVersion: version.GetBundleVersion(crcConfig.GetPreset(h.Config)),
-		PodmanVersion:    version.GetPodmanVersion(),
+		PodmanVersion:    version.GetBundleVersion(preset.Podman),
 	})
 }
 

--- a/pkg/crc/constants/constants.go
+++ b/pkg/crc/constants/constants.go
@@ -87,9 +87,9 @@ func defaultBundleForOs(preset crcpreset.Preset) map[string]string {
 	switch preset {
 	case crcpreset.Podman:
 		return map[string]string{
-			"darwin":  fmt.Sprintf("crc_podman_vfkit_%s_%s.crcbundle", version.GetPodmanVersion(), runtime.GOARCH),
-			"linux":   fmt.Sprintf("crc_podman_libvirt_%s_%s.crcbundle", version.GetPodmanVersion(), runtime.GOARCH),
-			"windows": fmt.Sprintf("crc_podman_hyperv_%s_%s.crcbundle", version.GetPodmanVersion(), runtime.GOARCH),
+			"darwin":  fmt.Sprintf("crc_podman_vfkit_%s_%s.crcbundle", version.GetBundleVersion(preset), runtime.GOARCH),
+			"linux":   fmt.Sprintf("crc_podman_libvirt_%s_%s.crcbundle", version.GetBundleVersion(preset), runtime.GOARCH),
+			"windows": fmt.Sprintf("crc_podman_hyperv_%s_%s.crcbundle", version.GetBundleVersion(preset), runtime.GOARCH),
 		}
 	case crcpreset.OKD:
 		return map[string]string{

--- a/pkg/crc/version/version.go
+++ b/pkg/crc/version/version.go
@@ -22,8 +22,8 @@ var (
 	// The SHA-1 of the commit this executable is build off
 	commitSha = "sha-unset"
 
-	// Bundle version which used for the release.
-	bundleVersion = "0.0.0-unset"
+	// OCP version which is used for the release.
+	ocpVersion = "0.0.0-unset"
 
 	// Podman version for podman specific bundles
 	podmanVersion = "0.0.0-unset"
@@ -73,7 +73,7 @@ func GetBundleVersion(preset crcPreset.Preset) string {
 	case crcPreset.OKD:
 		return okdVersion
 	default:
-		return bundleVersion
+		return ocpVersion
 	}
 }
 

--- a/pkg/crc/version/version.go
+++ b/pkg/crc/version/version.go
@@ -67,14 +67,14 @@ func GetCommitSha() string {
 }
 
 func GetBundleVersion(preset crcPreset.Preset) string {
-	if preset == crcPreset.OpenShift {
+	switch preset {
+	case crcPreset.Podman:
+		return podmanVersion
+	case crcPreset.OKD:
+		return okdVersion
+	default:
 		return bundleVersion
 	}
-	return okdVersion
-}
-
-func GetPodmanVersion() string {
-	return podmanVersion
 }
 
 func GetAdminHelperVersion() string {


### PR DESCRIPTION
This pr is a refactor to use `GetBundleVersion` for any type of
preset bundle and return the correct bundle version. After this
PR we don't need `GetPodmanVersion()` and it removes it.

