### PR TITLE
Show memory usage in 'status' command output

### DIFF
--- a/cmd/crc/cmd/status.go
+++ b/cmd/crc/cmd/status.go
@@ -43,6 +43,8 @@ type status struct {
 	DiskSize         int64                        `json:"diskSize,omitempty"`
 	CacheUsage       int64                        `json:"cacheUsage,omitempty"`
 	CacheDir         string                       `json:"cacheDir,omitempty"`
+	RAMSize          int64                        `json:"ramSize,omitempty"`
+	RAMUsage         int64                        `json:"ramUsage,omitempty"`
 	Preset           preset.Preset                `json:"preset"`
 }
 
@@ -80,6 +82,8 @@ func getStatus(client *daemonclient.Client, cacheDir string) *status {
 		PodmanVersion:    clusterStatus.PodmanVersion,
 		DiskUsage:        clusterStatus.DiskUse,
 		DiskSize:         clusterStatus.DiskSize,
+		RAMSize:          clusterStatus.RAMSize,
+		RAMUsage:         clusterStatus.RAMUse,
 		CacheUsage:       size,
 		CacheDir:         cacheDir,
 		Preset:           clusterStatus.Preset,
@@ -108,6 +112,10 @@ func (s *status) prettyPrintTo(writer io.Writer) error {
 	}
 
 	lines = append(lines,
+		line{"RAM Usage", fmt.Sprintf(
+			"%s of %s",
+			units.HumanSize(float64(s.RAMUsage)),
+			units.HumanSize(float64(s.RAMSize)))},
 		line{"Disk Usage", fmt.Sprintf(
 			"%s of %s (Inside the CRC VM)",
 			units.HumanSize(float64(s.DiskUsage)),

--- a/pkg/crc/api/api_client_test.go
+++ b/pkg/crc/api/api_client_test.go
@@ -72,6 +72,8 @@ func TestStatus(t *testing.T) {
 			PodmanVersion:    "3.3.1",
 			DiskUse:          int64(10000000000),
 			DiskSize:         int64(20000000000),
+			RAMUse:           int64(1000),
+			RAMSize:          int64(2000),
 			Preset:           preset.OpenShift,
 		},
 		statusResult,

--- a/pkg/crc/api/api_http_test.go
+++ b/pkg/crc/api/api_http_test.go
@@ -228,7 +228,7 @@ var testCases = []testCase{
 	// status
 	{
 		request:  get("status"),
-		response: jSon(`{"CrcStatus":"Running","OpenshiftStatus":"Running","OpenshiftVersion":"4.5.1","PodmanVersion":"3.3.1","DiskUse":10000000000,"DiskSize":20000000000,"Preset":"openshift"}`),
+		response: jSon(`{"CrcStatus":"Running","OpenshiftStatus":"Running","OpenshiftVersion":"4.5.1","PodmanVersion":"3.3.1","DiskUse":10000000000,"DiskSize":20000000000,"RAMUse":1000,"RAMSize":2000,"Preset":"openshift"}`),
 	},
 
 	// status with failure

--- a/pkg/crc/api/client/types.go
+++ b/pkg/crc/api/client/types.go
@@ -25,6 +25,8 @@ type ClusterStatusResult struct {
 	PodmanVersion    string `json:"PodmanVersion,omitempty"`
 	DiskUse          int64
 	DiskSize         int64
+	RAMUse           int64
+	RAMSize          int64
 	Preset           preset.Preset
 }
 
@@ -32,13 +34,13 @@ type ConsoleResult struct {
 	ClusterConfig types.ClusterConfig
 }
 
-// setOrUnsetConfigResult struct is used to return the result of
+// SetOrUnsetConfigResult struct is used to return the result of
 // setconfig/unsetconfig command
 type SetOrUnsetConfigResult struct {
 	Properties []string
 }
 
-// getConfigResult struct is used to return the result of getconfig command
+// GetConfigResult struct is used to return the result of getconfig command
 type GetConfigResult struct {
 	Configs map[string]interface{}
 }

--- a/pkg/crc/api/handlers.go
+++ b/pkg/crc/api/handlers.go
@@ -69,6 +69,8 @@ func (h *Handler) Status(c *context) error {
 		PodmanVersion:    res.PodmanVersion,
 		DiskUse:          res.DiskUse,
 		DiskSize:         res.DiskSize,
+		RAMSize:          res.RAMSize,
+		RAMUse:           res.RAMUse,
 		Preset:           res.Preset,
 	})
 }

--- a/pkg/crc/cluster/cluster.go
+++ b/pkg/crc/cluster/cluster.go
@@ -82,6 +82,28 @@ func GetRootPartitionUsage(sshRunner *ssh.Runner) (int64, int64, error) {
 	return diskSize, diskUsage, nil
 }
 
+// GetRAMUsage return RAM size and RAM usage in bytes
+func GetRAMUsage(sshRunner *ssh.Runner) (int64, int64, error) {
+	cmd := "awk '/^Mem/ {print $2,$3}' <(free -b)"
+	out, _, err := sshRunner.Run(cmd)
+
+	if err != nil {
+		return 0, 0, err
+	}
+
+	ramDetails := strings.Split(strings.TrimSpace(out), " ")
+	ramSize, err := strconv.ParseInt(ramDetails[0], 10, 64)
+	if err != nil {
+		return 0, 0, err
+	}
+	ramUsage, err := strconv.ParseInt(ramDetails[1], 10, 64)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	return ramSize, ramUsage, nil
+}
+
 func EnsureSSHKeyPresentInTheCluster(ctx context.Context, ocConfig oc.Config, sshPublicKeyPath string) error {
 	sshPublicKeyByte, err := ioutil.ReadFile(sshPublicKeyPath)
 	if err != nil {

--- a/pkg/crc/machine/client.go
+++ b/pkg/crc/machine/client.go
@@ -34,6 +34,7 @@ type client struct {
 	config crcConfig.Storage
 
 	diskDetails *memoize.Memoizer
+	ramDetails  *memoize.Memoizer
 }
 
 func NewClient(name string, debug bool, config crcConfig.Storage) Client {
@@ -42,6 +43,7 @@ func NewClient(name string, debug bool, config crcConfig.Storage) Client {
 		debug:       debug,
 		config:      config,
 		diskDetails: memoize.NewMemoizer(time.Minute, 5*time.Minute),
+		ramDetails:  memoize.NewMemoizer(30*time.Second, 2*time.Minute),
 	}
 }
 

--- a/pkg/crc/machine/fakemachine/client.go
+++ b/pkg/crc/machine/fakemachine/client.go
@@ -105,6 +105,8 @@ func (c *Client) Status() (*types.ClusterStatusResult, error) {
 		PodmanVersion:    "3.3.1",
 		DiskUse:          10_000_000_000,
 		DiskSize:         20_000_000_000,
+		RAMSize:          2_000,
+		RAMUse:           1_000,
 		Preset:           preset.OpenShift,
 	}, nil
 }

--- a/pkg/crc/machine/types/types.go
+++ b/pkg/crc/machine/types/types.go
@@ -69,6 +69,8 @@ type ClusterStatusResult struct {
 	PodmanVersion    string
 	DiskUse          int64
 	DiskSize         int64
+	RAMUse           int64
+	RAMSize          int64
 	Preset           crcpreset.Preset
 }
 


### PR DESCRIPTION


**Relates to:** https://github.com/code-ready/crc/issues/2876

## Solution/Idea
The solution is pretty straightforward, PR is add two field for 'total' and 'used' RAM in `status` daemon API and print them.
Daemon implements getting RAM with execution and parsing output of `free -b` command. 


## Testing


1.  call `status` command while you have any crc vm running.
2. stdout should contains `RAM Usage` row, with number of bytes use and total for your vm, for example:

```
CRC VM:          Running
Podman:          4.2.0
RAM Usage:       168.4MB of 9.373GB
Disk Usage:      1.769GB of 32.74GB (Inside the CRC VM)
Cache Usage:     34.23GB
Cache Directory: /Users/some/.crc/cache
```
