### PR TITLE
Validation: Use validation path in case windows path in used

### DIFF
--- a/pkg/crc/validation/validation.go
+++ b/pkg/crc/validation/validation.go
@@ -121,6 +121,11 @@ func ValidateURL(uri string) error {
 	// Relative paths will cause `ParseRequestURI` to error out, and will be handled in `ValidateBundlePath`
 	case !u.IsAbs():
 		return ValidatePath(uri)
+	// In case of windows where path started with C:\<path> the uri scheme would be `C`
+	// We are going to check if the uri scheme is a single letter and assume that it is windows drive path url
+	// and send it to ValidatePath
+	case len(u.Scheme) == 1:
+		return ValidatePath(uri)
 	case u.Scheme == "http", u.Scheme == "https":
 		return nil
 	case u.Scheme == "docker":


### PR DESCRIPTION
Current validation fails in case of windows path `C:\<path>` because url able to parse it and provide `C` as scheme which result to following error

```
 $ .\crc.exe setup -b C:\Users\prkumar\Downloads\crc_hyperv_4.11.1_amd64.crcbundle
 invalid C:\Users\prkumar\Downloads\crc_hyperv_4.11.1_amd64.crcbundle format (only supported http, https or docker)
```

This patch is make an assumption that in case of uri.scheme is single letter than it might be windows path and run validation path of it. As per MS document driver name shouldn't be more than single letter.

https://learn.microsoft.com/en-us/windows-hardware/customize/desktop/unattend/microsoft-windows-setup-diskconfiguration-disk-modifypartitions-modifypartition-letter


