### PR TITLE
Extend -b option to accept docker/http/https scheme

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,10 +162,10 @@ clean: clean_docs clean_macos_package clean_windows_msi
 
 .PHONY: build_e2e
 build_e2e: $(SOURCES)
-	GOARCH=amd64 GOOS=linux   go test ./test/e2e/ --ldflags="$(VERSION_VARIABLES)" -c -o $(BUILD_DIR)/linux-amd64/e2e.test
-	GOARCH=amd64 GOOS=windows go test ./test/e2e/ --ldflags="$(VERSION_VARIABLES)" -c -o $(BUILD_DIR)/windows-amd64/e2e.test.exe
-	GOARCH=amd64 GOOS=darwin  go test ./test/e2e/ --ldflags="$(VERSION_VARIABLES)" -c -o $(BUILD_DIR)/macos-amd64/e2e.test
-	GOARCH=arm64 GOOS=darwin  go test ./test/e2e/ --ldflags="$(VERSION_VARIABLES)" -c -o $(BUILD_DIR)/macos-arm64/e2e.test
+	GOARCH=amd64 GOOS=linux   go test ./test/e2e/ -tags "$(BUILDTAGS)" --ldflags="$(VERSION_VARIABLES)" -c -o $(BUILD_DIR)/linux-amd64/e2e.test
+	GOARCH=amd64 GOOS=windows go test ./test/e2e/ -tags "$(BUILDTAGS)" --ldflags="$(VERSION_VARIABLES)" -c -o $(BUILD_DIR)/windows-amd64/e2e.test.exe
+	GOARCH=amd64 GOOS=darwin  go test ./test/e2e/ -tags "$(BUILDTAGS)" --ldflags="$(VERSION_VARIABLES)" -c -o $(BUILD_DIR)/macos-amd64/e2e.test
+	GOARCH=arm64 GOOS=darwin  go test ./test/e2e/ -tags "$(BUILDTAGS)" --ldflags="$(VERSION_VARIABLES)" -c -o $(BUILD_DIR)/macos-arm64/e2e.test
 
 .PHONY: build_integration
 build_integration: $(SOURCES)
