### PR TITLE
ci: use v3 of checkout, setup-go and upload-artifact gh actions

### DIFF
--- a/.github/workflows/macos-installer.yml
+++ b/.github/workflows/macos-installer.yml
@@ -30,15 +30,15 @@ jobs:
           limit-access-to-actor: true
         timeout-minutes: 30
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go }}
       - name: Build macOS installer
         run: make NO_CODESIGN=1 out/macos-universal/crc-macos-installer.pkg
       - name: Upload macOS installer artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: macOS Installer (${{ matrix.os }})
           path: "./out/macos-universal/crc-macos-installer.pkg"

--- a/.github/workflows/make-check-win.yml
+++ b/.github/workflows/make-check-win.yml
@@ -20,9 +20,9 @@ jobs:
       - name: Downgrade mingw to workaround https://github.com/golang/go/issues/46099
         run: choco install mingw --version 10.2.0 --allow-downgrade
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go }}
       - name: Disable gofmt/goimports linters on Windows

--- a/.github/workflows/make-check.yml
+++ b/.github/workflows/make-check.yml
@@ -19,9 +19,9 @@ jobs:
           - 1.17
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go }}
       - name: Build

--- a/.github/workflows/make-rpm.yml
+++ b/.github/workflows/make-rpm.yml
@@ -17,9 +17,9 @@ jobs:
           - 1.17
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go }}
       - name: Build rpm

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -15,7 +15,7 @@ jobs:
           - ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Build docs
         run: CONTAINER_RUNTIME=docker make build_docs
       - name: Check links in docs

--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -18,9 +18,9 @@ jobs:
           - 1.17
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go }}
       - name: Set path for heat.exe and light.exe
@@ -29,7 +29,7 @@ jobs:
       - name: Build Windows installer
         run: make out/windows-amd64/crc-windows-installer.zip
       - name: Upload windows installer artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: Windows Installer (${{ matrix.os }})
           path: "./out/windows-amd64/crc-windows-installer.zip"


### PR DESCRIPTION
v2 actions based on nodejs 12 are deprecated
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/
