### PR TITLE
Vsock: Add alternate http/https port in case 80/443 in use

### DIFF
--- a/pkg/crc/api/handlers.go
+++ b/pkg/crc/api/handlers.go
@@ -116,6 +116,8 @@ func getStartConfig(cfg crcConfig.Storage, args client.StartConfig) types.StartC
 		NameServer:        cfg.Get(crcConfig.NameServer).AsString(),
 		PullSecret:        cluster.NewNonInteractivePullSecretLoader(cfg, args.PullSecretFile),
 		KubeAdminPassword: cfg.Get(crcConfig.KubeAdminPassword).AsString(),
+		IngressHTTPPort:   cfg.Get(crcConfig.IngressHTTPPort).AsUInt(),
+		IngressHTTPSPort:  cfg.Get(crcConfig.IngressHTTPSPort).AsUInt(),
 		Preset:            crcConfig.GetPreset(cfg),
 		EnableSharedDirs:  crcConfig.ShouldEnableSharedDirs(cfg),
 	}

--- a/pkg/crc/config/callbacks.go
+++ b/pkg/crc/config/callbacks.go
@@ -32,3 +32,16 @@ func RequiresCRCSetup(key string, _ interface{}) string {
 	return fmt.Sprintf("Changes to configuration property '%s' are only applied during 'crc setup'.\n"+
 		"Please run 'crc setup' for this configuration to take effect.", key)
 }
+
+func RequiresHTTPPortChangeWarning(key string, value interface{}) string {
+	return fmt.Sprintf("Changes to configuration property '%s' will break OpenShift HTTP routes.\n"+
+		"In order to access OpenShift applications through HTTP URLs "+
+		"the %d port must be manually specified, such as http://myapp.apps-crc.testing:%d", key, value, value)
+}
+
+func RequiresHTTPSPortChangeWarning(key string, value interface{}) string {
+	return fmt.Sprintf("Changes to configuration property '%s' will break OpenShift HTTPS routes.\n"+
+		"In order to access OpenShift applications through HTTPS URLs "+
+		"the %d port must be manually specified, such as https://myapp.apps-crc.testing:%d\n"+
+		"After this change, the OpenShift console will be non-functional because of OpenShift limitations", key, value, value)
+}

