### PR TITLE
e2e: execute crc setup as an isolated command

### DIFF
--- a/test/e2e/crcsuite/crcsuite.go
+++ b/test/e2e/crcsuite/crcsuite.go
@@ -68,6 +68,8 @@ func FeatureContext(s *godog.Suite) {
 		ExecuteCommand)
 	s.Step(`^execut(?:e|ing) crc (.*) command (.*)$`,
 		ExecuteCommandWithExpectedExitStatus)
+	s.Step(`^execut(?:e|ing) single crc (.*) command (.*)$`,
+		ExecuteSingleCommandWithExpectedExitStatus)
 
 	// CRC file operations
 	s.Step(`^file "([^"]*)" exists in CRC home folder$`,
@@ -428,4 +430,11 @@ func ExecuteCommandWithExpectedExitStatus(command string, expectedExitStatus str
 		command = fmt.Sprintf("%s -b %s", command, bundleLocation)
 	}
 	return crcCmd.CRC(command).ExecuteWithExpectedExit(expectedExitStatus)
+}
+
+func ExecuteSingleCommandWithExpectedExitStatus(command string, expectedExitStatus string) error {
+	if command == "setup" && userProvidedBundle {
+		command = fmt.Sprintf("%s -b %s", command, bundleLocation)
+	}
+	return crcCmd.CRC(command).ExecuteSingleWithExpectedExit(expectedExitStatus)
 }

--- a/test/e2e/features/basic.feature
+++ b/test/e2e/features/basic.feature
@@ -39,22 +39,7 @@ Feature: Basic test
     Scenario: CRC setup on Linux
         When executing "crc setup --check-only" fails
         Then executing crc start command fails
-        And executing crc setup command succeeds
-        And stderr should contain "Checking if CRC bundle is extracted in '$HOME/.crc'"
-        And stderr should contain "Checking if running as non-root"
-        And stderr should contain "Checking if Virtualization is enabled"
-        And stderr should contain "Checking if KVM is enabled"
-        And stderr should contain "Checking if libvirt is installed"
-        And stderr should contain "Checking if user is part of libvirt group"
-        And stderr should contain "Checking if libvirt daemon is running"
-        And stderr should contain "Checking if a supported libvirt version is installed"
-        And stderr should contain "Checking if libvirt 'crc' network is available"
-        And stderr should contain "Checking if libvirt 'crc' network is active"
-        And stderr should contain "Checking if NetworkManager is installed"
-        And stderr should contain "Checking if NetworkManager service is running"
-        And stderr should contain "Using root access: Executing systemctl daemon-reload command"
-        And stderr should contain "Using root access: Executing systemctl reload NetworkManager"
-        And stdout should contain "Your system is correctly setup for using CRC. Use 'crc start' to start the instance"
+        And executing single crc setup command succeeds
 
     @linux
     Scenario: Missing CRC setup
@@ -67,19 +52,11 @@ Feature: Basic test
     @darwin
     Scenario: CRC setup on Mac
         When executing "crc setup --check-only" fails
-        And executing crc setup command succeeds
-        And stderr should contain "Checking if running as non-root"
-        And stderr should contain "Checking if vfkit is installed"
-        And stderr should contain "Using root access: Changing ownership"
-
+        And executing single crc setup command succeeds
+        
     @windows
     Scenario: CRC setup on Windows
-        When executing crc setup command succeeds
-        Then stderr should contain "Extracting bundle from the CRC executable" if bundle is embedded
-        Then stderr should contain "Checking Windows release"
-        Then stderr should contain "Checking if Hyper-V is installed"
-        Then stderr should contain "Checking if user is a member of the Hyper-V Administrators group"
-        Then stderr should contain "Checking if the Hyper-V virtual switch exist"
+        When executing single crc setup command succeeds
 
     @darwin @linux @windows
     Scenario: Request start with monitoring stack


### PR DESCRIPTION
During e2e executions from time to time crc setup got freeze giving false positives. This is due to a wrong behavior on clicumber shell utility within the downloader progress bar to avoid this conflict crc setup will be executed as a single command with os.exec also we remove checks for setup outputs


