### PR TITLE
Fixes #3281 remove alpha from preset config option help

### DIFF
--- a/pkg/crc/config/settings.go
+++ b/pkg/crc/config/settings.go
@@ -57,7 +57,7 @@ func RegisterSettings(cfg *Config) {
 
 	// Preset setting should be on top because CPUs/Memory config depend on it.
 	cfg.AddSetting(Preset, string(preset.OpenShift), validatePreset, RequiresDeleteAndSetupMsg,
-		fmt.Sprintf("Virtual machine preset (alpha feature - valid values are: %s, %s and %s)", preset.Podman, preset.OpenShift, preset.OKD))
+		fmt.Sprintf("Virtual machine preset (valid values are: %s, %s and %s)", preset.Podman, preset.OpenShift, preset.OKD))
 	// Start command settings in config
 	cfg.AddSetting(Bundle, defaultBundlePath(cfg), validateBundlePath, SuccessfullyApplied,
 		fmt.Sprintf("Bundle path (string, default '%s')", defaultBundlePath(cfg)))


### PR DESCRIPTION
this was missed and as preset feature has been working for users for many releases now we can remove the alpha feature tag