--- a/pkg/crc/config/settings.go
+++ b/pkg/crc/config/settings.go
@@ -31,6 +31,8 @@ const (
 	KubeAdminPassword       = "kubeadmin-password"
 	Preset                  = "preset"
 	EnableSharedDirs        = "enable-shared-dirs"
+	IngressHTTPPort         = "ingress-http-port"
+	IngressHTTPSPort        = "ingress-https-port"
 )
 
 func RegisterSettings(cfg *Config) {
@@ -107,6 +109,10 @@ func RegisterSettings(cfg *Config) {
 
 	cfg.AddSetting(KubeAdminPassword, "", ValidateString, SuccessfullyApplied,
 		"User defined kubeadmin password")
+	cfg.AddSetting(IngressHTTPPort, constants.OpenShiftIngressHTTPPort, ValidatePort, RequiresHTTPPortChangeWarning,
+		fmt.Sprintf("HTTP port to use for OpenShift ingress/routes on the host (1024-65535, default: %d)", constants.OpenShiftIngressHTTPPort))
+	cfg.AddSetting(IngressHTTPSPort, constants.OpenShiftIngressHTTPSPort, ValidatePort, RequiresHTTPSPortChangeWarning,
+		fmt.Sprintf("HTTPS port to use for OpenShift ingress/routes on the host (1024-65535, default: %d)", constants.OpenShiftIngressHTTPSPort))
 }
 
 func defaultCPUs(cfg Storage) int {

--- a/pkg/crc/config/types.go
+++ b/pkg/crc/config/types.go
@@ -39,6 +39,10 @@ func (v SettingValue) AsInt() int {
 	return cast.ToInt(v.Value)
 }
 
+func (v SettingValue) AsUInt() uint {
+	return cast.ToUint(v.Value)
+}
+
 // validationFnType takes the key, value as args and checks if valid
 type ValidationFnType func(interface{}) (bool, string)
 type SetFn func(string, interface{}) string

--- a/pkg/crc/config/validations.go
+++ b/pkg/crc/config/validations.go
@@ -127,3 +127,14 @@ func validatePreset(value interface{}) (bool, string) {
 	}
 	return true, ""
 }
+
+func ValidatePort(value interface{}) (bool, string) {
+	port, err := cast.ToUintE(value)
+	if err != nil {
+		return false, "Requires integer value in range of 1024-65535"
+	}
+	if port < 1024 || port > 65535 {
+		return false, fmt.Sprintf("Provided %d but requires value in range of 1024-65535", port)
+	}
+	return true, ""
+}

--- a/pkg/crc/constants/constants.go
+++ b/pkg/crc/constants/constants.go
@@ -42,6 +42,9 @@ const (
 	ClusterDomain = ".crc.testing"
 	AppsDomain    = ".apps-crc.testing"
 
+	OpenShiftIngressHTTPPort  = 80
+	OpenShiftIngressHTTPSPort = 443
+
 	// This public key is owned by the CRC team (crc@crc.dev), and is used
 	// to sign bundles uploaded to an image registry.
 	// It can be fetched with: `gpg --recv-key DC7EAC400A1BFDFB`

--- a/pkg/crc/machine/start.go
+++ b/pkg/crc/machine/start.go
@@ -298,7 +298,7 @@ func (client *client) Start(ctx context.Context, startConfig types.StartConfig) 
 	}
 
 	if client.useVSock() {
-		if err := exposePorts(startConfig.Preset); err != nil {
+		if err := exposePorts(startConfig.Preset, startConfig.IngressHTTPPort, startConfig.IngressHTTPSPort); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/crc/machine/types/types.go
+++ b/pkg/crc/machine/types/types.go
@@ -31,6 +31,10 @@ type StartConfig struct {
 
 	// Shared dirs
 	EnableSharedDirs bool
+
+	// Ports to access openshift routes
+	IngressHTTPPort  uint
+	IngressHTTPSPort uint
 }
 
 type ClusterConfig struct {

--- a/pkg/crc/machine/vsock.go
+++ b/pkg/crc/machine/vsock.go
@@ -16,8 +16,8 @@ import (
 	"github.com/pkg/errors"
 )
 
-func exposePorts(preset crcPreset.Preset) error {
-	portsToExpose := vsockPorts(preset)
+func exposePorts(preset crcPreset.Preset, ingressHTTPPort, ingressHTTPSPort uint) error {
+	portsToExpose := vsockPorts(preset, ingressHTTPPort, ingressHTTPSPort)
 	daemonClient := daemonclient.New()
 	alreadyOpenedPorts, err := listOpenPorts(daemonClient)
 	if err != nil {
@@ -78,13 +78,13 @@ const (
 	virtualMachineIP = "192.168.127.2"
 	internalSSHPort  = "22"
 	localIP          = "127.0.0.1"
-	httpPort         = "80"
-	httpsPort        = "443"
+	remoteHTTPPort   = "80"
+	remoteHTTPSPort  = "443"
 	apiPort          = "6443"
 	cockpitPort      = "9090"
 )
 
-func vsockPorts(preset crcPreset.Preset) []types.ExposeRequest {
+func vsockPorts(preset crcPreset.Preset, ingressHTTPPort, ingressHTTPSPort uint) []types.ExposeRequest {
 	exposeRequest := []types.ExposeRequest{
 		{
 			Protocol: "tcp",
@@ -102,13 +102,13 @@ func vsockPorts(preset crcPreset.Preset) []types.ExposeRequest {
 			},
 			types.ExposeRequest{
 				Protocol: "tcp",
-				Local:    fmt.Sprintf(":%s", httpsPort),
-				Remote:   net.JoinHostPort(virtualMachineIP, httpsPort),
+				Local:    fmt.Sprintf(":%d", ingressHTTPSPort),
+				Remote:   net.JoinHostPort(virtualMachineIP, remoteHTTPSPort),
 			},
 			types.ExposeRequest{
 				Protocol: "tcp",
-				Local:    fmt.Sprintf(":%s", httpPort),
-				Remote:   net.JoinHostPort(virtualMachineIP, httpPort),
+				Local:    fmt.Sprintf(":%d", ingressHTTPPort),
+				Remote:   net.JoinHostPort(virtualMachineIP, remoteHTTPPort),
 			})
 	case crcPreset.Podman:
 		socketProtocol := types.UNIX


### PR DESCRIPTION
This patch try to solve user issue where port 80 or 443 already in
use and `crc start` fails by having alternate port 8080 and 8443.

Note: Now user have to add those ports to application routes to access
it. Like `https://myapp.apps-crc.testing:8443` or `http://myapp.apps-crc.testing:8080`

```
$ ./crc start
[...]
WARN Port 80 is already in use. Going to use 8080

$ curl --unix-socket ~/.crc/crc-http.sock http:/unix/network/services/forwarder/all | jq .
[
  {
    "local": "127.0.0.1:2222",
    "remote": "192.168.127.2:22",
    "protocol": "tcp"
  },
  {
    "local": "127.0.0.1:6443",
    "remote": "192.168.127.2:6443",
    "protocol": "tcp"
  },
  {
    "local": ":443",
    "remote": "192.168.127.2:443",
    "protocol": "tcp"
  },
  {
    "local": ":8080",
    "remote": "192.168.127.2:80",
    "protocol": "tcp"
  }
]
```


**Fixes:** Issue #3331 