@@ -206,7 +206,7 @@ export BUNDLE_PATH = $(HOME)/Downloads/crc_libvirt_$(OPENSHIFT_VERSION)_$(GOARCH
 endif
 
 integration:
-	@go test -timeout=60m $(REPOPATH)/test/integration -v $(GINKGO_OPTS)
+	@go test -timeout=60m -tags "$(BUILDTAGS)" $(REPOPATH)/test/integration -v $(GINKGO_OPTS)
 
 .PHONY: e2e ## Run e2e tests
 e2e:
@@ -221,7 +221,7 @@ ifndef CRC_BINARY
 	CRC_BINARY = --crc-binary=$(GOPATH)/bin
 endif
 e2e:
-	@go test --timeout=180m $(REPOPATH)/test/e2e --ldflags="$(VERSION_VARIABLES)" -v $(PULL_SECRET_FILE) $(BUNDLE_LOCATION) $(CRC_BINARY) $(GODOG_OPTS) $(CLEANUP_HOME) $(INSTALLER_PATH) $(USER_PASSWORD)
+	@go test --timeout=180m $(REPOPATH)/test/e2e -tags "$(BUILDTAGS)" --ldflags="$(VERSION_VARIABLES)" -v $(PULL_SECRET_FILE) $(BUNDLE_LOCATION) $(CRC_BINARY) $(GODOG_OPTS) $(CLEANUP_HOME) $(INSTALLER_PATH) $(USER_PASSWORD)
 
 .PHONY: e2e-stories e2e-story-health e2e-story-marketplace e2e-story-registry
 # cluster must already be running, crc must be in the path

--- a/pkg/crc/config/settings.go
+++ b/pkg/crc/config/settings.go
@@ -61,7 +61,8 @@ func RegisterSettings(cfg *Config) {
 		fmt.Sprintf("Virtual machine preset (valid values are: %s, %s and %s)", preset.Podman, preset.OpenShift, preset.OKD))
 	// Start command settings in config
 	cfg.AddSetting(Bundle, defaultBundlePath(cfg), validateBundlePath, SuccessfullyApplied,
-		fmt.Sprintf("Bundle path (string, default '%s')", defaultBundlePath(cfg)))
+		fmt.Sprintf("Bundle path/URI - absolute or local path, http, https or docker URI (string, like 'https://foo.com/%s', 'docker://quay.io/myorg/%s:%s' default '%s' )",
+			constants.GetDefaultBundle(GetPreset(cfg)), constants.GetDefaultBundle(GetPreset(cfg)), version.GetCRCVersion(), defaultBundlePath(cfg)))
 	cfg.AddSetting(CPUs, defaultCPUs(cfg), validateCPUs, RequiresRestartMsg,
 		fmt.Sprintf("Number of CPU cores (must be greater than or equal to '%d')", defaultCPUs(cfg)))
 	cfg.AddSetting(Memory, defaultMemory(cfg), validateMemory, RequiresRestartMsg,

--- a/pkg/crc/config/settings.go
+++ b/pkg/crc/config/settings.go
@@ -27,7 +27,6 @@ const (
 	ProxyCAFile             = "proxy-ca-file"
 	ConsentTelemetry        = "consent-telemetry"
 	EnableClusterMonitoring = "enable-cluster-monitoring"
-	AutostartTray           = "autostart-tray"
 	KubeAdminPassword       = "kubeadmin-password"
 	Preset                  = "preset"
 	EnableSharedDirs        = "enable-shared-dirs"

--- a/pkg/crc/constants/constants.go
+++ b/pkg/crc/constants/constants.go
@@ -86,7 +86,7 @@ func GetAdminHelperURL() string {
 	return GetAdminHelperURLForOs(runtime.GOOS)
 }
 
-func GetDefaultBundle(preset crcpreset.Preset) string {
+func BundleForPreset(preset crcpreset.Preset, version string) string {
 	var bundleName strings.Builder
 
 	bundleName.WriteString("crc")
@@ -107,8 +107,12 @@ func GetDefaultBundle(preset crcpreset.Preset) string {
 		bundleName.WriteString("_hyperv")
 	}
 
-	fmt.Fprintf(&bundleName, "_%s_%s.crcbundle", version.GetBundleVersion(preset), runtime.GOARCH)
+	fmt.Fprintf(&bundleName, "_%s_%s.crcbundle", version, runtime.GOARCH)
 	return bundleName.String()
+}
+
+func GetDefaultBundle(preset crcpreset.Preset) string {
+	return BundleForPreset(preset, version.GetBundleVersion(preset))
 }
 
 var (

--- a/pkg/crc/image/image.go
+++ b/pkg/crc/image/image.go
@@ -26,7 +26,7 @@ type imageHandler struct {
 	imageURI string
 }
 
-func uri(preset crcpreset.Preset) string {
+func defaultURI(preset crcpreset.Preset) string {
 	return fmt.Sprintf("//%s/%s:%s", constants.RegistryURI, getImageName(preset), version.GetCRCVersion())
 }
 
@@ -95,9 +95,12 @@ func getImageName(preset crcpreset.Preset) string {
 	}
 }
 
-func PullBundle(preset crcpreset.Preset) error {
+func PullBundle(preset crcpreset.Preset, imageURI string) error {
+	if imageURI == "" {
+		imageURI = defaultURI(preset)
+	}
 	imgHandler := imageHandler{
-		imageURI: uri(preset),
+		imageURI: strings.TrimPrefix(imageURI, "docker:"),
 	}
 	destDir, err := os.MkdirTemp(constants.MachineCacheDir, "tmpBundleImage")
 	if err != nil {

--- a/pkg/crc/image/image.go
+++ b/pkg/crc/image/image.go
@@ -29,7 +29,7 @@ type imageHandler struct {
 }
 
 func defaultURI(preset crcpreset.Preset) string {
-	return fmt.Sprintf("//%s/%s:%s", constants.RegistryURI, getImageName(preset), version.GetCRCVersion())
+	return fmt.Sprintf("//%s/%s:%s", constants.RegistryURI, getImageName(preset), version.GetBundleVersion(preset))
 }
 
 func ValidateURI(uri *url.URL) error {

--- a/pkg/crc/machine/bundle/metadata.go
+++ b/pkg/crc/machine/bundle/metadata.go
@@ -270,7 +270,7 @@ func getBundleDownloadInfo(preset preset.Preset) (*download.RemoteFile, error) {
 	return downloadInfo, nil
 }
 
-func Download(preset preset.Preset) error {
+func DownloadDefault(preset preset.Preset) error {
 	downloadInfo, err := getBundleDownloadInfo(preset)
 	if err != nil {
 		return err

--- a/pkg/crc/preflight/preflight_checks_common.go
+++ b/pkg/crc/preflight/preflight_checks_common.go
@@ -106,7 +106,7 @@ func fixBundleExtracted(bundlePath string, preset crcpreset.Preset) func() error
 					return err
 				}
 			} else {
-				if err := bundle.Download(preset); err != nil {
+				if err := bundle.DownloadDefault(preset); err != nil {
 					return err
 				}
 			}

--- a/pkg/crc/preflight/preflight_checks_common.go
+++ b/pkg/crc/preflight/preflight_checks_common.go
@@ -102,7 +102,7 @@ func fixBundleExtracted(bundlePath string, preset crcpreset.Preset) func() error
 			// In case of OKD or podman bundle then pull the bundle image from quay
 			// otherwise use mirror location to download the bundle.
 			if preset == crcpreset.OKD || preset == crcpreset.Podman {
-				if err := image.PullBundle(preset); err != nil {
+				if err := image.PullBundle(preset, ""); err != nil {
 					return err
 				}
 			} else {


### PR DESCRIPTION
This patch enable user to use `-b` option in different ways for
`crc config`, `crc setup` and `crc start`.

```
$ crc config set bundle <local_bundle_path or http://foo.com/bundle or docker://registry.com/bundle:version>

$ crc setup -b <local_bundle_path or http://foo.com/bundle or docker://registry.com/bundle:version>

$ crc start -b <local_bundle_path or http://foo.com/bundle or docker://registry.com/bundle:version>
```

Assumption here is user doesn't change the bundle name during upload to
different location (like fileshare or registry) since we are building
the bundleName using those info.


## Testing

To test different image location try following
```
$ crc setup -b docker://quay.io/praveenkumar/podman-bundle:4.1.1  => this will download and extract image 
$ crc start  -b docker://quay.io/praveenkumar/podman-bundle:4.1.1 => this will no do anything and consume it.

If you don't use `setup` and directly use `start` then it will download and extract as part of start command.
```

To test with http/https location
```
$ crc setup -b https://storage.googleapis.com/crc-bundle-github-ci/crc_podman_libvirt_4.1.1_amd64.crcbundle
$ crc start -b https://storage.googleapis.com/crc-bundle-github-ci/crc_podman_libvirt_4.1.1_amd64.crcbundle

Same as  image testing.
```
