### PR TITLE
Follow-up to https://github.com/code-ready/crc/pull/3355

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -257,7 +257,6 @@ gen_release_info:
 	@sed -i s/@PODMAN_VERSION@/$(PODMAN_VERSION)/ $(RELEASE_INFO)
 
 .PHONY: linux-release-binary macos-release-binary windows-release-binary
-linux-release-binary: LDFLAGS += -X '$(REPOPATH)/pkg/crc/version.linuxReleaseBuild=true' $(RELEASE_VERSION_VARIABLES)
 linux-release-binary: $(BUILD_DIR)/linux-amd64/crc
 
 macos-release-binary: LDFLAGS+= -X '$(REPOPATH)/pkg/crc/version.installerBuild=true' $(RELEASE_VERSION_VARIABLES)

--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ vendorcheck:
 	./verify-vendor.sh
 
 .PHONY: check
-check: cross build_e2e $(HOST_BUILD_DIR)/crc-embedder test cross-lint vendorcheck
+check: cross build_e2e $(HOST_BUILD_DIR)/crc-embedder test cross-lint vendorcheck build_integration
 
 # Start of the actual build targets
 

--- a/pkg/crc/constants/constants.go
+++ b/pkg/crc/constants/constants.go
@@ -162,10 +162,6 @@ func EnsureBaseDirectoriesExist() error {
 	return nil
 }
 
-func IsRelease() bool {
-	return version.IsInstaller() || version.IsLinuxRelease()
-}
-
 func GetPublicKeyPath() string {
 	return filepath.Join(MachineInstanceDir, DefaultName, "id_ecdsa.pub")
 }

--- a/pkg/crc/version/version.go
+++ b/pkg/crc/version/version.go
@@ -33,11 +33,6 @@ var (
 	// will be true for releases on macos and windows
 	// will be false for git builds on macos and windows
 	installerBuild = "false"
-
-	// will always false on macos and windows
-	// will be true for release on linux
-	// will be false for git builds on linux
-	linuxReleaseBuild = "false"
 )
 
 const (
@@ -87,10 +82,6 @@ func GetTrayVersion() string {
 
 func IsInstaller() bool {
 	return installerBuild != "false"
-}
-
-func IsLinuxRelease() bool {
-	return linuxReleaseBuild != "false"
 }
 
 func InstallPath() string {


### PR DESCRIPTION
This checks `build_integration` in `make check` to detect compilation breakage early.