### PR TITLE
msi: ignore errors from custom action creating the smb shared dir

### DIFF
--- a/packaging/windows/product.wxs.template
+++ b/packaging/windows/product.wxs.template
@@ -112,7 +112,7 @@
             Value="&quot;[POWERSHELLEXE]&quot; -NonInteractive -ExecutionPolicy Bypass -NoProfile -Command &quot;New-SmbShare -Name '[SHAREDDIRNAME]' -Path '[USERFOLDER]' -FullAccess '[LogonUser]'&quot;"
             Before="CreateSMBShare"
             Sequence="execute"/>
-        <CustomAction Id="CreateSMBShare" BinaryKey="WixCA" DllEntry="WixQuietExec64" Execute="deferred" Impersonate="no" Return="check" />
+        <CustomAction Id="CreateSMBShare" BinaryKey="WixCA" DllEntry="WixQuietExec64" Execute="deferred" Impersonate="no" Return="ignore" />
         <SetProperty Action="CAEnableFileAndPrinterSharing"
             Id="EnableFileAndPrinterSharing"
             Value="&quot;[POWERSHELLEXE]&quot; -NonInteractive -ExecutionPolicy Bypass -NoProfile -Command &quot;Set-NetFirewallRule -DisplayGroup 'File And Printer Sharing' -Enabled True -Profile 'Private,Public'&quot;"


### PR DESCRIPTION
if an smb share with the same name ('crc-dir0') already exits the custom action fails marking the whole installation as failed

we can safely ignore this error as crc also checks that the share exists before trying to use it
