### PR TITLE
Remove Validation for using a different bundle for release bits

### DIFF
--- a/cmd/crc/cmd/setup.go
+++ b/cmd/crc/cmd/setup.go
@@ -58,7 +58,7 @@ func runSetup(arguments []string) error {
 	}
 
 	if !config.Get(crcConfig.Bundle).IsDefault {
-		if err := validation.ValidatePath(config.Get(crcConfig.Bundle).AsString()); err != nil {
+		if err := validation.ValidateBundlePath(config.Get(crcConfig.Bundle).AsString(), crcConfig.GetPreset(config)); err != nil {
 			return err
 		}
 	}

--- a/pkg/crc/machine/bundle/metadata.go
+++ b/pkg/crc/machine/bundle/metadata.go
@@ -237,6 +237,13 @@ func GetBundleNameWithoutExtension(bundleName string) string {
 	return strings.TrimSuffix(bundleName, bundleExtension)
 }
 
+func GetBundleNameWithExtension(bundleName string) string {
+	if strings.HasSuffix(bundleName, bundleExtension) {
+		return bundleName
+	}
+	return fmt.Sprintf("%s%s", bundleName, bundleExtension)
+}
+
 func GetCustomBundleName(bundleFilename string) string {
 	re := regexp.MustCompile(`(?:_[0-9]+)*.crcbundle$`)
 	baseName := re.ReplaceAllLiteralString(bundleFilename, "")

--- a/pkg/crc/validation/validation.go
+++ b/pkg/crc/validation/validation.go
@@ -67,10 +67,11 @@ func ValidateBundlePath(bundlePath string, preset crcpreset.Preset) error {
 
 func ValidateBundle(bundlePath string, preset crcpreset.Preset) error {
 	bundleName := filepath.Base(bundlePath)
-	_, err := bundle.Get(bundleName)
+	bundleMetadata, err := bundle.Get(bundleName)
 	if err != nil {
 		return ValidateBundlePath(bundlePath, preset)
 	}
+	bundleMismatchWarning(bundleMetadata.GetBundleName(), preset)
 	/* 'bundle' is already unpacked in ~/.crc/cache */
 	return nil
 }

--- a/pkg/crc/validation/validation.go
+++ b/pkg/crc/validation/validation.go
@@ -70,11 +70,7 @@ func ValidateBundlePath(bundlePath string, preset crcpreset.Preset) error {
 			logging.Warnf("Using custom bundle %s", userProvidedBundle)
 			return nil
 		}
-		if !constants.IsRelease() {
-			logging.Warnf("Using unsupported bundle %s", userProvidedBundle)
-			return nil
-		}
-		return fmt.Errorf("%s is not supported by this crc executable, please use %s", userProvidedBundle, constants.GetDefaultBundle(preset))
+		logging.Warnf("Using %s bundle, but %s is expected for this release", userProvidedBundle, constants.GetDefaultBundle(preset))
 	}
 	return nil
 }

--- a/pkg/crc/validation/validation.go
+++ b/pkg/crc/validation/validation.go
@@ -61,6 +61,7 @@ func ValidateBundlePath(bundlePath string, preset crcpreset.Preset) error {
 	}
 
 	userProvidedBundle := filepath.Base(bundlePath)
+	userProvidedBundle = bundle.GetBundleNameWithExtension(userProvidedBundle)
 	if userProvidedBundle != constants.GetDefaultBundle(preset) {
 		// Should append underscore (_) here, as we don't want crc_libvirt_4.7.15.crcbundle
 		// to be detected as a custom bundle for crc_libvirt_4.7.1.crcbundle

--- a/pkg/crc/validation/validation.go
+++ b/pkg/crc/validation/validation.go
@@ -61,18 +61,7 @@ func ValidateBundlePath(bundlePath string, preset crcpreset.Preset) error {
 	}
 
 	userProvidedBundle := filepath.Base(bundlePath)
-	userProvidedBundle = bundle.GetBundleNameWithExtension(userProvidedBundle)
-	if userProvidedBundle != constants.GetDefaultBundle(preset) {
-		// Should append underscore (_) here, as we don't want crc_libvirt_4.7.15.crcbundle
-		// to be detected as a custom bundle for crc_libvirt_4.7.1.crcbundle
-		usingCustomBundle := strings.HasPrefix(bundle.GetBundleNameWithoutExtension(userProvidedBundle),
-			fmt.Sprintf("%s_", bundle.GetBundleNameWithoutExtension(constants.GetDefaultBundle(preset))))
-		if usingCustomBundle {
-			logging.Warnf("Using custom bundle %s", userProvidedBundle)
-			return nil
-		}
-		logging.Warnf("Using %s bundle, but %s is expected for this release", userProvidedBundle, constants.GetDefaultBundle(preset))
-	}
+	bundleMismatchWarning(userProvidedBundle, preset)
 	return nil
 }
 
@@ -84,6 +73,21 @@ func ValidateBundle(bundlePath string, preset crcpreset.Preset) error {
 	}
 	/* 'bundle' is already unpacked in ~/.crc/cache */
 	return nil
+}
+
+func bundleMismatchWarning(userProvidedBundle string, preset crcpreset.Preset) {
+	userProvidedBundle = bundle.GetBundleNameWithExtension(userProvidedBundle)
+	if userProvidedBundle != constants.GetDefaultBundle(preset) {
+		// Should append underscore (_) here, as we don't want crc_libvirt_4.7.15.crcbundle
+		// to be detected as a custom bundle for crc_libvirt_4.7.1.crcbundle
+		usingCustomBundle := strings.HasPrefix(bundle.GetBundleNameWithoutExtension(userProvidedBundle),
+			fmt.Sprintf("%s_", bundle.GetBundleNameWithoutExtension(constants.GetDefaultBundle(preset))))
+		if usingCustomBundle {
+			logging.Warnf("Using custom bundle %s", userProvidedBundle)
+		} else {
+			logging.Warnf("Using %s bundle, but %s is expected for this release", userProvidedBundle, constants.GetDefaultBundle(preset))
+		}
+	}
 }
 
 // ValidateIPAddress checks if provided IP is valid


### PR DESCRIPTION
This PR remove the validation of bundle version check and error out
in case it doesn't match with crc release bit bundle version.

Just a warn message displayed to user in case use of different bundle.


**Fixes:** Issue #3313