### PR TITLE
msi: use firewall rule's Group id to enable printer and file sharing

### DIFF
--- a/packaging/windows/product.wxs.template
+++ b/packaging/windows/product.wxs.template
@@ -118,7 +118,7 @@
             Value="&quot;[POWERSHELLEXE]&quot; -NonInteractive -ExecutionPolicy Bypass -NoProfile -Command &quot;Set-NetFirewallRule -Group '@FirewallAPI.dll,-28502' -Enabled True -Profile 'Private,Public'&quot;"
             Before="EnableFileAndPrinterSharing"
             Sequence="execute"/>
-        <CustomAction Id="EnableFileAndPrinterSharing" BinaryKey="WixCA" DllEntry="WixQuietExec64" Execute="deferred" Impersonate="no" Return="check" />
+        <CustomAction Id="EnableFileAndPrinterSharing" BinaryKey="WixCA" DllEntry="WixQuietExec64" Execute="deferred" Impersonate="no" Return="ignore" />
         <SetProperty Action="CARemoveSMBShare"
             Id="RemoveSMBShare"
             Value="&quot;[POWERSHELLEXE]&quot; -NonInteractive -ExecutionPolicy Bypass -NoProfile -Command &quot;Remove-SmbShare -Name '[SHAREDDIRNAME]' -Force&quot;"

--- a/packaging/windows/product.wxs.template
+++ b/packaging/windows/product.wxs.template
@@ -115,7 +115,7 @@
         <CustomAction Id="CreateSMBShare" BinaryKey="WixCA" DllEntry="WixQuietExec64" Execute="deferred" Impersonate="no" Return="ignore" />
         <SetProperty Action="CAEnableFileAndPrinterSharing"
             Id="EnableFileAndPrinterSharing"
-            Value="&quot;[POWERSHELLEXE]&quot; -NonInteractive -ExecutionPolicy Bypass -NoProfile -Command &quot;Set-NetFirewallRule -DisplayGroup 'File And Printer Sharing' -Enabled True -Profile 'Private,Public'&quot;"
+            Value="&quot;[POWERSHELLEXE]&quot; -NonInteractive -ExecutionPolicy Bypass -NoProfile -Command &quot;Set-NetFirewallRule -Group '@FirewallAPI.dll,-28502' -Enabled True -Profile 'Private,Public'&quot;"
             Before="EnableFileAndPrinterSharing"
             Sequence="execute"/>
         <CustomAction Id="EnableFileAndPrinterSharing" BinaryKey="WixCA" DllEntry="WixQuietExec64" Execute="deferred" Impersonate="no" Return="check" />


### PR DESCRIPTION
Fixes #3386 

Uses the solution mentioned in: https://github.com/code-ready/crc/issues/3386#issuecomment-1287146404

### How to test:
✅  Run the msi from this PR on a localized non-english version of windows 10 and installation should succeed
✅  Run the msi from this PR on a english version of windows 10 and installation should succeed
✅  Run the msi from this PR on a localized non-english version of windows 11 and installation should succeed
✅  Run the msi from this PR on a english version of windows 11 and installation should succeed