### PR TITLE
Cluster: Remove namespace details from proxy patch

### DIFF
--- a/pkg/crc/cluster/cluster.go
+++ b/pkg/crc/cluster/cluster.go
@@ -318,7 +318,7 @@ func AddProxyConfigToCluster(ctx context.Context, sshRunner *ssh.Runner, ocConfi
 	}
 	logging.Debugf("Patch string %s", string(patchEncode))
 
-	cmdArgs := []string{"patch", "proxy", "cluster", "-p", fmt.Sprintf("'%s'", string(patchEncode)), "-n", "openshift-config", "--type", "merge"}
+	cmdArgs := []string{"patch", "proxy", "cluster", "-p", fmt.Sprintf("'%s'", string(patchEncode)), "--type", "merge"}
 	if _, stderr, err := ocConfig.RunOcCommandPrivate(cmdArgs...); err != nil {
 		return fmt.Errorf("Failed to add proxy details %v: %s", err, stderr)
 	}

--- a/pkg/crc/constants/constants.go
+++ b/pkg/crc/constants/constants.go
@@ -24,7 +24,6 @@ const (
 	LogFile                   = "crc.log"
 	DaemonLogFile             = "crcd.log"
 	CrcLandingPageURL         = "https://console.redhat.com/openshift/create/local" // #nosec G101
-	DefaultPodmanURLBase      = "https://storage.googleapis.com/libpod-master-releases"
 	DefaultAdminHelperURLBase = "https://github.com/code-ready/admin-helper/releases/download/v%s/%s"
 	CRCMacTrayDownloadURL     = "https://github.com/code-ready/tray-electron/releases/download/%s/crc-tray-macos.tar.gz"
 	CRCWindowsTrayDownloadURL = "https://github.com/code-ready/tray-electron/releases/download/%s/crc-tray-windows.zip"


### PR DESCRIPTION
Proxy resource is cluster wide so it doesn't need namespace details
when applying the patch.

- https://docs.openshift.com/container-platform/latest/rest_api/config_apis/proxy-config-openshift-io-v1.html